### PR TITLE
fix(popout-board): followups for the merged popout board feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ aidlc-docs/
 .tmp/
 
 .env.local
+build-win.log

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -750,6 +750,39 @@ ipcMain.on('popout-open-session', (_event, payload: unknown) => {
     action: resolvedAction,
   });
 });
+
+// Active session / selected project sync between main and popouts.
+// Sent by any window when its local UI state changes; the main process
+// re-broadcasts to every OTHER window so the popout's kanban can highlight
+// the active card and selected project stays mirrored.
+ipcMain.on('ui-active-session-changed', (event, payload: unknown) => {
+  if (!payload || typeof payload !== 'object') return;
+  const { sessionId } = payload as { sessionId?: unknown };
+  if (sessionId !== null && typeof sessionId !== 'string') return;
+  const senderId = event.sender.id;
+  const targets: BrowserWindow[] = [];
+  if (mainWindow && !mainWindow.isDestroyed()) targets.push(mainWindow);
+  for (const win of popoutWindows) targets.push(win);
+  for (const win of targets) {
+    if (win.isDestroyed()) continue;
+    if (win.webContents.id === senderId) continue;
+    win.webContents.send('ui-active-session-changed', { sessionId });
+  }
+});
+ipcMain.on('ui-selected-project-changed', (event, payload: unknown) => {
+  if (!payload || typeof payload !== 'object') return;
+  const { projectDir } = payload as { projectDir?: unknown };
+  if (projectDir !== null && typeof projectDir !== 'string') return;
+  const senderId = event.sender.id;
+  const targets: BrowserWindow[] = [];
+  if (mainWindow && !mainWindow.isDestroyed()) targets.push(mainWindow);
+  for (const win of popoutWindows) targets.push(win);
+  for (const win of targets) {
+    if (win.isDestroyed()) continue;
+    if (win.webContents.id === senderId) continue;
+    win.webContents.send('ui-selected-project-changed', { projectDir });
+  }
+});
 ipcMain.on(
   'window-close-response',
   (

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -59,6 +59,38 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.removeListener('popout-open-session', listener);
     };
   },
+  uiActiveSessionChanged: (sessionId: string | null) =>
+    ipcRenderer.send('ui-active-session-changed', { sessionId }),
+  onUiActiveSessionChanged: (callback: (sessionId: string | null) => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: { sessionId?: string | null }
+    ) => {
+      const value = payload?.sessionId;
+      if (value !== null && typeof value !== 'string') return;
+      callback(value ?? null);
+    };
+    ipcRenderer.on('ui-active-session-changed', listener);
+    return () => {
+      ipcRenderer.removeListener('ui-active-session-changed', listener);
+    };
+  },
+  uiSelectedProjectChanged: (projectDir: string | null) =>
+    ipcRenderer.send('ui-selected-project-changed', { projectDir }),
+  onUiSelectedProjectChanged: (callback: (projectDir: string | null) => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: { projectDir?: string | null }
+    ) => {
+      const value = payload?.projectDir;
+      if (value !== null && typeof value !== 'string') return;
+      callback(value ?? null);
+    };
+    ipcRenderer.on('ui-selected-project-changed', listener);
+    return () => {
+      ipcRenderer.removeListener('ui-selected-project-changed', listener);
+    };
+  },
   onTitlebarMenuCommand: (callback: (command: string) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: { command?: string }) => {
       if (typeof payload?.command === 'string') {

--- a/src/app/api/archive/tasks/[id]/route.ts
+++ b/src/app/api/archive/tasks/[id]/route.ts
@@ -6,7 +6,13 @@ import {
   setTaskArchived,
 } from '@/lib/archive/archive-service';
 import { SettingsManager } from '@/lib/settings/manager';
+import * as dbTasks from '@/lib/db/tasks';
 import logger from '@/lib/logger';
+import {
+  broadcastSessionMutation,
+  broadcastTaskMutation,
+  getOriginClientIdFromRequest,
+} from '@/lib/ws/mutation-broadcast';
 
 export async function PATCH(
   req: NextRequest,
@@ -33,12 +39,19 @@ export async function PATCH(
   }
 
   try {
+    const projectId = dbTasks.getTask(id)?.projectId;
     await setTaskArchived(id, archived);
     if (archived) {
       const settings = await SettingsManager.load(auth.userId);
       if (settings.autoDeleteArchivedWorktrees) {
         await pruneExpiredArchivedWorktrees(settings.archivedWorktreeRetentionDays, auth.userId);
       }
+    }
+    if (projectId) {
+      const originClientId = getOriginClientIdFromRequest(req);
+      broadcastTaskMutation(auth.userId, { kind: 'updated', projectId, originClientId });
+      // Sessions linked to this task carry archived/isReadOnly state too.
+      broadcastSessionMutation(auth.userId, { kind: 'updated', projectId, originClientId });
     }
     return NextResponse.json({ ok: true });
   } catch (error) {
@@ -61,7 +74,13 @@ export async function DELETE(
   }
 
   try {
+    const projectId = dbTasks.getTask(id)?.projectId;
     await permanentlyDeleteArchivedTask(auth.userId, id);
+    if (projectId) {
+      const originClientId = getOriginClientIdFromRequest(req);
+      broadcastTaskMutation(auth.userId, { kind: 'deleted', projectId, originClientId });
+      broadcastSessionMutation(auth.userId, { kind: 'updated', projectId, originClientId });
+    }
     return NextResponse.json({ ok: true });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to delete archived task';

--- a/src/components/archive/archive-dashboard.tsx
+++ b/src/components/archive/archive-dashboard.tsx
@@ -17,6 +17,7 @@ import { useSessionClickHandlers } from '@/hooks/use-session-click-handlers';
 import { useWorktreeRetentionSettingsUpdate } from '@/hooks/use-worktree-retention-settings-update';
 import { useSessionStore } from '@/stores/session-store';
 import { useTaskStore } from '@/stores/task-store';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 import type { UnifiedSession } from '@/types/chat';
 import type { ArchiveItem, ArchiveProjectOption } from '@/lib/archive/archive-service';
 
@@ -251,7 +252,7 @@ export function ArchiveDashboard() {
     const endpoint = item.kind === 'task'
       ? `/api/archive/tasks/${item.id}`
       : `/api/sessions/${item.id}/archive`;
-    const res = await fetch(endpoint, {
+    const res = await fetchWithClientId(endpoint, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ archived: false }),
@@ -274,7 +275,7 @@ export function ArchiveDashboard() {
     const endpoint = item.kind === 'task'
       ? `/api/archive/tasks/${item.id}`
       : `/api/sessions/${item.id}`;
-    const res = await fetch(endpoint, { method: 'DELETE' });
+    const res = await fetchWithClientId(endpoint, { method: 'DELETE' });
     if (!res.ok) {
       const body = await res.json().catch(() => ({})) as { error?: string };
       const message = body.error ?? t('archive.errors.deleteFailed');

--- a/src/components/board/board-popout-layout.tsx
+++ b/src/components/board/board-popout-layout.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import { useSessionStore } from '@/stores/session-store';
 import { useBoardStore } from '@/stores/board-store';
 import { useWebSocket } from '@/hooks/use-websocket';
+import { useCrossWindowUiSync } from '@/hooks/use-cross-window-ui-sync';
 import { useElectronPlatform } from '@/hooks/use-electron-platform';
 import { ProjectStrip } from '@/components/chat/project-strip';
 import { ElectronTitlebarThemeSync } from '@/components/layout/electron-titlebar';
@@ -57,6 +58,7 @@ export function BoardPopoutLayout() {
   }
 
   useWebSocket();
+  useCrossWindowUiSync();
 
   useEffect(() => {
     (window as Window & { __TESSERA_POPOUT__?: boolean }).__TESSERA_POPOUT__ = true;

--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -5,6 +5,7 @@ import type React from 'react';
 import { FolderGit2, MessageSquare, Plus, Tag, TriangleAlert } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
+import { getTitleGeneratingStyle } from '@/lib/title-generating-style';
 import { setKanbanTaskDragData, setPanelSessionDragData } from '@/lib/dnd/panel-session-drag';
 import { useArchiveConfirm } from '@/hooks/use-archive-confirm';
 import { useCollectionStore } from '@/stores/collection-store';
@@ -324,6 +325,7 @@ export const KanbanChatCard = memo(function KanbanChatCard({
                     : cn('font-medium', session.hasCustomTitle && 'title-fade-in'),
                   'text-(--text-primary)',
                 )}
+                style={isGeneratingTitle ? getTitleGeneratingStyle(session.id) : undefined}
                 data-testid="kanban-card-title"
               >
                 {isGeneratingTitle ? 'Generating title...' : session.title}
@@ -883,6 +885,11 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                   (isGeneratingTitle || isPending) && 'title-generating',
                   'text-(--text-primary)',
                 )}
+                style={
+                  isGeneratingTitle || isPending
+                    ? getTitleGeneratingStyle(task.id)
+                    : undefined
+                }
               >
                 {task.title}
               </div>
@@ -1186,7 +1193,10 @@ function KanbanSubSessionItem({
             testId="kanban-sub-session-title-input"
           />
         ) : (
-          <span className={cn('flex-1 min-w-0 truncate', isGeneratingTitle && 'title-generating')}>
+          <span
+            className={cn('flex-1 min-w-0 truncate', isGeneratingTitle && 'title-generating')}
+            style={isGeneratingTitle ? getTitleGeneratingStyle(session.id) : undefined}
+          >
             {isGeneratingTitle ? 'Generating title...' : displayTitle}
           </span>
         )}

--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -45,13 +45,22 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
   const historyLoaded = useChatStore((state) =>
     state.isHistoryLoaded(sessionId),
   );
-  const autoLoadedRef = useRef(false);
+  // Track the last session this ChatArea instance auto-loaded for. Without
+  // this per-session reset, switching panels to a session that was never
+  // explicitly viewSession'd (e.g. opening a card forwarded from a popout
+  // window — see chat-layout's onPopoutOpenSession listener) leaves the
+  // panel stuck on ChatAreaSkeleton because the boolean ref short-circuits
+  // the autoLoad after the first session.
+  const autoLoadedSessionIdRef = useRef<string | null>(null);
   useEffect(() => {
-    if (autoLoadedRef.current) return;
-    if (session && !historyLoaded) {
-      autoLoadedRef.current = true;
-      viewSession(session);
+    if (!session) return;
+    if (autoLoadedSessionIdRef.current === session.id) return;
+    if (historyLoaded) {
+      autoLoadedSessionIdRef.current = session.id;
+      return;
     }
+    autoLoadedSessionIdRef.current = session.id;
+    void viewSession(session);
   }, [session, historyLoaded, viewSession]);
 
   if (!sessionId) {

--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/stores/settings-store";
 import { useBoardStore } from "@/stores/board-store";
 import { useWebSocket } from "@/hooks/use-websocket";
+import { useCrossWindowUiSync } from "@/hooks/use-cross-window-ui-sync";
 import { useResize } from "@/hooks/use-resize";
 import { useCallback, useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
@@ -121,6 +122,7 @@ export function ChatLayout() {
   const gitPanelWidth = useGitStore((state) => state.panelWidth);
   const setGitPanelWidth = useGitStore((state) => state.setPanelWidth);
   useWebSocket(); // Initialize WebSocket connection
+  useCrossWindowUiSync(); // Mirror activeSessionId / selectedProjectDir to popouts
 
   // BR-PERSIST-001: persistLayout debounce ref (200ms)
   const persistDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -52,6 +52,7 @@ import { CollectionMoveSubmenu } from './collection-move-submenu';
 import { DiffStatsBadge } from './diff-stats-badge';
 import { ProviderQuickMenu } from './provider-quick-menu';
 import { detectPrMismatch, prMismatchTooltip } from './task-pr-badge';
+import { getTitleGeneratingStyle } from '@/lib/title-generating-style';
 
 type CollectionItemType = 'chat' | 'task';
 type ItemContextMenuHandler = (
@@ -905,7 +906,11 @@ export function TaskItemRow({
                 'block truncate text-[0.8125rem] font-medium leading-snug text-(--sidebar-text-active)',
                 (isGeneratingTitle || isPending) && 'title-generating'
               )}
-              style={titleFadeStyle}
+              style={
+                isGeneratingTitle || isPending
+                  ? { ...titleFadeStyle, ...getTitleGeneratingStyle(task.id) }
+                  : titleFadeStyle
+              }
             >
               {task.title}
             </span>
@@ -1213,7 +1218,11 @@ export function ChatItemRow({
                 'block truncate text-[0.8125rem] font-medium leading-snug text-(--sidebar-text-active)',
                 isGeneratingTitle && 'title-generating'
               )}
-              style={titleFadeStyle}
+              style={
+                isGeneratingTitle
+                  ? { ...titleFadeStyle, ...getTitleGeneratingStyle(session.id) }
+                  : titleFadeStyle
+              }
             >
               {session.title}
             </span>

--- a/src/components/chat/header.tsx
+++ b/src/components/chat/header.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, useContext } from 'react';
 import { Pencil, Check, Hash, X as XIcon, MoreHorizontal, GitBranch } from 'lucide-react';
+import { getTitleGeneratingStyle } from '@/lib/title-generating-style';
 import { useSessionStore } from '@/stores/session-store';
 import { useTaskStore } from '@/stores/task-store';
 import { usePanelStore, selectActiveTab, EMPTY_PANELS, TabIdContext } from '@/stores/panel-store';
@@ -269,6 +270,7 @@ export function Header({ sessionId, panelId, isSinglePanel = false }: HeaderProp
                     'truncate text-[15px] font-semibold leading-none text-(--text-primary)',
                     isGeneratingTitle && 'title-generating'
                   )}
+                  style={isGeneratingTitle ? getTitleGeneratingStyle(session.id) : undefined}
                 >
                   {session.title}
                 </h2>

--- a/src/components/chat/project-strip.tsx
+++ b/src/components/chat/project-strip.tsx
@@ -11,6 +11,7 @@ import { useTabStore } from '@/stores/tab-store';
 import { ALL_PROJECTS_SENTINEL, getProjectColor } from '@/lib/constants/project-strip';
 import { ARCHIVE_DASHBOARD_SESSION_ID, SKILLS_DASHBOARD_SESSION_ID } from '@/lib/constants/special-sessions';
 import { useProjectStripDnd } from '@/hooks/use-project-strip-dnd';
+import { usePopoutActive } from '@/hooks/use-popout-active';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tooltip } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
@@ -43,6 +44,9 @@ export function ProjectStrip({
   const electronPlatform = useElectronPlatform();
   const isElectron = electronPlatform !== null;
   const isMacElectron = electronPlatform === 'darwin';
+  // The popout window only renders one project at a time, so the All
+  // Projects sentinel doesn't make sense while it's open.
+  const { isActive: isPopoutActive } = usePopoutActive();
 
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; encodedDir: string; displayName: string } | null>(null);
@@ -123,18 +127,31 @@ export function ProjectStrip({
       )}
 
       {/* All Projects button */}
-      <Tooltip content={t('projectStrip.allProjects')} delay={300}>
+      <Tooltip
+        content={
+          isPopoutActive
+            ? t('projectStrip.allProjectsDisabledPopout')
+            : t('projectStrip.allProjects')
+        }
+        delay={300}
+      >
         <button
-          onClick={() => handleProjectSelect(ALL_PROJECTS_SENTINEL)}
+          onClick={() => {
+            if (isPopoutActive) return;
+            handleProjectSelect(ALL_PROJECTS_SENTINEL);
+          }}
+          disabled={isPopoutActive}
+          aria-disabled={isPopoutActive}
           className={cn(
             'relative w-11 h-11 flex items-center justify-center shrink-0 transition-colors',
             isAllMode
               ? 'text-(--accent)'
-              : 'text-(--text-muted) hover:text-(--sidebar-text-active)'
+              : 'text-(--text-muted) hover:text-(--sidebar-text-active)',
+            isPopoutActive && 'opacity-40 cursor-not-allowed hover:text-(--text-muted)',
           )}
           data-testid="project-strip-all"
         >
-          {isAllMode && (
+          {isAllMode && !isPopoutActive && (
             <div className="absolute left-0 top-2 bottom-2 w-0.5 rounded-r bg-(--accent)" />
           )}
           <Home className="w-5 h-5" />

--- a/src/hooks/use-cross-window-ui-sync.ts
+++ b/src/hooks/use-cross-window-ui-sync.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useSessionStore } from '@/stores/session-store';
+import { useBoardStore } from '@/stores/board-store';
+
+interface ElectronUiSyncApi {
+  isElectron?: boolean;
+  uiActiveSessionChanged?: (sessionId: string | null) => void;
+  onUiActiveSessionChanged?: (cb: (sessionId: string | null) => void) => (() => void) | void;
+  uiSelectedProjectChanged?: (projectDir: string | null) => void;
+  onUiSelectedProjectChanged?: (cb: (projectDir: string | null) => void) => (() => void) | void;
+}
+
+function getApi(): ElectronUiSyncApi | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return (window as Window & { electronAPI?: ElectronUiSyncApi }).electronAPI;
+}
+
+/**
+ * Mirror activeSessionId and selectedProjectDir between the main window and
+ * any open popout boards. Bidirectional: any window's local UI change
+ * broadcasts via IPC; the main process re-broadcasts to every other window
+ * (see electron/main.ts handlers). A short-lived ref suppresses the
+ * outbound echo when applying an inbound change so the windows don't
+ * trade messages forever.
+ */
+export function useCrossWindowUiSync(): void {
+  const suppressedSessionRef = useRef<string | null | undefined>(undefined);
+  const suppressedProjectRef = useRef<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    const api = getApi();
+    if (!api?.isElectron) return;
+
+    let prevSession = useSessionStore.getState().activeSessionId;
+    let prevProject = useBoardStore.getState().selectedProjectDir;
+
+    const unsubSession = useSessionStore.subscribe((state) => {
+      const next = state.activeSessionId;
+      if (next === prevSession) return;
+      prevSession = next;
+      if (suppressedSessionRef.current === next) {
+        suppressedSessionRef.current = undefined;
+        return;
+      }
+      api.uiActiveSessionChanged?.(next);
+    });
+
+    const unsubProject = useBoardStore.subscribe((state) => {
+      const next = state.selectedProjectDir;
+      if (next === prevProject) return;
+      prevProject = next;
+      if (suppressedProjectRef.current === next) {
+        suppressedProjectRef.current = undefined;
+        return;
+      }
+      api.uiSelectedProjectChanged?.(next);
+    });
+
+    return () => {
+      unsubSession();
+      unsubProject();
+    };
+  }, []);
+
+  useEffect(() => {
+    const api = getApi();
+    if (!api?.isElectron) return;
+
+    const offSession = api.onUiActiveSessionChanged?.((sessionId) => {
+      const current = useSessionStore.getState().activeSessionId;
+      if (current === sessionId) return;
+      suppressedSessionRef.current = sessionId;
+      useSessionStore.getState().setActiveSession(sessionId);
+    });
+
+    const offProject = api.onUiSelectedProjectChanged?.((projectDir) => {
+      const current = useBoardStore.getState().selectedProjectDir;
+      if (current === projectDir) return;
+      suppressedProjectRef.current = projectDir;
+      useBoardStore.getState().setSelectedProjectDir(projectDir);
+    });
+
+    return () => {
+      if (typeof offSession === 'function') offSession();
+      if (typeof offProject === 'function') offProject();
+    };
+  }, []);
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -706,6 +706,7 @@ export const en: I18nMessages = {
   },
   projectStrip: {
     allProjects: 'All Projects',
+    allProjectsDisabledPopout: 'All Projects is unavailable while the board pop-out is open',
     addProject: 'Add Project',
   },
   gitPanel: {

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -706,6 +706,7 @@ export const ja: I18nMessages = {
   },
   projectStrip: {
     allProjects: 'すべてのプロジェクト',
+    allProjectsDisabledPopout: 'ボードのポップアウトが開いている間は、すべてのプロジェクトを利用できません',
     addProject: 'プロジェクトを追加',
   },
   gitPanel: {

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -713,6 +713,7 @@ export const ko: I18nMessages = {
   },
   projectStrip: {
     allProjects: '전체 프로젝트',
+    allProjectsDisabledPopout: '보드 팝아웃이 열려 있는 동안에는 전체 프로젝트를 사용할 수 없습니다',
     addProject: '프로젝트 추가',
   },
   gitPanel: {

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -711,6 +711,7 @@ export interface I18nMessages {
   };
   projectStrip: {
     allProjects: string;
+    allProjectsDisabledPopout: string;
     addProject: string;
   };
   gitPanel: {

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -706,6 +706,7 @@ export const zh: I18nMessages = {
   },
   projectStrip: {
     allProjects: '所有项目',
+    allProjectsDisabledPopout: '板视图弹出窗口打开时，"所有项目"不可用',
     addProject: '添加项目',
   },
   gitPanel: {

--- a/src/lib/title-generating-style.ts
+++ b/src/lib/title-generating-style.ts
@@ -1,0 +1,25 @@
+import type { CSSProperties } from 'react';
+
+/**
+ * Both the list view and the kanban view render the title-shimmer animation
+ * (`.title-generating` in globals.css) on a session whose AI title is being
+ * generated. CSS animations are normally local to each element, so when one
+ * view re-mounts mid-generation (virtualized list, sort change, popout sync)
+ * its animation restarts at phase 0 while the other keeps going — they drift
+ * out of sync visually.
+ *
+ * Pinning the animation phase to a deterministic offset derived from the
+ * session id makes both views show the same phase for the same session,
+ * regardless of when each element entered the DOM.
+ *
+ * Animation duration is 1.2s — keep this constant in sync with globals.css.
+ */
+const TITLE_SHIMMER_DURATION_MS = 1200;
+
+export function getTitleGeneratingStyle(sessionId: string): CSSProperties {
+  let hash = 0;
+  for (let i = 0; i < sessionId.length; i++) {
+    hash = (hash * 31 + sessionId.charCodeAt(i)) >>> 0;
+  }
+  return { animationDelay: `-${hash % TITLE_SHIMMER_DURATION_MS}ms` };
+}

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -485,7 +485,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     }));
 
     try {
-      const res = await fetch(`/api/archive/tasks/${id}`, {
+      const res = await fetchWithClientId(`/api/archive/tasks/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ archived }),


### PR DESCRIPTION
Followups on the popout board feature, from the review notes on the merged PR.

## What changed

### Major

1. **Active session is now highlighted in the popout's kanban.** The popout had its own session-store with `activeSessionId: null` and never received the main window's selection (clicks were forwarded one-way). Added a `useCrossWindowUiSync` hook + two IPC channels (`ui-active-session-changed`, `ui-selected-project-changed`) that the main process re-emits to every other window, so each window mirrors the others' UI state. Echo-loop suppressed via short-lived ref so the windows don't trade messages forever.

2. **New session created in the popout's kanban no longer hangs on a loading spinner when opened.** From the list view, click handlers explicitly call `viewSession` which fetches history. From the popout-forwarded path, the listener only set the active session and relied on `ChatArea`'s autoLoad — but the boolean `autoLoadedRef` had already fired for an earlier session in the same panel, so history never loaded. Replaced the boolean ref with a per-session-id ref so each new session gets its own chance to autoLoad.

3. **Project selection now syncs between windows.** Selecting a project in either the main window or a popout broadcasts via IPC (same channel as #1) and the other windows follow. Same loop-suppression mechanism.

4. **"All Projects" button is disabled while a popout is open.** It doesn't make sense to be in all-projects mode when the popout only renders one project at a time. Both windows now grey out the button with a tooltip explaining why. i18n strings added in en/ja/ko/zh.

### Minor

5. **AI title-generation shimmer is now phase-locked across views.** New `getTitleGeneratingStyle(sessionId)` helper returns a deterministic negative `animation-delay` derived from the session id. Applied at every place the `title-generating` class is rendered (kanban card, list view sections, chat header). Even when one view re-mounts mid-generation, both views show the same animation phase.

### Bonus fix found while testing

6. **Task archiving now broadcasts cross-window like other mutations do.** The `/api/sessions/:id/archive` route was already wired correctly; `/api/archive/tasks/:id` PATCH and DELETE were not, so archiving a task in one window never reached the popout's kanban or the list view in the other window. Server now emits `task_mutated` plus `session_mutated` (for linked child sessions); client paths in `task-store.toggleTaskArchive` and `archive-dashboard` switched to `fetchWithClientId` so the originator is identifiable in the broadcast.

## Files touched

```
electron/main.ts                              — new IPC channels, re-broadcast to other windows
electron/preload.ts                           — expose ui-* IPC to renderer
src/app/api/archive/tasks/[id]/route.ts       — broadcast on archive PATCH + permanent DELETE
src/components/archive/archive-dashboard.tsx  — fetchWithClientId for restore + delete
src/components/board/board-popout-layout.tsx  — useCrossWindowUiSync
src/components/board/kanban-card.tsx          — title-generating phase lock
src/components/chat/chat-area.tsx             — per-session autoLoad
src/components/chat/chat-layout.tsx           — useCrossWindowUiSync
src/components/chat/collection-group-sections.tsx — title-generating phase lock
src/components/chat/header.tsx                — title-generating phase lock
src/components/chat/project-strip.tsx         — All Projects disable when popout active
src/hooks/use-cross-window-ui-sync.ts         — NEW: bidirectional IPC sync hook
src/lib/i18n/en.ts                            — projectStrip.allProjectsDisabledPopout
src/lib/i18n/ja.ts                            — projectStrip.allProjectsDisabledPopout
src/lib/i18n/ko.ts                            — projectStrip.allProjectsDisabledPopout
src/lib/i18n/types.ts                         — projectStrip.allProjectsDisabledPopout
src/lib/i18n/zh.ts                            — projectStrip.allProjectsDisabledPopout
src/lib/title-generating-style.ts             — NEW: deterministic animation-delay helper
src/stores/task-store.ts                      — fetchWithClientId for archive
```

## Test plan

Verified end-to-end in a packaged Electron build:

- [x] Open the popout, click a card in either window — the active card highlights in both.
- [x] Create a new chat session in the popout's kanban, click it — chat area loads (no infinite spinner).
- [x] Switch projects in either window — the other window follows immediately.
- [x] Open the popout — All Projects button greys out in both windows with explanatory tooltip; close the popout, button re-enables.
- [x] Trigger AI title generation on a session visible in both list view and kanban view simultaneously — shimmer is in lockstep across both.
- [x] Archive a task in one window — the other window's kanban and list view both reflect the change immediately.
- [x] Restore / permanently delete a task from the archive dashboard — both windows update.
