### PR TITLE
Fix workspace file drops in composer

### DIFF
--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -38,6 +38,10 @@ import { useSessionRefs } from '@/hooks/use-session-refs';
 import { MessageRowShell } from './message-row-shell';
 import { SINGLE_PANEL_CONTENT_SHELL } from './single-panel-shell';
 import { SESSION_DRAG_MIME } from '@/types/panel';
+import {
+  getWorkspaceFileDragPath,
+  hasWorkspaceFileDragData,
+} from '@/lib/dnd/panel-session-drag';
 import { PanelSplitPicker } from './panel-split-picker';
 import { ComposerSessionControls } from './composer-session-controls';
 import { useEffectiveShortcut } from '@/hooks/use-effective-shortcut';
@@ -45,6 +49,7 @@ import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
 import { exportSessionReference, formatContinueConversationPrompt } from '@/lib/session/session-reference';
 import { CollectionQuickCreateSheet } from './collection-quick-create-sheet';
 import type { Collection } from '@/types/collection';
+import { insertWorkspaceFileReferenceAtCursor } from '@/lib/chat/workspace-file-reference';
 import {
   MessageInputAttachmentStrip,
   MessageInputSessionRefStrip,
@@ -386,27 +391,88 @@ export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isS
       !e.dataTransfer.types.includes(SESSION_DRAG_MIME);
   }, []);
 
+  const isWorkspaceFileDrag = useCallback((e: React.DragEvent) => {
+    return hasWorkspaceFileDragData(e.dataTransfer);
+  }, []);
+
+  const insertWorkspaceFileReference = useCallback((filePath: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      setInputValue((prev) => {
+        const { nextValue } = insertWorkspaceFileReferenceAtCursor(prev, prev.length, filePath);
+        setDraftInput(sessionId, nextValue);
+        return nextValue;
+      });
+      filePicker.close();
+      return;
+    }
+
+    const cursorPos = textarea.selectionStart;
+    const currentValue = textarea.value;
+    const { nextCursorPos, nextValue } = insertWorkspaceFileReferenceAtCursor(
+      currentValue,
+      cursorPos,
+      filePath,
+    );
+
+    setInputValue(nextValue);
+    setDraftInput(sessionId, nextValue);
+    filePicker.close();
+    requestAnimationFrame(() => {
+      textarea.setSelectionRange(nextCursorPos, nextCursorPos);
+      textarea.focus();
+    });
+  }, [filePicker, sessionId, setDraftInput]);
+
   const handleWrapperDragEnter = useCallback((e: React.DragEvent) => {
+    if (isWorkspaceFileDrag(e)) {
+      e.preventDefault();
+      e.stopPropagation();
+      setFileDragDepth((depth) => depth + 1);
+      return;
+    }
     handleSessionRefDragEnter(e);
     if (!isNativeFileDrag(e)) return;
     e.preventDefault();
     setFileDragDepth((depth) => depth + 1);
-  }, [handleSessionRefDragEnter, isNativeFileDrag]);
+  }, [handleSessionRefDragEnter, isNativeFileDrag, isWorkspaceFileDrag]);
 
   const handleWrapperDragOver = useCallback((e: React.DragEvent) => {
+    if (isWorkspaceFileDrag(e)) {
+      e.preventDefault();
+      e.stopPropagation();
+      e.dataTransfer.dropEffect = 'copy';
+      return;
+    }
     handleSessionRefDragOver(e);
     if (!isNativeFileDrag(e)) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'copy';
-  }, [handleSessionRefDragOver, isNativeFileDrag]);
+  }, [handleSessionRefDragOver, isNativeFileDrag, isWorkspaceFileDrag]);
 
   const handleWrapperDragLeave = useCallback((e: React.DragEvent) => {
+    if (isWorkspaceFileDrag(e)) {
+      e.stopPropagation();
+      setFileDragDepth((depth) => Math.max(0, depth - 1));
+      return;
+    }
     handleSessionRefDragLeave(e);
     if (!isNativeFileDrag(e)) return;
     setFileDragDepth((depth) => Math.max(0, depth - 1));
-  }, [handleSessionRefDragLeave, isNativeFileDrag]);
+  }, [handleSessionRefDragLeave, isNativeFileDrag, isWorkspaceFileDrag]);
 
   const handleWrapperDrop = useCallback((e: React.DragEvent) => {
+    if (isWorkspaceFileDrag(e)) {
+      e.preventDefault();
+      e.stopPropagation();
+      setFileDragDepth(0);
+      const filePath = getWorkspaceFileDragPath(e.dataTransfer);
+      if (filePath) {
+        insertWorkspaceFileReference(filePath);
+      }
+      return;
+    }
+
     // Let session ref handler try first
     handleSessionRefDrop(e);
 
@@ -419,7 +485,13 @@ export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isS
     if (files.length === 0) return;
 
     void handleFileDrop(files);
-  }, [handleFileDrop, handleSessionRefDrop, isNativeFileDrag]);
+  }, [
+    handleFileDrop,
+    handleSessionRefDrop,
+    insertWorkspaceFileReference,
+    isNativeFileDrag,
+    isWorkspaceFileDrag,
+  ]);
 
   const handleSend = () => {
     const trimmed = inputValue.trim();

--- a/src/hooks/use-session-refs.ts
+++ b/src/hooks/use-session-refs.ts
@@ -4,11 +4,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type React from 'react';
 import { useSessionStore } from '@/stores/session-store';
 import { useNotificationStore } from '@/stores/notification-store';
-import { SESSION_DRAG_MIME } from '@/types/panel';
 import type { SessionRefItem } from '@/types/session-ref';
 import { SESSION_REF_PLACEHOLDER_REGEX, MAX_SESSION_REFS } from '@/types/session-ref';
 import { useI18n } from '@/lib/i18n';
 import { exportSessionReference, formatSessionReference } from '@/lib/session/session-reference';
+import { isSessionReferenceDragData } from '@/lib/dnd/panel-session-drag';
+import { SESSION_DRAG_MIME } from '@/types/panel';
 
 interface UseSessionRefsOptions {
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
@@ -68,7 +69,7 @@ export function useSessionRefs({
   }, [refs]);
 
   const isSessionRefDragEvent = useCallback((event: React.DragEvent) => {
-    return event.dataTransfer.types.includes(SESSION_DRAG_MIME);
+    return isSessionReferenceDragData(event.dataTransfer);
   }, []);
 
   const clearDragState = useCallback(() => {

--- a/src/lib/chat/workspace-file-reference.ts
+++ b/src/lib/chat/workspace-file-reference.ts
@@ -1,0 +1,16 @@
+export function formatWorkspaceFileReference(filePath: string): string {
+  return `@${filePath} `;
+}
+
+export function insertWorkspaceFileReferenceAtCursor(
+  currentValue: string,
+  cursorPos: number,
+  filePath: string,
+): { nextValue: string; nextCursorPos: number } {
+  const safeCursorPos = Math.max(0, Math.min(cursorPos, currentValue.length));
+  const insertion = formatWorkspaceFileReference(filePath);
+  return {
+    nextValue: currentValue.slice(0, safeCursorPos) + insertion + currentValue.slice(safeCursorPos),
+    nextCursorPos: safeCursorPos + insertion.length,
+  };
+}

--- a/src/lib/dnd/panel-session-drag.ts
+++ b/src/lib/dnd/panel-session-drag.ts
@@ -1,4 +1,9 @@
-import { PANEL_NODE_DRAG_MIME, PANEL_SESSION_DRAG_MIME, SESSION_DRAG_MIME } from '@/types/panel';
+import {
+  PANEL_NODE_DRAG_MIME,
+  PANEL_SESSION_DRAG_MIME,
+  SESSION_DRAG_MIME,
+  WORKSPACE_FILE_DRAG_MIME,
+} from '@/types/panel';
 import { TASK_DND_MIME, TASK_ENTITY_DND_MIME } from '@/types/task';
 import {
   buildWorkspaceFileSessionId,
@@ -14,6 +19,21 @@ export interface PanelSessionDragPayload {
 export interface PanelNodeDragPayload {
   tabId: string;
   panelId: string;
+}
+
+export interface WorkspaceFileDragPayload {
+  sourceSessionId: string;
+  kind: WorkspaceFileTabKind;
+  path: string;
+}
+
+export function hasWorkspaceFileDragData(dataTransfer: Pick<DataTransfer, 'types'>): boolean {
+  return dataTransfer.types.includes(WORKSPACE_FILE_DRAG_MIME);
+}
+
+export function isSessionReferenceDragData(dataTransfer: Pick<DataTransfer, 'types'>): boolean {
+  return dataTransfer.types.includes(SESSION_DRAG_MIME) &&
+    !hasWorkspaceFileDragData(dataTransfer);
 }
 
 /**
@@ -101,6 +121,43 @@ export function parsePanelTitleDragData(
   }
 }
 
+export function parseWorkspaceFileDragData(
+  dataTransfer: Pick<DataTransfer, 'getData'>,
+): WorkspaceFileDragPayload | null {
+  try {
+    const raw = dataTransfer.getData(WORKSPACE_FILE_DRAG_MIME);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<WorkspaceFileDragPayload>;
+    if (
+      typeof parsed.sourceSessionId !== 'string' ||
+      typeof parsed.kind !== 'string' ||
+      typeof parsed.path !== 'string' ||
+      parsed.sourceSessionId.length === 0 ||
+      (parsed.kind !== 'file' && parsed.kind !== 'diff') ||
+      parsed.path.length === 0
+    ) {
+      return null;
+    }
+    return {
+      sourceSessionId: parsed.sourceSessionId,
+      kind: parsed.kind,
+      path: parsed.path,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getWorkspaceFileDragPath(
+  dataTransfer: Pick<DataTransfer, 'getData'>,
+): string | null {
+  const payload = parseWorkspaceFileDragData(dataTransfer);
+  if (payload) return payload.path;
+
+  const textPath = dataTransfer.getData('text/plain');
+  return textPath.length > 0 ? textPath : null;
+}
+
 /**
  * Workspace file/diff views are represented as special session IDs, so they
  * can reuse the existing panel split/replace drop behavior.
@@ -112,9 +169,15 @@ export function setWorkspaceFileDragData(
   filePath: string,
 ): void {
   const specialSessionId = buildWorkspaceFileSessionId(sourceSessionId, kind, filePath);
+  const workspaceFilePayload: WorkspaceFileDragPayload = {
+    sourceSessionId,
+    kind,
+    path: filePath,
+  };
   setPanelSessionDragData(dataTransfer, specialSessionId);
+  dataTransfer.setData(WORKSPACE_FILE_DRAG_MIME, JSON.stringify(workspaceFilePayload));
   dataTransfer.setData('text/plain', filePath);
-  dataTransfer.effectAllowed = 'move';
+  dataTransfer.effectAllowed = 'copyMove';
 }
 
 /**

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -85,6 +85,9 @@ export const PANEL_LAYOUT_STORAGE_KEY = 'tessera-panel-layout' as const;
 // 세션 드래그 MIME 타입 (session-item.tsx → panel-wrapper.tsx 간 공유)
 export const SESSION_DRAG_MIME = 'application/x-session-drag' as const;
 
+// 워크스페이스 파일 드래그 MIME 타입 (composer 파일 참조 삽입용)
+export const WORKSPACE_FILE_DRAG_MIME = 'application/x-workspace-file-drag' as const;
+
 // 패널 헤더 드래그 MIME 타입 (개별 패널 세션 이동/새 탭 생성용)
 export const PANEL_SESSION_DRAG_MIME = 'application/x-panel-session-drag' as const;
 

--- a/tests/workspace-file-drag-contract.test.ts
+++ b/tests/workspace-file-drag-contract.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  getWorkspaceFileDragPath,
+  hasWorkspaceFileDragData,
+  isSessionReferenceDragData,
+  parseWorkspaceFileDragData,
+  setWorkspaceFileDragData,
+} from '../src/lib/dnd/panel-session-drag';
+import {
+  SESSION_DRAG_MIME,
+  WORKSPACE_FILE_DRAG_MIME,
+} from '../src/types/panel';
+import { buildWorkspaceFileSessionId } from '../src/lib/workspace-tabs/special-session';
+import {
+  formatWorkspaceFileReference,
+  insertWorkspaceFileReferenceAtCursor,
+} from '../src/lib/chat/workspace-file-reference';
+
+class FakeDataTransfer {
+  effectAllowed = 'uninitialized';
+  dropEffect = 'none';
+  readonly data = new Map<string, string>();
+
+  get types(): string[] {
+    return Array.from(this.data.keys());
+  }
+
+  setData(type: string, value: string): void {
+    this.data.set(type, value);
+  }
+
+  getData(type: string): string {
+    return this.data.get(type) ?? '';
+  }
+}
+
+test('workspace file drags carry both panel and composer payloads', () => {
+  const transfer = new FakeDataTransfer();
+
+  setWorkspaceFileDragData(transfer, 'source-session', 'file', 'docs/readme.md');
+
+  assert.equal(
+    transfer.getData(SESSION_DRAG_MIME),
+    buildWorkspaceFileSessionId('source-session', 'file', 'docs/readme.md'),
+  );
+  assert.deepEqual(parseWorkspaceFileDragData(transfer), {
+    sourceSessionId: 'source-session',
+    kind: 'file',
+    path: 'docs/readme.md',
+  });
+  assert.equal(transfer.getData('text/plain'), 'docs/readme.md');
+  assert.equal(transfer.effectAllowed, 'copyMove');
+  assert.ok(transfer.types.includes(SESSION_DRAG_MIME));
+  assert.ok(transfer.types.includes(WORKSPACE_FILE_DRAG_MIME));
+  assert.equal(hasWorkspaceFileDragData(transfer), true);
+  assert.equal(isSessionReferenceDragData(transfer), false);
+  assert.equal(getWorkspaceFileDragPath(transfer), 'docs/readme.md');
+});
+
+test('workspace file drag parser rejects malformed payloads', () => {
+  for (const payload of [
+    '',
+    '{',
+    '{}',
+    JSON.stringify({ sourceSessionId: '', kind: 'file', path: 'docs/readme.md' }),
+    JSON.stringify({ sourceSessionId: 'source-session', kind: 'chat', path: 'docs/readme.md' }),
+    JSON.stringify({ sourceSessionId: 'source-session', kind: 'file', path: '' }),
+  ]) {
+    const transfer = new FakeDataTransfer();
+    transfer.setData(WORKSPACE_FILE_DRAG_MIME, payload);
+    assert.equal(parseWorkspaceFileDragData(transfer), null);
+  }
+});
+
+test('session reference drag detection ignores workspace file pseudo-sessions only', () => {
+  const sessionTransfer = new FakeDataTransfer();
+  sessionTransfer.setData(SESSION_DRAG_MIME, 'real-session-id');
+  assert.equal(isSessionReferenceDragData(sessionTransfer), true);
+  assert.equal(hasWorkspaceFileDragData(sessionTransfer), false);
+
+  const workspaceTransfer = new FakeDataTransfer();
+  workspaceTransfer.setData(SESSION_DRAG_MIME, '__workspace-file__|pseudo');
+  workspaceTransfer.setData(WORKSPACE_FILE_DRAG_MIME, JSON.stringify({
+    sourceSessionId: 'source-session',
+    kind: 'file',
+    path: 'docs/readme.md',
+  }));
+  assert.equal(isSessionReferenceDragData(workspaceTransfer), false);
+  assert.equal(hasWorkspaceFileDragData(workspaceTransfer), true);
+});
+
+test('workspace file path falls back to text/plain when structured payload is malformed', () => {
+  const transfer = new FakeDataTransfer();
+  transfer.setData(WORKSPACE_FILE_DRAG_MIME, '{');
+  transfer.setData('text/plain', 'docs/readme.md');
+  assert.equal(getWorkspaceFileDragPath(transfer), 'docs/readme.md');
+});
+
+test('workspace file references are inserted at the requested cursor', () => {
+  assert.equal(formatWorkspaceFileReference('docs/readme.md'), '@docs/readme.md ');
+  assert.deepEqual(
+    insertWorkspaceFileReferenceAtCursor('look  now', 5, 'docs/readme.md'),
+    {
+      nextValue: 'look @docs/readme.md  now',
+      nextCursorPos: 21,
+    },
+  );
+  assert.deepEqual(
+    insertWorkspaceFileReferenceAtCursor('tail', 999, 'src/app/page.tsx'),
+    {
+      nextValue: 'tail@src/app/page.tsx ',
+      nextCursorPos: 22,
+    },
+  );
+  assert.deepEqual(
+    insertWorkspaceFileReferenceAtCursor('head', -10, 'README.md'),
+    {
+      nextValue: '@README.md head',
+      nextCursorPos: 11,
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Add a dedicated workspace-file drag MIME while preserving panel session drag compatibility.
- Prioritize workspace file drops in the composer and insert @path references.
- Prevent workspace pseudo-session drags from triggering session export.

## Test Plan
- node --import tsx --test tests/*.test.*
- npx tsc --noEmit
- npm run lint
- npm run build

Fixes #42