### PR TITLE
Restore public contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Report a reproducible problem in Tessera
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please do not paste secrets, API keys, tokens, private prompts, or sensitive logs.
+  - type: input
+    id: version
+    attributes:
+      label: Tessera version
+      description: Use the release version, npm package version, or commit SHA.
+      placeholder: "v0.1.1 / @horang-labs/tessera@0.1.1 / commit SHA"
+    validations:
+      required: true
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime
+      options:
+        - Windows desktop
+        - macOS desktop
+        - npm/browser runtime
+        - Source development
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS and environment
+      placeholder: "Windows 11 + WSL2 Ubuntu 24.04 / macOS 15 / Ubuntu 24.04"
+    validations:
+      required: true
+  - type: dropdown
+    id: wsl
+    attributes:
+      label: WSL
+      options:
+        - Not applicable
+        - WSL2
+        - WSL1
+        - Not sure
+    validations:
+      required: true
+  - type: checkboxes
+    id: providers
+    attributes:
+      label: Affected provider or area
+      options:
+        - label: Claude Code
+        - label: Codex
+        - label: OpenCode
+        - label: Git / worktree / PR workflow
+        - label: Desktop app
+        - label: npm/browser runtime
+        - label: Settings / provider detection
+        - label: Other
+  - type: textarea
+    id: cli-location
+    attributes:
+      label: CLI install location and detection status
+      description: Especially useful on Windows/WSL.
+      placeholder: "Example: Codex and OpenCode are installed inside WSL2, Tessera is running on Windows desktop, Settings > Development shows only Git."
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open Tessera
+        2. Go to ...
+        3. Click ...
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or recordings
+      description: Attach anything that helps explain the issue. Redact sensitive paths, tokens, prompts, and repository names if needed.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: Suggest an improvement or new workflow
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or workflow
+      description: What are you trying to do, and what is hard today?
+      placeholder: "When I run several agents in parallel, I want to..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should Tessera do?
+    validations:
+      required: true
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Current workaround
+      description: How do you handle this today?
+  - type: checkboxes
+    id: area
+    attributes:
+      label: Area
+      options:
+        - label: Claude Code
+        - label: Codex
+        - label: OpenCode
+        - label: Multi-panel workspace
+        - label: Chat-to-task flow
+        - label: Git / worktree / PR workflow
+        - label: Desktop app
+        - label: npm/browser runtime
+        - label: Other
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, examples, or related tools.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+-
+
+## Testing
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] Manual test:
+- [ ] Not tested:
+
+## Screenshots or Recordings
+
+Add screenshots or a short recording for UI changes.
+
+## Notes
+
+Large features, new provider integrations, workflow changes, and architecture changes should have an issue first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to Tessera
+
+Thanks for your interest in contributing. Tessera is still early and moving quickly, so the easiest contributions to review are small, focused, and tied to a concrete issue or workflow.
+
+## Good Contributions
+
+- Clear bug reports with reproduction steps, logs, screenshots, or short screen recordings.
+- Platform fixes for Windows, WSL, macOS, and the npm/browser runtime.
+- Documentation improvements, setup notes, troubleshooting tips, and README fixes.
+- Small UI polish with before/after screenshots.
+- Provider-specific fixes that preserve the native behavior of Claude Code, Codex, or OpenCode.
+
+## Before You Start
+
+- For bugs, open an issue with the environment details and reproduction steps.
+- For larger features, new provider integrations, workflow changes, or architecture changes, open an issue first so we can align on the approach.
+- Open pull requests against `main` unless a maintainer asks otherwise.
+- Keep pull requests focused. Avoid unrelated refactors, broad formatting-only changes, or mixing several features into one PR.
+- Do not include secrets, private prompts, API keys, tokens, private repository names, or sensitive logs in issues or PRs.
+
+## Development Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the local development server:
+
+```bash
+npm run dev
+```
+
+The `dev` script runs Tessera's custom `server.ts` runtime in development mode on port `3100` by default. Do not run `next dev` directly for local development.
+
+To run on a different port:
+
+```bash
+PORT=32124 npm run dev
+```
+
+## Checks
+
+Before opening a PR, run the checks that match your change:
+
+```bash
+npm run lint
+npm run build
+```
+
+For UI changes, include screenshots or a short recording. For desktop/runtime changes, mention the OS and runtime you tested.
+
+## Pull Request Guidelines
+
+- Explain what changed and why.
+- Link the issue when there is one.
+- Include test notes, even if the note is "not tested" with a reason.
+- Keep the PR small enough to review in one pass when possible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@horang-labs/tessera",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@horang-labs/tessera",
-      "version": "0.1.0-beta.13",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@horang-labs/tessera",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.2",
   "description": "Open-source web and desktop workspace for AI coding agents",
   "private": false,
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- restore GitHub issue form YAML templates
- restore public pull request template and CONTRIBUTING guide
- bump public package metadata to 0.1.2

## Internal source
- juja-labs/tessera-internal@a750554a

## Verification
- OSS export script completed successfully
- verified restored files exist in export
- verified package.json/package-lock version 0.1.2 and private=false
- npm ci --ignore-scripts
- npm run build