### PR TITLE
Refresh Git panel changes and add fetch action

### DIFF
--- a/src/app/api/sessions/[id]/git/fetch/route.ts
+++ b/src/app/api/sessions/[id]/git/fetch/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuthenticatedUserId } from "@/lib/auth/api-auth";
+import { fetchGitPanelData, GitPanelError } from "@/lib/git/git-panel";
+import { jsonError } from "@/lib/http/json-error";
+import logger from "@/lib/logger";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  try {
+    const auth = await requireAuthenticatedUserId(request, {
+      error: { code: "unauthorized", message: "Unauthorized" },
+    });
+    if ("response" in auth) return auth.response;
+
+    const payload = await fetchGitPanelData(id, auth.userId);
+    return NextResponse.json(payload);
+  } catch (error) {
+    if (error instanceof GitPanelError) {
+      return jsonError(error.code, error.message, error.status);
+    }
+
+    logger.error({ error, sessionId: id }, "Failed to fetch git panel data");
+    return jsonError("internal_error", "Failed to fetch git panel data", 500);
+  }
+}

--- a/src/components/git/git-panel-sections.tsx
+++ b/src/components/git/git-panel-sections.tsx
@@ -18,6 +18,7 @@ import {
   GitMerge,
   GitPullRequest,
   LoaderCircle,
+  RefreshCw,
   RotateCcw,
   X,
 } from "lucide-react";
@@ -743,8 +744,10 @@ export function GitPanelFooterSection({
   mergePrPromptDraft,
   mergePrPromptPreview,
   mergeSource,
+  fetching,
   onActionInputChange,
   onCreatePr,
+  onFetch,
   onMerge,
   onMergePr,
   onMergePrPromptChange,
@@ -767,10 +770,12 @@ export function GitPanelFooterSection({
   mergePrPromptDraft: string;
   mergePrPromptPreview: string;
   mergeSource: string;
+  fetching: boolean;
   onActionInputChange: (value: string) => void;
   onCloseAction: () => void;
   onCommit: () => void;
   onCreatePr: () => void;
+  onFetch: () => void;
   onMerge: () => void;
   onMergePr: () => void;
   onMergePrPromptChange: (value: string) => void;
@@ -796,6 +801,7 @@ export function GitPanelFooterSection({
     createPrDisabled,
     mergePrDisabled,
   } = computeGitFooterButtonStates(data, isSessionBusy, activeAction);
+  const fetchDisabled = isSessionBusy || activeAction !== null || fetching;
 
   return (
     <div className="border-t border-(--chat-header-border) px-3 py-3 space-y-2">
@@ -961,6 +967,17 @@ export function GitPanelFooterSection({
             aria-label="Push"
           >
             <ArrowUp className="h-4 w-4" />
+          </Button>
+        </Tooltip>
+        <Tooltip content="Fetch" side="top">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={onFetch}
+            disabled={fetchDisabled}
+            aria-label="Fetch"
+          >
+            <RefreshCw className={cn("h-4 w-4", fetching && "animate-spin")} />
           </Button>
         </Tooltip>
         {showMergePr ? (

--- a/src/components/git/git-panel.tsx
+++ b/src/components/git/git-panel.tsx
@@ -160,6 +160,7 @@ export function GitPanel({
               onSetMergeSource={controller.setMergeSource}
               onSetPrBaseBranch={controller.setPrBaseBranch}
               onCommit={controller.handleCommit}
+              onFetch={controller.handleFetch}
               onMerge={controller.handleMerge}
               onCreatePr={controller.handleCreatePr}
               onMergePr={controller.handleMergePr}
@@ -170,6 +171,7 @@ export function GitPanel({
               onPush={controller.handlePush}
               onPull={controller.handlePull}
               onOpenExternal={controller.openExternal}
+              fetching={controller.fetching}
             />
           ) : null}
         </>

--- a/src/components/git/use-git-panel-controller.ts
+++ b/src/components/git/use-git-panel-controller.ts
@@ -35,6 +35,7 @@ interface GitPanelSessionCacheEntry {
 }
 
 const PANEL_CACHE_LIMIT = 20;
+const GIT_PANEL_POLL_INTERVAL_MS = 5000;
 const gitPanelSessionCache = new Map<string, GitPanelSessionCacheEntry>();
 
 async function writeClipboardText(value: string | null | undefined) {
@@ -92,6 +93,7 @@ export function useGitPanelController(sessionId: string | null) {
   );
   const [diffLoading, setDiffLoading] = useState(false);
   const [diffError, setDiffError] = useState<string | null>(null);
+  const [fetching, setFetching] = useState(false);
 
   const [activeAction, setActiveAction] = useState<ActiveGitAction>(null);
   const [actionInput, setActionInput] = useState("");
@@ -256,6 +258,19 @@ export function useGitPanelController(sessionId: string | null) {
       window.removeEventListener("focus", refreshOnVisible);
     };
   }, [loadPanel, sessionId]);
+
+  useEffect(() => {
+    if (!sessionId || isTransientSessionId(sessionId)) return;
+    if (typeof document === "undefined" || typeof window === "undefined") return;
+
+    const timer = window.setInterval(() => {
+      if (document.visibilityState === "visible") {
+        void loadChangedFiles();
+      }
+    }, GIT_PANEL_POLL_INTERVAL_MS);
+
+    return () => window.clearInterval(timer);
+  }, [loadChangedFiles, sessionId]);
 
   const panelData = useMemo<GitPanelData | null>(() => {
     if (!data) return null;
@@ -558,6 +573,38 @@ export function useGitPanelController(sessionId: string | null) {
     sendActionPrompt("pull", { branch: data?.branch ?? "" });
   }, [data?.branch, sendActionPrompt, sessionId]);
 
+  const handleFetch = useCallback(async () => {
+    if (!sessionId || fetching) return;
+
+    setFetching(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/sessions/${encodeURIComponent(sessionId)}/git/fetch`,
+        { method: "POST" },
+      );
+      const payload = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        throw new Error(
+          extractGitPanelErrorMessage(payload, "Failed to fetch git updates."),
+        );
+      }
+
+      setDiffCache({});
+      setDiffError(null);
+      applyGitPanelData(sessionId, payload as GitPanelData);
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error
+          ? nextError.message
+          : "Failed to fetch git updates.",
+      );
+    } finally {
+      setFetching(false);
+    }
+  }, [applyGitPanelData, fetching, sessionId]);
+
   const handleMerge = useCallback(() => {
     if (!sessionId || !mergeSource) return;
     sendActionPrompt("merge", {
@@ -652,8 +699,10 @@ export function useGitPanelController(sessionId: string | null) {
     diffError,
     diffLoading,
     error,
+    fetching,
     handleCommit,
     handleCreatePr,
+    handleFetch,
     handleMerge,
     handleMergePr,
     handlePull,

--- a/src/lib/git/git-panel.ts
+++ b/src/lib/git/git-panel.ts
@@ -362,6 +362,16 @@ function getDefaultBranchName(raw: string | null): string | null {
   return match?.[1] ?? null;
 }
 
+function getRecentCommitArgs(hasUpstream: boolean): string[] {
+  const baseArgs = ["log", "--format=%h%x09%s%x09%cr", "--date-order", "-n", "5"];
+  return hasUpstream ? [...baseArgs, "HEAD", "@{upstream}"] : baseArgs;
+}
+
+function getFetchRemoteName(upstream: string | null): string {
+  const remote = upstream?.split("/", 1)[0]?.trim();
+  return remote || "origin";
+}
+
 async function getChangedFiles(
   workDir: string,
   agentEnvironment: AgentEnvironment,
@@ -461,6 +471,21 @@ export async function getGitPanelData(
     }
   }
 
+  const upstreamPromise = runOptionalCommand(
+    "git",
+    ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+    workDir,
+    agentEnvironment,
+  );
+  const recentCommitsPromise = upstreamPromise.then((currentUpstream) =>
+    runOptionalCommand(
+      "git",
+      getRecentCommitArgs(Boolean(currentUpstream)),
+      workDir,
+      agentEnvironment,
+    ),
+  );
+
   const [
     branchRaw,
     upstream,
@@ -472,12 +497,7 @@ export async function getGitPanelData(
     recentCommitsRaw,
   ] = await Promise.all([
     runOptionalCommand("git", ["branch", "--show-current"], workDir, agentEnvironment),
-    runOptionalCommand(
-      "git",
-      ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
-      workDir,
-      agentEnvironment,
-    ),
+    upstreamPromise,
     runOptionalCommand(
       "git",
       ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"],
@@ -498,12 +518,7 @@ export async function getGitPanelData(
       agentEnvironment,
     ),
     getChangedFiles(workDir, agentEnvironment),
-    runOptionalCommand(
-      "git",
-      ["log", "--format=%h%x09%s%x09%cr", "-n", "5"],
-      workDir,
-      agentEnvironment,
-    ),
+    recentCommitsPromise,
   ]);
 
   const [detachedHead, headShaRaw] = await Promise.all([
@@ -565,6 +580,25 @@ export async function getGitChangedFilesData(
     sessionId,
     changedFiles: await getChangedFiles(workDir, agentEnvironment),
   };
+}
+
+export async function fetchGitPanelData(
+  sessionId: string,
+  userId?: string,
+): Promise<GitPanelData> {
+  const sessionContext = await resolveSessionContext(sessionId);
+  const { workDir } = sessionContext;
+  const agentEnvironment = await resolveCommandEnvironment(workDir, userId);
+  await resolveRepoRoot(workDir, agentEnvironment);
+  const upstream = await runOptionalCommand(
+    "git",
+    ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+    workDir,
+    agentEnvironment,
+  );
+  const remoteName = getFetchRemoteName(upstream);
+  await runCommand("git", ["fetch", "--prune", remoteName], workDir, agentEnvironment);
+  return getGitPanelData(sessionId, userId);
 }
 
 export async function getGitDiffData(

--- a/tests/git-panel-fetch-contract.test.mjs
+++ b/tests/git-panel-fetch-contract.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const gitPanelSource = fs.readFileSync(new URL('../src/lib/git/git-panel.ts', import.meta.url), 'utf8');
+const fetchRouteSource = fs.readFileSync(new URL('../src/app/api/sessions/[id]/git/fetch/route.ts', import.meta.url), 'utf8');
+const controllerSource = fs.readFileSync(new URL('../src/components/git/use-git-panel-controller.ts', import.meta.url), 'utf8');
+const sectionsSource = fs.readFileSync(new URL('../src/components/git/git-panel-sections.tsx', import.meta.url), 'utf8');
+
+test('git panel exposes a fetch operation that fetches the configured upstream remote and returns fresh panel data', () => {
+  assert.match(gitPanelSource, /export async function fetchGitPanelData/);
+  assert.match(gitPanelSource, /getFetchRemoteName/);
+  assert.match(gitPanelSource, /"git",\s*\[\s*"fetch",\s*"--prune",\s*remoteName\s*\]/);
+  assert.match(fetchRouteSource, /export async function POST/);
+  assert.match(fetchRouteSource, /fetchGitPanelData\(id,\s*auth\.userId\)/);
+});
+
+test('recent commits include upstream commits so fetch can update the panel', () => {
+  assert.match(gitPanelSource, /getRecentCommitArgs/);
+  const helperSource = gitPanelSource.match(/function getRecentCommitArgs[\s\S]*?\n}/)?.[0] ?? '';
+  assert.match(helperSource, /"HEAD",\s*"@\{upstream\}"/);
+  assert.doesNotMatch(helperSource, /HEAD\.\.\.@\{upstream\}/);
+  assert.match(helperSource, /--date-order/);
+});
+
+test('git panel footer includes a fetch button wired to the fetch endpoint', () => {
+  assert.match(controllerSource, /\/git\/fetch`/);
+  assert.match(controllerSource, /handleFetch/);
+  assert.match(sectionsSource, /onFetch/);
+  assert.match(sectionsSource, /aria-label="Fetch"/);
+});
+
+test('git panel periodically refreshes while visible so external edits are detected', () => {
+  assert.match(controllerSource, /GIT_PANEL_POLL_INTERVAL_MS/);
+  assert.match(
+    controllerSource,
+    /window\.setInterval\(\(\) => \{[\s\S]*document\.visibilityState === "visible"[\s\S]*loadChangedFiles\(\)[\s\S]*\}, GIT_PANEL_POLL_INTERVAL_MS\)/,
+  );
+});


### PR DESCRIPTION
## Summary
- add a Git panel Fetch action that runs git fetch --prune against the upstream remote and reloads panel data
- include upstream commits in the recent commits query so fetch can update that panel
- poll changed files while the Git panel is visible so external edits appear without refocusing Tessera

## Verification
- node --test tests/git-panel-fetch-contract.test.mjs
- node --test tests/*.test.mjs
- npm run build
- npx tsc --noEmit after build regenerated .next/types

Note: isolated PR worktree focused test passed; full build was run in the main workspace with the same patch because the temp worktree has no node_modules.