### PR TITLE
Add integrated terminal panels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.24",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
         "agentation": "^3.0.2",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
@@ -21,6 +23,7 @@
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.563.0",
         "next": "^16.2.3",
+        "node-pty": "^1.1.0",
         "pino": "^8.18.0",
         "posthog-js": "^1.372.6",
         "react": "^19.2.5",
@@ -4776,6 +4779,21 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
@@ -12305,6 +12323,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/node-api-version": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
@@ -12511,6 +12535,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,10 @@
     "asar": true,
     "asarUnpack": [
       "**/sql.js/**",
-      "**/node_modules/sql.js/**"
+      "**/node_modules/sql.js/**",
+      "**/node_modules/node-pty/prebuilds/**",
+      "**/node_modules/node-pty/build/Release/*.node",
+      "**/node_modules/node-pty/build/Debug/*.node"
     ],
     "files": [
       "**/*",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.24",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "agentation": "^3.0.2",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
@@ -84,6 +86,7 @@
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.563.0",
     "next": "^16.2.3",
+    "node-pty": "^1.1.0",
     "pino": "^8.18.0",
     "posthog-js": "^1.372.6",
     "react": "^19.2.5",

--- a/scripts/prepare-electron-runtime.mjs
+++ b/scripts/prepare-electron-runtime.mjs
@@ -263,6 +263,20 @@ async function writeRuntimePackageJson() {
   );
 }
 
+async function ensureExecutableRuntimeFiles() {
+  const executableFiles = [
+    'node_modules/node-pty/prebuilds/darwin-x64/spawn-helper',
+    'node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper',
+  ];
+
+  for (const relPath of executableFiles) {
+    const filePath = path.join(runtimeDir, relPath);
+    if (await pathExists(filePath)) {
+      await fs.chmod(filePath, 0o755);
+    }
+  }
+}
+
 async function main() {
   if (!(await pathExists(requiredServerFilesPath))) {
     throw new Error('Missing .next/required-server-files.json. Run `npm run build` first.');
@@ -295,6 +309,8 @@ async function main() {
     await copyFileToRuntime(relPath);
   }
   await copyTurbopackExternalAliases();
+
+  await ensureExecutableRuntimeFiles();
 
   await writeRuntimePackageJson();
 

--- a/scripts/prepare-electron-runtime.mjs
+++ b/scripts/prepare-electron-runtime.mjs
@@ -46,6 +46,8 @@ function shouldSkip(relativePath) {
     relativePath === 'node_modules/sharp' ||
     relativePath.startsWith('node_modules/@img/') ||
     relativePath === 'node_modules/@img' ||
+    (relativePath.startsWith('node_modules/node-pty/prebuilds/') &&
+      relativePath.endsWith('.pdb')) ||
     relativePath.startsWith('artifacts/') ||
     relativePath === 'artifacts' ||
     relativePath.startsWith('docs/') ||
@@ -281,6 +283,10 @@ async function main() {
   await addDirectory('node_modules/next', files);
   await addDirectory('node_modules/@next/env', files);
   await addDirectory('node_modules/sql.js', files);
+  await addDirectory('node_modules/node-pty/lib/worker', files);
+  await addDirectory('node_modules/node-pty/prebuilds', files);
+  await addDirectory('node_modules/node-pty/build/Release', files);
+  await addDirectory('node_modules/node-pty/build/Debug', files);
   await addNextTraceFiles(files);
   await addTracedEntrypointFiles(files);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import ThemeInitializer from '@/components/theme-initializer';
+import '@xterm/xterm/css/xterm.css';
 import './globals.css';
 import { I18nHtmlLang } from '@/components/i18n-html-lang';
 import { Agentation } from 'agentation';

--- a/src/components/panel/empty-panel-state.tsx
+++ b/src/components/panel/empty-panel-state.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useContext, useEffect, useMemo, useRef, type DragEvent, type MouseEvent } from 'react';
-import { X as XIcon, KeyboardIcon, FolderGit2, ListTodo, MessageSquare, AlertCircle, GripVertical, Plus } from 'lucide-react';
+import { X as XIcon, KeyboardIcon, FolderGit2, ListTodo, MessageSquare, AlertCircle, GripVertical, Plus, Terminal } from 'lucide-react';
 import { usePanelStore, TabIdContext, EMPTY_PANELS } from '@/stores/panel-store';
 import { useSessionStore } from '@/stores/session-store';
 import { useBoardStore } from '@/stores/board-store';
@@ -26,6 +26,7 @@ import { useProvidersStore } from '@/stores/providers-store';
 import { useFolderBrowserStore } from '@/stores/folder-browser-store';
 import type { Collection } from '@/types/collection';
 import { setPanelNodeDragData } from '@/lib/dnd/panel-session-drag';
+import { v4 as uuidv4 } from 'uuid';
 
 interface EmptyPanelStateProps {
   panelId: string;
@@ -38,6 +39,7 @@ export function EmptyPanelState({ panelId }: EmptyPanelStateProps) {
   const tabId = useContext(TabIdContext);
   const setActivePanelId = usePanelStore((state) => state.setActivePanelId);
   const closePanel = usePanelStore((state) => state.closePanel);
+  const assignTerminal = usePanelStore((state) => state.assignTerminal);
   const isActivePanel = usePanelStore((state) => state.tabPanels[tabId]?.activePanelId === panelId);
   const panelCount = usePanelStore((state) => Object.keys(state.tabPanels[tabId]?.panels ?? EMPTY_PANELS).length);
   const selectedProjectDir = useBoardStore((state) => state.selectedProjectDir);
@@ -185,6 +187,12 @@ export function EmptyPanelState({ panelId }: EmptyPanelStateProps) {
     taskTitle,
   ]);
 
+  const handleOpenTerminal = useCallback(() => {
+    setError(null);
+    setActivePanelId(panelId);
+    assignTerminal(panelId, uuidv4());
+  }, [assignTerminal, panelId, setActivePanelId]);
+
   useEffect(() => {
     if (!isActivePanel) return;
 
@@ -307,7 +315,7 @@ export function EmptyPanelState({ panelId }: EmptyPanelStateProps) {
               {t('task.creation.startAsLabel')}
             </span>
 
-            <div className="mt-3 grid max-w-md grid-cols-2 gap-2">
+            <div className="mt-3 grid max-w-md grid-cols-3 gap-2">
               <button
                 type="button"
                 onClick={() => setMode('chat')}
@@ -345,6 +353,21 @@ export function EmptyPanelState({ panelId }: EmptyPanelStateProps) {
                 </span>
                 <span className="mt-1 block text-[11px] leading-4 text-(--text-muted)">
                   {t('task.creation.taskWorktreeHint')}
+                </span>
+              </button>
+
+              <button
+                type="button"
+                onClick={handleOpenTerminal}
+                className="rounded-2xl border border-(--divider) bg-transparent px-4 py-3 text-left transition-colors hover:border-(--accent)/16 hover:bg-[color-mix(in_srgb,var(--accent)_4%,transparent)]"
+                data-testid="empty-panel-mode-terminal"
+              >
+                <Terminal className="h-4 w-4 text-(--accent-hover)" />
+                <span className="mt-2 block text-sm font-semibold text-(--text-primary)">
+                  Terminal
+                </span>
+                <span className="mt-1 block text-[11px] leading-4 text-(--text-muted)">
+                  Open a shell here.
                 </span>
               </button>
             </div>

--- a/src/components/panel/panel-container.tsx
+++ b/src/components/panel/panel-container.tsx
@@ -34,9 +34,20 @@ const PanelLeaf = memo(function PanelLeaf({ panelId }: { panelId: string }) {
   const terminalId = usePanelStore(
     (state) => state.tabPanels[tabId]?.panels[panelId]?.terminalId ?? null,
   );
+  const terminalSessionId = usePanelStore(
+    (state) => state.tabPanels[tabId]?.panels[panelId]?.terminalSessionId ?? null,
+  );
 
   const content = (() => {
-    if (terminalId) return <TerminalPanel panelId={panelId} terminalId={terminalId} />;
+    if (terminalId) {
+      return (
+        <TerminalPanel
+          panelId={panelId}
+          terminalId={terminalId}
+          terminalSessionId={terminalSessionId}
+        />
+      );
+    }
     if (sessionId === SKILLS_DASHBOARD_SESSION_ID) return <SkillDashboard />;
     if (sessionId === ARCHIVE_DASHBOARD_SESSION_ID) return <ArchiveDashboard />;
     if (sessionId) {

--- a/src/components/panel/panel-container.tsx
+++ b/src/components/panel/panel-container.tsx
@@ -12,6 +12,7 @@ import { SkillDashboard } from '@/components/skills/skill-dashboard';
 import { ArchiveDashboard } from '@/components/archive/archive-dashboard';
 import { WorkspaceExplorerTab } from '@/components/workspace/workspace-explorer-tab';
 import { WorkspaceFileTab } from '@/components/workspace/workspace-file-tab';
+import { TerminalPanel } from '@/components/terminal/terminal-panel';
 import {
   parseWorkspaceExplorerSessionId,
   parseWorkspaceFileSessionId,
@@ -30,8 +31,12 @@ const PanelLeaf = memo(function PanelLeaf({ panelId }: { panelId: string }) {
   const sessionId = usePanelStore(
     (state) => state.tabPanels[tabId]?.panels[panelId]?.sessionId ?? null,
   );
+  const terminalId = usePanelStore(
+    (state) => state.tabPanels[tabId]?.panels[panelId]?.terminalId ?? null,
+  );
 
   const content = (() => {
+    if (terminalId) return <TerminalPanel panelId={panelId} terminalId={terminalId} />;
     if (sessionId === SKILLS_DASHBOARD_SESSION_ID) return <SkillDashboard />;
     if (sessionId === ARCHIVE_DASHBOARD_SESSION_ID) return <ArchiveDashboard />;
     if (sessionId) {

--- a/src/components/panel/panel-wrapper.tsx
+++ b/src/components/panel/panel-wrapper.tsx
@@ -283,42 +283,14 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
       const panelStore = usePanelStore.getState();
       const sourcePanelId = panelNodeDrag.panelId;
       const sourceTabData = panelStore.tabPanels[currentTabId];
-      const sourcePanel = sourceTabData?.panels[sourcePanelId];
-      if (!sourceTabData || !sourcePanel) return;
+      if (!sourceTabData?.panels[sourcePanelId]) return;
 
-      const sourceSessionId = sourcePanel.sessionId;
-      if (currentEdge === 'center') {
-        panelStore.assignSession(sourcePanelId, currentSessionId);
-        panelStore.assignSession(panelId, sourceSessionId);
-        usePanelStore.getState().setActivePanelId(panelId);
+      const movedPanelId = panelStore.movePanelNode(sourcePanelId, panelId, currentEdge);
+      if (movedPanelId) {
         useTabStore.getState().pinTab(currentTabId);
-
-        if (sourceSessionId) {
-          const session = useSessionStore.getState().getSession(sourceSessionId);
-          if (session) {
-            viewSession(session, { forceReload: true });
-          }
-        }
-        return;
-      }
-
-      if (Object.keys(sourceTabData.panels).length > 1) {
-        panelStore.closePanel(sourcePanelId);
-      } else {
-        panelStore.assignSession(sourcePanelId, null);
-      }
-
-      const direction: 'horizontal' | 'vertical' =
-        currentEdge === 'left' || currentEdge === 'right' ? 'horizontal' : 'vertical';
-      const position: 'before' | 'after' =
-        currentEdge === 'left' || currentEdge === 'top' ? 'before' : 'after';
-      const newPanelId = usePanelStore.getState().splitPanel(panelId, direction, sourceSessionId, position);
-      if (newPanelId) {
-        useTabStore.getState().pinTab(currentTabId);
-      }
-
-      if (sourceSessionId) {
-        const session = useSessionStore.getState().getSession(sourceSessionId);
+        const nextTabData = usePanelStore.getState().tabPanels[currentTabId];
+        const movedSessionId = nextTabData?.panels[movedPanelId]?.sessionId ?? null;
+        const session = movedSessionId ? useSessionStore.getState().getSession(movedSessionId) : null;
         if (session) {
           viewSession(session, { forceReload: true });
         }

--- a/src/components/panel/panel-wrapper.tsx
+++ b/src/components/panel/panel-wrapper.tsx
@@ -171,7 +171,7 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
 
     const sourceTabData = droppedTabTreeId ? freshPs.tabPanels[droppedTabTreeId] : undefined;
     if (droppedTabTreeId === freshPs.activeTabId) return;
-    if (droppedTabTreeId && sourceTabData && Object.keys(sourceTabData.panels).length > 1) {
+    if (droppedTabTreeId && sourceTabData) {
       const isEdgeSplit = currentEdge !== 'center';
       if (isEdgeSplit) {
         const rect = wrapperRef.current?.getBoundingClientRect();

--- a/src/components/tab/tab-bar.tsx
+++ b/src/components/tab/tab-bar.tsx
@@ -9,12 +9,12 @@ import { usePanelStore } from '@/stores/panel-store';
 import { useSettingsStore } from '@/stores/settings-store';
 import { useI18n } from '@/lib/i18n';
 import { TAB_MIN_WIDTH, TAB_MAX_WIDTH } from '@/types/tab';
-import { PANEL_SESSION_DRAG_MIME } from '@/types/panel';
+import { PANEL_NODE_DRAG_MIME, PANEL_SESSION_DRAG_MIME } from '@/types/panel';
 import { useGitStore } from '@/stores/git-store';
 import { TabItem } from './tab-item';
 import { TabContextMenu } from './tab-context-menu';
 import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
-import { parsePanelTitleDragData } from '@/lib/dnd/panel-session-drag';
+import { parsePanelNodeDragData, parsePanelTitleDragData } from '@/lib/dnd/panel-session-drag';
 
 const TAB_SCROLL_MIN_STEP = 180;
 const TAB_SCROLL_EDGE_EPSILON = 1;
@@ -161,6 +161,10 @@ export const TabBar = memo(function TabBar() {
     return e.dataTransfer.types.includes(PANEL_SESSION_DRAG_MIME);
   }, []);
 
+  const hasPanelNodeDrag = useCallback(function hasPanelNodeDrag(e: React.DragEvent) {
+    return e.dataTransfer.types.includes(PANEL_NODE_DRAG_MIME);
+  }, []);
+
   const handlePanelTitleDropToNewTab = useCallback(function handlePanelTitleDropToNewTab(
     e: React.DragEvent,
   ): boolean {
@@ -183,25 +187,58 @@ export const TabBar = memo(function TabBar() {
     return true;
   }, []);
 
+  const handlePanelNodeDropToNewTab = useCallback(function handlePanelNodeDropToNewTab(
+    e: React.DragEvent,
+  ): boolean {
+    const payload = parsePanelNodeDragData(e.dataTransfer);
+    if (!payload) return false;
+
+    const panelStore = usePanelStore.getState();
+    const tabStore = useTabStore.getState();
+    const previousActiveTabId = tabStore.activeTabId;
+    const sourceTabData = panelStore.tabPanels[payload.tabId];
+    const sourcePanel = sourceTabData?.panels[payload.panelId];
+    const terminalId = sourcePanel?.terminalId ?? null;
+    const terminalSessionId = sourcePanel?.terminalSessionId ?? null;
+    if (!sourceTabData || !terminalId || payload.tabId !== previousActiveTabId) return false;
+
+    if (Object.keys(sourceTabData.panels).length > 1) {
+      panelStore.closePanel(payload.panelId);
+    } else {
+      panelStore.assignTerminal(payload.panelId, null);
+    }
+
+    const newTabId = tabStore.createTab(null, { insertAfterTabId: payload.tabId });
+    const newTabData = usePanelStore.getState().tabPanels[newTabId];
+    const newPanelId = newTabData?.activePanelId;
+    if (!newPanelId) return false;
+    usePanelStore.getState().assignTerminal(newPanelId, terminalId, terminalSessionId);
+
+    if (previousActiveTabId && previousActiveTabId !== newTabId) {
+      useTabStore.getState().setActiveTab(previousActiveTabId);
+    }
+    return true;
+  }, []);
+
   const handleCreateTabDragOver = useCallback(function handleCreateTabDragOver(e: React.DragEvent) {
-    if (!hasPanelTitleDrag(e)) return;
+    if (!hasPanelTitleDrag(e) && !hasPanelNodeDrag(e)) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
     setIsCreateTabDragOver(true);
-  }, [hasPanelTitleDrag]);
+  }, [hasPanelNodeDrag, hasPanelTitleDrag]);
 
   const handleCreateTabDragLeave = useCallback(function handleCreateTabDragLeave() {
     setIsCreateTabDragOver(false);
   }, []);
 
   const handleCreateTabDrop = useCallback(function handleCreateTabDrop(e: React.DragEvent) {
-    if (!hasPanelTitleDrag(e)) return;
+    if (!hasPanelTitleDrag(e) && !hasPanelNodeDrag(e)) return;
     e.preventDefault();
     setIsCreateTabDragOver(false);
-    if (handlePanelTitleDropToNewTab(e)) {
+    if (handlePanelTitleDropToNewTab(e) || handlePanelNodeDropToNewTab(e)) {
       clearTabDragState();
     }
-  }, [clearTabDragState, handlePanelTitleDropToNewTab, hasPanelTitleDrag]);
+  }, [clearTabDragState, handlePanelNodeDropToNewTab, handlePanelTitleDropToNewTab, hasPanelNodeDrag, hasPanelTitleDrag]);
 
   const handleScrollTabs = useCallback(function handleScrollTabs(direction: 'left' | 'right') {
     const container = containerRef.current;
@@ -307,11 +344,11 @@ export const TabBar = memo(function TabBar() {
   const [isEndZoneDragOver, setIsEndZoneDragOver] = useState(false);
 
   const handleEndZoneDragOver = useCallback(function handleEndZoneDragOver(e: React.DragEvent) {
-    if (!dragTabIdRef.current && !hasPanelTitleDrag(e)) return;
+    if (!dragTabIdRef.current && !hasPanelTitleDrag(e) && !hasPanelNodeDrag(e)) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
     setIsEndZoneDragOver(true);
-  }, [hasPanelTitleDrag]);
+  }, [hasPanelNodeDrag, hasPanelTitleDrag]);
 
   const handleEndZoneDragLeave = useCallback(function handleEndZoneDragLeave() {
     setIsEndZoneDragOver(false);
@@ -321,7 +358,7 @@ export const TabBar = memo(function TabBar() {
     e.preventDefault();
     setIsEndZoneDragOver(false);
 
-    if (handlePanelTitleDropToNewTab(e)) {
+    if (handlePanelTitleDropToNewTab(e) || handlePanelNodeDropToNewTab(e)) {
       clearTabDragState();
       return;
     }
@@ -339,7 +376,7 @@ export const TabBar = memo(function TabBar() {
       newTabs.push(draggedTab);
       return { tabs: newTabs };
     });
-  }, [clearTabDragState, handlePanelTitleDropToNewTab]);
+  }, [clearTabDragState, handlePanelNodeDropToNewTab, handlePanelTitleDropToNewTab]);
 
   // ---------------------------------------------------------------------------
   // Render

--- a/src/components/tab/tab-item.tsx
+++ b/src/components/tab/tab-item.tsx
@@ -74,7 +74,8 @@ export function getTabDragSessionId(
 }
 
 export function shouldDragTabPanelTree(tabData: TabPanelData | null | undefined): boolean {
-  return Object.keys(tabData?.panels ?? {}).length > 1;
+  const panels = tabData?.panels ?? {};
+  return Object.keys(panels).length > 1 || Object.values(panels).some((panel) => panel.terminalId);
 }
 
 // ---------------------------------------------------------------------------
@@ -145,6 +146,17 @@ export const TabItem = memo(function TabItem({
     ),
   );
 
+  const liveTerminalId = usePanelStore(
+    useCallback(
+      (state) => {
+        if (!isActive) return null;
+        const tabData = selectActiveTab(state);
+        return tabData?.panels[tabData.activePanelId]?.terminalId ?? null;
+      },
+      [isActive],
+    ),
+  );
+
   const liveSessionCount = usePanelStore(
     useCallback(
       (state) => {
@@ -170,8 +182,12 @@ export const TabItem = memo(function TabItem({
   const snapshotSessionId = inactiveTabData
     ? (inactiveTabData.panels[inactiveTabData.activePanelId]?.sessionId ?? null)
     : null;
+  const snapshotTerminalId = inactiveTabData
+    ? (inactiveTabData.panels[inactiveTabData.activePanelId]?.terminalId ?? null)
+    : null;
 
   const activePanelSessionId = isActive ? liveSessionId : snapshotSessionId;
+  const activePanelTerminalId = isActive ? liveTerminalId : snapshotTerminalId;
 
   // Special session handling (e.g., Skills Dashboard)
   const specialTitleKey = activePanelSessionId ? getSpecialSessionTitleKey(activePanelSessionId) : null;
@@ -197,6 +213,8 @@ export const TabItem = memo(function TabItem({
     displayTitle = getSpecialSessionTitle(activePanelSessionId) ?? displayTitle;
   } else if (tab.title !== null) {
     displayTitle = tab.title;
+  } else if (activePanelTerminalId) {
+    displayTitle = 'Terminal';
   } else if (activePanelSessionId && session) {
     displayTitle = session.title ?? session.id;
   }

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -6,7 +6,6 @@ import { wsClient } from '@/lib/ws/client';
 import type { ServerTransportMessage } from '@/lib/ws/message-types';
 import { Button } from '@/components/ui/button';
 import { TabIdContext, usePanelStore } from '@/stores/panel-store';
-import { useSessionStore } from '@/stores/session-store';
 import { getSessionSelectionId } from '@/lib/constants/special-sessions';
 import { getInitialTerminalCwd } from '@/lib/terminal/client-terminal-cwd';
 import { setPanelNodeDragData } from '@/lib/dnd/panel-session-drag';
@@ -14,6 +13,7 @@ import { setPanelNodeDragData } from '@/lib/dnd/panel-session-drag';
 interface TerminalPanelProps {
   panelId: string;
   terminalId: string;
+  terminalSessionId: string | null;
 }
 
 function isTerminalAssignedToAnyPanel(terminalId: string): boolean {
@@ -23,7 +23,7 @@ function isTerminalAssignedToAnyPanel(terminalId: string): boolean {
   );
 }
 
-export function TerminalPanel({ panelId, terminalId }: TerminalPanelProps) {
+export function TerminalPanel({ panelId, terminalId, terminalSessionId }: TerminalPanelProps) {
   const tabId = useContext(TabIdContext);
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<any>(null);
@@ -111,8 +111,8 @@ export function TerminalPanel({ panelId, terminalId }: TerminalPanelProps) {
         const dimensions = fitAddon.proposeDimensions();
         wsClient.createTerminal({
           terminalId,
-          cwd: getInitialTerminalCwd(),
-          sessionId: getSessionSelectionId(useSessionStore.getState().activeSessionId),
+          cwd: getInitialTerminalCwd(terminalSessionId),
+          sessionId: getSessionSelectionId(terminalSessionId),
           cols: dimensions?.cols,
           rows: dimensions?.rows,
         });
@@ -145,7 +145,7 @@ export function TerminalPanel({ panelId, terminalId }: TerminalPanelProps) {
         wsClient.closeTerminal(terminalId);
       }
     };
-  }, [terminalId]);
+  }, [terminalId, terminalSessionId]);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[#0f1115] text-[#d7dde3]" data-testid="terminal-panel">

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -6,6 +6,7 @@ import { wsClient } from '@/lib/ws/client';
 import type { ServerTransportMessage } from '@/lib/ws/message-types';
 import { Button } from '@/components/ui/button';
 import { TabIdContext, usePanelStore } from '@/stores/panel-store';
+import { useChatStore } from '@/stores/chat-store';
 import { getSessionSelectionId } from '@/lib/constants/special-sessions';
 import { getInitialTerminalCwd } from '@/lib/terminal/client-terminal-cwd';
 import { setPanelNodeDragData } from '@/lib/dnd/panel-session-drag';
@@ -32,8 +33,9 @@ export function TerminalPanel({ panelId, terminalId, terminalSessionId }: Termin
   const [status, setStatus] = useState<'starting' | 'running' | 'exited' | 'error'>('starting');
   const [subtitle, setSubtitle] = useState('Starting terminal...');
   const assignTerminal = usePanelStore((state) => state.assignTerminal);
+  const connectionStatus = useChatStore((state) => state.connectionStatus);
 
-  const handlePanelDragStart = useCallback((event: DragEvent<HTMLButtonElement>) => {
+  const handlePanelDragStart = useCallback((event: DragEvent<HTMLElement>) => {
     const didSet = setPanelNodeDragData(event.dataTransfer, { tabId, panelId });
     if (!didSet) {
       event.preventDefault();
@@ -108,14 +110,25 @@ export function TerminalPanel({ panelId, terminalId, terminalSessionId }: Termin
         terminalRef.current = terminal;
         fitAddonRef.current = fitAddon;
 
+        if (connectionStatus !== 'connected') {
+          setStatus('starting');
+          setSubtitle('Waiting for server connection...');
+          return;
+        }
+
         const dimensions = fitAddon.proposeDimensions();
-        wsClient.createTerminal({
+        const didCreateTerminal = wsClient.createTerminal({
           terminalId,
           cwd: getInitialTerminalCwd(terminalSessionId),
           sessionId: getSessionSelectionId(terminalSessionId),
           cols: dimensions?.cols,
           rows: dimensions?.rows,
         });
+        if (!didCreateTerminal) {
+          setStatus('starting');
+          setSubtitle('Waiting for server connection...');
+          return;
+        }
 
         resizeObserver = new ResizeObserver(() => {
           if (!fitAddonRef.current) return;
@@ -145,7 +158,7 @@ export function TerminalPanel({ panelId, terminalId, terminalSessionId }: Termin
         wsClient.closeTerminal(terminalId);
       }
     };
-  }, [terminalId, terminalSessionId]);
+  }, [connectionStatus, terminalId, terminalSessionId]);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[#0f1115] text-[#d7dde3]" data-testid="terminal-panel">
@@ -162,8 +175,18 @@ export function TerminalPanel({ panelId, terminalId, terminalSessionId }: Termin
           <GripVertical className="h-3.5 w-3.5" />
         </button>
         <TerminalIcon className="h-4 w-4 text-(--accent)" />
-        <span className="font-medium">Terminal</span>
-        <span className="min-w-0 flex-1 truncate text-white/55">{subtitle}</span>
+        <div className="flex min-w-0 shrink items-center gap-2 select-text">
+          <span className="font-medium">Terminal</span>
+          <span className="min-w-0 truncate text-white/55">{subtitle}</span>
+        </div>
+        <div
+          draggable
+          onDragStart={handlePanelDragStart}
+          title="Move terminal panel"
+          aria-label="Move terminal panel"
+          data-testid="terminal-panel-empty-drag-region"
+          className="h-full min-w-8 flex-1 cursor-grab active:cursor-grabbing"
+        />
         <span className="text-white/45">{status}</span>
         <Button
           variant="ghost"
@@ -175,7 +198,9 @@ export function TerminalPanel({ panelId, terminalId, terminalSessionId }: Termin
           <X className="h-3.5 w-3.5" />
         </Button>
       </div>
-      <div ref={containerRef} className="min-h-0 flex-1 p-2" />
+      <div className="min-h-0 flex-1 overflow-hidden p-2">
+        <div ref={containerRef} className="h-full min-h-0 overflow-hidden" />
+      </div>
     </div>
   );
 }

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -1,32 +1,55 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { Terminal as TerminalIcon, X } from 'lucide-react';
+import { useCallback, useContext, useEffect, useRef, useState, type DragEvent } from 'react';
+import { GripVertical, Terminal as TerminalIcon, X } from 'lucide-react';
 import { wsClient } from '@/lib/ws/client';
 import type { ServerTransportMessage } from '@/lib/ws/message-types';
 import { Button } from '@/components/ui/button';
-import { usePanelStore } from '@/stores/panel-store';
+import { TabIdContext, usePanelStore } from '@/stores/panel-store';
 import { useSessionStore } from '@/stores/session-store';
 import { getSessionSelectionId } from '@/lib/constants/special-sessions';
 import { getInitialTerminalCwd } from '@/lib/terminal/client-terminal-cwd';
+import { setPanelNodeDragData } from '@/lib/dnd/panel-session-drag';
 
 interface TerminalPanelProps {
   panelId: string;
   terminalId: string;
 }
 
+function isTerminalAssignedToAnyPanel(terminalId: string): boolean {
+  const { tabPanels } = usePanelStore.getState();
+  return Object.values(tabPanels).some((tabData) =>
+    Object.values(tabData.panels).some((panel) => panel.terminalId === terminalId),
+  );
+}
+
 export function TerminalPanel({ panelId, terminalId }: TerminalPanelProps) {
+  const tabId = useContext(TabIdContext);
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<any>(null);
   const fitAddonRef = useRef<any>(null);
+  const closeRequestedRef = useRef(false);
   const [status, setStatus] = useState<'starting' | 'running' | 'exited' | 'error'>('starting');
   const [subtitle, setSubtitle] = useState('Starting terminal...');
   const assignTerminal = usePanelStore((state) => state.assignTerminal);
-  const activeSessionId = useSessionStore((state) => state.activeSessionId);
+
+  const handlePanelDragStart = useCallback((event: DragEvent<HTMLButtonElement>) => {
+    const didSet = setPanelNodeDragData(event.dataTransfer, { tabId, panelId });
+    if (!didSet) {
+      event.preventDefault();
+    }
+  }, [panelId, tabId]);
+
+  const handleCloseTerminal = useCallback(() => {
+    closeRequestedRef.current = true;
+    wsClient.closeTerminal(terminalId);
+    assignTerminal(panelId, null);
+  }, [assignTerminal, panelId, terminalId]);
 
   useEffect(() => {
     let disposed = false;
     let resizeObserver: ResizeObserver | null = null;
+    closeRequestedRef.current = false;
     const unsubscribe = wsClient.subscribeServerMessages((message: ServerTransportMessage) => {
       if (!('terminalId' in message) || message.terminalId !== terminalId) return;
 
@@ -89,7 +112,7 @@ export function TerminalPanel({ panelId, terminalId }: TerminalPanelProps) {
         wsClient.createTerminal({
           terminalId,
           cwd: getInitialTerminalCwd(),
-          sessionId: getSessionSelectionId(activeSessionId),
+          sessionId: getSessionSelectionId(useSessionStore.getState().activeSessionId),
           cols: dimensions?.cols,
           rows: dimensions?.rows,
         });
@@ -115,14 +138,29 @@ export function TerminalPanel({ panelId, terminalId }: TerminalPanelProps) {
       disposed = true;
       unsubscribe();
       resizeObserver?.disconnect();
-      wsClient.closeTerminal(terminalId);
       terminalRef.current?.dispose?.();
+      terminalRef.current = null;
+      fitAddonRef.current = null;
+      if (!closeRequestedRef.current && !isTerminalAssignedToAnyPanel(terminalId)) {
+        wsClient.closeTerminal(terminalId);
+      }
     };
-  }, [activeSessionId, terminalId]);
+  }, [terminalId]);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[#0f1115] text-[#d7dde3]" data-testid="terminal-panel">
       <div className="flex h-9 shrink-0 items-center gap-2 border-b border-white/10 px-2 text-xs">
+        <button
+          type="button"
+          draggable
+          onDragStart={handlePanelDragStart}
+          title="Move terminal panel"
+          aria-label="Move terminal panel"
+          data-testid="terminal-panel-drag-handle"
+          className="cursor-grab rounded p-1 text-white/45 transition-colors hover:bg-white/10 hover:text-white active:cursor-grabbing"
+        >
+          <GripVertical className="h-3.5 w-3.5" />
+        </button>
         <TerminalIcon className="h-4 w-4 text-(--accent)" />
         <span className="font-medium">Terminal</span>
         <span className="min-w-0 flex-1 truncate text-white/55">{subtitle}</span>
@@ -131,7 +169,7 @@ export function TerminalPanel({ panelId, terminalId }: TerminalPanelProps) {
           variant="ghost"
           size="icon"
           className="h-7 w-7 text-white/60 hover:bg-white/10 hover:text-white"
-          onClick={() => assignTerminal(panelId, null)}
+          onClick={handleCloseTerminal}
           aria-label="Close terminal"
         >
           <X className="h-3.5 w-3.5" />

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Terminal as TerminalIcon, X } from 'lucide-react';
+import { wsClient } from '@/lib/ws/client';
+import type { ServerTransportMessage } from '@/lib/ws/message-types';
+import { Button } from '@/components/ui/button';
+import { usePanelStore } from '@/stores/panel-store';
+import { useSessionStore } from '@/stores/session-store';
+import { getSessionSelectionId } from '@/lib/constants/special-sessions';
+import { getInitialTerminalCwd } from '@/lib/terminal/client-terminal-cwd';
+
+interface TerminalPanelProps {
+  panelId: string;
+  terminalId: string;
+}
+
+export function TerminalPanel({ panelId, terminalId }: TerminalPanelProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<any>(null);
+  const fitAddonRef = useRef<any>(null);
+  const [status, setStatus] = useState<'starting' | 'running' | 'exited' | 'error'>('starting');
+  const [subtitle, setSubtitle] = useState('Starting terminal...');
+  const assignTerminal = usePanelStore((state) => state.assignTerminal);
+  const activeSessionId = useSessionStore((state) => state.activeSessionId);
+
+  useEffect(() => {
+    let disposed = false;
+    let resizeObserver: ResizeObserver | null = null;
+    const unsubscribe = wsClient.subscribeServerMessages((message: ServerTransportMessage) => {
+      if (!('terminalId' in message) || message.terminalId !== terminalId) return;
+
+      if (message.type === 'terminal_started') {
+        setStatus('running');
+        setSubtitle(`${message.shell} - ${message.cwd}`);
+        return;
+      }
+
+      if (message.type === 'terminal_output') {
+        terminalRef.current?.write(message.data);
+        return;
+      }
+
+      if (message.type === 'terminal_exit') {
+        setStatus('exited');
+        setSubtitle(`Terminal exited with code ${message.exitCode}`);
+        return;
+      }
+
+      if (message.type === 'terminal_error') {
+        setStatus('error');
+        setSubtitle(message.message);
+      }
+    });
+
+    async function mountTerminal() {
+      try {
+        const [{ Terminal }, { FitAddon }] = await Promise.all([
+          import('@xterm/xterm'),
+          import('@xterm/addon-fit'),
+        ]);
+        if (disposed || !containerRef.current) return;
+
+        const terminal = new Terminal({
+          cursorBlink: true,
+          convertEol: true,
+          fontFamily: 'Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+          fontSize: 12,
+          theme: {
+            background: '#0f1115',
+            foreground: '#d7dde3',
+            cursor: '#d7dde3',
+          },
+        });
+        const fitAddon = new FitAddon();
+        terminal.loadAddon(fitAddon);
+        terminal.open(containerRef.current);
+        fitAddon.fit();
+        terminal.focus();
+
+        terminal.onData((data: string) => {
+          wsClient.sendTerminalInput(terminalId, data);
+        });
+
+        terminalRef.current = terminal;
+        fitAddonRef.current = fitAddon;
+
+        const dimensions = fitAddon.proposeDimensions();
+        wsClient.createTerminal({
+          terminalId,
+          cwd: getInitialTerminalCwd(),
+          sessionId: getSessionSelectionId(activeSessionId),
+          cols: dimensions?.cols,
+          rows: dimensions?.rows,
+        });
+
+        resizeObserver = new ResizeObserver(() => {
+          if (!fitAddonRef.current) return;
+          fitAddonRef.current.fit();
+          const next = fitAddonRef.current.proposeDimensions();
+          if (next) {
+            wsClient.resizeTerminal(terminalId, next.cols, next.rows);
+          }
+        });
+        resizeObserver.observe(containerRef.current);
+      } catch (error) {
+        setStatus('error');
+        setSubtitle(error instanceof Error ? error.message : 'Terminal failed to load.');
+      }
+    }
+
+    void mountTerminal();
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+      resizeObserver?.disconnect();
+      wsClient.closeTerminal(terminalId);
+      terminalRef.current?.dispose?.();
+    };
+  }, [activeSessionId, terminalId]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-[#0f1115] text-[#d7dde3]" data-testid="terminal-panel">
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-white/10 px-2 text-xs">
+        <TerminalIcon className="h-4 w-4 text-(--accent)" />
+        <span className="font-medium">Terminal</span>
+        <span className="min-w-0 flex-1 truncate text-white/55">{subtitle}</span>
+        <span className="text-white/45">{status}</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 text-white/60 hover:bg-white/10 hover:text-white"
+          onClick={() => assignTerminal(panelId, null)}
+          aria-label="Close terminal"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <div ref={containerRef} className="min-h-0 flex-1 p-2" />
+    </div>
+  );
+}

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -21,6 +21,7 @@ import { useTabStore } from '@/stores/tab-store';
 import { useBoardStore } from '@/stores/board-store';
 import { toast } from '@/stores/notification-store';
 import { i18n } from '@/lib/i18n';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface UseKeyboardShortcutsOptions {
   /** Reserved for future use (help toggle). Currently unused. */
@@ -136,6 +137,7 @@ export function useKeyboardShortcuts(_options: UseKeyboardShortcutsOptions = {})
   const panels = usePanelStore((state) => selectActiveTab(state)?.panels ?? EMPTY_PANELS);
   const activePanelId = usePanelStore((state) => selectActiveTab(state)?.activePanelId ?? '');
   const splitPanel = usePanelStore((state) => state.splitPanel);
+  const createTerminalPanel = usePanelStore((state) => state.createTerminalPanel);
   const setActivePanelId = usePanelStore((state) => state.setActivePanelId);
 
   const tabs = useTabStore((state) => state.tabs);
@@ -209,6 +211,21 @@ export function useKeyboardShortcuts(_options: UseKeyboardShortcutsOptions = {})
     }
   }, [panels, activePanelId, splitPanel]);
 
+  const handleToggleTerminal = useCallback(() => {
+    if (!panels[activePanelId]) return;
+    const size = getActivePanelSize(activePanelId);
+    if (size && size.height / 2 < MIN_PANEL_HEIGHT) {
+      toast.warning(i18n.t('panel.tooSmallToSplit'));
+      return;
+    }
+
+    const terminalPanelId = createTerminalPanel(activePanelId, uuidv4(), 'vertical');
+    if (terminalPanelId) {
+      const tabStore = useTabStore.getState();
+      tabStore.pinTab(tabStore.activeTabId);
+    }
+  }, [panels, activePanelId, createTerminalPanel]);
+
   const handleFocusPanel = useCallback((direction: PanelFocusDirection) => {
     if (!panels[activePanelId]) return;
     const nextPanelId = getDirectionalPanelId(activePanelId, direction);
@@ -225,6 +242,7 @@ export function useKeyboardShortcuts(_options: UseKeyboardShortcutsOptions = {})
     'toggle-view':    handleToggleView,
     'split-right':    handleSplitRight,
     'split-down':     handleSplitDown,
+    'toggle-terminal': handleToggleTerminal,
     'focus-panel-left':  () => handleFocusPanel('left'),
     'focus-panel-right': () => handleFocusPanel('right'),
     'focus-panel-up':    () => handleFocusPanel('up'),
@@ -247,6 +265,6 @@ export function useKeyboardShortcuts(_options: UseKeyboardShortcutsOptions = {})
     overrides,
     handleNewTab, handleCloseTab, handleNextTab, handlePrevTab,
     handleToggleSidebar, handleToggleView, handleSplitRight, handleSplitDown,
-    handleFocusPanel,
+    handleToggleTerminal, handleFocusPanel,
   ]);
 }

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -488,6 +488,7 @@ export const en: I18nMessages = {
     toggleView: 'Toggle List / Board View',
     splitRight: 'Split Right',
     splitDown: 'Split Down',
+    toggleTerminal: 'Open Terminal',
     focusPanelLeft: 'Focus Panel Left',
     focusPanelRight: 'Focus Panel Right',
     focusPanelUp: 'Focus Panel Above',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -488,6 +488,7 @@ export const ja: I18nMessages = {
     toggleView: 'リスト/ボード表示切替',
     splitRight: '右に分割',
     splitDown: '下に分割',
+    toggleTerminal: 'ターミナルを開く',
     focusPanelLeft: '左のパネルへ移動',
     focusPanelRight: '右のパネルへ移動',
     focusPanelUp: '上のパネルへ移動',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -490,6 +490,7 @@ export const ko: I18nMessages = {
     toggleView: '리스트/보드 뷰 전환',
     splitRight: '우측 분할',
     splitDown: '아래 분할',
+    toggleTerminal: '터미널 열기',
     focusPanelLeft: '왼쪽 패널로 이동',
     focusPanelRight: '오른쪽 패널로 이동',
     focusPanelUp: '위 패널로 이동',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -488,6 +488,7 @@ export interface I18nMessages {
     toggleView: string;
     splitRight: string;
     splitDown: string;
+    toggleTerminal: string;
     focusPanelLeft: string;
     focusPanelRight: string;
     focusPanelUp: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -488,6 +488,7 @@ export const zh: I18nMessages = {
     toggleView: '切换列表/看板视图',
     splitRight: '向右分割',
     splitDown: '向下分割',
+    toggleTerminal: '打开终端',
     focusPanelLeft: '切换到左侧面板',
     focusPanelRight: '切换到右侧面板',
     focusPanelUp: '切换到上方面板',

--- a/src/lib/keyboard/registry.ts
+++ b/src/lib/keyboard/registry.ts
@@ -17,6 +17,7 @@ export const SHORTCUT_REGISTRY = {
   'toggle-view':    { default: '$mod+Alt+k',          category: 'view',  descKey: 'shortcut.toggleView' },
   'split-right':    { default: '$mod+Alt+\\',         category: 'panel', descKey: 'shortcut.splitRight' },
   'split-down':     { default: '$mod+Alt+-',          category: 'panel', descKey: 'shortcut.splitDown' },
+  'toggle-terminal': { default: 'Control+`',          category: 'panel', descKey: 'shortcut.toggleTerminal' },
   'focus-panel-left':  { default: '$mod+Alt+Shift+ArrowLeft',  category: 'panel', descKey: 'shortcut.focusPanelLeft' },
   'focus-panel-right': { default: '$mod+Alt+Shift+ArrowRight', category: 'panel', descKey: 'shortcut.focusPanelRight' },
   'focus-panel-up':    { default: '$mod+Alt+Shift+ArrowUp',    category: 'panel', descKey: 'shortcut.focusPanelUp' },

--- a/src/lib/terminal/client-terminal-cwd.ts
+++ b/src/lib/terminal/client-terminal-cwd.ts
@@ -3,9 +3,9 @@ import { getSessionSelectionId } from '@/lib/constants/special-sessions';
 import { useBoardStore } from '@/stores/board-store';
 import { useSessionStore } from '@/stores/session-store';
 
-export function getInitialTerminalCwd(): string | null {
+export function getInitialTerminalCwd(sessionId?: string | null): string | null {
   const sessionState = useSessionStore.getState();
-  const selectionSessionId = getSessionSelectionId(sessionState.activeSessionId);
+  const selectionSessionId = getSessionSelectionId(sessionId ?? sessionState.activeSessionId);
   if (selectionSessionId) {
     const activeSession = sessionState.getSession(selectionSessionId);
     if (activeSession?.workDir) {

--- a/src/lib/terminal/client-terminal-cwd.ts
+++ b/src/lib/terminal/client-terminal-cwd.ts
@@ -1,0 +1,25 @@
+import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
+import { getSessionSelectionId } from '@/lib/constants/special-sessions';
+import { useBoardStore } from '@/stores/board-store';
+import { useSessionStore } from '@/stores/session-store';
+
+export function getInitialTerminalCwd(): string | null {
+  const sessionState = useSessionStore.getState();
+  const selectionSessionId = getSessionSelectionId(sessionState.activeSessionId);
+  if (selectionSessionId) {
+    const activeSession = sessionState.getSession(selectionSessionId);
+    if (activeSession?.workDir) {
+      return activeSession.workDir;
+    }
+  }
+
+  const selectedProjectDir = useBoardStore.getState().selectedProjectDir;
+  if (selectedProjectDir && selectedProjectDir !== ALL_PROJECTS_SENTINEL) {
+    const selectedProject = sessionState.projects.find(
+      (project) => project.encodedDir === selectedProjectDir,
+    );
+    return selectedProject?.decodedPath ?? null;
+  }
+
+  return sessionState.projects[0]?.decodedPath ?? null;
+}

--- a/src/lib/terminal/shared-terminal-manager.ts
+++ b/src/lib/terminal/shared-terminal-manager.ts
@@ -1,0 +1,15 @@
+import type { ServerTransportMessage } from '@/lib/ws/message-types';
+import { TerminalManager } from './terminal-manager';
+
+type SendToUser = (userId: string, message: ServerTransportMessage) => void;
+
+let sendToUserRef: SendToUser | null = null;
+
+export const terminalManager = new TerminalManager((userId, message) => {
+  sendToUserRef?.(userId, message);
+});
+
+export function bindTerminalSender(sendToUser: SendToUser): TerminalManager {
+  sendToUserRef = sendToUser;
+  return terminalManager;
+}

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -16,6 +16,25 @@ type SendToUser = (userId: string, message: ServerTransportMessage) => void;
 const MAX_REPLAY_BUFFER_CHARS = 200_000;
 const TERMINAL_TRACE_PATH = getTesseraDataPath('terminal-debug.log');
 
+function hasUtf8Locale(value: string | undefined): boolean {
+  return /\butf-?8\b/i.test(value ?? '');
+}
+
+function buildTerminalEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const nextEnv = { ...env };
+
+  if (
+    getRuntimePlatform() === 'darwin'
+    && !hasUtf8Locale(nextEnv.LC_ALL)
+    && !hasUtf8Locale(nextEnv.LC_CTYPE)
+    && !hasUtf8Locale(nextEnv.LANG)
+  ) {
+    nextEnv.LC_CTYPE = 'UTF-8';
+  }
+
+  return nextEnv;
+}
+
 interface TerminalRuntime {
   terminalId: string;
   userId: string;
@@ -134,7 +153,7 @@ export class TerminalManager {
         cols: options.cols ?? 80,
         rows: options.rows ?? 24,
         cwd: shell.cwd,
-        env: process.env,
+        env: buildTerminalEnv(process.env),
         ...(getRuntimePlatform() === 'win32' ? { useConpty: false } : {}),
       });
       traceTerminalStage('spawn:after', { terminalId: options.terminalId });

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -1,0 +1,150 @@
+import logger from '@/lib/logger';
+import { resolveAllowedTerminalCwd, resolveTerminalShell } from './terminal-resolver';
+import type {
+  TerminalCreateOptions,
+  TerminalProcessHandle,
+  TerminalPtyFactory,
+} from './types';
+import type { ServerTransportMessage } from '@/lib/ws/message-types';
+
+type SendToUser = (userId: string, message: ServerTransportMessage) => void;
+
+interface TerminalRuntime {
+  terminalId: string;
+  userId: string;
+  process: TerminalProcessHandle;
+}
+
+async function loadNodePty(): Promise<TerminalPtyFactory> {
+  try {
+    return await import('node-pty') as TerminalPtyFactory;
+  } catch (error) {
+    throw new Error(
+      `Terminal support requires node-pty to be installed and built: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+export class TerminalManager {
+  private readonly terminals = new Map<string, TerminalRuntime>();
+
+  constructor(
+    private readonly sendToUser: SendToUser,
+    private readonly ptyFactoryLoader: () => Promise<TerminalPtyFactory> = loadNodePty,
+  ) {}
+
+  async create(options: TerminalCreateOptions): Promise<void> {
+    this.close(options.terminalId, options.userId);
+
+    try {
+      const ptyFactory = await this.ptyFactoryLoader();
+      const cwdResolution = resolveAllowedTerminalCwd({
+        cwd: options.cwd,
+        sessionId: options.sessionId,
+      });
+      if (!cwdResolution.ok) {
+        throw new Error(cwdResolution.message);
+      }
+      const shell = resolveTerminalShell({
+        cwd: cwdResolution.cwd,
+        shellKind: options.shellKind,
+      });
+      const terminalProcess = ptyFactory.spawn(shell.command, shell.args, {
+        name: 'xterm-256color',
+        cols: options.cols ?? 80,
+        rows: options.rows ?? 24,
+        cwd: shell.cwd,
+        env: process.env,
+      });
+
+      const key = this.getKey(options.userId, options.terminalId);
+      this.terminals.set(key, {
+        terminalId: options.terminalId,
+        userId: options.userId,
+        process: terminalProcess,
+      });
+
+      terminalProcess.onData((data) => {
+        this.sendToUser(options.userId, {
+          type: 'terminal_output',
+          terminalId: options.terminalId,
+          data,
+        });
+      });
+
+      terminalProcess.onExit((event) => {
+        this.terminals.delete(key);
+        this.sendToUser(options.userId, {
+          type: 'terminal_exit',
+          terminalId: options.terminalId,
+          exitCode: event.exitCode,
+          signal: event.signal,
+        });
+      });
+
+      this.sendToUser(options.userId, {
+        type: 'terminal_started',
+        terminalId: options.terminalId,
+        cwd: shell.cwd,
+        shell: shell.command,
+      });
+    } catch (error) {
+      logger.error({ error, terminalId: options.terminalId }, 'Failed to create terminal');
+      this.sendToUser(options.userId, {
+        type: 'terminal_error',
+        terminalId: options.terminalId,
+        message: error instanceof Error ? error.message : 'Failed to create terminal',
+      });
+    }
+  }
+
+  write(terminalId: string, userId: string, data: string): void {
+    const runtime = this.getOwnedTerminal(terminalId, userId);
+    runtime?.process.write(data);
+  }
+
+  resize(terminalId: string, userId: string, cols: number, rows: number): void {
+    const runtime = this.getOwnedTerminal(terminalId, userId);
+    if (!runtime) return;
+    runtime.process.resize(
+      Math.max(1, Math.floor(cols)),
+      Math.max(1, Math.floor(rows)),
+    );
+  }
+
+  close(terminalId: string, userId: string): void {
+    const runtime = this.getOwnedTerminal(terminalId, userId);
+    if (!runtime) return;
+    this.terminals.delete(terminalId);
+    runtime.process.kill();
+  }
+
+  closeAllForUser(userId: string): void {
+    for (const runtime of this.terminals.values()) {
+      if (runtime.userId === userId) {
+        this.close(runtime.terminalId, userId);
+      }
+    }
+  }
+
+  private getOwnedTerminal(terminalId: string, userId: string): TerminalRuntime | null {
+    const runtime = this.terminals.get(this.getKey(userId, terminalId));
+    if (!runtime) return null;
+    if (runtime.userId !== userId) {
+      logger.warn({ terminalId, userId }, 'Rejected terminal access for non-owner');
+      this.sendToUser(userId, {
+        type: 'terminal_error',
+        terminalId,
+        message: 'You do not own this terminal',
+      });
+      return null;
+    }
+    return runtime;
+  }
+
+  private getKey(userId: string, terminalId: string): string {
+    return `${userId}:${terminalId}`;
+  }
+}

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -1,14 +1,20 @@
+import fs from 'fs';
 import logger from '@/lib/logger';
+import { getAgentEnvironment } from '@/lib/cli/spawn-cli';
+import { getRuntimePlatform } from '@/lib/system/runtime-platform';
+import { getTesseraDataPath } from '@/lib/tessera-data-dir';
 import { resolveAllowedTerminalCwd, resolveTerminalShell } from './terminal-resolver';
 import type {
   TerminalCreateOptions,
   TerminalProcessHandle,
   TerminalPtyFactory,
+  TerminalShellKind,
 } from './types';
 import type { ServerTransportMessage } from '@/lib/ws/message-types';
 
 type SendToUser = (userId: string, message: ServerTransportMessage) => void;
 const MAX_REPLAY_BUFFER_CHARS = 200_000;
+const TERMINAL_TRACE_PATH = getTesseraDataPath('terminal-debug.log');
 
 interface TerminalRuntime {
   terminalId: string;
@@ -32,6 +38,23 @@ async function loadNodePty(): Promise<TerminalPtyFactory> {
   }
 }
 
+function traceTerminalStage(stage: string, metadata: Record<string, unknown> = {}): void {
+  if (process.env.TESSERA_TERMINAL_DEBUG !== '1') return;
+
+  try {
+    fs.appendFileSync(
+      TERMINAL_TRACE_PATH,
+      `${JSON.stringify({
+        time: new Date().toISOString(),
+        stage,
+        ...metadata,
+      })}\n`,
+    );
+  } catch {
+    // Best-effort debug trace only.
+  }
+}
+
 export class TerminalManager {
   private readonly terminals = new Map<string, TerminalRuntime>();
 
@@ -42,6 +65,21 @@ export class TerminalManager {
 
   async create(options: TerminalCreateOptions): Promise<void> {
     const key = this.getKey(options.userId, options.terminalId);
+    traceTerminalStage('create:enter', {
+      terminalId: options.terminalId,
+      userId: options.userId,
+      cwd: options.cwd,
+      sessionId: options.sessionId,
+      shellKind: options.shellKind,
+    });
+    logger.debug({
+      terminalId: options.terminalId,
+      userId: options.userId,
+      cwd: options.cwd,
+      sessionId: options.sessionId,
+      cols: options.cols,
+      rows: options.rows,
+    }, 'Terminal create requested');
     const existing = this.terminals.get(key);
     if (existing) {
       this.resize(options.terminalId, options.userId, options.cols ?? 80, options.rows ?? 24);
@@ -51,30 +89,61 @@ export class TerminalManager {
     }
 
     try {
+      traceTerminalStage('load-node-pty:before', { terminalId: options.terminalId });
+      logger.debug({ terminalId: options.terminalId }, 'Terminal loading node-pty');
       const ptyFactory = await this.ptyFactoryLoader();
+      traceTerminalStage('load-node-pty:after', { terminalId: options.terminalId });
+      logger.debug({ terminalId: options.terminalId }, 'Terminal loaded node-pty');
+      traceTerminalStage('resolve-cwd:before', { terminalId: options.terminalId });
       const cwdResolution = resolveAllowedTerminalCwd({
         cwd: options.cwd,
         sessionId: options.sessionId,
       });
+      traceTerminalStage('resolve-cwd:after', { terminalId: options.terminalId, cwdResolution });
+      logger.debug({ terminalId: options.terminalId, cwdResolution }, 'Terminal cwd resolved');
       if (!cwdResolution.ok) {
         throw new Error(cwdResolution.message);
       }
+      traceTerminalStage('resolve-shell-kind:before', { terminalId: options.terminalId });
+      const shellKind = await this.resolveShellKind(options);
+      traceTerminalStage('resolve-shell-kind:after', { terminalId: options.terminalId, shellKind });
+      logger.debug({ terminalId: options.terminalId, shellKind }, 'Terminal shell kind resolved');
+      traceTerminalStage('resolve-shell:before', { terminalId: options.terminalId });
       const shell = resolveTerminalShell({
         cwd: cwdResolution.cwd,
-        shellKind: options.shellKind,
+        shellKind,
       });
+      traceTerminalStage('resolve-shell:after', {
+        terminalId: options.terminalId,
+        command: shell.command,
+        args: shell.args,
+        cwd: shell.cwd,
+        displayCwd: shell.displayCwd,
+      });
+      logger.debug({
+        terminalId: options.terminalId,
+        command: shell.command,
+        args: shell.args,
+        cwd: shell.cwd,
+        displayCwd: shell.displayCwd,
+      }, 'Terminal shell resolved');
+      traceTerminalStage('spawn:before', { terminalId: options.terminalId });
+      logger.debug({ terminalId: options.terminalId }, 'Terminal spawning PTY');
       const terminalProcess = ptyFactory.spawn(shell.command, shell.args, {
         name: 'xterm-256color',
         cols: options.cols ?? 80,
         rows: options.rows ?? 24,
         cwd: shell.cwd,
         env: process.env,
+        ...(getRuntimePlatform() === 'win32' ? { useConpty: false } : {}),
       });
+      traceTerminalStage('spawn:after', { terminalId: options.terminalId });
+      logger.debug({ terminalId: options.terminalId }, 'Terminal PTY spawned');
 
       const runtime: TerminalRuntime = {
         terminalId: options.terminalId,
         userId: options.userId,
-        cwd: shell.cwd,
+        cwd: shell.displayCwd ?? shell.cwd,
         shell: shell.command,
         process: terminalProcess,
         outputBuffer: [],
@@ -159,6 +228,17 @@ export class TerminalManager {
 
   private getKey(userId: string, terminalId: string): string {
     return `${userId}:${terminalId}`;
+  }
+
+  private async resolveShellKind(
+    options: TerminalCreateOptions,
+  ): Promise<TerminalShellKind | undefined> {
+    if (options.shellKind && options.shellKind !== 'default') {
+      return options.shellKind;
+    }
+
+    const agentEnvironment = await getAgentEnvironment(options.userId);
+    return agentEnvironment === 'wsl' ? 'wsl' : options.shellKind;
   }
 
   private sendStarted(runtime: TerminalRuntime): void {

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -8,11 +8,16 @@ import type {
 import type { ServerTransportMessage } from '@/lib/ws/message-types';
 
 type SendToUser = (userId: string, message: ServerTransportMessage) => void;
+const MAX_REPLAY_BUFFER_CHARS = 200_000;
 
 interface TerminalRuntime {
   terminalId: string;
   userId: string;
+  cwd: string;
+  shell: string;
   process: TerminalProcessHandle;
+  outputBuffer: string[];
+  outputBufferSize: number;
 }
 
 async function loadNodePty(): Promise<TerminalPtyFactory> {
@@ -36,7 +41,14 @@ export class TerminalManager {
   ) {}
 
   async create(options: TerminalCreateOptions): Promise<void> {
-    this.close(options.terminalId, options.userId);
+    const key = this.getKey(options.userId, options.terminalId);
+    const existing = this.terminals.get(key);
+    if (existing) {
+      this.resize(options.terminalId, options.userId, options.cols ?? 80, options.rows ?? 24);
+      this.sendStarted(existing);
+      this.replayBufferedOutput(existing);
+      return;
+    }
 
     try {
       const ptyFactory = await this.ptyFactoryLoader();
@@ -59,14 +71,19 @@ export class TerminalManager {
         env: process.env,
       });
 
-      const key = this.getKey(options.userId, options.terminalId);
-      this.terminals.set(key, {
+      const runtime: TerminalRuntime = {
         terminalId: options.terminalId,
         userId: options.userId,
+        cwd: shell.cwd,
+        shell: shell.command,
         process: terminalProcess,
-      });
+        outputBuffer: [],
+        outputBufferSize: 0,
+      };
+      this.terminals.set(key, runtime);
 
       terminalProcess.onData((data) => {
+        this.appendBufferedOutput(runtime, data);
         this.sendToUser(options.userId, {
           type: 'terminal_output',
           terminalId: options.terminalId,
@@ -84,12 +101,7 @@ export class TerminalManager {
         });
       });
 
-      this.sendToUser(options.userId, {
-        type: 'terminal_started',
-        terminalId: options.terminalId,
-        cwd: shell.cwd,
-        shell: shell.command,
-      });
+      this.sendStarted(runtime);
     } catch (error) {
       logger.error({ error, terminalId: options.terminalId }, 'Failed to create terminal');
       this.sendToUser(options.userId, {
@@ -117,15 +129,16 @@ export class TerminalManager {
   close(terminalId: string, userId: string): void {
     const runtime = this.getOwnedTerminal(terminalId, userId);
     if (!runtime) return;
-    this.terminals.delete(terminalId);
+    this.terminals.delete(this.getKey(userId, terminalId));
     runtime.process.kill();
   }
 
   closeAllForUser(userId: string): void {
-    for (const runtime of this.terminals.values()) {
-      if (runtime.userId === userId) {
-        this.close(runtime.terminalId, userId);
-      }
+    const ownedTerminalIds = [...this.terminals.values()]
+      .filter((runtime) => runtime.userId === userId)
+      .map((runtime) => runtime.terminalId);
+    for (const terminalId of ownedTerminalIds) {
+      this.close(terminalId, userId);
     }
   }
 
@@ -146,5 +159,40 @@ export class TerminalManager {
 
   private getKey(userId: string, terminalId: string): string {
     return `${userId}:${terminalId}`;
+  }
+
+  private sendStarted(runtime: TerminalRuntime): void {
+    this.sendToUser(runtime.userId, {
+      type: 'terminal_started',
+      terminalId: runtime.terminalId,
+      cwd: runtime.cwd,
+      shell: runtime.shell,
+    });
+  }
+
+  private replayBufferedOutput(runtime: TerminalRuntime): void {
+    if (runtime.outputBuffer.length === 0) return;
+    this.sendToUser(runtime.userId, {
+      type: 'terminal_output',
+      terminalId: runtime.terminalId,
+      data: runtime.outputBuffer.join(''),
+    });
+  }
+
+  private appendBufferedOutput(runtime: TerminalRuntime, data: string): void {
+    runtime.outputBuffer.push(data);
+    runtime.outputBufferSize += data.length;
+
+    while (runtime.outputBufferSize > MAX_REPLAY_BUFFER_CHARS && runtime.outputBuffer.length > 0) {
+      const first = runtime.outputBuffer[0];
+      const overflow = runtime.outputBufferSize - MAX_REPLAY_BUFFER_CHARS;
+      if (first.length <= overflow) {
+        runtime.outputBuffer.shift();
+        runtime.outputBufferSize -= first.length;
+      } else {
+        runtime.outputBuffer[0] = first.slice(overflow);
+        runtime.outputBufferSize -= overflow;
+      }
+    }
   }
 }

--- a/src/lib/terminal/terminal-resolver.ts
+++ b/src/lib/terminal/terminal-resolver.ts
@@ -43,6 +43,83 @@ function isSameOrChildPath(candidate: string, allowedRoot: string): boolean {
   return Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative);
 }
 
+function isWindowsDrivePath(value: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(value) || /^[a-zA-Z]:$/.test(value);
+}
+
+function isWindowsHostedWslPath(value: string): boolean {
+  return /^\\\\(?:wsl\.localhost|wsl\$)\\/i.test(value)
+    || /^\/\/(?:wsl\.localhost|wsl\$)\//i.test(value);
+}
+
+function toWslPath(value: string): string | null {
+  const driveMatch = value.match(/^([a-zA-Z]):[\\/]*(.*)$/);
+  if (driveMatch) {
+    const drive = driveMatch[1].toLowerCase();
+    const rest = driveMatch[2].replace(/[\\/]+/g, '/').replace(/^\/+/, '');
+    return rest ? `/mnt/${drive}/${rest}` : `/mnt/${drive}`;
+  }
+
+  const uncMatch = value.match(/^\\\\(?:wsl\.localhost|wsl\$)\\([^\\]+)\\?(.*)$/i);
+  if (uncMatch) {
+    const rest = uncMatch[2].replace(/\\/g, '/').replace(/^\/+/, '');
+    return rest ? `/${rest}` : '/';
+  }
+
+  const slashUncMatch = value.match(/^\/\/(?:wsl\.localhost|wsl\$)\/([^/]+)\/?(.*)$/i);
+  if (slashUncMatch) {
+    const rest = slashUncMatch[2].replace(/^\/+/, '');
+    return rest ? `/${rest}` : '/';
+  }
+
+  if (value.startsWith('/')) {
+    return path.posix.normalize(value);
+  }
+
+  return null;
+}
+
+function resolveWindowsProcessCwd(env: NodeJS.ProcessEnv): string {
+  const userProfile = env.USERPROFILE?.trim();
+  if (userProfile && isWindowsDrivePath(userProfile)) {
+    return path.win32.normalize(userProfile);
+  }
+
+  const home = os.homedir();
+  if (isWindowsDrivePath(home)) {
+    return path.win32.normalize(home);
+  }
+
+  const windowsRoot = env.SystemRoot?.trim() || env.windir?.trim();
+  if (windowsRoot && isWindowsDrivePath(windowsRoot)) {
+    return path.win32.join(windowsRoot, 'System32');
+  }
+
+  return 'C:\\';
+}
+
+function resolveWindowsNativeTerminalCwd(cwd: string, env: NodeJS.ProcessEnv): string {
+  if (isWindowsHostedWslPath(cwd)) {
+    return resolveWindowsProcessCwd(env);
+  }
+
+  return cwd;
+}
+
+function quoteBashArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function buildWslTerminalScript(cwd: string): string {
+  return [
+    `cd -- ${quoteBashArg(cwd)} 2>/dev/null || cd ~`,
+    'shell="${SHELL:-}"',
+    'if [ -z "$shell" ] || [ ! -x "$shell" ]; then shell="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)"; fi',
+    'if [ -z "$shell" ] || [ ! -x "$shell" ]; then shell="$(command -v bash 2>/dev/null || command -v sh)"; fi',
+    'exec "$shell" -i',
+  ].join('; ');
+}
+
 export function resolveAllowedTerminalCwd(options: {
   cwd?: string | null;
   sessionId?: string | null;
@@ -104,13 +181,20 @@ export function resolveTerminalShell(options: {
   const shellKind = options.shellKind ?? 'default';
   const cwd = resolveTerminalCwd(options.cwd);
 
-  if (shellKind === 'wsl') {
-    throw new Error('WSL terminal profiles are not supported yet.');
+  if (shellKind === 'wsl' && platform === 'win32') {
+    const wslCwd = toWslPath(cwd) ?? '~';
+    return {
+      command: 'wsl.exe',
+      args: ['-e', 'sh', '-c', buildWslTerminalScript(wslCwd)],
+      cwd: resolveWindowsProcessCwd(env),
+      displayCwd: wslCwd,
+    };
   }
 
   if (platform === 'win32') {
+    const windowsCwd = resolveWindowsNativeTerminalCwd(cwd, env);
     if (shellKind === 'cmd') {
-      return { command: 'cmd.exe', args: [], cwd };
+      return { command: 'cmd.exe', args: [], cwd: windowsCwd };
     }
 
     return {
@@ -118,7 +202,7 @@ export function resolveTerminalShell(options: {
         ? env.ComSpec
         : 'powershell.exe',
       args: ['-NoLogo'],
-      cwd,
+      cwd: windowsCwd,
     };
   }
 

--- a/src/lib/terminal/terminal-resolver.ts
+++ b/src/lib/terminal/terminal-resolver.ts
@@ -1,0 +1,128 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getVisibleProjects } from '@/lib/db/projects';
+import { getSession } from '@/lib/db/sessions';
+import type { TerminalCwdResolution, TerminalResolvedShell, TerminalShellKind } from './types';
+
+export function resolveTerminalCwd(candidate?: string | null): string {
+  if (candidate) {
+    try {
+      const stat = fs.statSync(candidate);
+      if (stat.isDirectory()) {
+        return candidate;
+      }
+    } catch {
+      // Fall through to home directory.
+    }
+  }
+
+  return os.homedir();
+}
+
+function resolveExistingDirectory(candidate: string): string | null {
+  try {
+    const resolved = path.resolve(candidate);
+    const stat = fs.statSync(resolved);
+    return stat.isDirectory() ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeForComparison(value: string): string {
+  const normalized = path.resolve(value);
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+function isSameOrChildPath(candidate: string, allowedRoot: string): boolean {
+  const normalizedCandidate = normalizeForComparison(candidate);
+  const normalizedRoot = normalizeForComparison(allowedRoot);
+  if (normalizedCandidate === normalizedRoot) return true;
+  const relative = path.relative(normalizedRoot, normalizedCandidate);
+  return Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+export function resolveAllowedTerminalCwd(options: {
+  cwd?: string | null;
+  sessionId?: string | null;
+}): TerminalCwdResolution {
+  const requestedCwd = options.cwd?.trim();
+  const allowedRoots = new Set<string>();
+
+  for (const project of getVisibleProjects()) {
+    allowedRoots.add(project.decoded_path);
+  }
+
+  if (options.sessionId) {
+    const session = getSession(options.sessionId);
+    if (session?.work_dir) {
+      allowedRoots.add(session.work_dir);
+    }
+  }
+
+  if (allowedRoots.size === 0) {
+    return { ok: false, message: 'No project is available for terminal startup.' };
+  }
+
+  if (!requestedCwd) {
+    for (const root of allowedRoots) {
+      const existingRoot = resolveExistingDirectory(root);
+      if (existingRoot) {
+        return { ok: true, cwd: existingRoot };
+      }
+    }
+
+    return { ok: false, message: 'No registered project directory exists on this server.' };
+  }
+
+  const resolvedCandidate = resolveExistingDirectory(requestedCwd);
+  if (!resolvedCandidate) {
+    return { ok: false, message: 'Terminal cwd does not exist or is not a directory.' };
+  }
+
+  for (const root of allowedRoots) {
+    if (isSameOrChildPath(resolvedCandidate, root)) {
+      return { ok: true, cwd: resolvedCandidate };
+    }
+  }
+
+  return {
+    ok: false,
+    message: 'Terminal cwd must be inside a registered project or active worktree.',
+  };
+}
+
+export function resolveTerminalShell(options: {
+  cwd?: string | null;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  shellKind?: TerminalShellKind;
+}): TerminalResolvedShell {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const shellKind = options.shellKind ?? 'default';
+  const cwd = resolveTerminalCwd(options.cwd);
+
+  if (shellKind === 'wsl') {
+    throw new Error('WSL terminal profiles are not supported yet.');
+  }
+
+  if (platform === 'win32') {
+    if (shellKind === 'cmd') {
+      return { command: 'cmd.exe', args: [], cwd };
+    }
+
+    return {
+      command: env.ComSpec?.toLowerCase().includes('powershell')
+        ? env.ComSpec
+        : 'powershell.exe',
+      args: ['-NoLogo'],
+      cwd,
+    };
+  }
+
+  const command = env.SHELL || (platform === 'darwin' ? '/bin/zsh' : '/bin/bash');
+
+  return { command, args: [], cwd };
+}

--- a/src/lib/terminal/types.ts
+++ b/src/lib/terminal/types.ts
@@ -1,0 +1,44 @@
+export type TerminalShellKind = 'default' | 'cmd' | 'powershell' | 'wsl';
+
+export interface TerminalCreateOptions {
+  terminalId: string;
+  userId: string;
+  cwd?: string | null;
+  sessionId?: string | null;
+  shellKind?: TerminalShellKind;
+  cols?: number;
+  rows?: number;
+}
+
+export interface TerminalResolvedShell {
+  command: string;
+  args: string[];
+  cwd: string;
+}
+
+export type TerminalCwdResolution =
+  | { ok: true; cwd: string }
+  | { ok: false; message: string };
+
+export interface TerminalProcessHandle {
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(): void;
+}
+
+export interface TerminalPtyFactory {
+  spawn(
+    command: string,
+    args: string[],
+    options: {
+      name: string;
+      cols: number;
+      rows: number;
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+    },
+  ): TerminalProcessHandle & {
+    onData(callback: (data: string) => void): void;
+    onExit(callback: (event: { exitCode: number; signal?: number }) => void): void;
+  };
+}

--- a/src/lib/terminal/types.ts
+++ b/src/lib/terminal/types.ts
@@ -14,6 +14,7 @@ export interface TerminalResolvedShell {
   command: string;
   args: string[];
   cwd: string;
+  displayCwd?: string;
 }
 
 export type TerminalCwdResolution =
@@ -36,6 +37,8 @@ export interface TerminalPtyFactory {
       rows: number;
       cwd: string;
       env: NodeJS.ProcessEnv;
+      useConpty?: boolean;
+      useConptyDll?: boolean;
     },
   ): TerminalProcessHandle & {
     onData(callback: (data: string) => void): void;

--- a/src/lib/ws/client.ts
+++ b/src/lib/ws/client.ts
@@ -281,6 +281,29 @@ export class WebSocketClient {
     }
   }
 
+  createTerminal(args: {
+    terminalId: string;
+    cwd?: string | null;
+    sessionId?: string | null;
+    shellKind?: 'default' | 'cmd' | 'powershell' | 'wsl';
+    cols?: number;
+    rows?: number;
+  }) {
+    this.sendRequest('terminal_create', args);
+  }
+
+  sendTerminalInput(terminalId: string, data: string) {
+    this.sendRequest('terminal_input', { terminalId, data });
+  }
+
+  resizeTerminal(terminalId: string, cols: number, rows: number) {
+    this.sendRequest('terminal_resize', { terminalId, cols, rows });
+  }
+
+  closeTerminal(terminalId: string) {
+    this.sendRequest('terminal_close', { terminalId });
+  }
+
   private sendRequest<T extends ClientMessage['type']>(
     type: T,
     payload: Omit<Extract<ClientMessage, { type: T }>, 'type' | 'requestId'>,

--- a/src/lib/ws/client.ts
+++ b/src/lib/ws/client.ts
@@ -288,8 +288,8 @@ export class WebSocketClient {
     shellKind?: 'default' | 'cmd' | 'powershell' | 'wsl';
     cols?: number;
     rows?: number;
-  }) {
-    this.sendRequest('terminal_create', args);
+  }): boolean {
+    return this.sendRequest('terminal_create', args);
   }
 
   sendTerminalInput(terminalId: string, data: string) {

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -6,6 +6,7 @@ import type { SessionReplayEvent } from '@/lib/session-replay-types';
 import type { ProviderRateLimitsSnapshot } from '@/lib/status-display/types';
 import type { CliStatusEntry } from '@/lib/cli/connection-checker';
 import type { ProviderRuntimeControls } from '@/lib/session/session-control-types';
+import type { TerminalShellKind } from '@/lib/terminal/types';
 
 // ========== ContentBlock 타입 정의 (클립보드 이미지 붙여넣기) ==========
 
@@ -70,7 +71,11 @@ export type ClientMessage =
   | { type: 'get_commands'; requestId: string; sessionId: string }
   | { type: 'list_providers'; requestId: string }
   | { type: 'refresh_providers'; requestId: string }
-  | { type: 'check_cli_status'; requestId: string };
+  | { type: 'check_cli_status'; requestId: string }
+  | { type: 'terminal_create'; requestId: string; terminalId: string; cwd?: string | null; sessionId?: string | null; shellKind?: TerminalShellKind; cols?: number; rows?: number }
+  | { type: 'terminal_input'; requestId: string; terminalId: string; data: string }
+  | { type: 'terminal_resize'; requestId: string; terminalId: string; cols: number; rows: number }
+  | { type: 'terminal_close'; requestId: string; terminalId: string };
 
 export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'dontAsk' | 'bypassPermissions';
 
@@ -200,6 +205,10 @@ export type AppServerMessage =
       };
     }
   | { type: 'error'; sessionId?: string; code: string; message: string; requestId?: string }
+  | { type: 'terminal_started'; terminalId: string; cwd: string; shell: string }
+  | { type: 'terminal_output'; terminalId: string; data: string }
+  | { type: 'terminal_exit'; terminalId: string; exitCode: number; signal?: number }
+  | { type: 'terminal_error'; terminalId: string; message: string }
   | {
       type: 'interactive_prompt';
       sessionId: string;

--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -5,6 +5,7 @@ import { processManager } from '../cli/process-manager';
 import * as dbSessions from '../db/sessions';
 import logger from '../logger';
 import { refreshSessionDiffStateSoon } from '../git/session-diff-refresh';
+import { bindTerminalSender } from '../terminal/shared-terminal-manager';
 import type { ClientMessage, ServerTransportMessage } from './message-types';
 import type { ProviderMeta } from '../cli/providers/types';
 import {
@@ -270,6 +271,30 @@ export async function routeClientTransportMessage({
 
     case 'check_cli_status':
       await checkCliStatusForWebSocketUser(userId, message.requestId, sendToUser);
+      return;
+
+    case 'terminal_create':
+      await bindTerminalSender(sendToUser).create({
+        userId,
+        terminalId: message.terminalId,
+        cwd: message.cwd,
+        sessionId: message.sessionId,
+        shellKind: message.shellKind,
+        cols: message.cols,
+        rows: message.rows,
+      });
+      return;
+
+    case 'terminal_input':
+      bindTerminalSender(sendToUser).write(message.terminalId, userId, message.data);
+      return;
+
+    case 'terminal_resize':
+      bindTerminalSender(sendToUser).resize(message.terminalId, userId, message.cols, message.rows);
+      return;
+
+    case 'terminal_close':
+      bindTerminalSender(sendToUser).close(message.terminalId, userId);
       return;
 
     default:

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -14,6 +14,7 @@ import logger from '../logger';
 import { sessionHistory } from '../session-history';
 import { installDiffStatsBroadcast } from '../git/worktree-diff-stats-broadcast';
 import { installGitPanelBroadcast } from '../git/git-panel-broadcast';
+import { terminalManager } from '../terminal/shared-terminal-manager';
 import {
   logReceivedClientTransportMessage,
   parseClientTransportMessage,
@@ -181,6 +182,7 @@ export class WebSocketServer {
 
         if (wsSet.size === 0) {
           this.connections.delete(userId);
+          terminalManager.closeAllForUser(userId);
         }
       }
     });

--- a/src/stores/panel-store.ts
+++ b/src/stores/panel-store.ts
@@ -90,6 +90,7 @@ function cloneTabPanelTree(tabData: TabPanelData): TabPanelData | null {
       id: newPanelId,
       sessionId: oldPanel.sessionId,
       terminalId: oldPanel.terminalId ?? null,
+      terminalSessionId: oldPanel.terminalSessionId ?? null,
     };
   }
 
@@ -275,13 +276,13 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
     if (!activePanel) return null;
 
     if (activePanel.sessionId === null && !activePanel.terminalId) {
-      get().assignTerminal(panelId, terminalId);
+      get().assignTerminal(panelId, terminalId, activePanel.sessionId);
       return panelId;
     }
 
     const newPanelId = get().splitPanel(panelId, direction, null);
     if (!newPanelId) return null;
-    get().assignTerminal(newPanelId, terminalId);
+    get().assignTerminal(newPanelId, terminalId, activePanel.sessionId);
     return newPanelId;
   },
 
@@ -303,11 +304,13 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
           ...sourcePanel,
           sessionId: targetPanel.sessionId,
           terminalId: targetPanel.terminalId ?? null,
+          terminalSessionId: targetPanel.terminalSessionId ?? null,
         },
         [targetPanelId]: {
           ...targetPanel,
           sessionId: sourcePanel.sessionId,
           terminalId: sourcePanel.terminalId ?? null,
+          terminalSessionId: sourcePanel.terminalSessionId ?? null,
         },
       };
       const nextTabData: TabPanelData = {
@@ -501,7 +504,7 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
 
     const nextPanels = {
       ...tabData.panels,
-      [panelId]: { ...tabData.panels[panelId], sessionId, terminalId: null },
+      [panelId]: { ...tabData.panels[panelId], sessionId, terminalId: null, terminalSessionId: null },
     };
     const fallbackActivePanelId =
       sessionId === null && panelId === tabData.activePanelId
@@ -527,7 +530,7 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
     }
   },
 
-  assignTerminal: (panelId, terminalId) => {
+  assignTerminal: (panelId, terminalId, terminalSessionId = null) => {
     const state = get();
     const tabData = state.tabPanels[state.activeTabId];
     if (!tabData) return;
@@ -536,7 +539,7 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
 
     const nextPanels = {
       ...tabData.panels,
-      [panelId]: { ...panel, sessionId: null, terminalId },
+      [panelId]: { ...panel, sessionId: null, terminalId, terminalSessionId },
     };
     const nextTabData: TabPanelData = {
       ...tabData,

--- a/src/stores/panel-store.ts
+++ b/src/stores/panel-store.ts
@@ -86,7 +86,11 @@ function cloneTabPanelTree(tabData: TabPanelData): TabPanelData | null {
     const newPanelId = panelIdMap.get(oldPanelId);
     const oldPanel = tabData.panels[oldPanelId];
     if (!newPanelId || !oldPanel) return null;
-    panels[newPanelId] = { id: newPanelId, sessionId: oldPanel.sessionId };
+    panels[newPanelId] = {
+      id: newPanelId,
+      sessionId: oldPanel.sessionId,
+      terminalId: oldPanel.terminalId ?? null,
+    };
   }
 
   const activePanelId = panelIdMap.get(tabData.activePanelId) ?? findFirstLeafId(layout);
@@ -252,6 +256,24 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
     return newPanelId;
   },
 
+  createTerminalPanel: (panelId, terminalId, direction = 'vertical') => {
+    const state = get();
+    const tabData = state.tabPanels[state.activeTabId];
+    if (!tabData) return null;
+    const activePanel = tabData.panels[panelId];
+    if (!activePanel) return null;
+
+    if (activePanel.sessionId === null && !activePanel.terminalId) {
+      get().assignTerminal(panelId, terminalId);
+      return panelId;
+    }
+
+    const newPanelId = get().splitPanel(panelId, direction, null);
+    if (!newPanelId) return null;
+    get().assignTerminal(newPanelId, terminalId);
+    return newPanelId;
+  },
+
   graftTabIntoActiveTab: (sourceTabId, targetPanelId, edge) => {
     const state = get();
     const targetTabId = state.activeTabId;
@@ -392,7 +414,7 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
 
     const nextPanels = {
       ...tabData.panels,
-      [panelId]: { ...tabData.panels[panelId], sessionId },
+      [panelId]: { ...tabData.panels[panelId], sessionId, terminalId: null },
     };
     const fallbackActivePanelId =
       sessionId === null && panelId === tabData.activePanelId
@@ -416,6 +438,33 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
     if (tabId === state.activeTabId && panelId === tabData.activePanelId) {
       useSessionStore.getState().setActiveSession(nextPanels[nextActivePanelId]?.sessionId ?? null);
     }
+  },
+
+  assignTerminal: (panelId, terminalId) => {
+    const state = get();
+    const tabData = state.tabPanels[state.activeTabId];
+    if (!tabData) return;
+    const panel = tabData.panels[panelId];
+    if (!panel) return;
+
+    const nextPanels = {
+      ...tabData.panels,
+      [panelId]: { ...panel, sessionId: null, terminalId },
+    };
+    const nextTabData: TabPanelData = {
+      ...tabData,
+      panels: nextPanels,
+      activePanelId: panelId,
+    };
+
+    set({
+      tabPanels: {
+        ...state.tabPanels,
+        [state.activeTabId]: nextTabData,
+      },
+    });
+
+    useSessionStore.getState().setActiveSession(null);
   },
 
   resizeSplit: (leftAnchor, rightAnchor, ratio) => {

--- a/src/stores/panel-store.ts
+++ b/src/stores/panel-store.ts
@@ -113,6 +113,17 @@ function buildSplitNode(
   };
 }
 
+function replaceLeafWithExistingLeaf(node: PanelNode, sourcePanelId: string, targetPanelId: string): PanelNode {
+  if (node.type === 'leaf') {
+    return node.panelId === targetPanelId ? { type: 'leaf', panelId: sourcePanelId } : node;
+  }
+
+  const newLeft = replaceLeafWithExistingLeaf(node.children[0], sourcePanelId, targetPanelId);
+  const newRight = replaceLeafWithExistingLeaf(node.children[1], sourcePanelId, targetPanelId);
+  if (newLeft === node.children[0] && newRight === node.children[1]) return node;
+  return { ...node, children: [newLeft, newRight] };
+}
+
 // --- 개발 환경 불변 조건 검증 ---
 
 function assertInvariants(tabData: TabPanelData): void {
@@ -272,6 +283,82 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
     if (!newPanelId) return null;
     get().assignTerminal(newPanelId, terminalId);
     return newPanelId;
+  },
+
+  movePanelNode: (sourcePanelId, targetPanelId, edge) => {
+    const state = get();
+    const tabData = state.tabPanels[state.activeTabId];
+    if (!tabData) return null;
+    if (sourcePanelId === targetPanelId) return null;
+
+    const sourcePanel = tabData.panels[sourcePanelId];
+    const targetPanel = tabData.panels[targetPanelId];
+    if (!sourcePanel || !targetPanel) return null;
+    if (!containsLeaf(tabData.layout, sourcePanelId) || !containsLeaf(tabData.layout, targetPanelId)) return null;
+
+    if (edge === 'center') {
+      const nextPanels = {
+        ...tabData.panels,
+        [sourcePanelId]: {
+          ...sourcePanel,
+          sessionId: targetPanel.sessionId,
+          terminalId: targetPanel.terminalId ?? null,
+        },
+        [targetPanelId]: {
+          ...targetPanel,
+          sessionId: sourcePanel.sessionId,
+          terminalId: sourcePanel.terminalId ?? null,
+        },
+      };
+      const nextTabData: TabPanelData = {
+        ...tabData,
+        panels: nextPanels,
+        activePanelId: targetPanelId,
+      };
+
+      set({
+        tabPanels: {
+          ...state.tabPanels,
+          [state.activeTabId]: nextTabData,
+        },
+      });
+
+      assertInvariants(nextTabData);
+      useSessionStore.getState().setActiveSession(nextPanels[targetPanelId]?.sessionId ?? null);
+      return targetPanelId;
+    }
+
+    if (Object.keys(tabData.panels).length <= 1) return null;
+
+    const withoutSource = removePanelFromTree(tabData.layout, sourcePanelId);
+    if (!withoutSource || !containsLeaf(withoutSource, targetPanelId)) return null;
+
+    const movedLeaf: PanelNode = { type: 'leaf', panelId: sourcePanelId };
+    const targetLeaf: PanelNode = { type: 'leaf', panelId: targetPanelId };
+    const nextLayout = replaceLeafWithExistingLeaf(
+      withoutSource,
+      sourcePanelId,
+      targetPanelId,
+    );
+    const splitNode = buildSplitNode(targetLeaf, movedLeaf, edge);
+    const finalLayout = replaceLeafInTree(nextLayout, sourcePanelId, splitNode);
+
+    const nextTabData: TabPanelData = {
+      ...tabData,
+      layout: finalLayout,
+      activePanelId: sourcePanelId,
+    };
+
+    set({
+      tabPanels: {
+        ...state.tabPanels,
+        [state.activeTabId]: nextTabData,
+      },
+    });
+
+    assertInvariants(nextTabData);
+    useSessionStore.getState().setActiveSession(sourcePanel.sessionId);
+    return sourcePanelId;
   },
 
   graftTabIntoActiveTab: (sourceTabId, targetPanelId, edge) => {

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -3,6 +3,7 @@ export interface Panel {
   readonly id: string;
   sessionId: string | null;
   terminalId?: string | null;
+  terminalSessionId?: string | null;
 }
 
 // 레이아웃 트리 노드 유니온
@@ -52,7 +53,7 @@ export interface PanelStoreActions {
   closePanel(panelId: string): void;
   assignSession(panelId: string, sessionId: string | null): void;
   assignSessionInTab(tabId: string, panelId: string, sessionId: string | null): void;
-  assignTerminal(panelId: string, terminalId: string | null): void;
+  assignTerminal(panelId: string, terminalId: string | null, terminalSessionId?: string | null): void;
   setActivePanelId(panelId: string): void;
   resizeSplit(leftAnchor: string, rightAnchor: string, ratio: number): void;
   initializeWithSession(sessionId: string | null): void;

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -2,6 +2,7 @@
 export interface Panel {
   readonly id: string;
   sessionId: string | null;
+  terminalId?: string | null;
 }
 
 // 레이아웃 트리 노드 유니온
@@ -45,10 +46,12 @@ export interface PanelStoreState {
 export interface PanelStoreActions {
   // 기존 액션 (시그니처 동일)
   splitPanel(panelId: string, direction: 'horizontal' | 'vertical', newSessionId?: string | null, position?: 'before' | 'after'): string | null;
+  createTerminalPanel(panelId: string, terminalId: string, direction?: 'horizontal' | 'vertical'): string | null;
   graftTabIntoActiveTab(sourceTabId: string, targetPanelId: string, edge: PanelDropEdge): string | null;
   closePanel(panelId: string): void;
   assignSession(panelId: string, sessionId: string | null): void;
   assignSessionInTab(tabId: string, panelId: string, sessionId: string | null): void;
+  assignTerminal(panelId: string, terminalId: string | null): void;
   setActivePanelId(panelId: string): void;
   resizeSplit(leftAnchor: string, rightAnchor: string, ratio: number): void;
   initializeWithSession(sessionId: string | null): void;

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -47,6 +47,7 @@ export interface PanelStoreActions {
   // 기존 액션 (시그니처 동일)
   splitPanel(panelId: string, direction: 'horizontal' | 'vertical', newSessionId?: string | null, position?: 'before' | 'after'): string | null;
   createTerminalPanel(panelId: string, terminalId: string, direction?: 'horizontal' | 'vertical'): string | null;
+  movePanelNode(sourcePanelId: string, targetPanelId: string, edge: PanelDropEdge): string | null;
   graftTabIntoActiveTab(sourceTabId: string, targetPanelId: string, edge: PanelDropEdge): string | null;
   closePanel(panelId: string): void;
   assignSession(panelId: string, sessionId: string | null): void;

--- a/tests/terminal-contract.test.mjs
+++ b/tests/terminal-contract.test.mjs
@@ -72,8 +72,18 @@ test('terminal client subscribes before creating the server process', () => {
 
 test('terminal creation is not tied to active panel focus changes', () => {
   assert.doesNotMatch(terminalPanelSource, /useSessionStore\(\(state\) => state\.activeSessionId\)/);
-  assert.match(terminalPanelSource, /getSessionSelectionId\(useSessionStore\.getState\(\)\.activeSessionId\)/);
-  assert.match(terminalPanelSource, /\}, \[terminalId\]\);/);
+  assert.doesNotMatch(terminalPanelSource, /useSessionStore\.getState\(\)\.activeSessionId/);
+  assert.match(terminalPanelSource, /\}, \[terminalId, terminalSessionId\]\);/);
+});
+
+test('terminal panels preserve the source session context used to create them', () => {
+  assert.match(panelTypesSource, /terminalSessionId\?: string \| null/);
+  assert.match(panelStoreSource, /assignTerminal\(newPanelId, terminalId, activePanel\.sessionId\)/);
+  assert.match(panelStoreSource, /terminalSessionId: oldPanel\.terminalSessionId \?\? null/);
+  assert.match(panelStoreSource, /sessionId, terminalId: null, terminalSessionId: null/);
+  assert.match(terminalPanelSource, /terminalSessionId: string \| null/);
+  assert.match(terminalPanelSource, /sessionId: getSessionSelectionId\(terminalSessionId\)/);
+  assert.doesNotMatch(terminalPanelSource, /useSessionStore\.getState\(\)\.activeSessionId/);
 });
 
 test('terminal panels expose a panel drag handle', () => {
@@ -94,6 +104,8 @@ test('panel node drag preserves terminal panel identity', () => {
   assert.match(panelStoreSource, /movePanelNode:/);
   assert.match(panelStoreSource, /terminalId: sourcePanel\.terminalId \?\? null/);
   assert.match(panelStoreSource, /terminalId: targetPanel\.terminalId \?\? null/);
+  assert.match(panelStoreSource, /terminalSessionId: sourcePanel\.terminalSessionId \?\? null/);
+  assert.match(panelStoreSource, /terminalSessionId: targetPanel\.terminalSessionId \?\? null/);
 });
 
 test('wsl terminal profiles are blocked until path conversion is implemented', () => {

--- a/tests/terminal-contract.test.mjs
+++ b/tests/terminal-contract.test.mjs
@@ -9,6 +9,8 @@ const wsServerSource = fs.readFileSync(new URL('../src/lib/ws/server.ts', import
 const terminalManagerSource = fs.readFileSync(new URL('../src/lib/terminal/terminal-manager.ts', import.meta.url), 'utf8');
 const terminalResolverSource = fs.readFileSync(new URL('../src/lib/terminal/terminal-resolver.ts', import.meta.url), 'utf8');
 const terminalPanelSource = fs.readFileSync(new URL('../src/components/terminal/terminal-panel.tsx', import.meta.url), 'utf8');
+const panelWrapperSource = fs.readFileSync(new URL('../src/components/panel/panel-wrapper.tsx', import.meta.url), 'utf8');
+const panelStoreSource = fs.readFileSync(new URL('../src/stores/panel-store.ts', import.meta.url), 'utf8');
 const panelTypesSource = fs.readFileSync(new URL('../src/types/panel.ts', import.meta.url), 'utf8');
 
 test('terminal feature declares browser UI and server PTY dependencies', () => {
@@ -58,6 +60,7 @@ test('terminal cwd is server validated before spawning a PTY', () => {
 test('terminal ownership keys include user id and terminal id', () => {
   assert.match(terminalManagerSource, /getKey\(userId: string, terminalId: string\)/);
   assert.match(terminalManagerSource, /`\$\{userId\}:\$\{terminalId\}`/);
+  assert.match(terminalManagerSource, /this\.terminals\.delete\(this\.getKey\(userId, terminalId\)\)/);
 });
 
 test('terminal client subscribes before creating the server process', () => {
@@ -65,6 +68,32 @@ test('terminal client subscribes before creating the server process', () => {
     terminalPanelSource.indexOf('subscribeServerMessages') <
       terminalPanelSource.indexOf('wsClient.createTerminal'),
   );
+});
+
+test('terminal creation is not tied to active panel focus changes', () => {
+  assert.doesNotMatch(terminalPanelSource, /useSessionStore\(\(state\) => state\.activeSessionId\)/);
+  assert.match(terminalPanelSource, /getSessionSelectionId\(useSessionStore\.getState\(\)\.activeSessionId\)/);
+  assert.match(terminalPanelSource, /\}, \[terminalId\]\);/);
+});
+
+test('terminal panels expose a panel drag handle', () => {
+  assert.match(terminalPanelSource, /setPanelNodeDragData/);
+  assert.match(terminalPanelSource, /data-testid="terminal-panel-drag-handle"/);
+  assert.match(terminalPanelSource, /draggable/);
+});
+
+test('terminal remount attaches to the existing server process', () => {
+  assert.match(terminalManagerSource, /const existing = this\.terminals\.get\(key\)/);
+  assert.match(terminalManagerSource, /this\.sendStarted\(existing\)/);
+  assert.match(terminalManagerSource, /this\.replayBufferedOutput\(existing\)/);
+  assert.doesNotMatch(terminalManagerSource, /this\.close\(options\.terminalId, options\.userId\);\n\n    try/);
+});
+
+test('panel node drag preserves terminal panel identity', () => {
+  assert.match(panelWrapperSource, /movePanelNode/);
+  assert.match(panelStoreSource, /movePanelNode:/);
+  assert.match(panelStoreSource, /terminalId: sourcePanel\.terminalId \?\? null/);
+  assert.match(panelStoreSource, /terminalId: targetPanel\.terminalId \?\? null/);
 });
 
 test('wsl terminal profiles are blocked until path conversion is implemented', () => {

--- a/tests/terminal-contract.test.mjs
+++ b/tests/terminal-contract.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const packageJson = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const messageTypesSource = fs.readFileSync(new URL('../src/lib/ws/message-types.ts', import.meta.url), 'utf8');
+const routingSource = fs.readFileSync(new URL('../src/lib/ws/server-message-routing.ts', import.meta.url), 'utf8');
+const wsServerSource = fs.readFileSync(new URL('../src/lib/ws/server.ts', import.meta.url), 'utf8');
+const terminalManagerSource = fs.readFileSync(new URL('../src/lib/terminal/terminal-manager.ts', import.meta.url), 'utf8');
+const terminalResolverSource = fs.readFileSync(new URL('../src/lib/terminal/terminal-resolver.ts', import.meta.url), 'utf8');
+const terminalPanelSource = fs.readFileSync(new URL('../src/components/terminal/terminal-panel.tsx', import.meta.url), 'utf8');
+const panelTypesSource = fs.readFileSync(new URL('../src/types/panel.ts', import.meta.url), 'utf8');
+
+test('terminal feature declares browser UI and server PTY dependencies', () => {
+  assert.ok(packageJson.dependencies['@xterm/xterm']);
+  assert.ok(packageJson.dependencies['@xterm/addon-fit']);
+  assert.ok(packageJson.dependencies['node-pty']);
+});
+
+test('terminal websocket protocol covers process lifecycle', () => {
+  for (const type of [
+    'terminal_create',
+    'terminal_input',
+    'terminal_resize',
+    'terminal_close',
+    'terminal_started',
+    'terminal_output',
+    'terminal_exit',
+    'terminal_error',
+  ]) {
+    assert.match(messageTypesSource, new RegExp(`type: '${type}'`));
+  }
+});
+
+test('terminal messages route through the server terminal manager', () => {
+  assert.match(routingSource, /bindTerminalSender\(sendToUser\)\.create/);
+  assert.match(routingSource, /case 'terminal_create':/);
+  assert.match(routingSource, /case 'terminal_input':/);
+  assert.match(routingSource, /case 'terminal_resize':/);
+  assert.match(routingSource, /case 'terminal_close':/);
+});
+
+test('panels can own terminal process identity separately from agent sessions', () => {
+  assert.match(panelTypesSource, /terminalId\?: string \| null/);
+});
+
+test('terminal processes are cleaned up after the final websocket disconnects', () => {
+  assert.match(wsServerSource, /terminalManager\.closeAllForUser\(userId\)/);
+});
+
+test('terminal cwd is server validated before spawning a PTY', () => {
+  assert.match(terminalManagerSource, /resolveAllowedTerminalCwd/);
+  assert.match(terminalResolverSource, /getVisibleProjects/);
+  assert.match(terminalResolverSource, /getSession/);
+  assert.match(terminalResolverSource, /Terminal cwd must be inside a registered project or active worktree/);
+});
+
+test('terminal ownership keys include user id and terminal id', () => {
+  assert.match(terminalManagerSource, /getKey\(userId: string, terminalId: string\)/);
+  assert.match(terminalManagerSource, /`\$\{userId\}:\$\{terminalId\}`/);
+});
+
+test('terminal client subscribes before creating the server process', () => {
+  assert.ok(
+    terminalPanelSource.indexOf('subscribeServerMessages') <
+      terminalPanelSource.indexOf('wsClient.createTerminal'),
+  );
+});
+
+test('wsl terminal profiles are blocked until path conversion is implemented', () => {
+  assert.match(terminalResolverSource, /WSL terminal profiles are not supported yet/);
+});

--- a/tests/terminal-contract.test.mjs
+++ b/tests/terminal-contract.test.mjs
@@ -9,9 +9,13 @@ const wsServerSource = fs.readFileSync(new URL('../src/lib/ws/server.ts', import
 const terminalManagerSource = fs.readFileSync(new URL('../src/lib/terminal/terminal-manager.ts', import.meta.url), 'utf8');
 const terminalResolverSource = fs.readFileSync(new URL('../src/lib/terminal/terminal-resolver.ts', import.meta.url), 'utf8');
 const terminalPanelSource = fs.readFileSync(new URL('../src/components/terminal/terminal-panel.tsx', import.meta.url), 'utf8');
+const wsClientSource = fs.readFileSync(new URL('../src/lib/ws/client.ts', import.meta.url), 'utf8');
 const panelWrapperSource = fs.readFileSync(new URL('../src/components/panel/panel-wrapper.tsx', import.meta.url), 'utf8');
 const panelStoreSource = fs.readFileSync(new URL('../src/stores/panel-store.ts', import.meta.url), 'utf8');
+const tabItemSource = fs.readFileSync(new URL('../src/components/tab/tab-item.tsx', import.meta.url), 'utf8');
+const tabBarSource = fs.readFileSync(new URL('../src/components/tab/tab-bar.tsx', import.meta.url), 'utf8');
 const panelTypesSource = fs.readFileSync(new URL('../src/types/panel.ts', import.meta.url), 'utf8');
+const prepareElectronRuntimeSource = fs.readFileSync(new URL('../scripts/prepare-electron-runtime.mjs', import.meta.url), 'utf8');
 
 test('terminal feature declares browser UI and server PTY dependencies', () => {
   assert.ok(packageJson.dependencies['@xterm/xterm']);
@@ -68,12 +72,16 @@ test('terminal client subscribes before creating the server process', () => {
     terminalPanelSource.indexOf('subscribeServerMessages') <
       terminalPanelSource.indexOf('wsClient.createTerminal'),
   );
+  assert.match(terminalPanelSource, /connectionStatus !== 'connected'/);
+  assert.match(terminalPanelSource, /didCreateTerminal/);
+  assert.match(wsClientSource, /createTerminal\(args: \{/);
+  assert.match(wsClientSource, /\}\): boolean \{/);
 });
 
 test('terminal creation is not tied to active panel focus changes', () => {
   assert.doesNotMatch(terminalPanelSource, /useSessionStore\(\(state\) => state\.activeSessionId\)/);
   assert.doesNotMatch(terminalPanelSource, /useSessionStore\.getState\(\)\.activeSessionId/);
-  assert.match(terminalPanelSource, /\}, \[terminalId, terminalSessionId\]\);/);
+  assert.match(terminalPanelSource, /\}, \[connectionStatus, terminalId, terminalSessionId\]\);/);
 });
 
 test('terminal panels preserve the source session context used to create them', () => {
@@ -89,7 +97,23 @@ test('terminal panels preserve the source session context used to create them', 
 test('terminal panels expose a panel drag handle', () => {
   assert.match(terminalPanelSource, /setPanelNodeDragData/);
   assert.match(terminalPanelSource, /data-testid="terminal-panel-drag-handle"/);
+  assert.match(terminalPanelSource, /data-testid="terminal-panel-empty-drag-region"/);
   assert.match(terminalPanelSource, /draggable/);
+});
+
+test('terminal-only tabs can be dragged into another panel tree', () => {
+  assert.match(tabItemSource, /Object\.values\(panels\)\.some\(\(panel\) => panel\.terminalId\)/);
+  assert.match(tabItemSource, /displayTitle = 'Terminal'/);
+  assert.doesNotMatch(panelWrapperSource, /droppedTabTreeId && sourceTabData && Object\.keys\(sourceTabData\.panels\)\.length > 1/);
+});
+
+test('terminal panels can be pulled into a new tab from a multi-panel layout', () => {
+  assert.match(tabBarSource, /parsePanelNodeDragData/);
+  assert.match(tabBarSource, /const terminalId = sourcePanel\?\.terminalId \?\? null/);
+  assert.match(tabBarSource, /const terminalSessionId = sourcePanel\?\.terminalSessionId \?\? null/);
+  assert.match(tabBarSource, /panelStore\.closePanel\(payload\.panelId\)/);
+  assert.match(tabBarSource, /tabStore\.createTab\(null, \{ insertAfterTabId: payload\.tabId \}\)/);
+  assert.match(tabBarSource, /assignTerminal\(newPanelId, terminalId, terminalSessionId\)/);
 });
 
 test('terminal remount attaches to the existing server process', () => {
@@ -108,6 +132,26 @@ test('panel node drag preserves terminal panel identity', () => {
   assert.match(panelStoreSource, /terminalSessionId: targetPanel\.terminalSessionId \?\? null/);
 });
 
-test('wsl terminal profiles are blocked until path conversion is implemented', () => {
-  assert.match(terminalResolverSource, /WSL terminal profiles are not supported yet/);
+test('terminal shell selection follows the configured agent environment', () => {
+  assert.match(terminalManagerSource, /getAgentEnvironment/);
+  assert.match(terminalManagerSource, /agentEnvironment === 'wsl'/);
+  assert.match(terminalManagerSource, /useConpty: false/);
+  assert.match(terminalResolverSource, /command: 'wsl\.exe'/);
+  assert.match(terminalResolverSource, /args: \['-e', 'sh', '-c', buildWslTerminalScript\(wslCwd\)\]/);
+  assert.doesNotMatch(terminalResolverSource, /'-lc'/);
+  assert.match(terminalResolverSource, /getent passwd "\$\(id -un\)"/);
+  assert.match(terminalResolverSource, /exec "\$shell" -i/);
+  assert.match(terminalResolverSource, /resolveWindowsNativeTerminalCwd/);
+  assert.match(terminalResolverSource, /isWindowsHostedWslPath/);
+  assert.doesNotMatch(terminalResolverSource, /WSL terminal profiles are not supported yet/);
+});
+
+test('electron packages node-pty native runtime assets outside the asar', () => {
+  assert.ok(packageJson.build.asarUnpack.includes('**/node_modules/node-pty/prebuilds/**'));
+  assert.ok(packageJson.build.asarUnpack.includes('**/node_modules/node-pty/build/Release/*.node'));
+  assert.match(prepareElectronRuntimeSource, /addDirectory\('node_modules\/node-pty\/lib\/worker'/);
+  assert.match(prepareElectronRuntimeSource, /addDirectory\('node_modules\/node-pty\/prebuilds'/);
+  assert.match(prepareElectronRuntimeSource, /addDirectory\('node_modules\/node-pty\/build\/Release'/);
+  assert.match(prepareElectronRuntimeSource, /node_modules\/node-pty\/prebuilds\//);
+  assert.match(prepareElectronRuntimeSource, /\.pdb/);
 });


### PR DESCRIPTION
## Summary
- add server-backed Terminal panels using xterm.js in the renderer and node-pty on the Tessera server
- wire terminal lifecycle/input/resize messages through the existing websocket client/server path
- add panel state support, an empty-panel Terminal entry point, and a configurable Ctrl+` terminal shortcut
- clean up terminal processes when the user disconnects and validate terminal cwd against registered projects or active session worktrees

## Related
- Related to #24
- Follows the integrated Terminal/TUI panel direction discussed with the maintainers: server-owned PTY process, renderer-owned terminal UI, one process per Terminal panel, and no nested terminal tabs in v1.

## Limitation
- WSL terminal profiles are intentionally blocked in this first pass. Native Windows/macOS/Linux shells are supported, but WSL needs proper path conversion/profile handling before it is enabled.

## Testing
- `node --test tests/electron-updater-contract.test.mjs tests/terminal-contract.test.mjs`
- `npx tsc --noEmit`
- `npm run build`