### PR TITLE
feat: Pop board view into its own window

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -709,9 +709,24 @@ function broadcastPopoutState(): void {
 
 // ── IPC ────────────────────────────────────────────────────────────────────
 ipcMain.handle('get-server-port', () => serverPort);
-ipcMain.handle('open-board-window', () => {
+ipcMain.handle('open-board-window', (_event, payload?: unknown) => {
   if (!serverPort) return { ok: false };
-  const win = createPopoutWindow(serverPort, '/board-popout');
+  const params = new URLSearchParams();
+  if (payload && typeof payload === 'object') {
+    const { projectDir, collectionFilter } = payload as {
+      projectDir?: unknown;
+      collectionFilter?: unknown;
+    };
+    if (typeof projectDir === 'string' && projectDir.length > 0) {
+      params.set('projectDir', projectDir);
+    }
+    if (typeof collectionFilter === 'string' && collectionFilter.length > 0) {
+      params.set('collectionFilter', collectionFilter);
+    }
+  }
+  const query = params.toString();
+  const route = query ? `/board-popout?${query}` : '/board-popout';
+  const win = createPopoutWindow(serverPort, route);
   return { ok: true, windowId: win.id };
 });
 ipcMain.handle('close-board-popouts', () => {
@@ -721,13 +736,19 @@ ipcMain.handle('close-board-popouts', () => {
   return { ok: true };
 });
 ipcMain.handle('get-popout-state', () => ({ count: popoutWindows.size }));
-ipcMain.on('popout-open-session', (_event, sessionId: unknown) => {
+ipcMain.on('popout-open-session', (_event, payload: unknown) => {
+  if (!payload || typeof payload !== 'object') return;
+  const { sessionId, action } = payload as { sessionId?: unknown; action?: unknown };
   if (typeof sessionId !== 'string' || !sessionId) return;
+  const resolvedAction: 'preview' | 'pin' = action === 'pin' ? 'pin' : 'preview';
   if (!mainWindow || mainWindow.isDestroyed()) return;
   if (mainWindow.isMinimized()) mainWindow.restore();
   if (!mainWindow.isVisible()) mainWindow.show();
   mainWindow.focus();
-  mainWindow.webContents.send('popout-open-session', { sessionId });
+  mainWindow.webContents.send('popout-open-session', {
+    sessionId,
+    action: resolvedAction,
+  });
 });
 ipcMain.on(
   'window-close-response',

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -266,6 +266,7 @@ if (process.env.TESSERA_DISABLE_GPU === '1') {
 }
 
 let mainWindow: BrowserWindow | null = null;
+const popoutWindows = new Set<BrowserWindow>();
 let serverProcess: ChildProcess | null = null;
 let serverPort = 0;
 let isQuitting = false;
@@ -642,8 +643,92 @@ function createWindow(port: number): BrowserWindow {
   return win;
 }
 
+// ── Popout window ──────────────────────────────────────────────────────────
+function createPopoutWindow(port: number, route: string): BrowserWindow {
+  const isWindows = process.platform === 'win32';
+  const isMac = process.platform === 'darwin';
+  const initialTitlebarTheme: TitlebarTheme = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    minWidth: 600,
+    minHeight: 400,
+    title: 'Tessera Board',
+    show: false,
+    icon: path.join(__dirname, '..', 'assets', 'icon.png'),
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      webSecurity: true,
+    },
+    autoHideMenuBar: !isMac,
+    backgroundColor: isWindows ? WINDOWS_TITLEBAR_THEME[initialTitlebarTheme].color : undefined,
+    titleBarStyle: isMac ? 'hiddenInset' : isWindows ? 'hidden' : 'default',
+    titleBarOverlay: isWindows ? getTitlebarOverlayOptions(initialTitlebarTheme) : false,
+  });
+
+  if (!isMac) {
+    win.removeMenu();
+  }
+
+  const url = `http://localhost:${port}${route}`;
+  win.loadURL(url);
+
+  win.once('ready-to-show', () => win.show());
+
+  win.webContents.setWindowOpenHandler(({ url: openUrl }) => {
+    if (openUrl.startsWith('https://') || openUrl.startsWith('http://')) {
+      shell.openExternal(openUrl);
+    }
+    return { action: 'deny' };
+  });
+
+  win.webContents.on('context-menu', (_event, params) => {
+    const template = buildWebContentsContextMenuTemplate(params);
+    if (template.length === 0) return;
+    const menu = Menu.buildFromTemplate(template);
+    menu.popup({ window: win, x: params.x, y: params.y });
+  });
+
+  popoutWindows.add(win);
+  broadcastPopoutState();
+  win.on('closed', () => {
+    popoutWindows.delete(win);
+    broadcastPopoutState();
+  });
+
+  return win;
+}
+
+function broadcastPopoutState(): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  mainWindow.webContents.send('popout-state-changed', { count: popoutWindows.size });
+}
+
 // ── IPC ────────────────────────────────────────────────────────────────────
 ipcMain.handle('get-server-port', () => serverPort);
+ipcMain.handle('open-board-window', () => {
+  if (!serverPort) return { ok: false };
+  const win = createPopoutWindow(serverPort, '/board-popout');
+  return { ok: true, windowId: win.id };
+});
+ipcMain.handle('close-board-popouts', () => {
+  for (const win of Array.from(popoutWindows)) {
+    if (!win.isDestroyed()) win.close();
+  }
+  return { ok: true };
+});
+ipcMain.handle('get-popout-state', () => ({ count: popoutWindows.size }));
+ipcMain.on('popout-open-session', (_event, sessionId: unknown) => {
+  if (typeof sessionId !== 'string' || !sessionId) return;
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (mainWindow.isMinimized()) mainWindow.restore();
+  if (!mainWindow.isVisible()) mainWindow.show();
+  mainWindow.focus();
+  mainWindow.webContents.send('popout-open-session', { sessionId });
+});
 ipcMain.on(
   'window-close-response',
   (

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -26,6 +26,33 @@ contextBridge.exposeInMainWorld('electronAPI', {
     section: 'file' | 'edit' | 'view' | 'window' | 'help',
     anchor: { x: number; y: number }
   ) => ipcRenderer.invoke('titlebar-popup-menu', section, anchor),
+  openBoardWindow: () => ipcRenderer.invoke('open-board-window'),
+  closeBoardPopouts: () => ipcRenderer.invoke('close-board-popouts'),
+  getPopoutState: () => ipcRenderer.invoke('get-popout-state'),
+  onPopoutStateChanged: (callback: (count: number) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: { count?: number }) => {
+      if (typeof payload?.count === 'number') {
+        callback(payload.count);
+      }
+    };
+    ipcRenderer.on('popout-state-changed', listener);
+    return () => {
+      ipcRenderer.removeListener('popout-state-changed', listener);
+    };
+  },
+  popoutOpenSession: (sessionId: string) =>
+    ipcRenderer.send('popout-open-session', sessionId),
+  onPopoutOpenSession: (callback: (sessionId: string) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: { sessionId?: string }) => {
+      if (typeof payload?.sessionId === 'string') {
+        callback(payload.sessionId);
+      }
+    };
+    ipcRenderer.on('popout-open-session', listener);
+    return () => {
+      ipcRenderer.removeListener('popout-open-session', listener);
+    };
+  },
   onTitlebarMenuCommand: (callback: (command: string) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: { command?: string }) => {
       if (typeof payload?.command === 'string') {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -26,7 +26,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     section: 'file' | 'edit' | 'view' | 'window' | 'help',
     anchor: { x: number; y: number }
   ) => ipcRenderer.invoke('titlebar-popup-menu', section, anchor),
-  openBoardWindow: () => ipcRenderer.invoke('open-board-window'),
+  openBoardWindow: (payload?: { projectDir?: string | null; collectionFilter?: string | null }) =>
+    ipcRenderer.invoke('open-board-window', payload),
   closeBoardPopouts: () => ipcRenderer.invoke('close-board-popouts'),
   getPopoutState: () => ipcRenderer.invoke('get-popout-state'),
   onPopoutStateChanged: (callback: (count: number) => void) => {
@@ -40,13 +41,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.removeListener('popout-state-changed', listener);
     };
   },
-  popoutOpenSession: (sessionId: string) =>
-    ipcRenderer.send('popout-open-session', sessionId),
-  onPopoutOpenSession: (callback: (sessionId: string) => void) => {
-    const listener = (_event: Electron.IpcRendererEvent, payload: { sessionId?: string }) => {
-      if (typeof payload?.sessionId === 'string') {
-        callback(payload.sessionId);
-      }
+  popoutOpenSession: (sessionId: string, action: 'preview' | 'pin' = 'preview') =>
+    ipcRenderer.send('popout-open-session', { sessionId, action }),
+  onPopoutOpenSession: (
+    callback: (payload: { sessionId: string; action: 'preview' | 'pin' }) => void
+  ) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: { sessionId?: string; action?: string }
+    ) => {
+      if (typeof payload?.sessionId !== 'string') return;
+      const action: 'preview' | 'pin' = payload.action === 'pin' ? 'pin' : 'preview';
+      callback({ sessionId: payload.sessionId, action });
     };
     ipcRenderer.on('popout-open-session', listener);
     return () => {

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import * as dbCollections from '@/lib/db/collections';
 import { isCollection } from '@/types/collection';
+import {
+  broadcastCollectionMutation,
+  broadcastSessionMutation,
+  getOriginClientIdFromRequest,
+} from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -66,6 +71,14 @@ export async function PATCH(
   try {
     dbCollections.updateCollection(id, patch);
     logger.info({ id, ...patch }, 'Collection updated');
+    const projectId = dbCollections.getCollectionProjectId(id);
+    if (projectId) {
+      broadcastCollectionMutation(auth.userId, {
+        kind: 'updated',
+        projectId,
+        originClientId: getOriginClientIdFromRequest(req),
+      });
+    }
     return NextResponse.json({ ok: true });
   } catch (err: unknown) {
     logger.error({ id, error: err }, 'Failed to update collection');
@@ -95,8 +108,22 @@ export async function DELETE(
   }
 
   try {
+    const projectId = dbCollections.getCollectionProjectId(id);
     const { movedCount } = dbCollections.deleteCollection(id);
     logger.info({ id, movedCount }, 'Collection deleted');
+    if (projectId) {
+      const originClientId = getOriginClientIdFromRequest(req);
+      broadcastCollectionMutation(auth.userId, {
+        kind: 'deleted',
+        projectId,
+        originClientId,
+      });
+      broadcastSessionMutation(auth.userId, {
+        kind: 'updated',
+        projectId,
+        originClientId,
+      });
+    }
     return NextResponse.json({ ok: true, movedCount });
   } catch (err: unknown) {
     logger.error({ id, error: err }, 'Failed to delete collection');

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import * as dbCollections from '@/lib/db/collections';
 import { generateCollectionId } from '@/types/collection';
+import { broadcastCollectionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -73,6 +74,11 @@ export async function POST(req: NextRequest) {
       sortOrder
     );
     logger.info({ id, projectId: normalizedProjectId, label: label.trim() }, 'Collection created');
+    broadcastCollectionMutation(auth.userId, {
+      kind: 'created',
+      projectId: normalizedProjectId,
+      originClientId: getOriginClientIdFromRequest(req),
+    });
     return NextResponse.json({ collection }, { status: 201 });
   } catch (err: unknown) {
     logger.error({ error: err }, 'Failed to create collection');

--- a/src/app/api/sessions/[id]/archive/route.ts
+++ b/src/app/api/sessions/[id]/archive/route.ts
@@ -4,6 +4,8 @@ import logger from '@/lib/logger';
 import { archiveSession } from '@/lib/session/session-archive';
 import { pruneExpiredArchivedWorktrees, restoreArchivedChat } from '@/lib/archive/archive-service';
 import { SettingsManager } from '@/lib/settings/manager';
+import { getSession } from '@/lib/db/sessions';
+import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 
 /**
  * PATCH /api/sessions/[id]/archive
@@ -61,6 +63,12 @@ export async function PATCH(
     }
 
     logger.info({ sessionId, archived }, 'Session archive status updated');
+
+    broadcastSessionMutation(auth.userId, {
+      kind: 'updated',
+      projectId: getSession(sessionId)?.project_id,
+      originClientId: getOriginClientIdFromRequest(req),
+    });
 
     return NextResponse.json(result);
   } catch (err) {

--- a/src/app/api/sessions/[id]/collection/route.ts
+++ b/src/app/api/sessions/[id]/collection/route.ts
@@ -3,6 +3,7 @@ import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import { getSession, updateSession } from '@/lib/db/sessions';
 import { collectionExists } from '@/lib/db/collections';
 import { updateTask } from '@/lib/db/tasks';
+import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -57,6 +58,11 @@ export async function PATCH(
       });
       logger.info({ sessionId: id, collectionId: collectionId ?? null }, 'Session collection updated');
     }
+    broadcastSessionMutation(auth.userId, {
+      kind: 'updated',
+      projectId: session.project_id,
+      originClientId: getOriginClientIdFromRequest(req),
+    });
     return NextResponse.json({ ok: true });
   } catch (err: unknown) {
     logger.error({ sessionId: id, error: err }, 'Failed to update session collection');

--- a/src/app/api/sessions/[id]/generate-title/route.ts
+++ b/src/app/api/sessions/[id]/generate-title/route.ts
@@ -4,6 +4,7 @@ import { generateAITitle } from '@/lib/session/ai-title-generator';
 import * as dbSessions from '@/lib/db/sessions';
 import logger from '@/lib/logger';
 import { syncSingleSessionTaskTitleFromSession } from '@/lib/task-title-sync';
+import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 
 /**
  * POST /api/sessions/[id]/generate-title
@@ -36,6 +37,12 @@ export async function POST(
     syncSingleSessionTaskTitleFromSession(sessionId, result.title);
 
     logger.info({ userId, sessionId, title: result.title }, 'AI title saved to DB');
+
+    broadcastSessionMutation(userId, {
+      kind: 'updated',
+      projectId: dbSessions.getSession(sessionId)?.project_id,
+      originClientId: getOriginClientIdFromRequest(req),
+    });
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/sessions/[id]/move/route.ts
+++ b/src/app/api/sessions/[id]/move/route.ts
@@ -3,6 +3,7 @@ import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import * as dbSessions from '@/lib/db/sessions';
 import * as dbProjects from '@/lib/db/projects';
 import { processManager } from '@/lib/cli/process-manager';
+import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -93,6 +94,11 @@ export async function PATCH(
       sessionId,
       from: session.project_id,
       to: targetProjectId,
+    });
+
+    broadcastSessionMutation(auth.userId, {
+      kind: 'updated',
+      originClientId: getOriginClientIdFromRequest(req),
     });
 
     return NextResponse.json({

--- a/src/app/api/sessions/[id]/rename/route.ts
+++ b/src/app/api/sessions/[id]/rename/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { sessionOrchestrator } from '@/lib/session/session-orchestrator';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
+import { getSession } from '@/lib/db/sessions';
+import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -31,6 +33,12 @@ export async function PATCH(
     await sessionOrchestrator.renameSession(userId, sessionId, title);
 
     logger.info({ userId, sessionId, title }, 'Session renamed via API');
+
+    broadcastSessionMutation(userId, {
+      kind: 'updated',
+      projectId: getSession(sessionId)?.project_id,
+      originClientId: getOriginClientIdFromRequest(req),
+    });
 
     return NextResponse.json({ success: true, title });
   } catch (err: any) {

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import { sessionOrchestrator } from '@/lib/session/session-orchestrator';
+import { getSession } from '@/lib/db/sessions';
+import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -30,9 +32,18 @@ export async function DELETE(
   }
 
   try {
+    const sessionRow = getSession(sessionId);
+    const projectId = sessionRow?.project_id;
+
     await sessionOrchestrator.deleteSession(userId, sessionId);
 
     logger.info({ userId, sessionId }, 'Session deleted via API');
+
+    broadcastSessionMutation(userId, {
+      kind: 'deleted',
+      projectId,
+      originClientId: getOriginClientIdFromRequest(request),
+    });
 
     return NextResponse.json({ success: true });
   } catch (err: any) {

--- a/src/app/api/sessions/projects/[encodedDir]/route.ts
+++ b/src/app/api/sessions/projects/[encodedDir]/route.ts
@@ -5,6 +5,7 @@ import { validateEncodedPath } from '@/lib/validation/path';
 import * as dbProjects from '@/lib/db/projects';
 import * as dbSessions from '@/lib/db/sessions';
 import { getCachedOrScheduleBulk } from '@/lib/git/worktree-diff-stats-bulk';
+import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -139,6 +140,12 @@ export async function DELETE(
     dbProjects.removeProject(encodedDir);
 
     logger.info({ userId, encodedDir }, 'Project removed from sidebar');
+
+    broadcastSessionMutation(userId, {
+      kind: 'project_deleted',
+      projectId: encodedDir,
+      originClientId: getOriginClientIdFromRequest(req),
+    });
 
     return NextResponse.json({ success: true });
   } catch (error: any) {

--- a/src/app/api/sessions/projects/reorder/route.ts
+++ b/src/app/api/sessions/projects/reorder/route.ts
@@ -1,5 +1,7 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { reorderProjects } from '@/lib/db/projects';
+import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
+import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -8,7 +10,10 @@ import logger from '@/lib/logger';
  *
  * Updates sort_order for all projects in the given order.
  */
-export async function PATCH(request: Request) {
+export async function PATCH(request: NextRequest) {
+  const auth = await requireAuthenticatedUserId(request);
+  if ('response' in auth) return auth.response;
+
   try {
     const body = await request.json();
     const { orderedIds } = body;
@@ -19,6 +24,11 @@ export async function PATCH(request: Request) {
 
     reorderProjects(orderedIds);
     logger.info({ count: orderedIds.length }, 'Projects reordered');
+
+    broadcastSessionMutation(auth.userId, {
+      kind: 'project_reordered',
+      originClientId: getOriginClientIdFromRequest(request),
+    });
 
     return NextResponse.json({ success: true });
   } catch (error: unknown) {

--- a/src/app/api/sessions/reorder/route.ts
+++ b/src/app/api/sessions/reorder/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import { reorderSessions, reorderSessionsByIds } from '@/lib/db/sessions';
+import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -30,6 +31,12 @@ export async function PATCH(req: NextRequest) {
       reorderSessionsByIds(orderedIds);
       logger.info({ count: orderedIds.length }, 'Sessions reordered by IDs');
     }
+
+    broadcastSessionMutation(auth.userId, {
+      kind: 'reordered',
+      projectId: typeof projectId === 'string' ? projectId : undefined,
+      originClientId: getOriginClientIdFromRequest(req),
+    });
 
     return NextResponse.json({ success: true });
   } catch (error: unknown) {

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -5,6 +5,7 @@ import { collectionExists } from '@/lib/db/collections';
 import { taskExists } from '@/lib/db/tasks';
 import logger from '@/lib/logger';
 import { persistCreatedSessionRecord } from '@/lib/session/session-persistence';
+import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 
 /**
  * POST /api/sessions - Create a new session (pending; CLI spawns on first message)
@@ -101,6 +102,12 @@ export async function POST(req: NextRequest) {
         collectionId: typeof collectionId === 'string' && collectionId.trim().length > 0 ? collectionId.trim() : undefined,
         hasCustomTitle: hasCustomTitle === true,
         worktreeBranch: normalizedWorktreeBranch,
+      });
+
+      broadcastSessionMutation(userId, {
+        kind: 'created',
+        projectId: targetProjectId,
+        originClientId: getOriginClientIdFromRequest(req),
       });
 
       return NextResponse.json({

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -8,6 +8,11 @@ import { sessionOrchestrator } from '@/lib/session/session-orchestrator';
 import { syncSingleSessionSessionTitleFromTask } from '@/lib/task-title-sync';
 import { suppressDiffAutoPromoteForTask } from '@/lib/git/worktree-diff-auto-promote';
 import { getCachedDiffStats } from '@/lib/git/worktree-diff-stats-cache';
+import {
+  broadcastSessionMutation,
+  broadcastTaskMutation,
+  getOriginClientIdFromRequest,
+} from '@/lib/ws/mutation-broadcast';
 
 /**
  * GET /api/tasks/[id]
@@ -126,6 +131,19 @@ export async function PATCH(
       });
     }
     logger.info({ taskId: id, ...patch }, 'Task updated');
+    const originClientId = getOriginClientIdFromRequest(req);
+    broadcastTaskMutation(auth.userId, {
+      kind: 'updated',
+      projectId: task.projectId,
+      originClientId,
+    });
+    if (patch.workflow_status !== undefined) {
+      broadcastSessionMutation(auth.userId, {
+        kind: 'updated',
+        projectId: task.projectId,
+        originClientId,
+      });
+    }
     return NextResponse.json({ ok: true });
   } catch (err: unknown) {
     logger.error({ id, error: err }, 'Failed to update task');
@@ -159,6 +177,17 @@ export async function DELETE(
     const { deletedSessionCount: fallbackDeletedSessionCount } = dbTasks.deleteTask(id);
     const deletedSessionCount = task.sessions.length + fallbackDeletedSessionCount;
     logger.info({ taskId: id, deletedSessionCount }, 'Task deleted via API');
+    const originClientId = getOriginClientIdFromRequest(req);
+    broadcastTaskMutation(auth.userId, {
+      kind: 'deleted',
+      projectId: task.projectId,
+      originClientId,
+    });
+    broadcastSessionMutation(auth.userId, {
+      kind: 'updated',
+      projectId: task.projectId,
+      originClientId,
+    });
     return NextResponse.json({
       ok: true,
       deletedSessionCount,

--- a/src/app/api/tasks/[id]/sessions/route.ts
+++ b/src/app/api/tasks/[id]/sessions/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import * as dbTasks from '@/lib/db/tasks';
+import {
+  broadcastSessionMutation,
+  broadcastTaskMutation,
+  getOriginClientIdFromRequest,
+} from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -17,7 +22,8 @@ export async function POST(
 
   const { id: taskId } = await params;
 
-  if (!dbTasks.taskExists(taskId)) {
+  const taskRow = dbTasks.getTask(taskId);
+  if (!taskRow) {
     return NextResponse.json({ error: 'Task not found' }, { status: 404 });
   }
 
@@ -37,6 +43,17 @@ export async function POST(
   try {
     dbTasks.addSessionToTask(taskId, sessionId.trim());
     logger.info({ taskId, sessionId }, 'Session added to task via API');
+    const originClientId = getOriginClientIdFromRequest(req);
+    broadcastSessionMutation(auth.userId, {
+      kind: 'created',
+      projectId: taskRow.projectId,
+      originClientId,
+    });
+    broadcastTaskMutation(auth.userId, {
+      kind: 'updated',
+      projectId: taskRow.projectId,
+      originClientId,
+    });
     return NextResponse.json({ ok: true });
   } catch (err: unknown) {
     logger.error({ taskId, sessionId, error: err }, 'Failed to add session to task');

--- a/src/app/api/tasks/reorder/route.ts
+++ b/src/app/api/tasks/reorder/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
-import { reorderTasks } from '@/lib/db/tasks';
+import { reorderTasks, getTask } from '@/lib/db/tasks';
+import { broadcastTaskMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 /**
@@ -23,6 +24,15 @@ export async function PATCH(req: NextRequest) {
 
     reorderTasks(orderedIds);
     logger.info({ count: orderedIds.length }, 'Tasks reordered');
+
+    const projectId = getTask(orderedIds[0])?.projectId;
+    if (projectId) {
+      broadcastTaskMutation(auth.userId, {
+        kind: 'reordered',
+        projectId,
+        originClientId: getOriginClientIdFromRequest(req),
+      });
+    }
 
     return NextResponse.json({ success: true });
   } catch (error: unknown) {

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -6,6 +6,7 @@ import * as dbTasks from '@/lib/db/tasks';
 import { collectionExists } from '@/lib/db/collections';
 import { generateTaskId } from '@/types/task-entity';
 import { getCachedOrScheduleBulk } from '@/lib/git/worktree-diff-stats-bulk';
+import { broadcastTaskMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
 async function pathExists(candidate: string): Promise<boolean> {
@@ -121,6 +122,11 @@ export async function POST(req: NextRequest) {
     const activeSessionIds = processManager.getActiveSessionIds();
     const task = dbTasks.getTask(id, activeSessionIds);
     logger.info({ taskId: id, projectId }, 'Task created via API');
+    broadcastTaskMutation(auth.userId, {
+      kind: 'created',
+      projectId: projectId.trim(),
+      originClientId: getOriginClientIdFromRequest(req),
+    });
     return NextResponse.json({ task }, { status: 201 });
   } catch (err: unknown) {
     logger.error({ error: err }, 'Failed to create task');

--- a/src/app/board-popout/page.tsx
+++ b/src/app/board-popout/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/stores/auth-store';
+import { BoardPopoutLayout } from '@/components/board/board-popout-layout';
+
+export default function BoardPopoutPage() {
+  const router = useRouter();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const user = useAuthStore((state) => state.user);
+  const checkAuth = useAuthStore((state) => state.checkAuth);
+  const [authChecked, setAuthChecked] = useState(false);
+
+  useEffect(() => {
+    checkAuth().finally(() => setAuthChecked(true));
+  }, [checkAuth]);
+
+  useEffect(() => {
+    if (authChecked && !isAuthenticated) {
+      router.push('/login');
+    }
+  }, [authChecked, isAuthenticated, router]);
+
+  if (!authChecked || !isAuthenticated || !user) {
+    return null;
+  }
+
+  return <BoardPopoutLayout />;
+}

--- a/src/components/board/board-popout-layout.tsx
+++ b/src/components/board/board-popout-layout.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { useSessionStore } from '@/stores/session-store';
+import { useBoardStore } from '@/stores/board-store';
+import { useWebSocket } from '@/hooks/use-websocket';
+import { useElectronPlatform } from '@/hooks/use-electron-platform';
+import { ProjectStrip } from '@/components/chat/project-strip';
+import { ElectronTitlebarThemeSync } from '@/components/layout/electron-titlebar';
+import { KeyboardShortcutProvider } from '@/components/keyboard/keyboard-shortcut-provider';
+import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
+import { cn } from '@/lib/utils';
+
+const KanbanBoard = dynamic(
+  () => import('@/components/board/kanban-board').then((m) => m.KanbanBoard),
+  { ssr: false },
+);
+const ToastContainer = dynamic(
+  () => import('@/components/notifications/toast-container').then((m) => m.ToastContainer),
+  { ssr: false },
+);
+
+export function BoardPopoutLayout() {
+  const electronPlatform = useElectronPlatform();
+  const isMacElectron = electronPlatform === 'darwin';
+  const isWindowsElectron = electronPlatform === 'win32';
+  const isElectronTitlebar = isMacElectron || isWindowsElectron;
+  const projects = useSessionStore((s) => s.projects);
+  const [projectsLoaded, setProjectsLoaded] = useState(projects.length > 0);
+
+  useWebSocket();
+
+  useEffect(() => {
+    (window as Window & { __TESSERA_POPOUT__?: boolean }).__TESSERA_POPOUT__ = true;
+    return () => {
+      (window as Window & { __TESSERA_POPOUT__?: boolean }).__TESSERA_POPOUT__ = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.resolve(useSessionStore.getState().loadProjects()).finally(() => {
+      if (!cancelled) setProjectsLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!projectsLoaded) return;
+    const current = useBoardStore.getState().selectedProjectDir;
+    if (projects.length === 0) {
+      if (current !== ALL_PROJECTS_SENTINEL) {
+        useBoardStore.getState().setSelectedProjectDir(ALL_PROJECTS_SENTINEL);
+      }
+      return;
+    }
+    if (current === null) {
+      const proj = projects.find((p) => p.isCurrent) ?? projects[0];
+      useBoardStore.getState().setSelectedProjectDir(proj.encodedDir);
+    } else if (current !== ALL_PROJECTS_SENTINEL) {
+      const stillExists = projects.some((p) => p.encodedDir === current);
+      if (!stillExists) {
+        const proj = projects.find((p) => p.isCurrent) ?? projects[0];
+        useBoardStore.getState().setSelectedProjectDir(proj.encodedDir);
+      }
+    }
+  }, [projects, projectsLoaded]);
+
+  return (
+    <KeyboardShortcutProvider>
+      <ElectronTitlebarThemeSync />
+      <div className="flex h-screen flex-col overflow-hidden bg-(--board-bg)" data-testid="board-popout-layout">
+        {isElectronTitlebar && (
+          <div
+            className={cn(
+              'electron-drag shrink-0 flex items-center select-none',
+              isWindowsElectron && 'h-[40px] bg-(--electron-titlebar-bg) border-b border-(--electron-titlebar-border)',
+              isMacElectron && 'h-10 bg-(--chat-header-bg) border-b border-(--chat-header-border) pl-20',
+            )}
+            data-testid="board-popout-titlebar"
+          >
+            <div className="px-3 text-[0.8125rem] font-semibold text-(--text-muted) truncate">
+              Tessera Board
+            </div>
+          </div>
+        )}
+        <div className="flex flex-1 overflow-hidden">
+          <ProjectStrip onAddProject={() => {}} onRemoveProject={() => {}} />
+          <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+            <KanbanBoard />
+          </div>
+        </div>
+      </div>
+      <ToastContainer />
+    </KeyboardShortcutProvider>
+  );
+}

--- a/src/components/board/board-popout-layout.tsx
+++ b/src/components/board/board-popout-layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useSessionStore } from '@/stores/session-store';
 import { useBoardStore } from '@/stores/board-store';
@@ -11,6 +11,20 @@ import { ElectronTitlebarThemeSync } from '@/components/layout/electron-titlebar
 import { KeyboardShortcutProvider } from '@/components/keyboard/keyboard-shortcut-provider';
 import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
 import { cn } from '@/lib/utils';
+
+interface PopoutHydrationParams {
+  projectDir: string | null;
+  collectionFilter: string | null;
+}
+
+function readPopoutHydrationParams(): PopoutHydrationParams {
+  if (typeof window === 'undefined') return { projectDir: null, collectionFilter: null };
+  const params = new URLSearchParams(window.location.search);
+  return {
+    projectDir: params.get('projectDir'),
+    collectionFilter: params.get('collectionFilter'),
+  };
+}
 
 const KanbanBoard = dynamic(
   () => import('@/components/board/kanban-board').then((m) => m.KanbanBoard),
@@ -28,6 +42,19 @@ export function BoardPopoutLayout() {
   const isElectronTitlebar = isMacElectron || isWindowsElectron;
   const projects = useSessionStore((s) => s.projects);
   const [projectsLoaded, setProjectsLoaded] = useState(projects.length > 0);
+  const hydrationRef = useRef<PopoutHydrationParams>({ projectDir: null, collectionFilter: null });
+  const hasHydratedRef = useRef(false);
+
+  if (!hasHydratedRef.current && typeof window !== 'undefined') {
+    hasHydratedRef.current = true;
+    const params = readPopoutHydrationParams();
+    hydrationRef.current = params;
+    const boardState = useBoardStore.getState();
+    if (params.projectDir) {
+      boardState.setSelectedProjectDir(params.projectDir);
+    }
+    boardState.setCollectionFilter(params.collectionFilter ?? null);
+  }
 
   useWebSocket();
 
@@ -88,7 +115,11 @@ export function BoardPopoutLayout() {
           </div>
         )}
         <div className="flex flex-1 overflow-hidden">
-          <ProjectStrip onAddProject={() => {}} onRemoveProject={() => {}} />
+          <ProjectStrip
+            onAddProject={() => {}}
+            onRemoveProject={() => {}}
+            hideManagementActions
+          />
           <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
             <KanbanBoard />
           </div>

--- a/src/components/board/collection-filter-bar.tsx
+++ b/src/components/board/collection-filter-bar.tsx
@@ -5,11 +5,15 @@ import { Tag, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tooltip } from '@/components/ui/tooltip';
 import { useI18n } from '@/lib/i18n';
+import { useBoardStore } from '@/stores/board-store';
 import type { Collection } from '@/types/collection';
 
 interface ElectronApiBoardPopout {
   isElectron?: boolean;
-  openBoardWindow?: () => Promise<unknown>;
+  openBoardWindow?: (payload?: {
+    projectDir?: string | null;
+    collectionFilter?: string | null;
+  }) => Promise<unknown>;
 }
 
 function getBoardPopoutApi(): ElectronApiBoardPopout | undefined {
@@ -118,7 +122,11 @@ export const CollectionFilterBar = memo(function CollectionFilterBar({
   const canPopout = Boolean(electronApi?.isElectron && electronApi.openBoardWindow) && !isPopoutWindow();
 
   const handlePopout = useCallback(() => {
-    void electronApi?.openBoardWindow?.();
+    const { selectedProjectDir, activeCollectionFilter } = useBoardStore.getState();
+    void electronApi?.openBoardWindow?.({
+      projectDir: selectedProjectDir,
+      collectionFilter: activeCollectionFilter,
+    });
   }, [electronApi]);
 
   return (

--- a/src/components/board/collection-filter-bar.tsx
+++ b/src/components/board/collection-filter-bar.tsx
@@ -1,11 +1,26 @@
 'use client';
 
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { Tag } from 'lucide-react';
+import { Tag, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tooltip } from '@/components/ui/tooltip';
 import { useI18n } from '@/lib/i18n';
 import type { Collection } from '@/types/collection';
+
+interface ElectronApiBoardPopout {
+  isElectron?: boolean;
+  openBoardWindow?: () => Promise<unknown>;
+}
+
+function getBoardPopoutApi(): ElectronApiBoardPopout | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return (window as Window & { electronAPI?: ElectronApiBoardPopout }).electronAPI;
+}
+
+function isPopoutWindow(): boolean {
+  if (typeof window === 'undefined') return false;
+  return Boolean((window as Window & { __TESSERA_POPOUT__?: boolean }).__TESSERA_POPOUT__);
+}
 
 interface CollectionFilterBarProps {
   collections: Collection[];
@@ -99,9 +114,16 @@ export const CollectionFilterBar = memo(function CollectionFilterBar({
     </div>
   );
 
+  const electronApi = getBoardPopoutApi();
+  const canPopout = Boolean(electronApi?.isElectron && electronApi.openBoardWindow) && !isPopoutWindow();
+
+  const handlePopout = useCallback(() => {
+    void electronApi?.openBoardWindow?.();
+  }, [electronApi]);
+
   return (
     <div
-      className="flex min-w-0 shrink-0 items-center bg-(--board-bg) px-3 py-2"
+      className="flex min-w-0 shrink-0 items-center gap-2 bg-(--board-bg) px-3 py-2"
       data-testid="collection-filter-bar"
     >
       {isChipScrollerOverflowing ? (
@@ -113,6 +135,22 @@ export const CollectionFilterBar = memo(function CollectionFilterBar({
           {chipScroller}
         </Tooltip>
       ) : chipScroller}
+      {canPopout && (
+        <Tooltip content="Open board in new window" delay={350}>
+          <button
+            type="button"
+            onClick={handlePopout}
+            className={cn(
+              'shrink-0 rounded p-1.5 text-(--text-muted) transition-colors',
+              'hover:bg-(--sidebar-hover) hover:text-(--text-primary) cursor-pointer',
+            )}
+            aria-label="Open board in new window"
+            data-testid="board-popout-button"
+          >
+            <ExternalLink className="w-4 h-4" />
+          </button>
+        </Tooltip>
+      )}
     </div>
   );
 });

--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -12,7 +12,10 @@ import { useSettingsStore } from '@/stores/settings-store';
 import { getProviderSessionRuntimeConfig } from '@/lib/settings/provider-defaults';
 import { captureTelemetryEvent } from '@/lib/telemetry/client';
 import { useSessionCrud } from '@/hooks/use-session-crud';
-import { useSessionClickHandlers } from '@/hooks/use-session-click-handlers';
+import {
+  useSessionClickHandlers,
+  tryForwardClickToMainWindow,
+} from '@/hooks/use-session-click-handlers';
 import { setKanbanChatDragData } from '@/lib/dnd/panel-session-drag';
 import { WORKFLOW_STATUS_ORDER } from '@/types/task-entity';
 import type { WorkflowStatus, TaskEntity } from '@/types/task-entity';
@@ -547,6 +550,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
   }, [renameSession]);
 
   const handleCardOpenInNewTab = useCallback(async (taskId: string) => {
+    if (tryForwardClickToMainWindow(taskId, 'pin')) return;
     useTabStore.getState().createTabWithSession(taskId);
   }, []);
 
@@ -710,7 +714,9 @@ export const KanbanBoard = memo(function KanbanBoard() {
     if (!taskMenuAnchor) return;
     const primarySession = taskMenuAnchor.task.sessions[0];
     if (primarySession) {
-      useTabStore.getState().createTabWithSession(primarySession.id);
+      if (!tryForwardClickToMainWindow(primarySession.id, 'pin')) {
+        useTabStore.getState().createTabWithSession(primarySession.id);
+      }
     }
     setTaskMenuAnchor(null);
   }, [taskMenuAnchor]);

--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -30,6 +30,7 @@ import { DeleteSessionDialog } from '@/components/chat/delete-session-dialog';
 import { DeleteTaskDialog } from '@/components/chat/delete-task-dialog';
 import { MoveProjectDialog } from '@/components/chat/move-project-dialog';
 import { wsClient } from '@/lib/ws/client';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 import {
   getKanbanScrollPosition,
   getKanbanScrollPositionKey,
@@ -612,7 +613,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
       }
       const runtimeConfig = getProviderSessionRuntimeConfig(settings, providerId);
 
-      const res = await fetch('/api/sessions', {
+      const res = await fetchWithClientId('/api/sessions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -84,6 +84,9 @@ export const KanbanBoard = memo(function KanbanBoard() {
   const collections = useCollectionStore((s) =>
     selectedProjectDir ? s.collectionsByProject[selectedProjectDir] ?? EMPTY_COLLECTIONS : EMPTY_COLLECTIONS
   );
+  const collectionsLoadedForProject = useCollectionStore((s) =>
+    selectedProjectDir ? Boolean(s.loadedProjects[selectedProjectDir]) : false
+  );
 
   // Task store
   const tasks = useTaskStore((s) => s.tasks);
@@ -326,9 +329,13 @@ export const KanbanBoard = memo(function KanbanBoard() {
 
   useEffect(() => {
     if (!activeCollectionFilter) return;
+    // Don't clear the filter while collections are still loading -- otherwise a
+    // popout opened with a hydrated filter would see an empty collection list
+    // and reset itself before loadCollections() resolves.
+    if (!collectionsLoadedForProject) return;
     if (collections.some((collection) => collection.id === activeCollectionFilter)) return;
     setCollectionFilter(null);
-  }, [activeCollectionFilter, collections, setCollectionFilter]);
+  }, [activeCollectionFilter, collections, collectionsLoadedForProject, setCollectionFilter]);
 
   const selectedProject = useMemo(() => {
     return projects.find((project) => project.encodedDir === selectedProjectDir) ?? null;

--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -409,15 +409,24 @@ export function ChatLayout() {
     const electronApi = (window as Window & {
       electronAPI?: {
         isElectron?: boolean;
-        onPopoutOpenSession?: (cb: (sessionId: string) => void) => (() => void) | void;
+        onPopoutOpenSession?: (
+          cb: (payload: { sessionId: string; action: 'preview' | 'pin' }) => void
+        ) => (() => void) | void;
       };
     }).electronAPI;
     if (!electronApi?.isElectron || !electronApi.onPopoutOpenSession) return;
-    const cleanup = electronApi.onPopoutOpenSession((sessionId) => {
+    const cleanup = electronApi.onPopoutOpenSession(({ sessionId, action }) => {
       if (!sessionId) return;
       const tabStore = useTabStore.getState();
       const location = tabStore.findSessionLocation(sessionId);
-      if (location) {
+      if (action === 'pin') {
+        if (location) {
+          tabStore.setActiveTab(location.tabId);
+          tabStore.pinTab(location.tabId);
+        } else {
+          tabStore.createTabWithSession(sessionId);
+        }
+      } else if (location) {
         tabStore.setActiveTab(location.tabId);
         usePanelStore.getState().setActivePanelId(location.panelId);
       } else {

--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -374,6 +374,62 @@ export function ChatLayout() {
     [activeSessionId],
   );
 
+  // When the last popout board window closes, refresh tasks/collections in the
+  // main window so changes made in the popout become visible.
+  useEffect(function reloadBoardOnPopoutClose() {
+    if (typeof window === 'undefined') return;
+    const electronApi = (window as Window & {
+      electronAPI?: {
+        isElectron?: boolean;
+        onPopoutStateChanged?: (cb: (count: number) => void) => (() => void) | void;
+      };
+    }).electronAPI;
+    if (!electronApi?.isElectron || !electronApi.onPopoutStateChanged) return;
+
+    let prev = 0;
+    const cleanup = electronApi.onPopoutStateChanged(async (next) => {
+      const wasActive = prev > 0;
+      prev = next;
+      if (!wasActive || next !== 0) return;
+      try {
+        const { reloadBoardData } = await import('@/hooks/use-popout-active');
+        await reloadBoardData();
+      } catch (err) {
+        console.warn('[ChatLayout] popout reload failed:', err);
+      }
+    });
+    return () => {
+      if (typeof cleanup === 'function') cleanup();
+    };
+  }, []);
+
+  // Listen for session-open requests forwarded from popout board windows.
+  useEffect(function listenForPopoutOpenSession() {
+    if (typeof window === 'undefined') return;
+    const electronApi = (window as Window & {
+      electronAPI?: {
+        isElectron?: boolean;
+        onPopoutOpenSession?: (cb: (sessionId: string) => void) => (() => void) | void;
+      };
+    }).electronAPI;
+    if (!electronApi?.isElectron || !electronApi.onPopoutOpenSession) return;
+    const cleanup = electronApi.onPopoutOpenSession((sessionId) => {
+      if (!sessionId) return;
+      const tabStore = useTabStore.getState();
+      const location = tabStore.findSessionLocation(sessionId);
+      if (location) {
+        tabStore.setActiveTab(location.tabId);
+        usePanelStore.getState().setActivePanelId(location.panelId);
+      } else {
+        tabStore.openPreview(sessionId);
+      }
+      useSessionStore.getState().setActiveSession(sessionId);
+    });
+    return () => {
+      if (typeof cleanup === 'function') cleanup();
+    };
+  }, []);
+
   // BR-TOGGLE-005: 반응형 강제 collapsed (<1024px)
   useEffect(() => {
     const handleResize = () => {

--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -422,6 +422,7 @@ export function ChatLayout() {
       if (action === 'pin') {
         if (location) {
           tabStore.setActiveTab(location.tabId);
+          usePanelStore.getState().setActivePanelId(location.panelId);
           tabStore.pinTab(location.tabId);
         } else {
           tabStore.createTabWithSession(sessionId);

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -20,6 +20,7 @@ import {
 import { useArchiveConfirm } from '@/hooks/use-archive-confirm';
 import { useInlineRename } from '@/hooks/use-inline-rename';
 import { setPanelSessionDragData } from '@/lib/dnd/panel-session-drag';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 import { useBoardStore } from '@/stores/board-store';
@@ -296,7 +297,7 @@ export function CollectionContextMenu({
     async (collectionId: string | null) => {
       onClose();
       if (menu.type === 'chat') {
-        await fetch(`/api/sessions/${menu.targetId}/collection`, {
+        await fetchWithClientId(`/api/sessions/${menu.targetId}/collection`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ collectionId }),

--- a/src/components/chat/collection-group.tsx
+++ b/src/components/chat/collection-group.tsx
@@ -10,6 +10,7 @@ import {
   getPrioritizedCollectionIndicatorStatus,
 } from '@/lib/chat/collection-status-indicator';
 import { getProviderSessionRuntimeConfig } from '@/lib/settings/provider-defaults';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 import { useBoardStore } from '@/stores/board-store';
 import {
   selectAnyAwaitingUserPrompt,
@@ -54,7 +55,7 @@ async function addSessionToTask(task: TaskEntity, requestedProviderId?: string) 
     }
     const runtimeConfig = getProviderSessionRuntimeConfig(settings, providerId);
 
-    const sessionResponse = await fetch('/api/sessions', {
+    const sessionResponse = await fetchWithClientId('/api/sessions', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/src/components/chat/left-panel.tsx
+++ b/src/components/chat/left-panel.tsx
@@ -16,6 +16,8 @@ import { useSessionStore } from '@/stores/session-store';
 import { useTabStore } from '@/stores/tab-store';
 import { useFolderBrowserStore } from '@/stores/folder-browser-store';
 import { useSessionCrud } from '@/hooks/use-session-crud';
+import { usePopoutActive } from '@/hooks/use-popout-active';
+import { ExternalLink } from 'lucide-react';
 
 interface LeftPanelProps {
   width: number;
@@ -29,6 +31,7 @@ export function LeftPanel({ width }: LeftPanelProps) {
   const viewMode = useBoardStore((state) => state.viewMode);
   const projects = useSessionStore((state) => state.projects);
   const { deleteProject } = useSessionCrud();
+  const { isActive: isPopoutActive, closePopouts } = usePopoutActive();
 
   const handleAddProject = openFolderBrowser;
 
@@ -58,8 +61,32 @@ export function LeftPanel({ width }: LeftPanelProps) {
       <ProjectStrip onAddProject={handleAddProject} onRemoveProject={setRemoveTarget} />
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <AppHeader />
-        <div className="min-h-0 flex-1 overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-hidden relative">
           {viewMode === 'board' ? <KanbanBoard /> : <Sidebar />}
+          {viewMode === 'board' && isPopoutActive && (
+            <div
+              className="absolute inset-0 z-20 flex items-center justify-center bg-(--board-bg)/80 backdrop-blur-sm"
+              data-testid="board-popout-lock"
+            >
+              <div className="flex flex-col items-center gap-3 px-6 py-5 max-w-sm text-center rounded-lg border border-(--divider) bg-(--sidebar-bg) shadow-lg">
+                <ExternalLink className="w-6 h-6 text-(--text-muted)" />
+                <div className="text-[0.875rem] font-semibold text-(--text-primary)">
+                  Board open in another window
+                </div>
+                <div className="text-[0.8125rem] text-(--text-muted)">
+                  The board view is currently popped out. Close the pop-out window to use it here.
+                </div>
+                <button
+                  type="button"
+                  onClick={() => { void closePopouts(); }}
+                  className="mt-1 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-(--accent) text-white text-[0.8125rem] font-medium cursor-pointer hover:opacity-90 transition-opacity"
+                  data-testid="board-popout-close-btn"
+                >
+                  Close pop-out window
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       </div>
       <FolderBrowserDialog

--- a/src/components/chat/project-strip.tsx
+++ b/src/components/chat/project-strip.tsx
@@ -22,9 +22,18 @@ import { useI18n } from '@/lib/i18n';
 interface ProjectStripProps {
   onAddProject: () => void;
   onRemoveProject?: (encodedDir: string) => void;
+  /**
+   * When true, hide management actions that don't make sense in the popout
+   * board window (add project, remove project, bottom action stack).
+   */
+  hideManagementActions?: boolean;
 }
 
-export function ProjectStrip({ onAddProject, onRemoveProject }: ProjectStripProps) {
+export function ProjectStrip({
+  onAddProject,
+  onRemoveProject,
+  hideManagementActions = false,
+}: ProjectStripProps) {
   const { t } = useI18n();
   const projects = useSessionStore((state) => state.projects);
   const selectedProjectDir = useBoardStore((state) => state.selectedProjectDir);
@@ -41,8 +50,9 @@ export function ProjectStrip({ onAddProject, onRemoveProject }: ProjectStripProp
 
   const handleContextMenu = useCallback((e: React.MouseEvent, encodedDir: string, displayName: string) => {
     e.preventDefault();
+    if (hideManagementActions) return;
     setContextMenu({ x: e.clientX, y: e.clientY, encodedDir, displayName });
-  }, []);
+  }, [hideManagementActions]);
 
   const handleProjectSelect = useCallback((projectDir: string) => {
     setSelectedProjectDir(projectDir);
@@ -100,15 +110,17 @@ export function ProjectStrip({ onAddProject, onRemoveProject }: ProjectStripProp
       )}
 
       {/* Add project button */}
-      <Tooltip content={t('projectStrip.addProject')} delay={300}>
-        <button
-          onClick={onAddProject}
-          className="w-11 h-9 flex items-center justify-center shrink-0 text-(--text-muted) hover:text-(--sidebar-text-active) transition-colors"
-          data-testid="project-strip-add"
-        >
-          <Plus className="w-4 h-4" />
-        </button>
-      </Tooltip>
+      {!hideManagementActions && (
+        <Tooltip content={t('projectStrip.addProject')} delay={300}>
+          <button
+            onClick={onAddProject}
+            className="w-11 h-9 flex items-center justify-center shrink-0 text-(--text-muted) hover:text-(--sidebar-text-active) transition-colors"
+            data-testid="project-strip-add"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+        </Tooltip>
+      )}
 
       {/* All Projects button */}
       <Tooltip content={t('projectStrip.allProjects')} delay={300}>
@@ -182,6 +194,7 @@ export function ProjectStrip({ onAddProject, onRemoveProject }: ProjectStripProp
       <div className="w-6 mx-auto border-t border-(--divider)" />
 
       {/* Global action icons */}
+      {!hideManagementActions && (
       <div className="flex flex-col items-center shrink-0">
         <NotificationBell direction="right" />
         <Tooltip content={t('skill.dashboardTitle')} delay={300}>
@@ -236,6 +249,7 @@ export function ProjectStrip({ onAddProject, onRemoveProject }: ProjectStripProp
           </Tooltip>
         )}
       </div>
+      )}
 
       {/* Context menu portal */}
       {contextMenu && typeof document !== 'undefined' && createPortal(

--- a/src/components/chat/project-strip.tsx
+++ b/src/components/chat/project-strip.tsx
@@ -191,7 +191,9 @@ export function ProjectStrip({
         </div>
       </ScrollArea>
 
-      <div className="w-6 mx-auto border-t border-(--divider)" />
+      {!hideManagementActions && (
+        <div className="w-6 mx-auto border-t border-(--divider)" />
+      )}
 
       {/* Global action icons */}
       {!hideManagementActions && (

--- a/src/hooks/use-collection-dnd.ts
+++ b/src/hooks/use-collection-dnd.ts
@@ -9,6 +9,7 @@ import { useSelectionStore } from '@/stores/selection-store';
 import { useCollectionStore } from '@/stores/collection-store';
 import { COLLECTION_ITEM_DND_MIME, COLLECTION_GROUP_DND_MIME, TASK_MULTI_DND_MIME } from '@/types/task';
 import { setPanelSessionDragData } from '@/lib/dnd/panel-session-drag';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 
 /**
  * useCollectionDnd
@@ -532,7 +533,7 @@ export function useCollectionDnd(): UseCollectionDndReturn {
       );
       // Persist (fire-and-forget — server reorders)
       for (const u of updates) {
-        fetch(`/api/collections/${u.id}`, {
+        fetchWithClientId(`/api/collections/${u.id}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ sortOrder: u.sortOrder }),

--- a/src/hooks/use-popout-active.ts
+++ b/src/hooks/use-popout-active.ts
@@ -33,7 +33,7 @@ export async function reloadBoardData(): Promise<void> {
   await Promise.all(
     targetProjectIds.flatMap((projectId) => [
       useTaskStore.getState().loadTasks(projectId),
-      useCollectionStore.getState().loadCollections(projectId),
+      useCollectionStore.getState().loadCollections(projectId, { force: true }),
     ]),
   );
 }

--- a/src/hooks/use-popout-active.ts
+++ b/src/hooks/use-popout-active.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSessionStore } from '@/stores/session-store';
+import { useTaskStore } from '@/stores/task-store';
+import { useCollectionStore } from '@/stores/collection-store';
+import { useBoardStore } from '@/stores/board-store';
+import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
+
+interface PopoutElectronApi {
+  isElectron?: boolean;
+  getPopoutState?: () => Promise<{ count?: number }>;
+  onPopoutStateChanged?: (cb: (count: number) => void) => (() => void) | void;
+  closeBoardPopouts?: () => Promise<unknown>;
+}
+
+function getApi(): PopoutElectronApi | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return (window as Window & { electronAPI?: PopoutElectronApi }).electronAPI;
+}
+
+export async function reloadBoardData(): Promise<void> {
+  await useSessionStore.getState().loadProjects();
+
+  const selectedProjectDir = useBoardStore.getState().selectedProjectDir;
+  const projects = useSessionStore.getState().projects;
+
+  const targetProjectIds =
+    selectedProjectDir === ALL_PROJECTS_SENTINEL || selectedProjectDir === null
+      ? projects.map((p) => p.encodedDir)
+      : [selectedProjectDir];
+
+  await Promise.all(
+    targetProjectIds.flatMap((projectId) => [
+      useTaskStore.getState().loadTasks(projectId),
+      useCollectionStore.getState().loadCollections(projectId),
+    ]),
+  );
+}
+
+export function usePopoutActive(): {
+  isActive: boolean;
+  closePopouts: () => Promise<void>;
+} {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const api = getApi();
+    if (!api?.isElectron) return;
+
+    let cancelled = false;
+    void api.getPopoutState?.().then((state) => {
+      if (!cancelled && typeof state?.count === 'number') {
+        setCount(state.count);
+      }
+    });
+
+    const cleanup = api.onPopoutStateChanged?.((next) => setCount(next));
+    return () => {
+      cancelled = true;
+      if (typeof cleanup === 'function') cleanup();
+    };
+  }, []);
+
+  return {
+    isActive: count > 0,
+    closePopouts: async () => {
+      await getApi()?.closeBoardPopouts?.();
+    },
+  };
+}

--- a/src/hooks/use-session-click-handlers.ts
+++ b/src/hooks/use-session-click-handlers.ts
@@ -10,6 +10,21 @@ import { useSessionNavigation } from '@/hooks/use-session-navigation';
 import { getSessionSelectionId } from '@/lib/constants/special-sessions';
 import type { UnifiedSession } from '@/types/chat';
 
+interface PopoutElectronApi {
+  isElectron?: boolean;
+  popoutOpenSession?: (sessionId: string) => void;
+}
+
+function tryForwardClickToMainWindow(sessionId: string): boolean {
+  if (typeof window === 'undefined') return false;
+  const popoutFlag = (window as Window & { __TESSERA_POPOUT__?: boolean }).__TESSERA_POPOUT__;
+  if (!popoutFlag) return false;
+  const electronApi = (window as Window & { electronAPI?: PopoutElectronApi }).electronAPI;
+  if (!electronApi?.isElectron || !electronApi.popoutOpenSession) return false;
+  electronApi.popoutOpenSession(sessionId);
+  return true;
+}
+
 /**
  * useSessionClickHandlers
  *
@@ -81,6 +96,12 @@ export function useSessionClickHandlers(options?: {
         wsClient.sendMarkAsRead(session.id);
       }
 
+      // BRANCH B0 — When inside the popout board window, forward to main window
+      // so the task opens there, then return without local navigation.
+      if (tryForwardClickToMainWindow(session.id)) {
+        return;
+      }
+
       // 2. Cross-tab location search (BR-SIDEBAR-004: replaces isInAnotherPanel)
       const location = useTabStore.getState().findSessionLocation(session.id);
       const currentActiveTabId = useTabStore.getState().activeTabId;
@@ -109,6 +130,9 @@ export function useSessionClickHandlers(options?: {
   // Handle session double-click — always opens as pinned tab
   const handleSessionDoubleClick = useCallback(
     async (session: UnifiedSession): Promise<void> => {
+      if (tryForwardClickToMainWindow(session.id)) {
+        return;
+      }
       const tabStore = useTabStore.getState();
       const location = tabStore.findSessionLocation(session.id);
       if (location) {

--- a/src/hooks/use-session-click-handlers.ts
+++ b/src/hooks/use-session-click-handlers.ts
@@ -12,16 +12,19 @@ import type { UnifiedSession } from '@/types/chat';
 
 interface PopoutElectronApi {
   isElectron?: boolean;
-  popoutOpenSession?: (sessionId: string) => void;
+  popoutOpenSession?: (sessionId: string, action?: 'preview' | 'pin') => void;
 }
 
-function tryForwardClickToMainWindow(sessionId: string): boolean {
+export function tryForwardClickToMainWindow(
+  sessionId: string,
+  action: 'preview' | 'pin' = 'preview'
+): boolean {
   if (typeof window === 'undefined') return false;
   const popoutFlag = (window as Window & { __TESSERA_POPOUT__?: boolean }).__TESSERA_POPOUT__;
   if (!popoutFlag) return false;
   const electronApi = (window as Window & { electronAPI?: PopoutElectronApi }).electronAPI;
   if (!electronApi?.isElectron || !electronApi.popoutOpenSession) return false;
-  electronApi.popoutOpenSession(sessionId);
+  electronApi.popoutOpenSession(sessionId, action);
   return true;
 }
 
@@ -98,7 +101,7 @@ export function useSessionClickHandlers(options?: {
 
       // When inside the popout board window, forward to main window
       // so the task opens there, then return without local navigation.
-      if (tryForwardClickToMainWindow(session.id)) {
+      if (tryForwardClickToMainWindow(session.id, 'preview')) {
         return;
       }
 
@@ -130,7 +133,7 @@ export function useSessionClickHandlers(options?: {
   // Handle session double-click — always opens as pinned tab
   const handleSessionDoubleClick = useCallback(
     async (session: UnifiedSession): Promise<void> => {
-      if (tryForwardClickToMainWindow(session.id)) {
+      if (tryForwardClickToMainWindow(session.id, 'pin')) {
         return;
       }
       const tabStore = useTabStore.getState();

--- a/src/hooks/use-session-click-handlers.ts
+++ b/src/hooks/use-session-click-handlers.ts
@@ -96,7 +96,7 @@ export function useSessionClickHandlers(options?: {
         wsClient.sendMarkAsRead(session.id);
       }
 
-      // BRANCH B0 — When inside the popout board window, forward to main window
+      // When inside the popout board window, forward to main window
       // so the task opens there, then return without local navigation.
       if (tryForwardClickToMainWindow(session.id)) {
         return;

--- a/src/hooks/use-session-crud.ts
+++ b/src/hooks/use-session-crud.ts
@@ -17,6 +17,7 @@ import { getProviderSessionRuntimeConfig } from '@/lib/settings/provider-default
 import { toast } from '@/stores/notification-store';
 import { useI18n } from '@/lib/i18n';
 import { captureTelemetryEvent } from '@/lib/telemetry/client';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 import type { UnifiedSession } from '@/types/chat';
 
 interface SessionCreateOptions {
@@ -41,7 +42,7 @@ export function useSessionCrud() {
   const [isGeneratingTitle, setIsGeneratingTitle] = useState(false);
 
   const requestSessionDelete = useCallback((sessionId: string) => {
-    return fetch(`/api/sessions/${sessionId}`, { method: 'DELETE' });
+    return fetchWithClientId(`/api/sessions/${sessionId}`, { method: 'DELETE' });
   }, []);
 
   const removeSessionFromStores = useCallback(
@@ -147,7 +148,7 @@ export function useSessionCrud() {
       try {
         const settings = useSettingsStore.getState().settings;
         const runtimeConfig = getProviderSessionRuntimeConfig(settings, resolvedProviderId);
-        const response = await fetch('/api/sessions', {
+        const response = await fetchWithClientId('/api/sessions', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -313,7 +314,7 @@ export function useSessionCrud() {
   const deleteProject = useCallback(
     async (encodedDir: string): Promise<void> => {
       try {
-        const response = await fetch(`/api/sessions/projects/${encodeURIComponent(encodedDir)}`, {
+        const response = await fetchWithClientId(`/api/sessions/projects/${encodeURIComponent(encodedDir)}`, {
           method: 'DELETE',
         });
 
@@ -348,7 +349,7 @@ export function useSessionCrud() {
       setIsRenaming(true);
 
       try {
-        const response = await fetch(`/api/sessions/${sessionId}/rename`, {
+        const response = await fetchWithClientId(`/api/sessions/${sessionId}/rename`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ title: newTitle }),
@@ -406,7 +407,7 @@ export function useSessionCrud() {
       useSessionStore.getState().setGeneratingTitle(sessionId, true);
 
       try {
-        const response = await fetch(`/api/sessions/${sessionId}/generate-title`, {
+        const response = await fetchWithClientId(`/api/sessions/${sessionId}/generate-title`, {
           method: 'POST',
         });
 

--- a/src/hooks/use-worktree-session.ts
+++ b/src/hooks/use-worktree-session.ts
@@ -6,6 +6,7 @@ import { useTaskStore } from '@/stores/task-store';
 import { useSettingsStore } from '@/stores/settings-store';
 import { toast } from '@/stores/notification-store';
 import logger from '@/lib/logger';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 import type { TaskEntity, WorkflowStatus } from '@/types/task-entity';
 
 interface CreateWorktreeSessionOptions {
@@ -162,7 +163,7 @@ export function useWorktreeSession() {
         let createdTaskId: string | null = null;
         if (tempId && taskTitle) {
           try {
-            const taskRes = await fetch('/api/tasks', {
+            const taskRes = await fetchWithClientId('/api/tasks', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({

--- a/src/lib/api/fetch-with-client-id.ts
+++ b/src/lib/api/fetch-with-client-id.ts
@@ -1,0 +1,12 @@
+import { getClientId } from '@/lib/ws/client-id';
+
+export async function fetchWithClientId(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const headers = new Headers(init?.headers ?? {});
+  if (!headers.has('x-tessera-client-id')) {
+    headers.set('x-tessera-client-id', getClientId());
+  }
+  return fetch(input, { ...init, headers });
+}

--- a/src/lib/db/collections.ts
+++ b/src/lib/db/collections.ts
@@ -31,6 +31,13 @@ export function getCollections(projectId: string): CollectionRow[] {
 /**
  * Check if a collection exists by ID.
  */
+export function getCollectionProjectId(id: string): string | undefined {
+  const row = getDb()
+    .prepare('SELECT project_id FROM collections WHERE id = ?')
+    .get(id) as { project_id: string } | undefined;
+  return row?.project_id;
+}
+
 export function collectionExists(id: string, projectId?: string): boolean {
   const row = projectId
     ? getDb()

--- a/src/lib/ws/client-id.ts
+++ b/src/lib/ws/client-id.ts
@@ -1,0 +1,17 @@
+// Stable per-renderer ID used to attribute WebSocket origin and dedupe
+// REST mutation broadcasts back to the originating window.
+let cachedClientId: string | null = null;
+
+function generateClientId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `c-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function getClientId(): string {
+  if (cachedClientId === null) {
+    cachedClientId = generateClientId();
+  }
+  return cachedClientId;
+}

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -17,8 +17,11 @@ import { useSessionStore } from '@/stores/session-store';
 import { useSkillAnalysisStore } from '@/stores/skill-analysis-store';
 import { useTaskStore } from '@/stores/task-store';
 import { useUsageStore } from '@/stores/usage-store';
+import { useCollectionStore } from '@/stores/collection-store';
 import { i18n } from '@/lib/i18n';
 import type { ServerTransportMessage } from './message-types';
+import { getClientId } from './client-id';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 
 interface HandleIncomingServerMessageOptions {
   msg: ServerTransportMessage;
@@ -188,6 +191,30 @@ export function handleIncomingServerMessage({
       );
       return { wasReconnect };
 
+    case 'session_mutated':
+      if (msg.originClientId && msg.originClientId === getClientId()) {
+        return { wasReconnect };
+      }
+      void useSessionStore.getState().loadProjects();
+      if (msg.projectId) {
+        void useTaskStore.getState().loadTasks(msg.projectId, { setCurrent: false });
+      }
+      return { wasReconnect };
+
+    case 'task_mutated':
+      if (msg.originClientId && msg.originClientId === getClientId()) {
+        return { wasReconnect };
+      }
+      void useTaskStore.getState().loadTasks(msg.projectId, { setCurrent: false });
+      return { wasReconnect };
+
+    case 'collection_mutated':
+      if (msg.originClientId && msg.originClientId === getClientId()) {
+        return { wasReconnect };
+      }
+      void useCollectionStore.getState().loadCollections(msg.projectId, { force: true, setCurrent: false });
+      return { wasReconnect };
+
     case 'git_panel_state':
       useGitPanelStore.getState().applyGitPanelData(msg.sessionId, msg.data);
       if (msg.data.diffStats !== undefined) {
@@ -322,7 +349,7 @@ function handleSessionTitleUpdatedMessage(
       onClick: () => {
         sessionStore.updateSessionTitle(msg.sessionId, previousTitle, false);
         useTaskStore.getState().syncLinkedTaskTitle(msg.sessionId, previousTitle);
-        fetch(`/api/sessions/${msg.sessionId}/rename`, {
+        fetchWithClientId(`/api/sessions/${msg.sessionId}/rename`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ title: previousTitle }),

--- a/src/lib/ws/client.ts
+++ b/src/lib/ws/client.ts
@@ -10,10 +10,12 @@ import {
 } from '@/lib/chat/session-client-effects';
 import { handleIncomingServerMessage } from './client-message-handlers';
 import { applyOptimisticUserMessage, buildClientRequest } from './client-transport';
+import { getClientId } from './client-id';
 
 type ServerMessageListener = (msg: ServerTransportMessage) => void;
 
 export class WebSocketClient {
+  readonly clientId: string = getClientId();
   private ws: WebSocket | null = null;
   private reconnectAttempt = 0;
   private readonly MAX_RECONNECT_ATTEMPTS = 5;

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -329,6 +329,24 @@ export type AppServerMessage =
       type: 'git_panel_state';
       sessionId: string;
       data: import('@/types/git').GitPanelData;
+    }
+  | {
+      type: 'session_mutated';
+      kind: 'created' | 'updated' | 'deleted' | 'reordered' | 'project_reordered' | 'project_deleted';
+      originClientId?: string;
+      projectId?: string;
+    }
+  | {
+      type: 'task_mutated';
+      kind: 'created' | 'updated' | 'deleted' | 'reordered';
+      originClientId?: string;
+      projectId: string;
+    }
+  | {
+      type: 'collection_mutated';
+      kind: 'created' | 'updated' | 'deleted';
+      originClientId?: string;
+      projectId: string;
     };
 
 /**

--- a/src/lib/ws/mutation-broadcast.ts
+++ b/src/lib/ws/mutation-broadcast.ts
@@ -1,0 +1,30 @@
+import { wsServer } from './server';
+
+export function getOriginClientIdFromRequest(req: Request | { headers: Headers }): string | undefined {
+  const value = req.headers.get('x-tessera-client-id');
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function broadcastSessionMutation(userId: string, params: {
+  kind: 'created' | 'updated' | 'deleted' | 'reordered' | 'project_reordered' | 'project_deleted';
+  originClientId?: string;
+  projectId?: string;
+}): void {
+  wsServer.sendToUser(userId, { type: 'session_mutated', ...params });
+}
+
+export function broadcastTaskMutation(userId: string, params: {
+  kind: 'created' | 'updated' | 'deleted' | 'reordered';
+  originClientId?: string;
+  projectId: string;
+}): void {
+  wsServer.sendToUser(userId, { type: 'task_mutated', ...params });
+}
+
+export function broadcastCollectionMutation(userId: string, params: {
+  kind: 'created' | 'updated' | 'deleted';
+  originClientId?: string;
+  projectId: string;
+}): void {
+  wsServer.sendToUser(userId, { type: 'collection_mutated', ...params });
+}

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -405,5 +405,8 @@ export class WebSocketServer {
   }
 }
 
-// Singleton instance
-export const wsServer = new WebSocketServer();
+// Singleton instance (globalThis to survive Next.js hot reload and webpack/tsx module boundary)
+const WS_SERVER_KEY = Symbol.for('tessera.wsServer');
+const _wsServerGlobal = globalThis as unknown as Record<symbol, WebSocketServer>;
+export const wsServer: WebSocketServer =
+  _wsServerGlobal[WS_SERVER_KEY] || (_wsServerGlobal[WS_SERVER_KEY] = new WebSocketServer());

--- a/src/stores/collection-store.ts
+++ b/src/stores/collection-store.ts
@@ -5,6 +5,8 @@ import { useTaskStore } from './task-store';
 
 interface LoadCollectionsOptions {
   setCurrent?: boolean;
+  /** Bypass the per-project loaded cache and refetch from the API. */
+  force?: boolean;
 }
 
 interface CollectionState {
@@ -108,9 +110,10 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
 
   loadCollections: async (projectId, options) => {
     const shouldSetCurrent = options?.setCurrent !== false;
+    const force = options?.force === true;
     const currentState = get();
 
-    if (currentState.loadedProjects[projectId]) {
+    if (!force && currentState.loadedProjects[projectId]) {
       if (shouldSetCurrent) {
         set({
           collections: currentState.collectionsByProject[projectId] ?? [],

--- a/src/stores/collection-store.ts
+++ b/src/stores/collection-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { Collection } from '@/types/collection';
 import { useSessionStore } from './session-store';
 import { useTaskStore } from './task-store';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 
 interface LoadCollectionsOptions {
   setCurrent?: boolean;
@@ -173,7 +174,7 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
 
   addCollection: async (projectId, label, color) => {
     try {
-      const res = await fetch('/api/collections', {
+      const res = await fetchWithClientId('/api/collections', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ projectId, label, color }),
@@ -221,7 +222,7 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
     }));
 
     try {
-      const res = await fetch(`/api/collections/${id}`, {
+      const res = await fetchWithClientId(`/api/collections/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ label, color }),
@@ -271,7 +272,7 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
     }));
 
     try {
-      const res = await fetch(`/api/collections/${id}`, { method: 'DELETE' });
+      const res = await fetchWithClientId(`/api/collections/${id}`, { method: 'DELETE' });
       if (!res.ok) {
         set((currentState) => ({
           ...updateProjectCache(

--- a/src/stores/selection-store.ts
+++ b/src/stores/selection-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { useSessionStore } from './session-store';
 import { useTaskStore } from './task-store';
 import { toast } from './notification-store';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 
 interface SelectionState {
   /** Set of selected session IDs */
@@ -129,7 +130,7 @@ export const useSelectionStore = create<SelectionState>((set, get) => ({
 
     for (const id of ids) {
       try {
-        const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`, {
+        const res = await fetchWithClientId(`/api/sessions/${encodeURIComponent(id)}`, {
           method: 'DELETE',
         });
         if (res.ok) {

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -6,6 +6,7 @@ import { useTaskStore } from './task-store';
 import { toast } from './notification-store';
 import { wsClient } from '@/lib/ws/client';
 import { captureTelemetryEvent } from '@/lib/telemetry/client';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 
 
 interface SessionState {
@@ -832,7 +833,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     }));
 
     // Server sync with rollback
-    fetch(`/api/sessions/${sessionId}/collection`, {
+    fetchWithClientId(`/api/sessions/${sessionId}/collection`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ collectionId }),
@@ -906,7 +907,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       })),
     }));
 
-    fetch(`/api/sessions/${sessionId}/archive`, {
+    fetchWithClientId(`/api/sessions/${sessionId}/archive`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ archived }),
@@ -1003,7 +1004,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     }));
 
     // Server sync with rollback
-    fetch(`/api/sessions/${sessionId}/move`, {
+    fetchWithClientId(`/api/sessions/${sessionId}/move`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ targetProjectId }),
@@ -1069,7 +1070,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 
     // Persist to server
     const orderedIds = projects.map((p) => p.encodedDir);
-    fetch('/api/sessions/projects/reorder', {
+    fetchWithClientId('/api/sessions/projects/reorder', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ orderedIds }),
@@ -1098,7 +1099,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     }));
 
     // Persist to server
-    fetch('/api/sessions/reorder', {
+    fetchWithClientId('/api/sessions/reorder', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ projectId: projectDir, orderedIds }),
@@ -1120,7 +1121,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         ),
       })),
     }));
-    fetch('/api/sessions/reorder', {
+    fetchWithClientId('/api/sessions/reorder', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ orderedIds }),

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { TaskEntity, WorkflowStatus } from '@/types/task-entity';
 import { useSessionStore } from './session-store';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 
 interface LoadTasksOptions {
   setCurrent?: boolean;
@@ -266,7 +267,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
 
   createTask: async (params) => {
     try {
-      const res = await fetch('/api/tasks', {
+      const res = await fetchWithClientId('/api/tasks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(params),
@@ -347,7 +348,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     }
 
     try {
-      const res = await fetch(`/api/tasks/${id}`, {
+      const res = await fetchWithClientId(`/api/tasks/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(patch),
@@ -424,7 +425,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     }
 
     try {
-      const res = await fetch(`/api/tasks/${id}`, { method: 'DELETE' });
+      const res = await fetchWithClientId(`/api/tasks/${id}`, { method: 'DELETE' });
       if (!res.ok) {
         await useSessionStore.getState().loadProjects();
         if (projectId)
@@ -530,7 +531,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       ),
     }));
 
-    fetch('/api/tasks/reorder', {
+    fetchWithClientId('/api/tasks/reorder', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ orderedIds }),


### PR DESCRIPTION
## Summary

- Adds a popout icon to the board's collection filter bar; in Electron it opens the board in a dedicated `/board-popout` window.
- Task clicks inside the popout focus the main window and open the session there via IPC, preserving the existing tab/panel flow.
- While a popout is active, the main window's board view is locked behind an overlay with a "Close pop-out window" action; closing the popout (externally or via the button) refreshes tasks/collections/projects so any changes made in the popout appear in the main window.

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `NODE_ENV=production npm run build`
- [x] Manual test: Confirmed all functionality works as intended.
- [x] Platforms tested: Tested via `npm run dev` on Windows, didn't test any specific exe/appimage/etc directly

## Screenshots or Recordings

<img width="707" height="390" alt="image" src="https://github.com/user-attachments/assets/eec6fcc5-7b42-458a-a325-a5979e374cec" />

<img width="1911" height="1010" alt="image" src="https://github.com/user-attachments/assets/890d5626-87c9-42a5-b356-aa57fb1de343" />
