### PR TITLE
Add chat message search

### DIFF
--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { memo, useContext, useEffect, useRef } from "react";
+import { memo, useContext, useEffect, useMemo, useRef } from "react";
 import { selectIsTurnInFlight, useChatStore } from "@/stores/chat-store";
 import { useSessionStore } from "@/stores/session-store";
 import { useSessionNavigation } from "@/hooks/use-session-navigation";
 import { useWindowedMessages } from "@/hooks/use-windowed-messages";
+import { useMessageSearch } from "@/hooks/use-message-search";
+import { groupMessages } from "@/lib/chat/group-messages";
 import { Header } from "./header";
 import { MessageList } from "./message-list";
 import { MessageInput } from "./message-input";
@@ -63,6 +65,15 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
     autoLoadedSessionIdRef.current = session.id;
     void viewSession(session);
   }, [session, historyLoaded, viewSession]);
+  const groupedMessagesForSearch = useMemo(
+    () => groupMessages(windowedMessages),
+    [windowedMessages],
+  );
+  const messageSearch = useMessageSearch(
+    windowedMessages,
+    groupedMessagesForSearch,
+    sessionId,
+  );
 
   if (!sessionId) {
     return (
@@ -120,7 +131,23 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
 
   return (
     <div className="flex-1 flex flex-col h-full bg-(--chat-bg)">
-      <Header sessionId={sessionId} panelId={panelId} isSinglePanel={isSinglePanel} />
+      <Header
+        sessionId={sessionId}
+        panelId={panelId}
+        isSinglePanel={isSinglePanel}
+        search={{
+          isOpen: messageSearch.isSearchOpen,
+          query: messageSearch.query,
+          matchCount: messageSearch.matches.length,
+          activeMatchIndex: messageSearch.activeMatchIndex,
+          hasMore,
+          onOpen: messageSearch.openSearch,
+          onClose: messageSearch.closeSearch,
+          onQueryChange: messageSearch.setQuery,
+          onNext: messageSearch.goToNextMatch,
+          onPrevious: messageSearch.goToPreviousMatch,
+        }}
+      />
 
       <div className="flex-1 overflow-hidden">
         <MessageList
@@ -133,6 +160,10 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
           isSinglePanel={isSinglePanel}
           isTabActive={isViewActive}
           isTurnInFlight={isTurnInFlight}
+          search={{
+            activeMatchMessageId: messageSearch.activeMatch?.messageId ?? null,
+            activeGroupedRowIndex: messageSearch.activeGroupedRowIndex,
+          }}
         />
       </div>
 

--- a/src/components/chat/header.tsx
+++ b/src/components/chat/header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback, useContext } from 'react';
-import { Pencil, Check, Hash, X as XIcon, MoreHorizontal, GitBranch } from 'lucide-react';
+import { Pencil, Check, Hash, X as XIcon, MoreHorizontal, GitBranch, Search } from 'lucide-react';
 import { getTitleGeneratingStyle } from '@/lib/title-generating-style';
 import { useSessionStore } from '@/stores/session-store';
 import { useTaskStore } from '@/stores/task-store';
@@ -15,14 +15,27 @@ import { wsClient } from '@/lib/ws/client';
 import { SINGLE_PANEL_CONTENT_SHELL } from './single-panel-shell';
 import { ProviderBadge } from './provider-brand';
 import { setPanelTitleDragData } from '@/lib/dnd/panel-session-drag';
+import { MessageSearchBar } from './message-search-bar';
 
 interface HeaderProps {
   sessionId: string;
   panelId: string;
   isSinglePanel?: boolean;
+  search?: {
+    isOpen: boolean;
+    query: string;
+    matchCount: number;
+    activeMatchIndex: number;
+    hasMore: boolean;
+    onOpen: () => void;
+    onClose: () => void;
+    onQueryChange: (query: string) => void;
+    onNext: () => void;
+    onPrevious: () => void;
+  };
 }
 
-export function Header({ sessionId, panelId, isSinglePanel = false }: HeaderProps) {
+export function Header({ sessionId, panelId, isSinglePanel = false, search }: HeaderProps) {
   const { t } = useI18n();
   const tabId = useContext(TabIdContext);
   const session = useSessionStore((state) =>
@@ -310,6 +323,35 @@ export function Header({ sessionId, panelId, isSinglePanel = false }: HeaderProp
 
         {/* Right: actions */}
         <div className="flex shrink-0 items-center gap-2">
+          {search?.isOpen ? (
+            <MessageSearchBar
+              query={search.query}
+              matchCount={search.matchCount}
+              activeMatchIndex={search.activeMatchIndex}
+              hasMore={search.hasMore}
+              onQueryChange={search.onQueryChange}
+              onNext={search.onNext}
+              onPrevious={search.onPrevious}
+              onClose={search.onClose}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={search?.onOpen}
+              title={t('chat.search.open')}
+              aria-label={t('chat.search.open')}
+              className={cn(
+                'rounded p-0.5 transition-all duration-150',
+                'text-(--text-muted) hover:text-(--sidebar-text-active)',
+                'hover:bg-(--sidebar-hover)',
+                !search && 'pointer-events-none opacity-40',
+              )}
+              data-testid="message-search-open-button"
+            >
+              <Search className="h-3.5 w-3.5" />
+            </button>
+          )}
+
           {/* More actions button — hover only */}
           <button
             ref={moreButtonRef}

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -137,13 +137,16 @@ function MessageListSessionView({
     isTurnInFlight,
   });
 
+  const activeSearchGroupedRowIndex = search?.activeGroupedRowIndex ?? -1;
+  const activeSearchMatchMessageId = search?.activeMatchMessageId ?? null;
+
   useEffect(() => {
-    if (!search || search.activeGroupedRowIndex < 0) return;
-    virtualizer.scrollToIndex(search.activeGroupedRowIndex, {
+    if (activeSearchGroupedRowIndex < 0 || !activeSearchMatchMessageId) return;
+    virtualizer.scrollToIndex(activeSearchGroupedRowIndex, {
       align: 'center',
       behavior: 'smooth',
     });
-  }, [search?.activeGroupedRowIndex, search?.activeMatchMessageId, virtualizer]);
+  }, [activeSearchGroupedRowIndex, activeSearchMatchMessageId, virtualizer]);
 
   // 선택된 도구호출을 groupedMessages에서 찾기
   const selectedToolCall = useMemo(() => {
@@ -272,8 +275,8 @@ function MessageListSessionView({
                   const item = groupedMessages[virtualRow.index];
                   const key = virtualRow.key as string;
                   const isActiveSearchRow =
-                    search?.activeGroupedRowIndex === virtualRow.index &&
-                    search.activeMatchMessageId != null;
+                    activeSearchGroupedRowIndex === virtualRow.index &&
+                    activeSearchMatchMessageId != null;
                   return (
                     <div
                       key={key}

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useCallback, useRef } from 'react';
+import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import type { EnhancedMessage, ToolCallMessage } from '@/types/chat';
 import { MessageBubble } from './message-bubble';
 import { LoadingIndicator } from './loading-indicator';
@@ -33,6 +33,10 @@ interface MessageListProps {
   isSinglePanel?: boolean;
   isTabActive?: boolean;
   isTurnInFlight?: boolean;
+  search?: {
+    activeMatchMessageId: string | null;
+    activeGroupedRowIndex: number;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -98,6 +102,7 @@ function MessageListSessionView({
   isSinglePanel = false,
   isTabActive = true,
   isTurnInFlight = false,
+  search,
 }: MessageListProps) {
   'use no memo'; // React Compiler caches virtualizer.getVirtualItems() on the stable instance ref — but the virtualizer is mutable, so we must opt out.
   const { t } = useI18n();
@@ -131,6 +136,14 @@ function MessageListSessionView({
     isTabActive,
     isTurnInFlight,
   });
+
+  useEffect(() => {
+    if (!search || search.activeGroupedRowIndex < 0) return;
+    virtualizer.scrollToIndex(search.activeGroupedRowIndex, {
+      align: 'center',
+      behavior: 'smooth',
+    });
+  }, [search?.activeGroupedRowIndex, search?.activeMatchMessageId, virtualizer]);
 
   // 선택된 도구호출을 groupedMessages에서 찾기
   const selectedToolCall = useMemo(() => {
@@ -258,12 +271,20 @@ function MessageListSessionView({
                 {virtualItems.map((virtualRow) => {
                   const item = groupedMessages[virtualRow.index];
                   const key = virtualRow.key as string;
+                  const isActiveSearchRow =
+                    search?.activeGroupedRowIndex === virtualRow.index &&
+                    search.activeMatchMessageId != null;
                   return (
                     <div
                       key={key}
                       data-index={virtualRow.index}
                       data-item-key={key}
+                      data-search-active-match={isActiveSearchRow ? 'true' : undefined}
                       ref={virtualizer.measureElement}
+                      className={cn(
+                        'rounded-md transition-colors',
+                        isActiveSearchRow && 'bg-(--accent)/10 ring-1 ring-(--accent)/30',
+                      )}
                       style={{
                         position: 'absolute',
                         top: 0,

--- a/src/components/chat/message-search-bar.tsx
+++ b/src/components/chat/message-search-bar.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { ChevronDown, ChevronUp, Search, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useI18n } from '@/lib/i18n';
+
+interface MessageSearchBarProps {
+  query: string;
+  matchCount: number;
+  activeMatchIndex: number;
+  hasMore: boolean;
+  onQueryChange: (query: string) => void;
+  onNext: () => void;
+  onPrevious: () => void;
+  onClose: () => void;
+}
+
+export function MessageSearchBar({
+  query,
+  matchCount,
+  activeMatchIndex,
+  hasMore,
+  onQueryChange,
+  onNext,
+  onPrevious,
+  onClose,
+}: MessageSearchBarProps) {
+  const { t } = useI18n();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const hasQuery = query.trim().length > 0;
+  const canNavigate = matchCount > 0;
+  const counterLabel = hasQuery
+    ? canNavigate
+      ? t('chat.search.count', {
+          current: String(activeMatchIndex + 1),
+          total: String(matchCount),
+        })
+      : t('chat.search.noMatches')
+    : '';
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        'flex h-7 min-w-0 items-center gap-1 rounded-md border border-(--input-border)',
+        'bg-(--input-bg) px-1.5 text-(--text-secondary) shadow-sm',
+      )}
+      data-testid="message-search-bar"
+    >
+      <Search className="h-3.5 w-3.5 shrink-0 text-(--text-muted)" aria-hidden="true" />
+      <input
+        ref={inputRef}
+        value={query}
+        onChange={(event) => onQueryChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            if (event.shiftKey) onPrevious();
+            else onNext();
+          } else if (event.key === 'Escape') {
+            event.preventDefault();
+            onClose();
+          }
+        }}
+        placeholder={t('chat.search.placeholder')}
+        aria-label={t('chat.search.placeholder')}
+        className="h-full w-28 min-w-0 bg-transparent text-xs text-(--text-primary) outline-none placeholder:text-(--text-muted) sm:w-36"
+      />
+      <span
+        className="min-w-[3.5rem] text-right text-[11px] leading-none text-(--text-muted)"
+        title={hasMore ? t('chat.search.loadedOnlyHint') : undefined}
+      >
+        {counterLabel}
+      </span>
+      <button
+        type="button"
+        onClick={onPrevious}
+        disabled={!canNavigate}
+        title={t('chat.search.previous')}
+        aria-label={t('chat.search.previous')}
+        className="rounded p-0.5 text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--text-primary) disabled:opacity-40"
+      >
+        <ChevronUp className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={!canNavigate}
+        title={t('chat.search.next')}
+        aria-label={t('chat.search.next')}
+        className="rounded p-0.5 text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--text-primary) disabled:opacity-40"
+      >
+        <ChevronDown className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={onClose}
+        title={t('chat.search.close')}
+        aria-label={t('chat.search.close')}
+        className="rounded p-0.5 text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--text-primary)"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/use-message-search.ts
+++ b/src/hooks/use-message-search.ts
@@ -23,6 +23,11 @@ export interface UseMessageSearchResult {
   goToPreviousMatch: () => void;
 }
 
+function clampMatchIndex(index: number, matchCount: number): number {
+  if (matchCount === 0) return 0;
+  return Math.min(index, matchCount - 1);
+}
+
 export function useMessageSearch(
   messages: EnhancedMessage[],
   groupedMessages: GroupedItem[],
@@ -33,24 +38,28 @@ export function useMessageSearch(
   const [activeMatchIndex, setActiveMatchIndex] = useState(0);
 
   const matches = useMemo(
-    () => findMessageSearchMatches(messages, query),
-    [messages, query],
+    () =>
+      findMessageSearchMatches(messages, query).filter(
+        (match) =>
+          findGroupedRowIndexForMessage(groupedMessages, match.messageId) >= 0,
+      ),
+    [messages, groupedMessages, query],
   );
 
+  // Reset ephemeral search UI when the panel switches to a different session.
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     setQuery('');
     setActiveMatchIndex(0);
     setIsSearchOpen(false);
   }, [sessionId]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
-  useEffect(() => {
-    setActiveMatchIndex((current) => {
-      if (matches.length === 0) return 0;
-      return Math.min(current, matches.length - 1);
-    });
-  }, [matches.length]);
-
-  const activeMatch = matches[activeMatchIndex] ?? null;
+  const safeActiveMatchIndex = clampMatchIndex(
+    activeMatchIndex,
+    matches.length,
+  );
+  const activeMatch = matches[safeActiveMatchIndex] ?? null;
   const activeGroupedRowIndex = activeMatch
     ? findGroupedRowIndexForMessage(groupedMessages, activeMatch.messageId)
     : -1;
@@ -67,15 +76,19 @@ export function useMessageSearch(
 
   const goToNextMatch = useCallback(() => {
     setActiveMatchIndex((current) => {
-      if (matches.length === 0) return 0;
-      return (current + 1) % matches.length;
+      if (matches.length === 0) {
+        return 0;
+      }
+      return (clampMatchIndex(current, matches.length) + 1) % matches.length;
     });
   }, [matches.length]);
 
   const goToPreviousMatch = useCallback(() => {
     setActiveMatchIndex((current) => {
-      if (matches.length === 0) return 0;
-      return (current - 1 + matches.length) % matches.length;
+      if (matches.length === 0) {
+        return 0;
+      }
+      return (clampMatchIndex(current, matches.length) - 1 + matches.length) % matches.length;
     });
   }, [matches.length]);
 
@@ -88,7 +101,7 @@ export function useMessageSearch(
     isSearchOpen,
     query,
     matches,
-    activeMatchIndex,
+    activeMatchIndex: safeActiveMatchIndex,
     activeMatch,
     activeGroupedRowIndex,
     openSearch,

--- a/src/hooks/use-message-search.ts
+++ b/src/hooks/use-message-search.ts
@@ -1,0 +1,100 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { EnhancedMessage } from '@/types/chat';
+import type { GroupedItem } from '@/lib/chat/group-messages';
+import {
+  findGroupedRowIndexForMessage,
+  findMessageSearchMatches,
+  type MessageSearchMatch,
+} from '@/lib/chat/message-search';
+
+export interface UseMessageSearchResult {
+  isSearchOpen: boolean;
+  query: string;
+  matches: MessageSearchMatch[];
+  activeMatchIndex: number;
+  activeMatch: MessageSearchMatch | null;
+  activeGroupedRowIndex: number;
+  openSearch: () => void;
+  closeSearch: () => void;
+  setQuery: (query: string) => void;
+  goToNextMatch: () => void;
+  goToPreviousMatch: () => void;
+}
+
+export function useMessageSearch(
+  messages: EnhancedMessage[],
+  groupedMessages: GroupedItem[],
+  sessionId: string,
+): UseMessageSearchResult {
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeMatchIndex, setActiveMatchIndex] = useState(0);
+
+  const matches = useMemo(
+    () => findMessageSearchMatches(messages, query),
+    [messages, query],
+  );
+
+  useEffect(() => {
+    setQuery('');
+    setActiveMatchIndex(0);
+    setIsSearchOpen(false);
+  }, [sessionId]);
+
+  useEffect(() => {
+    setActiveMatchIndex((current) => {
+      if (matches.length === 0) return 0;
+      return Math.min(current, matches.length - 1);
+    });
+  }, [matches.length]);
+
+  const activeMatch = matches[activeMatchIndex] ?? null;
+  const activeGroupedRowIndex = activeMatch
+    ? findGroupedRowIndexForMessage(groupedMessages, activeMatch.messageId)
+    : -1;
+
+  const openSearch = useCallback(() => {
+    setIsSearchOpen(true);
+  }, []);
+
+  const closeSearch = useCallback(() => {
+    setIsSearchOpen(false);
+    setQuery('');
+    setActiveMatchIndex(0);
+  }, []);
+
+  const goToNextMatch = useCallback(() => {
+    setActiveMatchIndex((current) => {
+      if (matches.length === 0) return 0;
+      return (current + 1) % matches.length;
+    });
+  }, [matches.length]);
+
+  const goToPreviousMatch = useCallback(() => {
+    setActiveMatchIndex((current) => {
+      if (matches.length === 0) return 0;
+      return (current - 1 + matches.length) % matches.length;
+    });
+  }, [matches.length]);
+
+  const updateQuery = useCallback((nextQuery: string) => {
+    setQuery(nextQuery);
+    setActiveMatchIndex(0);
+  }, []);
+
+  return {
+    isSearchOpen,
+    query,
+    matches,
+    activeMatchIndex,
+    activeMatch,
+    activeGroupedRowIndex,
+    openSearch,
+    closeSearch,
+    setQuery: updateQuery,
+    goToNextMatch,
+    goToPreviousMatch,
+  };
+}

--- a/src/lib/chat/message-search.ts
+++ b/src/lib/chat/message-search.ts
@@ -1,0 +1,92 @@
+import type { EnhancedMessage } from '@/types/chat';
+import type { GroupedItem } from '@/lib/chat/group-messages';
+
+export interface MessageSearchMatch {
+  messageId: string;
+  messageType: EnhancedMessage['type'];
+  preview: string;
+}
+
+function normalizeSearchText(value: string): string {
+  return value.toLocaleLowerCase();
+}
+
+function stringifySearchValue(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}
+
+function getTextContentSearchText(content: Extract<EnhancedMessage, { type: 'text' }>['content']): string {
+  if (typeof content === 'string') return content;
+  return content
+    .map((block) => {
+      if (!block || typeof block !== 'object') return '';
+      if ('text' in block && typeof block.text === 'string') return block.text;
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function getMessageSearchText(message: EnhancedMessage): string {
+  switch (message.type) {
+    case 'text':
+      return getTextContentSearchText(message.content);
+    case 'thinking':
+      return message.content;
+    case 'system':
+      return message.message;
+    case 'progress_hook':
+      return message.errorMessage ?? '';
+    case 'tool_call':
+      return [
+        message.toolName,
+        stringifySearchValue(message.toolParams),
+        message.output,
+        message.error,
+      ].filter(Boolean).join('\n');
+    default:
+      return '';
+  }
+}
+
+export function findMessageSearchMatches(
+  messages: EnhancedMessage[],
+  rawQuery: string,
+): MessageSearchMatch[] {
+  const query = rawQuery.trim();
+  if (!query) return [];
+
+  const normalizedQuery = normalizeSearchText(query);
+  const matches: MessageSearchMatch[] = [];
+
+  for (const message of messages) {
+    const text = getMessageSearchText(message);
+    if (!normalizeSearchText(text).includes(normalizedQuery)) continue;
+    matches.push({
+      messageId: message.id,
+      messageType: message.type,
+      preview: text.replace(/\s+/g, ' ').trim().slice(0, 160),
+    });
+  }
+
+  return matches;
+}
+
+function groupedItemContainsMessage(item: GroupedItem, messageId: string): boolean {
+  if (item.kind === 'single') return item.message.id === messageId;
+  return item.messages.some((message) => message.id === messageId);
+}
+
+export function findGroupedRowIndexForMessage(
+  groupedMessages: GroupedItem[],
+  messageId: string,
+): number {
+  return groupedMessages.findIndex((item) => groupedItemContainsMessage(item, messageId));
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -389,6 +389,16 @@ export const en: I18nMessages = {
     closeTabsToLeft: 'Close Tabs to the Left',
     closeTabsToRight: 'Close Tabs to the Right',
     closeAllTabs: 'Close All Tabs',
+    search: {
+      open: 'Search messages',
+      close: 'Close search',
+      placeholder: 'Search messages',
+      previous: 'Previous match',
+      next: 'Next match',
+      noMatches: 'No matches',
+      count: '{{current}}/{{total}}',
+      loadedOnlyHint: 'Older messages may need loading first.',
+    },
     connectionStatus: {
       connected: 'Connected',
       reconnecting: 'Reconnecting',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -389,6 +389,16 @@ export const ja: I18nMessages = {
     closeTabsToLeft: '左側のタブをすべて閉じる',
     closeTabsToRight: '右側のタブをすべて閉じる',
     closeAllTabs: 'すべてのタブを閉じる',
+    search: {
+      open: 'メッセージを検索',
+      close: '検索を閉じる',
+      placeholder: 'メッセージを検索',
+      previous: '前の一致',
+      next: '次の一致',
+      noMatches: '一致なし',
+      count: '{{current}}/{{total}}',
+      loadedOnlyHint: '古いメッセージは先に読み込む必要があります。',
+    },
     connectionStatus: {
       connected: '接続済み',
       reconnecting: '再接続中',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -391,6 +391,16 @@ export const ko: I18nMessages = {
     closeTabsToLeft: '왼쪽 탭 모두 닫기',
     closeTabsToRight: '오른쪽 탭 모두 닫기',
     closeAllTabs: '모든 탭 닫기',
+    search: {
+      open: '메시지 검색',
+      close: '검색 닫기',
+      placeholder: '메시지 검색',
+      previous: '이전 일치',
+      next: '다음 일치',
+      noMatches: '일치 없음',
+      count: '{{current}}/{{total}}',
+      loadedOnlyHint: '이전 메시지는 먼저 불러와야 할 수 있습니다.',
+    },
     connectionStatus: {
       connected: '연결됨',
       reconnecting: '재연결 중',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -389,6 +389,16 @@ export interface I18nMessages {
     closeTabsToLeft: string;
     closeTabsToRight: string;
     closeAllTabs: string;
+    search: {
+      open: string;
+      close: string;
+      placeholder: string;
+      previous: string;
+      next: string;
+      noMatches: string;
+      count: string;
+      loadedOnlyHint: string;
+    };
     connectionStatus: {
       connected: string;
       reconnecting: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -389,6 +389,16 @@ export const zh: I18nMessages = {
     closeTabsToLeft: '关闭左侧标签',
     closeTabsToRight: '关闭右侧标签',
     closeAllTabs: '关闭所有标签',
+    search: {
+      open: '搜索消息',
+      close: '关闭搜索',
+      placeholder: '搜索消息',
+      previous: '上一个匹配',
+      next: '下一个匹配',
+      noMatches: '无匹配',
+      count: '{{current}}/{{total}}',
+      loadedOnlyHint: '较早的消息可能需要先加载。',
+    },
     connectionStatus: {
       connected: '已连接',
       reconnecting: '重新连接中',

--- a/tests/message-search.test.mjs
+++ b/tests/message-search.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const source = fs.readFileSync(new URL('../src/lib/chat/message-search.ts', import.meta.url), 'utf8');
+
+function stringifySearchValue(value) {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}
+
+function getMessageSearchText(message) {
+  switch (message.type) {
+    case 'text':
+      if (typeof message.content === 'string') return message.content;
+      return message.content
+        .map((block) => block && typeof block === 'object' && typeof block.text === 'string' ? block.text : '')
+        .filter(Boolean)
+        .join('\n');
+    case 'thinking':
+      return message.content;
+    case 'system':
+      return message.message;
+    case 'progress_hook':
+      return message.errorMessage || '';
+    case 'tool_call':
+      return [
+        message.toolName,
+        stringifySearchValue(message.toolParams),
+        message.output,
+        message.error,
+      ].filter(Boolean).join('\n');
+    default:
+      return '';
+  }
+}
+
+function findMessageSearchMatches(messages, rawQuery) {
+  const query = rawQuery.trim();
+  if (!query) return [];
+  const normalizedQuery = query.toLocaleLowerCase();
+  const matches = [];
+  for (const message of messages) {
+    const text = getMessageSearchText(message);
+    if (!text.toLocaleLowerCase().includes(normalizedQuery)) continue;
+    matches.push({
+      messageId: message.id,
+      messageType: message.type,
+      preview: text.replace(/\s+/g, ' ').trim().slice(0, 160),
+    });
+  }
+  return matches;
+}
+
+test('message-search utility exports the expected pure functions', () => {
+  assert.match(source, /export function getMessageSearchText/);
+  assert.match(source, /export function findMessageSearchMatches/);
+  assert.match(source, /export function findGroupedRowIndexForMessage/);
+});
+
+test('findMessageSearchMatches searches loaded message content case-insensitively', () => {
+  const messages = [
+    { id: 'u1', type: 'text', role: 'user', timestamp: 't', content: 'Please inspect auth flow' },
+    { id: 'a1', type: 'text', role: 'assistant', timestamp: 't', content: 'The login handler is in route.ts' },
+    { id: 'think1', type: 'thinking', sessionId: 's', timestamp: 't', content: 'Checking AUTH middleware', status: 'completed' },
+    { id: 'sys1', type: 'system', sessionId: 's', timestamp: 't', message: 'Auth warning', severity: 'warning' },
+    { id: 'prog1', type: 'progress_hook', sessionId: 's', timestamp: 't', hookEvent: 'x', data: {}, errorMessage: 'Auth hook failed' },
+    { id: 'tool1', type: 'tool_call', sessionId: 's', timestamp: 't', toolName: 'Read', toolParams: { file: 'auth.ts' }, status: 'completed', output: 'auth token' },
+  ];
+
+  const matches = findMessageSearchMatches(messages, 'AUTH');
+  assert.deepEqual(matches.map((match) => match.messageId), ['u1', 'think1', 'sys1', 'prog1', 'tool1']);
+  assert.equal(matches[0].preview, 'Please inspect auth flow');
+});
+
+test('findMessageSearchMatches searches text blocks in array content', () => {
+  const messages = [
+    {
+      id: 'multi',
+      type: 'text',
+      role: 'user',
+      timestamp: 't',
+      content: [
+        { type: 'text', text: 'first block' },
+        { type: 'text', text: 'needle block' },
+        { type: 'image', url: 'ignored' },
+      ],
+    },
+  ];
+
+  assert.deepEqual(findMessageSearchMatches(messages, 'needle').map((match) => match.messageId), ['multi']);
+});
+
+test('findMessageSearchMatches returns no matches for blank queries', () => {
+  assert.deepEqual(findMessageSearchMatches([
+    { id: 'u1', type: 'text', role: 'user', timestamp: 't', content: 'hello' },
+  ], '   '), []);
+});


### PR DESCRIPTION
## Summary
- add in-chat message search for loaded AI agent tab messages
- add compact header search controls with previous/next navigation
- scroll the virtualized message list to the active match and highlight it
- add localized search strings and focused message search tests

## Tests
- node --test tests/message-search.test.mjs
- git diff --check HEAD~1..HEAD

## Notes
- Search covers messages currently loaded in the client. Older paginated history may need to be loaded first.