### PR TITLE
Fix Windows npm CLI shim detection

### DIFF
--- a/src/lib/cli/cli-exec.ts
+++ b/src/lib/cli/cli-exec.ts
@@ -1,8 +1,7 @@
-import { spawn } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { getRuntimePlatform } from '../system/runtime-platform';
 import { getSpawnCliCache } from './spawn-cli-cache';
-import { buildSpawnEnvironment } from './spawn-cli-runtime';
+import { spawnCliProcess } from './spawn-cli-runtime';
 
 export interface ExecResult {
   /** True iff the process closed with exit code 0 AND did not time out. */
@@ -48,22 +47,11 @@ export function __resetWslDetectionCacheForTests(): void {
   _wslDetectionCache = undefined;
 }
 
-function quoteBashArg(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-
-function buildBashExecScript(command: string, args: string[]): string {
-  return ['exec', quoteBashArg(command), ...args.map(quoteBashArg)].join(' ');
-}
-
 /**
  * Runs a CLI binary with a hard timeout, capturing stdout/stderr as strings.
  *
- * Routing:
- *   - server=Windows native, env=wsl  → `wsl bash -lic 'exec <command> <args...>'`
- *   - server=WSL, env=native          → `cmd.exe /c "<command> <args>"`
- *     (reaches the Windows host's PATH via WSL interop)
- *   - otherwise                       → `spawn(command, args)` directly
+ * Routing is delegated to spawn-cli-runtime so status probes and real sessions
+ * resolve Windows npm shims (`*.cmd`, `*.ps1`) the same way.
  *
  * Never throws — all failure modes map to `{ ok: false, ... }`.
  */
@@ -73,42 +61,12 @@ export async function execCli(
   environment: CliEnvironment,
   timeoutMs: number,
 ): Promise<ExecResult> {
-  const onWin32 = getRuntimePlatform() === 'win32';
-  const onWsl = !onWin32 && isRunningInWsl();
-
-  let spawnCommand: string;
-  let spawnArgs: string[];
-
-  if (onWin32 && environment === 'wsl') {
-    spawnCommand = 'wsl';
-    // Match WSL session spawning so status checks see the same PATH a user
-    // gets from their WSL shell.
-    spawnArgs = ['bash', '-lic', buildBashExecScript(command, args)];
-  } else if (onWsl && environment === 'native') {
-    // cmd.exe /c takes a single command string. Our callers only run
-    // fixed verbs like `claude --version` with no user input, so a
-    // simple space-join is safe. Do NOT shell-escape — it would mangle
-    // the expected argv on the Windows side.
-    spawnCommand = 'cmd.exe';
-    spawnArgs = ['/c', [command, ...args].join(' ')];
-  } else {
-    // Native on the server's own platform, including the WSL self-check
-    // (env=wsl when the server itself runs in WSL).
-    spawnCommand = command;
-    spawnArgs = args;
-  }
-
-  // Finder/Dock-launched macOS apps do not inherit the user's login-shell PATH.
-  // Use the same PATH reconstruction as real CLI spawns so status probes and
-  // provider pickers see CLIs installed by Homebrew, npm, pnpm, etc.
-  const env = buildSpawnEnvironment(process.env, getSpawnCliCache());
-
   return new Promise((resolve) => {
-    const proc = spawn(spawnCommand, spawnArgs, {
+    const proc = spawnCliProcess(command, args, {
       windowsHide: true,
-      env,
+      env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    }, environment, getSpawnCliCache());
 
     let stdout = '';
     let stderr = '';

--- a/src/lib/cli/spawn-cli-runtime.ts
+++ b/src/lib/cli/spawn-cli-runtime.ts
@@ -24,13 +24,22 @@ export function buildSpawnEnvironment(
   cache: SpawnCliCache,
 ): NodeJS.ProcessEnv {
   const env = { ...baseEnv };
+
+  if (getRuntimePlatform() === 'win32') {
+    const windowsPath = resolveWindowsCliPath(env);
+    if (windowsPath) {
+      mergeIntoEnvironmentPath(env, windowsPath);
+    }
+    return env;
+  }
+
   const loginShellPath = resolveLoginShellPath(cache);
 
   if (!loginShellPath) {
     return env;
   }
 
-  env.PATH = mergePathValues(loginShellPath, env.PATH);
+  mergeIntoEnvironmentPath(env, loginShellPath);
   return env;
 }
 
@@ -46,6 +55,10 @@ export function spawnCliProcess(
 
   if (agentEnv === 'wsl' && getRuntimePlatform() === 'win32') {
     return spawnWslCli(command, args, spawnOptions, cache, env);
+  }
+
+  if (agentEnv === 'native' && getRuntimePlatform() === 'win32') {
+    return spawnWindowsNativeCli(command, args, spawnOptions, cache, env);
   }
 
   if (agentEnv === 'native' && isRunningInWsl()) {
@@ -108,11 +121,35 @@ function getLoginShell(): string | null {
 function mergePathValues(primaryPath: string, secondaryPath?: string): string {
   const merged = [primaryPath, secondaryPath]
     .filter((value): value is string => typeof value === 'string' && value.length > 0)
-    .flatMap((value) => value.split(delimiter))
+    .flatMap((value) => value.split(getEnvironmentPathDelimiter()))
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
 
-  return [...new Set(merged)].join(delimiter);
+  return [...new Set(merged)].join(getEnvironmentPathDelimiter());
+}
+
+function getEnvironmentPathDelimiter(): string {
+  return getRuntimePlatform() === 'win32' ? ';' : delimiter;
+}
+
+function getPathEnvironmentKey(env: NodeJS.ProcessEnv): string {
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+}
+
+function mergeIntoEnvironmentPath(env: NodeJS.ProcessEnv, primaryPath: string): void {
+  const pathKey = getPathEnvironmentKey(env);
+  env[pathKey] = mergePathValues(primaryPath, env[pathKey]);
+}
+
+function resolveWindowsCliPath(env: NodeJS.ProcessEnv): string | null {
+  const appData = env.APPDATA?.trim();
+  const userProfile = env.USERPROFILE?.trim();
+  const candidates = [
+    appData ? `${appData}\\npm` : null,
+    userProfile ? `${userProfile}\\AppData\\Roaming\\npm` : null,
+  ].filter((value): value is string => Boolean(value));
+
+  return candidates.length > 0 ? [...new Set(candidates)].join(getEnvironmentPathDelimiter()) : null;
 }
 
 function parseMarkedPath(stdout: string): string | null {
@@ -211,10 +248,46 @@ function spawnWindowsNativeCli(
   const resolvedCommand = resolveWindowsNativeBinaryPath(cache, command, env);
 
   if (resolvedCommand) {
-    return spawn(resolvedCommand, args, options);
+    return spawnResolvedWindowsNativeCli(resolvedCommand, args, options);
   }
 
   return spawnWindowsNativeCliViaPowerShell(command, args, options);
+}
+
+function spawnResolvedWindowsNativeCli(
+  windowsPath: string,
+  args: string[],
+  options: SpawnOptions,
+): ChildProcess {
+  const extension = getWindowsPathExtension(windowsPath);
+  const platform = getRuntimePlatform();
+
+  if (platform === 'win32') {
+    if (extension === '.cmd' || extension === '.bat') {
+      return spawn('cmd.exe', ['/d', '/c', windowsPath, ...args], options);
+    }
+
+    if (extension === '.ps1') {
+      return spawn(
+        'powershell.exe',
+        ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', windowsPath, ...args],
+        options,
+      );
+    }
+
+    return spawn(windowsPath, args, options);
+  }
+
+  if (extension === '.cmd' || extension === '.bat' || extension === '.ps1') {
+    return spawnWindowsNativeCliViaPowerShell(windowsPath, args, options);
+  }
+
+  const wslPath = windowsExecutablePathToWslPath(windowsPath);
+  if (wslPath) {
+    return spawn(wslPath, args, options);
+  }
+
+  return spawnWindowsNativeCliViaPowerShell(windowsPath, args, options);
 }
 
 function spawnWindowsNativeCliViaPowerShell(
@@ -252,6 +325,10 @@ function quotePowerShellString(value: string): string {
 }
 
 function toWindowsPath(cwd: string): string | null {
+  if (/^[a-zA-Z]:[\\/]/.test(cwd)) {
+    return cwd.replace(/\//g, '\\');
+  }
+
   const mountedDriveMatch = cwd.match(/^\/mnt\/([a-zA-Z])(?:\/(.*))?$/);
   if (mountedDriveMatch) {
     const drive = mountedDriveMatch[1].toUpperCase();
@@ -313,13 +390,8 @@ function resolveWindowsNativeBinaryPath(
     return null;
   }
 
-  const wslPath = windowsExecutablePathToWslPath(windowsPath);
-  if (!wslPath) {
-    return null;
-  }
-
-  cache.windowsNativeBinaryPaths.set(command, wslPath);
-  return wslPath;
+  cache.windowsNativeBinaryPaths.set(command, windowsPath);
+  return windowsPath;
 }
 
 function resolveWindowsNativeBinaryPathFromWhere(
@@ -338,13 +410,45 @@ function resolveWindowsNativeBinaryPathFromWhere(
       return null;
     }
 
-    return probe.stdout
+    const candidates = probe.stdout
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .find((line) => /\.(?:exe|com)$/i.test(line)) ?? null;
+      .filter(isSupportedWindowsNativeBinaryPath);
+
+    return pickPreferredWindowsNativeBinaryPath(candidates);
   } catch {
     return null;
   }
+}
+
+function isSupportedWindowsNativeBinaryPath(value: string): boolean {
+  return ['.exe', '.com', '.cmd', '.bat', '.ps1'].includes(getWindowsPathExtension(value));
+}
+
+function pickPreferredWindowsNativeBinaryPath(candidates: string[]): string | null {
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const priority = new Map([
+    ['.exe', 0],
+    ['.com', 1],
+    ['.cmd', 2],
+    ['.bat', 3],
+    ['.ps1', 4],
+  ]);
+
+  return candidates
+    .slice()
+    .sort((a, b) => (
+      (priority.get(getWindowsPathExtension(a)) ?? Number.MAX_SAFE_INTEGER)
+      - (priority.get(getWindowsPathExtension(b)) ?? Number.MAX_SAFE_INTEGER)
+    ))[0] ?? null;
+}
+
+function getWindowsPathExtension(value: string): string {
+  const match = value.match(/\.([^.\\/]+)$/);
+  return match ? `.${match[1].toLowerCase()}` : '';
 }
 
 function quoteCmdArg(value: string): string {


### PR DESCRIPTION
## Summary
- Fix Windows native CLI detection for npm-installed Codex/OpenCode/Claude shims.
- Route Windows `.cmd`/`.bat` npm wrappers through `cmd.exe` and keep `.ps1` as a fallback.
- Share the same spawn resolver between provider status checks and real session launches.

## Verification
- npx tsc --noEmit --pretty false --project tsconfig.server.json
- npx eslint src/lib/cli/spawn-cli-runtime.ts src/lib/cli/cli-exec.ts

## Notes
- This public PR is a direct patch on top of current public main.
- The earlier export branch was deleted because it was based on stale exported history.