### PR TITLE
fix(chat): autoscroll unfocused side-by-side panels

### DIFF
--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -24,9 +24,10 @@ interface ChatAreaProps {
 export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaProps) {
   const { t } = useI18n();
   const tabId = useContext(TabIdContext);
-  const isTabActive = useTabStore((state) => state.activeTabId === tabId);
-  const isPanelActive = usePanelStore((state) => state.tabPanels[tabId]?.activePanelId === panelId);
-  const isViewActive = isTabActive && isPanelActive;
+  // Side-by-side panels in the active tab are all on-screen even though only
+  // one is the panel-store's "active" panel; gating autoscroll on isPanelActive
+  // froze the unfocused panel's viewport during streaming (issue #16).
+  const isViewActive = useTabStore((state) => state.activeTabId === tabId);
   const { windowedMessages, hasMore, loadMore, isLoadingMore } =
     useWindowedMessages(sessionId);
   const isSinglePanel = usePanelStore(


### PR DESCRIPTION
## Summary

Fixes #16. When two chat sessions are opened side-by-side in a single tab, the unfocused panel's viewport stopped following streaming output — tokens grew the message list but the scroll position stayed put until you clicked into that panel.

## Root cause

`ChatArea` derived `isViewActive = isTabActive && isPanelActive` and passed it to the autoscroll hook. The `isPanelActive` half tracks the panel-store's "currently focused panel for input" — but in a split layout, every panel in the active tab is *visually* on-screen, regardless of which one currently has panel focus. The autoscroll hook (`use-virtual-message-list`) treats `!isViewActive` as "not visible" and short-circuits scroll updates, only restoring to bottom on the next focus event.

## Fix

Drop the `isPanelActive` half of the gate. Tab visibility (`isTabActive`) is the correct signal for whether the panel is on-screen. Inactive *tabs* still render with `visibility: hidden` and continue to use the existing `markBottomOnNextResume` path, so the hidden-tab semantics don't change.

One file, three lines:

```diff
-  const isTabActive = useTabStore((state) => state.activeTabId === tabId);
-  const isPanelActive = usePanelStore((state) => state.tabPanels[tabId]?.activePanelId === panelId);
-  const isViewActive = isTabActive && isPanelActive;
+  const isViewActive = useTabStore((state) => state.activeTabId === tabId);
```

## Test plan

- [x] Open two chat sessions side-by-side in one tab, kick off streaming tasks in both. Click into one — the other keeps auto-scrolling.
- [x] Switch tabs and back — previously-active tab still restores to bottom on focus (existing behavior preserved).
- [x] Single-panel tab still autoscrolls normally.