### PR TITLE
fix(github): make PR detection reliable + extend to bare sessions

### DIFF
--- a/electron/server-child.ts
+++ b/electron/server-child.ts
@@ -14,6 +14,9 @@ import { processManager } from '../src/lib/cli/process-manager';
 import { getAgentEnvironment } from '../src/lib/cli/spawn-cli';
 import { getElectronAuthUserId } from '../src/lib/auth/electron-user';
 import { rateLimitPoller } from '../src/lib/rate-limit/poller';
+import { taskPrPoller } from '../src/lib/github/task-pr-poller';
+import { installTaskPrStatusBroadcast, uninstallTaskPrStatusBroadcast } from '../src/lib/github/task-pr-broadcast';
+import { installSessionPrStatusBroadcast, uninstallSessionPrStatusBroadcast } from '../src/lib/github/session-pr-broadcast';
 import { prewarmCliStatusSnapshot } from '../src/lib/cli/provider-status-prewarm';
 import { snapshotTelemetryStartupDataState } from '../src/lib/telemetry/server-state';
 import logger from '../src/lib/logger';
@@ -94,6 +97,13 @@ initDatabase().then(() => {
     });
     rateLimitPoller.start();
 
+    // Wire PR sync broadcasts and start the background PR poller. Without
+    // these the in-process subscribe callbacks on syncTaskPr/syncSessionPr
+    // have no listeners, so live updates never reach Electron clients.
+    installTaskPrStatusBroadcast((msg) => wsServer.broadcast(msg));
+    installSessionPrStatusBroadcast((msg) => wsServer.broadcast(msg));
+    void taskPrPoller.start();
+
     logger.info({ port, hostname, env: process.env.NODE_ENV }, 'Electron server started');
     console.log(`> Ready on http://${hostname}:${port}`);
     console.log(`> WebSocket on ws://${hostname}:${port}/ws`);
@@ -123,6 +133,11 @@ initDatabase().then(() => {
 
       logger.info('Stopping rate limit poller...');
       rateLimitPoller.stop();
+
+      logger.info('Stopping task PR poller...');
+      taskPrPoller.stop();
+      uninstallTaskPrStatusBroadcast();
+      uninstallSessionPrStatusBroadcast();
 
       logger.info('Cleaning up CLI processes...');
       await processManager.cleanup();

--- a/server.ts
+++ b/server.ts
@@ -9,6 +9,7 @@ import { processManager } from './src/lib/cli/process-manager';
 import { rateLimitPoller } from './src/lib/rate-limit/poller';
 import { taskPrPoller } from './src/lib/github/task-pr-poller';
 import { installTaskPrStatusBroadcast, uninstallTaskPrStatusBroadcast } from './src/lib/github/task-pr-broadcast';
+import { installSessionPrStatusBroadcast, uninstallSessionPrStatusBroadcast } from './src/lib/github/session-pr-broadcast';
 import { ensureRSAKeys } from './src/lib/auth/keys';
 import { readUsersFile } from './src/lib/users';
 import { SettingsManager } from './src/lib/settings/manager';
@@ -77,6 +78,7 @@ async function startServer() {
 
     // Start task PR poller + relay updates to connected clients
     installTaskPrStatusBroadcast((msg) => wsServer.broadcast(msg));
+    installSessionPrStatusBroadcast((msg) => wsServer.broadcast(msg));
     void taskPrPoller.start();
 
     logger.info({
@@ -124,6 +126,7 @@ async function startServer() {
       logger.info('Stopping task PR poller...');
       taskPrPoller.stop();
       uninstallTaskPrStatusBroadcast();
+      uninstallSessionPrStatusBroadcast();
 
       // processManager.cleanup() kills every spawned CLI plus its process
       // group (spawn-cli-runtime marks children as detached: true on Unix,

--- a/src/app/api/sessions/[id]/refresh-git/route.ts
+++ b/src/app/api/sessions/[id]/refresh-git/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuthenticatedUserId } from "@/lib/auth/api-auth";
+import { refreshSessionDiffStateInBackground } from "@/lib/git/session-diff-refresh";
+import { jsonError } from "@/lib/http/json-error";
+
+/**
+ * Kick off the same git/PR refresh that runs at agent turn-end. Lets the
+ * client recover from staleness when work happens outside Tessera (CLI push,
+ * external `gh pr create`, etc.) without waiting for the background poll.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const auth = await requireAuthenticatedUserId(request, {
+    error: { code: "unauthorized", message: "Unauthorized" },
+  });
+  if ("response" in auth) return auth.response;
+
+  if (!id) {
+    return jsonError("invalid_request", "session id is required", 400);
+  }
+
+  refreshSessionDiffStateInBackground(id, auth.userId, "client_refresh_request");
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/git/use-git-panel-controller.ts
+++ b/src/components/git/use-git-panel-controller.ts
@@ -230,9 +230,19 @@ export function useGitPanelController(sessionId: string | null) {
     if (typeof document === "undefined") return;
 
     const refreshOnVisible = () => {
-      if (document.visibilityState === "visible") {
-        void loadPanel({ silent: true });
+      if (document.visibilityState !== "visible") return;
+      // Ask the server to re-probe git state + PR status (covers work done
+      // outside Tessera — CLI push, external gh pr create, etc.). Don't await:
+      // the WS broadcast and the loadPanel re-read below converge the UI.
+      if (!isTransientSessionId(sessionId)) {
+        void fetch(
+          `/api/sessions/${encodeURIComponent(sessionId)}/refresh-git`,
+          { method: "POST" },
+        ).catch(() => {
+          // Best-effort — staleness recovers on the next focus or poll tick.
+        });
       }
+      void loadPanel({ silent: true });
     };
 
     document.addEventListener("visibilitychange", refreshOnVisible);

--- a/src/components/git/use-git-panel-controller.ts
+++ b/src/components/git/use-git-panel-controller.ts
@@ -6,6 +6,7 @@ import { isTurnInFlight, useChatStore } from "@/stores/chat-store";
 import { useGitPanelStore } from "@/stores/git-panel-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useSessionStore } from "@/stores/session-store";
+import { useSessionPrStore } from "@/stores/session-pr-store";
 import { useTaskStore } from "@/stores/task-store";
 import type {
   GitChangedFilesData,
@@ -111,6 +112,9 @@ export function useGitPanelController(sessionId: string | null) {
   const liveTaskId = data?.taskId ?? taskSnapshot?.id;
   const livePrStatus = useTaskStore((state) =>
     liveTaskId ? state.prStatusByTaskId[liveTaskId] : undefined,
+  );
+  const liveSessionPr = useSessionPrStore((state) =>
+    !liveTaskId && sessionId ? state.prBySessionId[sessionId] : undefined,
   );
   const gitConfig = useSettingsStore((state) => state.settings.gitConfig);
 
@@ -267,7 +271,7 @@ export function useGitPanelController(sessionId: string | null) {
           prUnsupported: taskSnapshot.prUnsupported,
           remoteBranchExists: taskSnapshot.remoteBranchExists,
         }
-      : livePrStatus;
+      : (livePrStatus ?? liveSessionPr);
 
     return {
       ...data,
@@ -277,7 +281,7 @@ export function useGitPanelController(sessionId: string | null) {
       remoteBranchExists:
         livePr?.remoteBranchExists ?? data.remoteBranchExists,
     };
-  }, [data, livePrStatus, sessionSnapshot?.diffStats, taskSnapshot]);
+  }, [data, liveSessionPr, livePrStatus, sessionSnapshot?.diffStats, taskSnapshot]);
 
   const closeAction = useCallback(() => {
     setActiveAction(null);

--- a/src/lib/db/sessions.ts
+++ b/src/lib/db/sessions.ts
@@ -185,6 +185,22 @@ export function getSessionsByWorkDir(workDir: string): Array<Pick<SessionRow, 'i
 }
 
 /**
+ * Sessions that the bare-session PR poller should sweep: have a working
+ * directory, are not bound to a task (those flow through task-pr-sync),
+ * and aren't soft-deleted or archived.
+ */
+export function getSessionsEligibleForBareSessionPrSync(): Array<Pick<SessionRow, 'id' | 'work_dir'>> {
+  return getDb().prepare(`
+    SELECT id, work_dir
+    FROM sessions
+    WHERE deleted = 0
+      AND archived = 0
+      AND task_id IS NULL
+      AND work_dir IS NOT NULL
+  `).all() as Array<Pick<SessionRow, 'id' | 'work_dir'>>;
+}
+
+/**
  * Clear worktree metadata for all sessions that reference the given work_dir.
  */
 export function clearWorktreeMetadataByWorkDir(workDir: string): void {

--- a/src/lib/git/git-panel.ts
+++ b/src/lib/git/git-panel.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/filesystem/path-environment";
 import * as dbSessions from "@/lib/db/sessions";
 import * as dbTasks from "@/lib/db/tasks";
+import { getCachedSessionPr } from "@/lib/github/session-pr-sync";
 import { computeWorktreeFileDiffStats } from "@/lib/git/worktree-diff-stats";
 import { getCachedDiffStats } from "@/lib/git/worktree-diff-stats-cache";
 import { getAgentEnvironment, spawnCli } from "@/lib/cli/spawn-cli";
@@ -302,7 +303,7 @@ export function summarizeStatusCheckRollup(items: unknown[]): GitChecksSummary {
 async function resolveGitHubPanelState(
   workDir: string,
   remoteUrl: string | null,
-  prContext: dbTasks.TaskPrSyncContext | null,
+  prSummary: { wasUnsupported: boolean; prStatus?: unknown } | null,
   agentEnvironment: AgentEnvironment,
 ): Promise<GitPanelData["github"]> {
   if (!normalizeGithubUrl(remoteUrl)) {
@@ -336,19 +337,19 @@ async function resolveGitHubPanelState(
     };
   }
 
-  if (prContext?.wasUnsupported) {
+  if (prSummary?.wasUnsupported) {
     return {
       available: false,
       reasonCode: "unknown",
-      reason: "GitHub PR sync is unavailable for this task.",
+      reason: "GitHub PR sync is unavailable for this session.",
       pullRequest: null,
     };
   }
 
   return {
     available: true,
-    reasonCode: prContext?.prStatus ? null : "no_pull_request",
-    reason: prContext?.prStatus
+    reasonCode: prSummary?.prStatus ? null : "no_pull_request",
+    reason: prSummary?.prStatus
       ? null
       : "No pull request is linked to the current branch.",
     pullRequest: null,
@@ -443,6 +444,12 @@ export async function getGitPanelData(
   const prContext = sessionContext.taskId
     ? dbTasks.getTaskPrSyncContext(sessionContext.taskId)
     : null;
+  // Bare sessions (no task) carry PR state in an in-memory cache populated
+  // by syncSessionPr — same probe pipeline as tasks, just keyed by sessionId
+  // since there's no task row to persist to.
+  const bareSessionPr = sessionContext.taskId
+    ? null
+    : getCachedSessionPr(sessionId) ?? null;
 
   const [
     branchRaw,
@@ -494,7 +501,12 @@ export async function getGitPanelData(
     runOptionalCommand("git", ["rev-parse", "HEAD"], workDir, agentEnvironment),
   ]);
   const { ahead, behind } = parseAheadBehind(aheadBehindRaw);
-  const github = await resolveGitHubPanelState(workDir, remoteUrl, prContext, agentEnvironment);
+  const prSummary = prContext
+    ? { wasUnsupported: prContext.wasUnsupported, prStatus: prContext.prStatus }
+    : bareSessionPr
+      ? { wasUnsupported: bareSessionPr.prUnsupported, prStatus: bareSessionPr.prStatus }
+      : null;
+  const github = await resolveGitHubPanelState(workDir, remoteUrl, prSummary, agentEnvironment);
 
   return {
     sessionId,
@@ -522,9 +534,11 @@ export async function getGitPanelData(
     diffStats: sessionContext.worktreeBranch
       ? getCachedDiffStats(workDir) ?? undefined
       : undefined,
-    prStatus: prContext?.prStatus,
-    prUnsupported: prContext?.wasUnsupported ?? false,
-    remoteBranchExists: prContext?.remoteBranchExists,
+    prStatus: prContext?.prStatus ?? bareSessionPr?.prStatus,
+    prUnsupported:
+      prContext?.wasUnsupported ?? bareSessionPr?.prUnsupported ?? false,
+    remoteBranchExists:
+      prContext?.remoteBranchExists ?? bareSessionPr?.remoteBranchExists,
     headSha: headShaRaw && /^[0-9a-f]{40}$/i.test(headShaRaw) ? headShaRaw : null,
   };
 }

--- a/src/lib/git/git-panel.ts
+++ b/src/lib/git/git-panel.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/filesystem/path-environment";
 import * as dbSessions from "@/lib/db/sessions";
 import * as dbTasks from "@/lib/db/tasks";
-import { getCachedSessionPr } from "@/lib/github/session-pr-sync";
+import { getCachedSessionPr, syncSessionPr } from "@/lib/github/session-pr-sync";
 import { computeWorktreeFileDiffStats } from "@/lib/git/worktree-diff-stats";
 import { getCachedDiffStats } from "@/lib/git/worktree-diff-stats-cache";
 import { getAgentEnvironment, spawnCli } from "@/lib/cli/spawn-cli";
@@ -446,10 +446,20 @@ export async function getGitPanelData(
     : null;
   // Bare sessions (no task) carry PR state in an in-memory cache populated
   // by syncSessionPr — same probe pipeline as tasks, just keyed by sessionId
-  // since there's no task row to persist to.
-  const bareSessionPr = sessionContext.taskId
+  // since there's no task row to persist to. The cache is rebuilt on
+  // restart, so on the first panel load we probe inline to avoid the panel
+  // showing "no PR" until the next focus/poll tick.
+  let bareSessionPr = sessionContext.taskId
     ? null
     : getCachedSessionPr(sessionId) ?? null;
+  if (!sessionContext.taskId && !bareSessionPr && workDir) {
+    try {
+      await syncSessionPr(sessionId, { agentEnvironment });
+      bareSessionPr = getCachedSessionPr(sessionId) ?? null;
+    } catch {
+      // Best-effort — the visibility refresh and poller will fill it in.
+    }
+  }
 
   const [
     branchRaw,

--- a/src/lib/git/session-diff-refresh.ts
+++ b/src/lib/git/session-diff-refresh.ts
@@ -45,16 +45,19 @@ export async function refreshSessionDiffState(
     );
   }
 
-  await runOperation('git_panel_state', flushGitPanelRecompute(sessionId, userId));
-
+  // Run PR sync BEFORE the git-panel recompute so the panel data picks up
+  // the freshly-probed PR state in the same broadcast. Otherwise the panel
+  // is built from stale prContext/sessionPr cache and the PR-derived
+  // github.available / github.reasonCode lag until the next reload.
   if (session.task_id) {
     const agentEnvironment = await getAgentEnvironment(userId);
     await runOperation('task_pr_status', syncTaskPr(session.task_id, { agentEnvironment }));
   } else if (session.work_dir) {
-    // Bare sessions still want PR linkage when they're working in a real repo.
     const agentEnvironment = await getAgentEnvironment(userId);
     await runOperation('session_pr_status', syncSessionPr(sessionId, { agentEnvironment }));
   }
+
+  await runOperation('git_panel_state', flushGitPanelRecompute(sessionId, userId));
 }
 
 export function refreshSessionDiffStateInBackground(

--- a/src/lib/git/session-diff-refresh.ts
+++ b/src/lib/git/session-diff-refresh.ts
@@ -2,6 +2,7 @@ import * as dbSessions from '@/lib/db/sessions';
 import { getAgentEnvironment } from '@/lib/cli/spawn-cli';
 import logger from '@/lib/logger';
 import { syncTaskPr } from '@/lib/github/task-pr-sync';
+import { syncSessionPr } from '@/lib/github/session-pr-sync';
 import { flushGitPanelRecompute } from './git-panel-cache';
 import { flushRecompute } from './worktree-diff-stats-cache';
 
@@ -49,6 +50,10 @@ export async function refreshSessionDiffState(
   if (session.task_id) {
     const agentEnvironment = await getAgentEnvironment(userId);
     await runOperation('task_pr_status', syncTaskPr(session.task_id, { agentEnvironment }));
+  } else if (session.work_dir) {
+    // Bare sessions still want PR linkage when they're working in a real repo.
+    const agentEnvironment = await getAgentEnvironment(userId);
+    await runOperation('session_pr_status', syncSessionPr(sessionId, { agentEnvironment }));
   }
 }
 

--- a/src/lib/github/pr-status-provider.ts
+++ b/src/lib/github/pr-status-provider.ts
@@ -95,6 +95,25 @@ export function resetGhAvailabilityCache(): void {
   ghAvailableCache.clear();
 }
 
+/**
+ * Resolve the worktree's current HEAD branch, or null if HEAD is detached
+ * or git fails. Used by callers that don't have a stored branch (bare
+ * sessions) but still want to drive `probeTaskPrStatus`.
+ */
+export async function resolveCurrentBranch(
+  workDir: string,
+  agentEnvironment: AgentEnvironment = 'native',
+): Promise<string | null> {
+  if (!workDir) return null;
+  const result = await execGitInDir(
+    ['rev-parse', '--abbrev-ref', 'HEAD'],
+    workDir,
+    agentEnvironment,
+  );
+  const head = result?.stdout.trim();
+  return head && head !== 'HEAD' ? head : null;
+}
+
 function normalizeGithubOwnerRepo(remoteUrl: string | null): string | null {
   if (!remoteUrl) return null;
   const trimmed = remoteUrl.trim();

--- a/src/lib/github/pr-status-provider.ts
+++ b/src/lib/github/pr-status-provider.ts
@@ -38,6 +38,11 @@ export type PrProbeResult =
        * when HEAD is detached or unresolvable.
        */
       resolvedBranch: string | null;
+    }
+  | {
+      kind: 'transient_error';
+      stderr: string;
+      resolvedBranch: string | null;
     };
 
 const ghAvailableCache = new Map<AgentEnvironment, boolean>();
@@ -191,8 +196,10 @@ export async function probeTaskPrStatus(params: {
       return { kind: 'unsupported', reason: 'gh_unauthenticated' };
     }
     logger.warn({ branch: probeBranch, ownerRepo, stderr: run.stderr.slice(0, 300) }, 'gh pr list failed');
-    // Transient failure — don't mark unsupported, just report no update.
-    return { kind: 'ok', prStatus: null, remoteBranchExists, resolvedBranch };
+    // Transient failure (network blip, rate limit, subprocess hiccup). Surface
+    // a distinct kind so callers can leave the previously-known PR state in the
+    // DB instead of overwriting it with null and broadcasting "PR gone".
+    return { kind: 'transient_error', stderr: run.stderr, resolvedBranch };
   }
 
   let payload: GhPrListItem[] = [];

--- a/src/lib/github/session-pr-broadcast.ts
+++ b/src/lib/github/session-pr-broadcast.ts
@@ -1,0 +1,37 @@
+/**
+ * Relays session PR sync updates from the sync service to every connected
+ * WebSocket client. Mirrors task-pr-broadcast for sessions that aren't
+ * tied to a task.
+ */
+
+import logger from '@/lib/logger';
+import type { ServerTransportMessage } from '@/lib/ws/message-types';
+import { subscribeSessionPrUpdates } from './session-pr-sync';
+
+type BroadcastFn = (message: ServerTransportMessage) => void;
+
+let unsubscribe: (() => void) | null = null;
+
+export function installSessionPrStatusBroadcast(broadcast: BroadcastFn): void {
+  if (unsubscribe) return;
+  unsubscribe = subscribeSessionPrUpdates((update) => {
+    try {
+      broadcast({
+        type: 'session_pr_status_update',
+        sessionId: update.sessionId,
+        prStatus: update.prStatus,
+        prUnsupported: update.prUnsupported,
+        remoteBranchExists: update.remoteBranchExists,
+      });
+    } catch (err) {
+      logger.warn({ err, sessionId: update.sessionId }, 'Failed to broadcast session PR update');
+    }
+  });
+}
+
+export function uninstallSessionPrStatusBroadcast(): void {
+  if (unsubscribe) {
+    unsubscribe();
+    unsubscribe = null;
+  }
+}

--- a/src/lib/github/session-pr-sync.ts
+++ b/src/lib/github/session-pr-sync.ts
@@ -1,0 +1,194 @@
+/**
+ * Session-scoped PR detection for sessions that aren't tied to a kanban task.
+ *
+ * Mirrors the task-pr-sync surface but stores results in an in-memory cache
+ * keyed by sessionId rather than the tasks table — bare sessions don't own
+ * a row that can carry PR state. The cache is recomputed on demand
+ * (refresh-git endpoint, agent turn-end, background poll) and lost on
+ * server restart, which is fine: probes are cheap and the next access
+ * recomputes within ~200ms.
+ */
+
+import * as dbSessions from '@/lib/db/sessions';
+import logger from '@/lib/logger';
+import type { AgentEnvironment } from '@/lib/settings/types';
+import type { TaskPrStatus } from '@/types/task-pr-status';
+import { probeTaskPrStatus, resolveCurrentBranch } from './pr-status-provider';
+
+export interface SessionPrCacheEntry {
+  prStatus?: TaskPrStatus;
+  prUnsupported: boolean;
+  remoteBranchExists?: boolean;
+  lastSyncedAt: number;
+}
+
+export interface SessionPrUpdate {
+  sessionId: string;
+  prStatus?: TaskPrStatus;
+  prUnsupported: boolean;
+  remoteBranchExists?: boolean;
+}
+
+type Listener = (update: SessionPrUpdate) => void;
+
+const GLOBAL_KEY = Symbol.for('tessera.sessionPrSync');
+interface SyncState {
+  cache: Map<string, SessionPrCacheEntry>;
+  listeners: Set<Listener>;
+  inFlight: Map<string, Promise<void>>;
+}
+
+const g = globalThis as unknown as { [GLOBAL_KEY]?: SyncState };
+
+function getState(): SyncState {
+  if (!g[GLOBAL_KEY]) {
+    g[GLOBAL_KEY] = {
+      cache: new Map(),
+      listeners: new Set(),
+      inFlight: new Map(),
+    };
+  }
+  return g[GLOBAL_KEY]!;
+}
+
+export function subscribeSessionPrUpdates(listener: Listener): () => void {
+  const state = getState();
+  state.listeners.add(listener);
+  return () => {
+    state.listeners.delete(listener);
+  };
+}
+
+export function getCachedSessionPr(sessionId: string): SessionPrCacheEntry | undefined {
+  return getState().cache.get(sessionId);
+}
+
+export function clearCachedSessionPr(sessionId: string): void {
+  getState().cache.delete(sessionId);
+}
+
+function notify(update: SessionPrUpdate): void {
+  for (const listener of getState().listeners) {
+    try {
+      listener(update);
+    } catch (err) {
+      logger.warn({ err, sessionId: update.sessionId }, 'Session PR subscriber threw');
+    }
+  }
+}
+
+function prStatusesEqual(a: TaskPrStatus | undefined, b: TaskPrStatus | undefined): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return (
+    a.number === b.number &&
+    a.state === b.state &&
+    a.url === b.url &&
+    (a.mergedAt ?? null) === (b.mergedAt ?? null)
+  );
+}
+
+/**
+ * Probe a single session's PR state. Skips sessions that have a task_id
+ * (those go through syncTaskPr) or no work_dir. Idempotent and coalesced
+ * per sessionId.
+ */
+export function syncSessionPr(
+  sessionId: string,
+  options: { agentEnvironment?: AgentEnvironment } = {},
+): Promise<void> {
+  const state = getState();
+  const existing = state.inFlight.get(sessionId);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      const session = dbSessions.getSession(sessionId);
+      if (!session) return;
+      // Sessions linked to a task go through the task pipeline so the kanban
+      // badge stays the source of truth.
+      if (session.task_id) return;
+      if (!session.work_dir) return;
+
+      const branch = await resolveCurrentBranch(session.work_dir, options.agentEnvironment);
+      if (!branch) {
+        applyAndNotify(sessionId, { prUnsupported: true });
+        return;
+      }
+
+      const probe = await probeTaskPrStatus({
+        workDir: session.work_dir,
+        branch,
+        agentEnvironment: options.agentEnvironment,
+      });
+
+      if (probe.kind === 'unsupported') {
+        applyAndNotify(sessionId, { prUnsupported: true });
+        return;
+      }
+
+      if (probe.kind === 'transient_error') {
+        // Same rule as task sync: leave the previously-known state in place.
+        return;
+      }
+
+      const nextStatus = probe.prStatus ?? undefined;
+      const nextRemote = probe.remoteBranchExists;
+      const previous = state.cache.get(sessionId);
+      const unchanged =
+        previous
+        && previous.prUnsupported === false
+        && previous.remoteBranchExists === nextRemote
+        && prStatusesEqual(previous.prStatus, nextStatus);
+      if (unchanged) return;
+
+      applyAndNotify(sessionId, {
+        prStatus: nextStatus,
+        prUnsupported: false,
+        remoteBranchExists: nextRemote,
+      });
+    } catch (err) {
+      logger.warn({ err, sessionId }, 'Session PR sync failed');
+    } finally {
+      state.inFlight.delete(sessionId);
+    }
+  })();
+
+  state.inFlight.set(sessionId, promise);
+  return promise;
+}
+
+function applyAndNotify(sessionId: string, payload: Omit<SessionPrUpdate, 'sessionId'>): void {
+  const state = getState();
+  state.cache.set(sessionId, {
+    prStatus: payload.prStatus,
+    prUnsupported: payload.prUnsupported,
+    remoteBranchExists: payload.remoteBranchExists,
+    lastSyncedAt: Date.now(),
+  });
+  notify({ sessionId, ...payload });
+}
+
+/**
+ * Sweep every session that has a workdir but no task_id. Used by the
+ * background poller to catch out-of-band PR changes for bare sessions.
+ */
+export async function syncAllEligibleSessionPrs(
+  options: { agentEnvironment?: AgentEnvironment } = {},
+): Promise<void> {
+  const rows = dbSessions.getSessionsEligibleForBareSessionPrSync();
+  const CONCURRENCY = 3;
+  let cursor = 0;
+
+  const worker = async () => {
+    while (cursor < rows.length) {
+      const idx = cursor++;
+      const row = rows[idx];
+      if (!row) break;
+      await syncSessionPr(row.id, options);
+    }
+  };
+
+  const workers = Array.from({ length: Math.min(CONCURRENCY, rows.length) }, () => worker());
+  await Promise.all(workers);
+}

--- a/src/lib/github/session-pr-sync.ts
+++ b/src/lib/github/session-pr-sync.ts
@@ -112,7 +112,7 @@ export function syncSessionPr(
 
       const branch = await resolveCurrentBranch(session.work_dir, options.agentEnvironment);
       if (!branch) {
-        applyAndNotify(sessionId, { prUnsupported: true });
+        markUnsupportedIfChanged(sessionId);
         return;
       }
 
@@ -123,7 +123,7 @@ export function syncSessionPr(
       });
 
       if (probe.kind === 'unsupported') {
-        applyAndNotify(sessionId, { prUnsupported: true });
+        markUnsupportedIfChanged(sessionId);
         return;
       }
 
@@ -167,6 +167,17 @@ function applyAndNotify(sessionId: string, payload: Omit<SessionPrUpdate, 'sessi
     lastSyncedAt: Date.now(),
   });
   notify({ sessionId, ...payload });
+}
+
+function markUnsupportedIfChanged(sessionId: string): void {
+  const previous = getState().cache.get(sessionId);
+  if (previous?.prUnsupported === true) {
+    // Cache already reflects unsupported state — skip broadcast so the
+    // 60s poll doesn't spam clients with no-op messages for non-GitHub
+    // repos, missing branches, or unauthenticated gh.
+    return;
+  }
+  applyAndNotify(sessionId, { prUnsupported: true });
 }
 
 /**

--- a/src/lib/github/task-pr-poller.ts
+++ b/src/lib/github/task-pr-poller.ts
@@ -12,7 +12,18 @@ import { SettingsManager } from '@/lib/settings/manager';
 import type { AgentEnvironment } from '@/lib/settings/types';
 import { syncAllEligibleTaskPrs } from './task-pr-sync';
 
-const POLL_INTERVAL_MS = 600_000; // 10 minutes
+// 60s strikes a balance between staleness and gh-CLI / GitHub-API load.
+// The probe coalesces in-flight requests per task and only writes the DB
+// (+ broadcasts) when something actually changed, so a tighter cadence
+// stays cheap. Overrides via TESSERA_PR_POLL_INTERVAL_MS for testing.
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+const POLL_INTERVAL_MS = (() => {
+  const raw = process.env.TESSERA_PR_POLL_INTERVAL_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed >= 5_000
+    ? parsed
+    : DEFAULT_POLL_INTERVAL_MS;
+})();
 
 class TaskPrPoller {
   private interval: NodeJS.Timeout | null = null;

--- a/src/lib/github/task-pr-poller.ts
+++ b/src/lib/github/task-pr-poller.ts
@@ -11,6 +11,7 @@ import { getElectronAuthUserId } from '@/lib/auth/electron-user';
 import { SettingsManager } from '@/lib/settings/manager';
 import type { AgentEnvironment } from '@/lib/settings/types';
 import { syncAllEligibleTaskPrs } from './task-pr-sync';
+import { syncAllEligibleSessionPrs } from './session-pr-sync';
 
 // 60s strikes a balance between staleness and gh-CLI / GitHub-API load.
 // The probe coalesces in-flight requests per task and only writes the DB
@@ -61,10 +62,12 @@ class TaskPrPoller {
     this.running = true;
     try {
       const startedAt = Date.now();
-      await syncAllEligibleTaskPrs({ agentEnvironment: await resolvePollerAgentEnvironment() });
-      logger.debug({ reason, durationMs: Date.now() - startedAt }, 'Task PR poll complete');
+      const agentEnvironment = await resolvePollerAgentEnvironment();
+      await syncAllEligibleTaskPrs({ agentEnvironment });
+      await syncAllEligibleSessionPrs({ agentEnvironment });
+      logger.debug({ reason, durationMs: Date.now() - startedAt }, 'PR poll complete');
     } catch (err) {
-      logger.error({ err, reason }, 'Task PR poll error');
+      logger.error({ err, reason }, 'PR poll error');
     } finally {
       this.running = false;
     }

--- a/src/lib/github/task-pr-sync.ts
+++ b/src/lib/github/task-pr-sync.ts
@@ -120,6 +120,13 @@ export function syncTaskPr(
         dbTasks.setTaskWorktreeBranch(taskId, probe.resolvedBranch);
       }
 
+      if (probe.kind === 'transient_error') {
+        // Leave the previously-known PR state alone — the next probe will
+        // settle it. Overwriting with null here is what made PR detection
+        // appear to lose tracked PRs intermittently.
+        return;
+      }
+
       const nextStatus = probe.prStatus ?? null;
       const nextRemoteExists = probe.remoteBranchExists;
       const prUnchanged =

--- a/src/lib/session/session-orchestrator.ts
+++ b/src/lib/session/session-orchestrator.ts
@@ -24,6 +24,7 @@ import { getAgentEnvironment } from '../cli/spawn-cli';
 import { createGitRunner } from '../worktrees/git-runner';
 import { isManagedWorktreePath, removeManagedWorktree } from '../worktrees/managed';
 import { syncSingleSessionTaskTitleFromSession } from '../task-title-sync';
+import { clearCachedSessionPr } from '../github/session-pr-sync';
 
 const MAX_SESSIONS = 20;
 
@@ -173,6 +174,7 @@ export class SessionOrchestrator {
       await sessionHistory.deleteSession(sessionId);
 
       dbSessions.deleteSession(sessionId);
+      clearCachedSessionPr(sessionId);
 
       logger.info({ userId, sessionId }, 'Session deleted successfully');
     } catch (err) {

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -14,6 +14,7 @@ import { useGitPanelStore } from '@/stores/git-panel-store';
 import { useNotificationStore } from '@/stores/notification-store';
 import { useRateLimitStore } from '@/stores/rate-limit-store';
 import { useSessionStore } from '@/stores/session-store';
+import { useSessionPrStore } from '@/stores/session-pr-store';
 import { useSkillAnalysisStore } from '@/stores/skill-analysis-store';
 import { useTaskStore } from '@/stores/task-store';
 import { useUsageStore } from '@/stores/usage-store';
@@ -185,6 +186,15 @@ export function handleIncomingServerMessage({
     case 'task_pr_status_update':
       useTaskStore.getState().applyPrStatusUpdate(
         msg.taskId,
+        msg.prStatus,
+        msg.prUnsupported,
+        msg.remoteBranchExists,
+      );
+      return { wasReconnect };
+
+    case 'session_pr_status_update':
+      useSessionPrStore.getState().applyPrStatusUpdate(
+        msg.sessionId,
         msg.prStatus,
         msg.prUnsupported,
         msg.remoteBranchExists,

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -57,6 +57,7 @@ export function handleIncomingServerMessage({
       chatStore.clearSession(msg.sessionId);
       useUsageStore.getState().clearUsage(msg.sessionId);
       useCommandStore.getState().clearSession(msg.sessionId);
+      useSessionPrStore.getState().clearSession(msg.sessionId);
       return { wasReconnect };
 
     case 'session_stopped':

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -326,6 +326,13 @@ export type AppServerMessage =
       remoteBranchExists?: boolean;
     }
   | {
+      type: 'session_pr_status_update';
+      sessionId: string;
+      prStatus?: import('@/types/task-pr-status').TaskPrStatus;
+      prUnsupported: boolean;
+      remoteBranchExists?: boolean;
+    }
+  | {
       type: 'git_panel_state';
       sessionId: string;
       data: import('@/types/git').GitPanelData;

--- a/src/stores/session-pr-store.ts
+++ b/src/stores/session-pr-store.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+import type { TaskPrStatus } from '@/types/task-pr-status';
+
+export interface SessionPrCacheEntry {
+  prStatus?: TaskPrStatus;
+  prUnsupported: boolean;
+  remoteBranchExists?: boolean;
+}
+
+interface SessionPrState {
+  prBySessionId: Record<string, SessionPrCacheEntry>;
+  applyPrStatusUpdate: (
+    sessionId: string,
+    prStatus: TaskPrStatus | undefined,
+    prUnsupported: boolean,
+    remoteBranchExists: boolean | undefined,
+  ) => void;
+}
+
+export const useSessionPrStore = create<SessionPrState>((set) => ({
+  prBySessionId: {},
+  applyPrStatusUpdate: (sessionId, prStatus, prUnsupported, remoteBranchExists) => {
+    set((state) => ({
+      prBySessionId: {
+        ...state.prBySessionId,
+        [sessionId]: { prStatus, prUnsupported, remoteBranchExists },
+      },
+    }));
+  },
+}));

--- a/src/stores/session-pr-store.ts
+++ b/src/stores/session-pr-store.ts
@@ -15,6 +15,7 @@ interface SessionPrState {
     prUnsupported: boolean,
     remoteBranchExists: boolean | undefined,
   ) => void;
+  clearSession: (sessionId: string) => void;
 }
 
 export const useSessionPrStore = create<SessionPrState>((set) => ({
@@ -26,5 +27,12 @@ export const useSessionPrStore = create<SessionPrState>((set) => ({
         [sessionId]: { prStatus, prUnsupported, remoteBranchExists },
       },
     }));
+  },
+  clearSession: (sessionId) => {
+    set((state) => {
+      if (!(sessionId in state.prBySessionId)) return state;
+      const { [sessionId]: _removed, ...rest } = state.prBySessionId;
+      return { prBySessionId: rest };
+    });
   },
 }));


### PR DESCRIPTION
Closes #15.

This PR fixes the flaky PR detection / greyed-out controls reported in #15, and along the way fills two adjacent gaps that surfaced during testing.

## What changed

### 1. Transient `gh` failures no longer overwrite known PR state
`probeTaskPrStatus` previously returned `{ kind: 'ok', prStatus: null }` whenever `gh pr list` failed for a non-auth reason (network blip, rate-limit, subprocess hiccup). Downstream `syncTaskPr` then wrote `null` to the task row and broadcast "PR gone". Next sweep would re-discover the PR — but in the meantime the panel showed no PR linkage and the controls were disabled. 
The probe now returns a distinct `kind: 'transient_error'`. `syncTaskPr` and `syncSessionPr` skip the DB / cache write entirely on that branch, leaving the previously-known state in place until the next successful probe.

### 2. PR detection works for bare sessions (sessions with no kanban task)
The Git panel renders for any session with a workdir, but PR storage was attached to the `tasks` table — so a bare session showed "no PR" indefinitely with no path to discovery. The probe itself never needed a task; the storage did.

Added a parallel session-scoped pipeline:
- New `src/lib/github/session-pr-sync.ts` — same probe, in-memory cache keyed by sessionId, coalesced per session, with subscribe/notify mirroring the task-pr surface. State is rebuilt on next access after restart.
- New `src/lib/github/session-pr-broadcast.ts` — relays updates to all WS clients via a new `session_pr_status_update` message type.
- New `src/stores/session-pr-store.ts` — client-side cache.
- `getGitPanelData` now reads from the session cache as a fallback when there's no task; the existing `resolveGitHubPanelState` was generalized to accept a `prSummary` shape from either source.
- `session-diff-refresh` routes bare sessions through `syncSessionPr` at agent turn-end (and at any other refresh trigger).
- `use-git-panel-controller` merges the session-store fallback into `panelData` alongside the task fallback.

### 3. Electron's server-child was missing the PR broadcast + poller
`server.ts` (the standalone dev / CLI entrypoint) installed `installTaskPrStatusBroadcast` and started `taskPrPoller` at startup — but `electron/server-child.ts` didn't. So in Electron mode `syncTaskPr`'s `notify()` callbacks had nobody listening, and the background sweep never ran. PR detection was relying entirely on direct REST reads after a successful sync. Both wirings are now installed in the Electron lifecycle (and torn down on shutdown).

### 4. Faster background poll + on-focus refresh
- Default poll interval dropped from 600s to 60s (`TESSERA_PR_POLL_INTERVAL_MS` env override available, min 5s). The poll now sweeps both eligible tasks and eligible bare sessions; each `syncSessionPr` call coalesces in-flight probes and only writes / broadcasts on actual change, so the tighter cadence stays cheap.
- New `POST /api/sessions/:id/refresh-git` runs the same refresh pipeline as agent turn-end. The git-panel hook fires it whenever the renderer regains visibility/focus, so work done outside Tessera (CLI in another terminal, `gh pr create` from VS Code, etc.) is picked up within ~1s of refocusing.

## Files touched

```
electron/server-child.ts                       — install task+session broadcasts, start poller
server.ts                                      — install session broadcast alongside task
src/app/api/sessions/[id]/refresh-git/route.ts — NEW: on-demand refresh endpoint
src/components/git/use-git-panel-controller.ts — visibility refresh, session PR fallback
src/lib/db/sessions.ts                         — getSessionsEligibleForBareSessionPrSync
src/lib/git/git-panel.ts                       — session PR fallback in panel data
src/lib/git/session-diff-refresh.ts            — route bare sessions through syncSessionPr
src/lib/github/pr-status-provider.ts           — transient_error kind, resolveCurrentBranch
src/lib/github/session-pr-broadcast.ts         — NEW: WS relay for session PR updates
src/lib/github/session-pr-sync.ts              — NEW: session-scoped PR sync + cache
src/lib/github/task-pr-poller.ts               — 60s default + sweep bare sessions
src/lib/github/task-pr-sync.ts                 — skip DB write on transient_error
src/lib/ws/client-message-handlers.ts          — handle session_pr_status_update
src/lib/ws/message-types.ts                    — new WS message variant
src/stores/session-pr-store.ts                 — NEW: client-side session PR cache
```

## Test plan

Verified end-to-end in a packaged Electron build:

- [x] Bare session, push + `gh pr create` from external terminal → PR badge and Merge PR button appear within ~1s of refocusing Tessera.
- [x] Same flow without focusing Tessera → PR appears within 60s via the poller.
- [x] Closing the PR externally → Tessera flips from open to closed within the same windows.
- [x] Existing task-bound PR detection continues to work (now strictly better in Electron mode since the broadcast and poller are actually running).
- [x] Transient `gh` failures no longer cause known PRs to vanish mid-session (verified by inspection — hard to repro on demand).