### PR TITLE
Add agent context session brief panel

### DIFF
--- a/src/components/git/agent-context-panel.tsx
+++ b/src/components/git/agent-context-panel.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { FileSearch } from "lucide-react";
+import type { AgentTimelineItem } from "@/lib/agent-context-summary";
+import { buildAgentContextSummary } from "@/lib/agent-context-summary";
+import { useChatStore } from "@/stores/chat-store";
+import type { EnhancedMessage } from "@/types/chat";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+const EMPTY_MESSAGES: EnhancedMessage[] = [];
+
+type LogFilterKey =
+  | "cmd"
+  | "read"
+  | "search"
+  | "edit"
+  | "issue"
+  | "task"
+  | "todo"
+  | "web";
+
+interface FilterOption {
+  key: LogFilterKey;
+  label: string;
+}
+
+const FILTER_OPTIONS: FilterOption[] = [
+  { key: "cmd", label: "CMD" },
+  { key: "read", label: "READ" },
+  { key: "search", label: "SEARCH" },
+  { key: "edit", label: "EDIT" },
+  { key: "issue", label: "ISSUE" },
+  { key: "task", label: "TASK" },
+  { key: "todo", label: "TODO" },
+  { key: "web", label: "WEB" },
+];
+
+const EMPTY_FILTER_COUNTS: Record<LogFilterKey, number> = {
+  cmd: 0,
+  read: 0,
+  search: 0,
+  edit: 0,
+  issue: 0,
+  task: 0,
+  todo: 0,
+  web: 0,
+};
+
+function formatTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "";
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+function formatShortTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "";
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}
+
+function getFilterKey(item: AgentTimelineItem): LogFilterKey {
+  return item.kind;
+}
+
+function getKindLabel(item: AgentTimelineItem): string {
+  const key = getFilterKey(item);
+  switch (key) {
+    case "read":
+      return "READ";
+    case "search":
+      return "SEARCH";
+    case "cmd":
+      return "CMD";
+    case "edit":
+      return "EDIT";
+    case "issue":
+      return "ISSUE";
+    case "task":
+      return "TASK";
+    case "todo":
+      return "TODO";
+    case "web":
+      return "WEB";
+  }
+}
+
+function getKindClass(item: AgentTimelineItem): string {
+  const key = getFilterKey(item);
+  switch (key) {
+    case "read":
+      return "text-(--accent)";
+    case "search":
+      return "text-(--status-info-text)";
+    case "cmd":
+      return "text-(--text-secondary)";
+    case "edit":
+      return "text-(--status-success-text)";
+    case "issue":
+      return "text-(--status-error-text)";
+    case "task":
+      return "text-(--status-info-text)";
+    case "todo":
+      return "text-(--warning)";
+    case "web":
+      return "text-(--status-info-text)";
+  }
+}
+
+function getEventText(item: AgentTimelineItem): string {
+  return item.command || item.path || item.title;
+}
+
+function getRowDetailParts(item: AgentTimelineItem): string[] {
+  const parts = [item.detail];
+  if (item.kind !== "cmd" && !(item.kind === "read" && item.command)) {
+    parts.push(item.meta);
+  }
+  return parts.filter((part): part is string => Boolean(part));
+}
+
+function getEventTitle(item: AgentTimelineItem): string {
+  const parts = [
+    formatTime(item.timestamp),
+    getKindLabel(item),
+    getEventText(item),
+    item.detail,
+    item.meta,
+    item.status,
+  ].filter(Boolean);
+  return parts.join(" | ");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function firstRecordString(record: Record<string, unknown> | undefined, keys: string[]): string | undefined {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const value = nonEmptyString(record[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function getToolResultErrorText(result: unknown): string | undefined {
+  if (typeof result === "string") return nonEmptyString(result);
+  if (!isRecord(result)) return undefined;
+
+  const direct = firstRecordString(result, [
+    "stderr",
+    "error",
+    "message",
+    "output",
+    "stdout",
+    "content",
+    "responseText",
+  ]);
+  if (direct) return direct;
+
+  const task = isRecord(result.task) ? result.task : undefined;
+  return firstRecordString(task, ["output", "result", "message"]);
+}
+
+function useIssueDetail(item: AgentTimelineItem): {
+  detail: string;
+  isLoading: boolean;
+} {
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const cachedOutput = useChatStore((state) =>
+    item.toolUseId ? state.toolOutputCache.get(item.toolUseId) : undefined,
+  );
+  const shouldLoadSavedOutput = Boolean(
+    !item.errorDetail && item.hasOutput && item.sessionId && item.toolUseId && !cachedOutput,
+  );
+
+  useEffect(() => {
+    if (!shouldLoadSavedOutput) return;
+
+    let isCancelled = false;
+    async function fetchIssueOutput(): Promise<void> {
+      setIsLoading(true);
+      setLoadError(null);
+      try {
+        const params = new URLSearchParams({ toolUseId: item.toolUseId! });
+        const response = await fetch(`/api/sessions/${item.sessionId}/tool-output?${params}`);
+        if (!response.ok) {
+          throw new Error(response.status === 404 ? "No saved tool output found" : `Failed to load tool output (${response.status})`);
+        }
+
+        const data = await response.json();
+        if (isCancelled) return;
+        useChatStore.getState().setToolOutput(item.sessionId!, item.toolUseId!, {
+          output: data.output,
+          toolUseResult: data.toolUseResult,
+          isError: data.isError,
+        });
+      } catch (error) {
+        if (!isCancelled) {
+          setLoadError((error as Error).message);
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void fetchIssueOutput();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [item.sessionId, item.toolUseId, shouldLoadSavedOutput]);
+
+  const cachedDetail = getToolResultErrorText(cachedOutput?.toolUseResult)
+    || nonEmptyString(cachedOutput?.output);
+  const detail = item.errorDetail
+    || cachedDetail
+    || loadError
+    || (shouldLoadSavedOutput || isLoading ? "Loading saved tool output..." : "No error output captured for this failed tool call.");
+
+  return { detail, isLoading };
+}
+
+function IssueEventCell({ item }: { item: AgentTimelineItem }) {
+  const { detail, isLoading } = useIssueDetail(item);
+
+  return (
+    <span
+      title={[formatTime(item.timestamp), getKindLabel(item), getEventText(item), detail].filter(Boolean).join(" | ")}
+      className="line-clamp-4 min-w-0 overflow-hidden whitespace-normal text-(--text-secondary) [overflow-wrap:anywhere]"
+    >
+      {getEventText(item)}
+      <span className={cn("text-(--text-muted)", isLoading && "italic")}> · {detail}</span>
+    </span>
+  );
+}
+
+function buildFilterCounts(timeline: AgentTimelineItem[]): Record<LogFilterKey, number> {
+  const counts = { ...EMPTY_FILTER_COUNTS };
+  for (const item of timeline) {
+    counts[getFilterKey(item)] += 1;
+  }
+  return counts;
+}
+
+function itemMatchesFilters(item: AgentTimelineItem, filters: Set<LogFilterKey>): boolean {
+  return filters.size === 0 || filters.has(getFilterKey(item));
+}
+
+function TimelineRow({ item }: { item: AgentTimelineItem }) {
+  const eventText = getEventText(item);
+  const detailParts = getRowDetailParts(item);
+  const eventCell = (
+    <span className="line-clamp-3 min-w-0 overflow-hidden whitespace-normal text-(--text-secondary) [overflow-wrap:anywhere]">
+      {eventText}
+      {detailParts.length > 0 ? (
+        <span className="text-(--text-muted)"> · {detailParts.join(" · ")}</span>
+      ) : null}
+    </span>
+  );
+
+  return (
+    <li
+      title={item.kind === "issue" ? undefined : getEventTitle(item)}
+      className="grid min-h-[22px] grid-cols-[44px_46px_minmax(0,1fr)] items-start gap-x-2 border-b border-(--chat-header-border) px-1.5 py-0.5 font-mono text-[10.5px] leading-[1.32] transition-colors hover:bg-(--sidebar-hover)"
+    >
+      <time className="truncate pt-px tabular-nums text-(--text-muted)" dateTime={item.timestamp}>
+        {formatShortTime(item.timestamp)}
+      </time>
+      <span className={cn("truncate pt-px text-[10px] font-semibold", getKindClass(item))}>
+        {getKindLabel(item)}
+      </span>
+      {item.kind === "issue" ? <IssueEventCell item={item} /> : eventCell}
+    </li>
+  );
+}
+
+function FilterBar({
+  activeFilters,
+  counts,
+  totalCount,
+  onClear,
+  onToggle,
+}: {
+  activeFilters: Set<LogFilterKey>;
+  counts: Record<LogFilterKey, number>;
+  totalCount: number;
+  onClear: () => void;
+  onToggle: (key: LogFilterKey) => void;
+}) {
+  return (
+    <div className="mt-2 flex min-w-0 flex-wrap items-center gap-1 overflow-hidden">
+      <button
+        type="button"
+        aria-pressed={activeFilters.size === 0}
+        onClick={onClear}
+        className={cn(
+          "flex h-5 shrink-0 items-center gap-1 border px-1.5 font-mono text-[10px] leading-none transition-colors",
+          activeFilters.size === 0
+            ? "border-(--accent) bg-(--accent)/10 text-(--accent)"
+            : "border-(--divider) text-(--text-muted) hover:text-(--text-primary)",
+        )}
+      >
+        ALL
+        <span className="tabular-nums">{totalCount}</span>
+      </button>
+      {FILTER_OPTIONS.map((filter) => {
+        const isActive = activeFilters.has(filter.key);
+        const count = counts[filter.key];
+        return (
+          <button
+            key={filter.key}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => onToggle(filter.key)}
+            className={cn(
+              "flex h-5 shrink-0 items-center gap-1 border px-1.5 font-mono text-[10px] leading-none transition-colors",
+              isActive
+                ? "border-(--accent) bg-(--accent)/10 text-(--accent)"
+                : count > 0
+                  ? "border-(--divider) text-(--text-muted) hover:text-(--text-primary)"
+                  : "border-(--divider) text-(--text-muted)/55",
+            )}
+          >
+            {filter.label}
+            <span className="tabular-nums">{count}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export const AgentContextPanel = memo(function AgentContextPanel({
+  sessionId,
+}: {
+  sessionId: string | null;
+}) {
+  const streamRef = useRef<HTMLDivElement>(null);
+  const [activeFilterKeys, setActiveFilterKeys] = useState<LogFilterKey[]>([]);
+  const messages = useChatStore((state) =>
+    sessionId ? state.messages.get(sessionId) ?? EMPTY_MESSAGES : EMPTY_MESSAGES,
+  );
+
+  const summary = useMemo(
+    () => buildAgentContextSummary(messages),
+    [messages],
+  );
+  const activeFilters = useMemo(() => new Set(activeFilterKeys), [activeFilterKeys]);
+  const filterCounts = useMemo(() => buildFilterCounts(summary.timeline), [summary.timeline]);
+  const filteredTimeline = useMemo(
+    () => summary.timeline.filter((item) => itemMatchesFilters(item, activeFilters)),
+    [activeFilters, summary.timeline],
+  );
+
+  const hasAnyContext = summary.timeline.length > 0;
+  const isLive = summary.timeline.some((item) =>
+    item.status === "running" || item.status === "active" || item.status === "pending" || item.status === "in_progress",
+  );
+  const lastTimelineItem = filteredTimeline[filteredTimeline.length - 1];
+  const streamFollowKey = lastTimelineItem
+    ? `${filteredTimeline.length}:${lastTimelineItem.id}:${lastTimelineItem.status || ""}:${activeFilterKeys.join(",")}`
+    : `empty:${activeFilterKeys.join(",")}:${summary.timeline.length}`;
+
+  const scrollToBottom = useCallback(() => {
+    const stream = streamRef.current;
+    if (!stream) return;
+
+    stream.scrollTop = stream.scrollHeight;
+  }, []);
+
+  useLayoutEffect(() => {
+    scrollToBottom();
+  }, [scrollToBottom, streamFollowKey]);
+
+  useEffect(() => {
+    function handleVisibilityChange(): void {
+      if (document.visibilityState === "visible") {
+        scrollToBottom();
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", scrollToBottom);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", scrollToBottom);
+    };
+  }, [scrollToBottom]);
+
+  function toggleFilter(key: LogFilterKey): void {
+    setActiveFilterKeys((current) =>
+      current.includes(key)
+        ? current.filter((item) => item !== key)
+        : [...current, key],
+    );
+  }
+
+  if (!sessionId) {
+    return (
+      <div className="flex h-full items-center justify-center px-6 text-center">
+        <div>
+          <FileSearch className="mx-auto h-5 w-5 text-(--text-muted)" />
+          <h3 className="mt-2 text-sm font-medium text-(--text-primary)">No session selected</h3>
+          <p className="mt-1 text-xs leading-5 text-(--text-muted)">
+            Select a session to track agent context.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-x-hidden">
+      <div className="shrink-0 border-b border-(--chat-header-border) px-2.5 py-2">
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="min-w-0 truncate text-sm font-semibold text-(--text-primary)">Agent context</h2>
+          <span
+            className={cn(
+              "inline-flex h-5 shrink-0 items-center gap-1.5 border px-1.5 font-mono text-[10px] uppercase",
+              isLive
+                ? "border-(--accent)/40 text-(--accent)"
+                : "border-(--divider) text-(--text-muted)",
+            )}
+          >
+            <span className={cn("h-1.5 w-1.5 rounded-full", isLive ? "bg-(--accent) motion-safe:animate-pulse" : "bg-(--text-muted)")} />
+            {isLive ? "Live" : "Idle"}
+          </span>
+        </div>
+        <FilterBar
+          activeFilters={activeFilters}
+          counts={filterCounts}
+          totalCount={summary.timeline.length}
+          onClear={() => setActiveFilterKeys([])}
+          onToggle={toggleFilter}
+        />
+      </div>
+
+      {!hasAnyContext ? (
+        <div className="flex flex-1 items-center justify-center px-6 text-center">
+          <div>
+            <FileSearch className="mx-auto h-5 w-5 text-(--text-muted)" />
+            <h3 className="mt-2 text-sm font-medium text-(--text-primary)">No agent context yet</h3>
+            <p className="mt-1 text-xs leading-5 text-(--text-muted)">
+              Tool calls, tasks, and todos will appear as the session runs.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <ScrollArea ref={streamRef} className="scrollbar-none min-h-0 flex-1 overflow-x-hidden">
+          <div className="sticky top-0 z-10 grid h-5 grid-cols-[44px_46px_minmax(0,1fr)] items-center gap-x-2 border-b border-(--divider) bg-(--sidebar-bg) px-1.5 font-mono text-[9.5px] uppercase leading-none text-(--text-muted)">
+            <span>T</span>
+            <span>Kind</span>
+            <span>Event</span>
+          </div>
+          {filteredTimeline.length > 0 ? (
+            <ol className="pb-8">
+              {filteredTimeline.map((item) => (
+                <TimelineRow key={item.id} item={item} />
+              ))}
+            </ol>
+          ) : (
+            <div className="flex h-32 items-center justify-center px-4 text-center text-xs text-(--text-muted)">
+              No matching events.
+            </div>
+          )}
+        </ScrollArea>
+      )}
+    </div>
+  );
+});

--- a/src/components/git/git-panel.tsx
+++ b/src/components/git/git-panel.tsx
@@ -2,9 +2,10 @@
 
 import { useCallback, useState } from "react";
 import type { ReactNode } from "react";
-import { FileText, GitCommitHorizontal, X } from "lucide-react";
+import { Bot, FileText, GitCommitHorizontal, X } from "lucide-react";
 import { useElectronPlatform } from "@/hooks/use-electron-platform";
 import type { GitChangedFile } from "@/types/git";
+import { AgentContextPanel } from "./agent-context-panel";
 import {
   GitPanelCommitsSection,
   GitPanelContentSection,
@@ -19,7 +20,7 @@ import {
 import { WorkspaceFilePanel } from "@/components/workspace/workspace-file-panel";
 import { cn } from "@/lib/utils";
 
-type GitPanelTab = "git" | "files";
+type GitPanelTab = "git" | "files" | "agent";
 
 function GitPanelTabButton({
   active,
@@ -115,6 +116,13 @@ export function GitPanel({
           >
             Files
           </GitPanelTabButton>
+          <GitPanelTabButton
+            active={activePanelTab === "agent"}
+            icon={<Bot className="h-3.5 w-3.5" />}
+            onClick={() => setActivePanelTab("agent")}
+          >
+            Agent
+          </GitPanelTabButton>
         </div>
         {onClose ? (
           <button
@@ -144,6 +152,10 @@ export function GitPanel({
       {activePanelTab === "files" ? (
         <div className="min-h-0 flex-1">
           <WorkspaceFilePanel key={sessionId ?? "no-session"} sessionId={sessionId} />
+        </div>
+      ) : activePanelTab === "agent" ? (
+        <div className="min-h-0 flex-1">
+          <AgentContextPanel sessionId={sessionId} />
         </div>
       ) : (
         <>

--- a/src/lib/agent-context-events.ts
+++ b/src/lib/agent-context-events.ts
@@ -1,0 +1,473 @@
+import { normalizeToolResult } from '@/lib/tool-results/normalize-tool-result';
+import type { AgentContextEvent, AgentContextStatus, AgentReferenceSource } from '@/types/agent-context';
+import type { ToolCallKind } from '@/types/tool-call-kind';
+import type { ToolDisplayMetadata } from '@/types/tool-display';
+
+interface BuildToolAgentContextEventsArgs {
+  toolName: string;
+  toolKind?: ToolCallKind;
+  toolParams: Record<string, any>;
+  toolDisplay?: ToolDisplayMetadata;
+  status: 'running' | 'completed' | 'error';
+  output?: string;
+  error?: string;
+  toolUseResult?: unknown;
+}
+
+const REFERENCE_PATH_KEYS = new Set([
+  'file_path',
+  'filePath',
+  'filepath',
+  'file_paths',
+  'paths',
+  'path',
+  'relative_path',
+  'notebook_path',
+]);
+
+const READ_LIKE_SHELL_COMMANDS = new Set([
+  'cat',
+  'convert',
+  'file',
+  'head',
+  'identify',
+  'less',
+  'magick',
+  'sed',
+  'tail',
+  'tesseract',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, maxLength: number): string {
+  const normalized = normalizeWhitespace(value);
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}...`;
+}
+
+function normalizeToolResultSafely(toolKind: ToolCallKind | undefined, result: unknown): unknown {
+  try {
+    return normalizeToolResult(toolKind, result);
+  } catch {
+    return undefined;
+  }
+}
+
+function isLikelyFilePath(value: string): boolean {
+  const path = value.trim();
+  if (!path || path === '.' || path === '..') return false;
+  if (path.includes('*')) return false;
+  if (path.endsWith('/')) return false;
+  if (/^https?:\/\//.test(path)) return false;
+  if (/^[A-Z_][A-Z0-9_]*=/.test(path)) return false;
+  return path.includes('/') || /\.[A-Za-z0-9]{1,12}(?:\[[0-9]+\])?$/.test(path);
+}
+
+function normalizeSlashes(value: string): string {
+  return value.replace(/\/{2,}/g, '/').replace(/\/\.\//g, '/');
+}
+
+function cleanShellPathToken(value: string): string {
+  return value
+    .trim()
+    .replace(/^[<>"']+|[<>"',;:]+$/g, '')
+    .replace(/\[[0-9]+\]$/, '');
+}
+
+function normalizeReferencedPath(value: string, cwd?: string): string | null {
+  const cleaned = cleanShellPathToken(value);
+  if (!isLikelyFilePath(cleaned)) return null;
+  if (cleaned.startsWith('/tmp/') || cleaned.startsWith('~/tmp/')) return null;
+  if (cleaned.startsWith('/')) return normalizeSlashes(cleaned);
+  if (cleaned.startsWith('~')) return cleaned;
+  return cwd ? normalizeSlashes(`${cwd}/${cleaned}`) : cleaned;
+}
+
+function addReferenceEvent(
+  events: AgentContextEvent[],
+  path: unknown,
+  source: AgentReferenceSource,
+  cwd?: string,
+): void {
+  if (Array.isArray(path)) {
+    for (const item of path) addReferenceEvent(events, item, source, cwd);
+    return;
+  }
+  if (typeof path !== 'string' || !path.trim()) return;
+
+  const normalizedPath = normalizeReferencedPath(path, cwd);
+  if (!normalizedPath) return;
+  if (events.some((event) => event.kind === 'reference' && event.path === normalizedPath && event.source === source)) {
+    return;
+  }
+
+  events.push({
+    kind: 'reference',
+    title: normalizedPath,
+    path: normalizedPath,
+    source,
+    meta: source,
+  });
+}
+
+function collectParamPathReferences(
+  value: unknown,
+  events: AgentContextEvent[],
+  source: AgentReferenceSource,
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectParamPathReferences(item, events, source);
+    return;
+  }
+  if (!isRecord(value)) return;
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (REFERENCE_PATH_KEYS.has(key)) {
+      addReferenceEvent(events, nestedValue, source);
+      continue;
+    }
+    collectParamPathReferences(nestedValue, events, source);
+  }
+}
+
+function collectReadLikeShellCommandReferences(
+  command: unknown,
+  events: AgentContextEvent[],
+  cwd?: string,
+): void {
+  if (typeof command !== 'string') return;
+
+  const unwrapped = command
+    .replace(/^\/usr\/bin\/(?:ba|z|c|fi)?sh\s+-lc\s+/, '')
+    .trim()
+    .replace(/^['"]|['"]$/g, '');
+  const firstWord = unwrapped.match(/^\s*(?:\S+\/)?([A-Za-z0-9_-]+)/)?.[1]?.toLowerCase();
+  if (!firstWord || !READ_LIKE_SHELL_COMMANDS.has(firstWord)) return;
+
+  const tokenMatches = unwrapped.match(/(?:~?\/?[\w.@+-][\w.@+/\-[\]]*\.[A-Za-z0-9]{1,12}(?:\[[0-9]+\])?)/g) || [];
+  for (const token of tokenMatches) {
+    addReferenceEvent(events, token, 'inspect', cwd);
+  }
+}
+
+function addResultReferences(
+  result: unknown,
+  events: AgentContextEvent[],
+  source: AgentReferenceSource,
+): void {
+  if (!isRecord(result)) return;
+
+  if (result.kind === 'file_read') {
+    addReferenceEvent(events, result.path, 'read');
+    return;
+  }
+
+  if (result.kind === 'search_result') {
+    addReferenceEvent(events, result.files, source);
+  }
+}
+
+function collectCommandActionReferences(
+  toolParams: Record<string, any>,
+  events: AgentContextEvent[],
+  cwd?: string,
+  fallbackCommand?: string,
+): void {
+  const actions = Array.isArray(toolParams.commandActions) ? toolParams.commandActions : [];
+
+  for (const action of actions) {
+    if (!isRecord(action)) continue;
+
+    if (action.type === 'read') {
+      addReferenceEvent(events, action.path, 'read', cwd);
+      continue;
+    }
+
+    if (action.type === 'search' || action.type === 'listFiles') {
+      addReferenceEvent(events, action.path, 'search', cwd);
+      continue;
+    }
+
+    collectReadLikeShellCommandReferences(action.command, events, cwd);
+  }
+
+  if (actions.length === 0) {
+    collectReadLikeShellCommandReferences(fallbackCommand, events, cwd);
+  }
+}
+
+function getCommandText(args: BuildToolAgentContextEventsArgs): string {
+  return args.toolDisplay?.shellCommand?.displayCommand
+    || (typeof args.toolParams.command === 'string' ? args.toolParams.command : '')
+    || (typeof args.toolParams.description === 'string' ? args.toolParams.description : '');
+}
+
+function getCommandCwd(args: BuildToolAgentContextEventsArgs): string | undefined {
+  return args.toolDisplay?.shellCommand?.cwd
+    || (typeof args.toolParams.cwd === 'string' ? args.toolParams.cwd : undefined);
+}
+
+function isVerificationCommand(command: string): boolean {
+  return /\b(test|jest|vitest|playwright|cypress|lint|eslint|tsc|typecheck|build)\b/i.test(command);
+}
+
+function addTodoEvents(result: unknown, events: AgentContextEvent[]): void {
+  if (!isRecord(result) || result.kind !== 'todo_update' || !Array.isArray(result.next)) return;
+
+  for (const todo of result.next) {
+    if (!isRecord(todo)) continue;
+    if (todo.status !== 'pending' && todo.status !== 'in_progress') continue;
+    const title = typeof todo.content === 'string' && todo.content.trim()
+      ? todo.content
+      : 'Untitled task';
+    events.push({
+      kind: 'todo',
+      title,
+      meta: todo.status.replace('_', ' '),
+      status: todo.status,
+    });
+  }
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function recordString(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  return record ? nonEmptyString(record[key]) : undefined;
+}
+
+function recordNumber(record: Record<string, unknown> | undefined, key: string): number | undefined {
+  const value = record?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function joinMeta(parts: Array<string | undefined>): string | undefined {
+  const compact = parts.filter((part): part is string => Boolean(part));
+  return compact.length > 0 ? compact.join(' | ') : undefined;
+}
+
+function formatDurationMs(value: number | undefined): string | undefined {
+  if (typeof value !== 'number') return undefined;
+  if (value < 1000) return `${Math.round(value)}ms`;
+  return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0)}s`;
+}
+
+function getTaskParam(args: BuildToolAgentContextEventsArgs, key: string): string | undefined {
+  return nonEmptyString(args.toolParams[key]);
+}
+
+function taskStatusFromToolStatus(status: BuildToolAgentContextEventsArgs['status']): AgentContextStatus {
+  return status;
+}
+
+function getSubagentTaskStatus(
+  argsStatus: BuildToolAgentContextEventsArgs['status'],
+  phase: string | undefined,
+  rawStatus: string | undefined,
+): AgentContextStatus {
+  if (argsStatus === 'error') return 'error';
+  if (phase === 'started' || phase === 'async_started') return 'running';
+  if (rawStatus === 'completed') return 'completed';
+  if (rawStatus === 'failed') return 'error';
+  if (rawStatus === 'cancelled') return 'warning';
+  return taskStatusFromToolStatus(argsStatus);
+}
+
+function getBackgroundTaskStatus(
+  argsStatus: BuildToolAgentContextEventsArgs['status'],
+  retrievalStatus: string | undefined,
+  taskStatus: string | undefined,
+): AgentContextStatus {
+  if (argsStatus === 'error' || retrievalStatus === 'error' || retrievalStatus === 'not_found') return 'error';
+  if (taskStatus === 'running') return 'running';
+  if (taskStatus === 'completed') return 'completed';
+  if (taskStatus === 'failed') return 'error';
+  return taskStatusFromToolStatus(argsStatus);
+}
+
+function addFallbackTaskEvent(
+  args: BuildToolAgentContextEventsArgs,
+  events: AgentContextEvent[],
+): void {
+  const title = getTaskParam(args, 'description')
+    || getTaskParam(args, 'prompt')
+    || args.toolName
+    || 'Task';
+  const detail = nonEmptyString(args.error) || nonEmptyString(args.output);
+  const meta = joinMeta([
+    getTaskParam(args, 'subagent_type'),
+    getTaskParam(args, 'agentType'),
+    getTaskParam(args, 'model'),
+  ]);
+
+  events.push({
+    kind: 'task',
+    title: truncate(title, 140),
+    ...(detail ? { detail: truncate(detail, 180) } : {}),
+    ...(meta ? { meta } : {}),
+    status: taskStatusFromToolStatus(args.status),
+  });
+}
+
+function addSubagentTaskEvents(
+  args: BuildToolAgentContextEventsArgs,
+  result: unknown,
+  events: AgentContextEvent[],
+): void {
+  if (!isRecord(result) || result.kind !== 'subagent_task') {
+    addFallbackTaskEvent(args, events);
+    return;
+  }
+
+  const phase = recordString(result, 'phase');
+  const rawStatus = recordString(result, 'status');
+  const prompt = recordString(result, 'prompt') || getTaskParam(args, 'prompt');
+  const description = recordString(result, 'description') || getTaskParam(args, 'description');
+  const responseText = recordString(result, 'responseText');
+  const agentId = recordString(result, 'agentId');
+  const agentType = recordString(result, 'agentType')
+    || getTaskParam(args, 'subagent_type')
+    || getTaskParam(args, 'agentType');
+  const model = recordString(result, 'model') || getTaskParam(args, 'model');
+  const outputFile = recordString(result, 'outputFile');
+  const metrics = isRecord(result['metrics']) ? result['metrics'] : undefined;
+  const duration = formatDurationMs(recordNumber(metrics, 'totalDurationMs'));
+  const toolUseCount = recordNumber(metrics, 'totalToolUseCount');
+  const totalTokens = recordNumber(metrics, 'totalTokens');
+  const title = description || prompt || (agentId ? `Task ${agentId}` : args.toolName || 'Task');
+  const detail = phase === 'completed'
+    ? responseText || prompt
+    : prompt || responseText;
+  const meta = joinMeta([
+    phase ? phase.replace('_', ' ') : undefined,
+    agentType,
+    agentId,
+    model,
+    result['runInBackground'] === true ? 'background' : undefined,
+    duration,
+    typeof toolUseCount === 'number' ? `${toolUseCount} tools` : undefined,
+    typeof totalTokens === 'number' ? `${totalTokens} tok` : undefined,
+    outputFile,
+  ]);
+
+  events.push({
+    kind: 'task',
+    title: truncate(title, 140),
+    ...(detail ? { detail: truncate(detail, 180) } : {}),
+    ...(meta ? { meta } : {}),
+    status: getSubagentTaskStatus(args.status, phase, rawStatus),
+  });
+}
+
+function addBackgroundTaskEvents(
+  args: BuildToolAgentContextEventsArgs,
+  result: unknown,
+  events: AgentContextEvent[],
+): void {
+  if (!isRecord(result) || result.kind !== 'background_task') {
+    addFallbackTaskEvent(args, events);
+    return;
+  }
+
+  const action = recordString(result, 'action');
+  const task = isRecord(result['task']) ? result['task'] : undefined;
+  const taskId = recordString(task, 'id');
+  const taskType = recordString(task, 'type');
+
+  if (action === 'output') {
+    const description = recordString(task, 'description');
+    const prompt = recordString(task, 'prompt');
+    const output = recordString(task, 'result') || recordString(task, 'output');
+    const retrievalStatus = recordString(result, 'retrievalStatus');
+    const taskStatus = recordString(task, 'status');
+    const exitCode = recordNumber(task, 'exitCode');
+    const title = description || prompt || (taskId ? `Task output ${taskId}` : args.toolName || 'Task output');
+    const meta = joinMeta([
+      action,
+      taskId,
+      taskType,
+      retrievalStatus,
+      typeof exitCode === 'number' ? `exit ${exitCode}` : undefined,
+    ]);
+
+    events.push({
+      kind: 'task',
+      title: truncate(title, 140),
+      ...(output ? { detail: truncate(output, 180) } : {}),
+      ...(meta ? { meta } : {}),
+      status: getBackgroundTaskStatus(args.status, retrievalStatus, taskStatus),
+    });
+    return;
+  }
+
+  if (action === 'stop') {
+    const message = recordString(result, 'message');
+    const command = recordString(result, 'command');
+    const meta = joinMeta([action, taskId, taskType]);
+
+    events.push({
+      kind: 'task',
+      title: truncate(message || (taskId ? `Stop task ${taskId}` : args.toolName || 'Stop task'), 140),
+      ...(command ? { detail: truncate(command, 180) } : {}),
+      ...(meta ? { meta } : {}),
+      status: args.status === 'error' ? 'error' : 'completed',
+    });
+    return;
+  }
+
+  addFallbackTaskEvent(args, events);
+}
+
+export function buildToolAgentContextEvents(args: BuildToolAgentContextEventsArgs): AgentContextEvent[] {
+  const events: AgentContextEvent[] = [];
+  const normalizedResult = normalizeToolResultSafely(args.toolKind, args.toolUseResult);
+
+  if (args.toolKind === 'shell_command') {
+    const command = getCommandText(args).trim();
+    const cwd = getCommandCwd(args);
+    if (command) {
+      events.push({
+        kind: isVerificationCommand(command) ? 'verification' : 'command',
+        title: command,
+        command,
+        ...(cwd ? { meta: cwd } : {}),
+        status: args.status,
+        ...(args.status === 'error'
+          ? { detail: truncate(args.error || args.output || 'Command failed', 180) }
+          : {}),
+      });
+    }
+    collectCommandActionReferences(args.toolParams, events, cwd, command);
+  } else if (args.toolKind === 'file_read') {
+    collectParamPathReferences(args.toolParams, events, 'read');
+    addResultReferences(normalizedResult, events, 'read');
+  } else if (args.toolKind === 'search_grep' || args.toolKind === 'search_glob') {
+    collectParamPathReferences(args.toolParams, events, 'search');
+    addResultReferences(normalizedResult, events, 'search');
+  } else if (args.toolKind === 'subagent_task') {
+    addSubagentTaskEvents(args, normalizedResult, events);
+  } else if (args.toolKind === 'task_output' || args.toolKind === 'task_stop') {
+    addBackgroundTaskEvents(args, normalizedResult, events);
+  } else if (args.toolKind === 'todo_update') {
+    addTodoEvents(normalizedResult, events);
+  }
+
+  if (args.status === 'error') {
+    events.push({
+      kind: 'issue',
+      title: args.toolName,
+      detail: truncate(args.error || args.output || 'Tool call failed', 180),
+      status: 'error',
+    });
+  }
+
+  return events;
+}

--- a/src/lib/agent-context-summary.ts
+++ b/src/lib/agent-context-summary.ts
@@ -1,0 +1,604 @@
+import type { EnhancedMessage, ToolCallMessage } from '@/types/chat';
+import type { SessionReplayEvent } from '@/lib/session-replay-types';
+import { inferToolCallKindFromToolName, type ToolCallKind } from '@/types/tool-call-kind';
+
+export interface AgentReferencedFile {
+  path: string;
+  count: number;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  sources: Array<'read' | 'search' | 'inspect'>;
+}
+
+export interface AgentCommandItem {
+  id: string;
+  command: string;
+  status: 'running' | 'completed' | 'error';
+  timestamp: string;
+  cwd?: string;
+  error?: string;
+  isVerification: boolean;
+}
+
+export interface AgentIssueItem {
+  id: string;
+  label: string;
+  detail?: string;
+  tone: 'error' | 'warning';
+  timestamp: string;
+}
+
+export interface AgentPromptHistoryItem {
+  id: string;
+  label: string;
+  detail?: string;
+  timestamp: string;
+  status: 'active' | 'resolved';
+}
+
+export interface AgentTodoItem {
+  id: string;
+  content: string;
+  status: 'pending' | 'in_progress';
+  timestamp: string;
+}
+
+export type AgentTimelineKind =
+  | 'cmd'
+  | 'read'
+  | 'search'
+  | 'edit'
+  | 'issue'
+  | 'task'
+  | 'todo'
+  | 'web';
+
+export type AgentTimelineStatus =
+  | 'running'
+  | 'completed'
+  | 'error'
+  | 'pending'
+  | 'in_progress'
+  | 'resolved'
+  | 'active'
+  | 'warning';
+
+export interface AgentTimelineItem {
+  id: string;
+  kind: AgentTimelineKind;
+  timestamp: string;
+  title: string;
+  detail?: string;
+  meta?: string;
+  status?: AgentTimelineStatus;
+  path?: string;
+  command?: string;
+  sessionId?: string;
+  toolUseId?: string;
+  hasOutput?: boolean;
+  errorDetail?: string;
+}
+
+export interface AgentContextSummary {
+  referencedFiles: AgentReferencedFile[];
+  commands: AgentCommandItem[];
+  verificationCommands: AgentCommandItem[];
+  issuesAndPrompts: AgentIssueItem[];
+  todos: AgentTodoItem[];
+  timeline: AgentTimelineItem[];
+}
+
+const READ_LIKE_COMMANDS = new Set([
+  'cat',
+  'file',
+  'gc',
+  'get-content',
+  'head',
+  'less',
+  'more',
+  'nl',
+  'sed',
+  'stat',
+  'tail',
+  'wc',
+]);
+
+const WRITE_LIKE_SHELL_PATTERNS = [
+  /\bsed\b[\s\S]*?(?:^|\s)-i(?:\s|$|[A-Za-z0-9._=-])/,
+  /(^|[^>])>>?($|[^>])/,
+  /(^|[\s|;&])tee(\s|$)/,
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, maxLength: number): string {
+  const normalized = normalizeWhitespace(value);
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}...`;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function recordString(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  return record ? nonEmptyString(record[key]) : undefined;
+}
+
+function firstRecordString(record: Record<string, unknown> | undefined, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = recordString(record, key);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function toolResultRecord(message: ToolCallMessage): Record<string, unknown> | undefined {
+  return isRecord(message.toolUseResult) ? message.toolUseResult : undefined;
+}
+
+function extractToolResultErrorDetail(result: unknown): string | undefined {
+  if (typeof result === 'string') return nonEmptyString(result);
+  if (!isRecord(result)) return undefined;
+
+  const direct = firstRecordString(result, [
+    'stderr',
+    'error',
+    'message',
+    'output',
+    'stdout',
+    'content',
+    'responseText',
+  ]);
+  if (direct) return direct;
+
+  const task = isRecord(result.task) ? result.task : undefined;
+  return firstRecordString(task, ['output', 'result', 'message']);
+}
+
+function getEffectiveToolKind(message: ToolCallMessage): ToolCallKind | undefined {
+  return message.toolKind ?? inferToolCallKindFromToolName(message.toolName);
+}
+
+function getDisplayCommand(message: ToolCallMessage): string {
+  return message.toolDisplay?.shellCommand?.displayCommand
+    || nonEmptyString(message.toolParams.command)
+    || nonEmptyString(message.toolParams.description)
+    || message.toolName;
+}
+
+function getCommandCwd(message: ToolCallMessage): string | undefined {
+  return message.toolDisplay?.shellCommand?.cwd || nonEmptyString(message.toolParams.cwd);
+}
+
+function unwrapShellLauncher(command: string): string {
+  const trimmed = command.trim();
+  const match = trimmed.match(/^(?:\/usr\/bin\/env\s+)?(?:\/(?:usr\/)?bin\/)?(?:ba|z|c|fi)?sh\s+-lc\s+([\s\S]+)$/);
+  const inner = match?.[1]?.trim();
+  if (!inner) return trimmed;
+
+  const quote = inner[0];
+  if ((quote === '"' || quote === "'") && inner.endsWith(quote)) {
+    return inner.slice(1, -1).trim();
+  }
+  return inner;
+}
+
+function getShellCommandName(command: string): string | undefined {
+  const unwrapped = unwrapShellLauncher(command);
+  const match = unwrapped.match(/^\s*(?:sudo\s+)?(?:command\s+)?(?:(?:[A-Za-z_][A-Za-z0-9_]*=.*)\s+)*(?:\S+\/)?([A-Za-z0-9._-]+)/);
+  return match?.[1]?.toLowerCase();
+}
+
+function isWriteLikeShellCommand(command: string): boolean {
+  return WRITE_LIKE_SHELL_PATTERNS.some((pattern) => pattern.test(command));
+}
+
+function isReadLikeShellCommand(command: string): boolean {
+  const commandName = getShellCommandName(command);
+  return !!commandName && READ_LIKE_COMMANDS.has(commandName) && !isWriteLikeShellCommand(command);
+}
+
+function statusForMessage(message: ToolCallMessage): AgentTimelineStatus {
+  return message.status;
+}
+
+function joinMeta(parts: Array<string | undefined>): string | undefined {
+  const compact = parts.filter((part): part is string => Boolean(part));
+  return compact.length > 0 ? compact.join(' | ') : undefined;
+}
+
+function formatDurationMs(value: unknown): string | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  if (value < 1000) return `${Math.round(value)}ms`;
+  return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0)}s`;
+}
+
+function buildIssueTimelineItem(message: ToolCallMessage): AgentTimelineItem {
+  const toolKind = getEffectiveToolKind(message);
+  const command = toolKind === 'shell_command' ? getDisplayCommand(message) : undefined;
+  const errorDetail = nonEmptyString(message.error)
+    || extractToolResultErrorDetail(message.toolUseResult)
+    || nonEmptyString(message.output);
+  const title =
+    command
+    || (toolKind === 'file_read'
+      ? firstRecordString(message.toolParams, ['file_path', 'filePath', 'path', 'notebook_path'])
+      : undefined)
+    || (toolKind === 'search_grep' || toolKind === 'search_glob'
+      ? firstRecordString(message.toolParams, ['pattern', 'query', 'regex'])
+      : undefined)
+    || (toolKind === 'subagent_task' || toolKind === 'task_output' || toolKind === 'task_stop'
+      ? firstRecordString(message.toolParams, ['description', 'prompt'])
+      : undefined)
+    || message.toolName;
+  const detail = errorDetail
+    ? truncate(errorDetail, 180)
+    : 'No error output captured';
+
+  return {
+    id: message.id,
+    kind: 'issue',
+    timestamp: message.timestamp,
+    title,
+    detail: truncate(detail, 180),
+    status: 'error',
+    ...(command ? { command } : {}),
+    sessionId: message.sessionId,
+    ...(message.toolUseId ? { toolUseId: message.toolUseId } : {}),
+    ...(message.hasOutput ? { hasOutput: message.hasOutput } : {}),
+    ...(errorDetail ? { errorDetail } : {}),
+  };
+}
+
+function buildShellTimelineItem(message: ToolCallMessage): AgentTimelineItem {
+  const command = getDisplayCommand(message);
+  const cwd = getCommandCwd(message);
+  return {
+    id: message.id,
+    kind: isReadLikeShellCommand(command) ? 'read' : 'cmd',
+    timestamp: message.timestamp,
+    title: command,
+    command,
+    status: statusForMessage(message),
+    ...(cwd ? { meta: cwd } : {}),
+  };
+}
+
+function buildReadTimelineItem(message: ToolCallMessage): AgentTimelineItem {
+  const result = toolResultRecord(message);
+  const path = recordString(result, 'path')
+    || firstRecordString(message.toolParams, ['file_path', 'filePath', 'path', 'notebook_path'])
+    || message.toolName;
+  const startLine = typeof result?.startLine === 'number' ? result.startLine : undefined;
+  const lineCount = typeof result?.lineCount === 'number' ? result.lineCount : undefined;
+  const meta = typeof startLine === 'number' && typeof lineCount === 'number'
+    ? `${startLine}-${startLine + Math.max(0, lineCount - 1)}`
+    : undefined;
+
+  return {
+    id: message.id,
+    kind: 'read',
+    timestamp: message.timestamp,
+    title: path,
+    path,
+    status: statusForMessage(message),
+    ...(meta ? { meta } : {}),
+  };
+}
+
+function buildSearchTimelineItem(message: ToolCallMessage): AgentTimelineItem {
+  const result = toolResultRecord(message);
+  const pattern = firstRecordString(message.toolParams, ['pattern', 'query', 'regex']);
+  const path = firstRecordString(message.toolParams, ['path', 'cwd', 'include']);
+  const title = pattern
+    ? path ? `${pattern} · ${path}` : pattern
+    : path || message.toolName;
+  const totalFiles = typeof result?.totalFiles === 'number' ? result.totalFiles : undefined;
+  const duration = formatDurationMs(result?.durationMs);
+  const meta = joinMeta([
+    typeof totalFiles === 'number' ? `${totalFiles} files` : undefined,
+    duration,
+  ]);
+
+  return {
+    id: message.id,
+    kind: 'search',
+    timestamp: message.timestamp,
+    title,
+    status: statusForMessage(message),
+    ...(meta ? { meta } : {}),
+  };
+}
+
+function buildEditTimelineItem(message: ToolCallMessage): AgentTimelineItem {
+  const result = toolResultRecord(message);
+  const path = recordString(result, 'path')
+    || firstRecordString(message.toolParams, ['file_path', 'filePath', 'path'])
+    || message.toolName;
+  const operation = recordString(result, 'operation');
+
+  return {
+    id: message.id,
+    kind: 'edit',
+    timestamp: message.timestamp,
+    title: path,
+    path,
+    status: statusForMessage(message),
+    ...(operation ? { meta: operation } : {}),
+  };
+}
+
+function todoContent(todo: unknown): string | undefined {
+  if (!isRecord(todo)) return undefined;
+  return firstRecordString(todo, ['content', 'text', 'title']);
+}
+
+function todoStatus(todo: unknown): AgentTodoItem['status'] | undefined {
+  if (!isRecord(todo)) return undefined;
+  return todo.status === 'pending' || todo.status === 'in_progress' ? todo.status : undefined;
+}
+
+function collectTodos(message: ToolCallMessage): AgentTodoItem[] {
+  const result = toolResultRecord(message);
+  const rawTodos = Array.isArray(result?.next)
+    ? result.next
+    : Array.isArray(message.toolParams.todos)
+      ? message.toolParams.todos
+      : [];
+
+  return rawTodos.flatMap((todo, index) => {
+    const status = todoStatus(todo);
+    const content = todoContent(todo);
+    if (!status || !content) return [];
+    return [{
+      id: `${message.id}-todo-${index}`,
+      content,
+      status,
+      timestamp: message.timestamp,
+    }];
+  });
+}
+
+function buildTodoTimelineItem(message: ToolCallMessage, activeTodos: AgentTodoItem[]): AgentTimelineItem {
+  const result = toolResultRecord(message);
+  const total = Array.isArray(result?.next)
+    ? result.next.length
+    : Array.isArray(message.toolParams.todos)
+      ? message.toolParams.todos.length
+      : undefined;
+  const title = activeTodos[0]?.content
+    || (typeof total === 'number' ? `${total} todos updated` : message.toolName);
+  const detail = activeTodos.length > 1
+    ? activeTodos.slice(1, 4).map((todo) => todo.content).join(' · ')
+    : undefined;
+  const hasInProgress = activeTodos.some((todo) => todo.status === 'in_progress');
+
+  return {
+    id: message.id,
+    kind: 'todo',
+    timestamp: message.timestamp,
+    title,
+    status: hasInProgress ? 'in_progress' : statusForMessage(message),
+    ...(detail ? { detail: truncate(detail, 180) } : {}),
+    ...(typeof total === 'number' ? { meta: `${activeTodos.length}/${total} active` } : {}),
+  };
+}
+
+function buildTaskTimelineItem(message: ToolCallMessage): AgentTimelineItem {
+  const result = toolResultRecord(message);
+  const task = isRecord(result?.task) ? result.task : undefined;
+  const title = recordString(result, 'description')
+    || recordString(task, 'description')
+    || firstRecordString(message.toolParams, ['description', 'prompt'])
+    || message.toolName;
+  const prompt = recordString(result, 'prompt') || recordString(task, 'prompt') || recordString(message.toolParams, 'prompt');
+  const responseText = recordString(result, 'responseText') || recordString(task, 'result') || recordString(task, 'output');
+  const phase = recordString(result, 'phase') || recordString(result, 'action');
+  const resultStatus = recordString(result, 'status') || recordString(task, 'status');
+  const agentType = recordString(result, 'agentType') || recordString(task, 'type');
+  const agentId = recordString(result, 'agentId') || recordString(task, 'id');
+  const status: AgentTimelineStatus =
+    resultStatus === 'failed' ? 'error'
+      : resultStatus === 'running' || phase === 'started' || phase === 'async_started' ? 'running'
+        : statusForMessage(message);
+
+  return {
+    id: message.id,
+    kind: 'task',
+    timestamp: message.timestamp,
+    title,
+    status,
+    ...(prompt && prompt !== title ? { detail: truncate(prompt, 180) } : responseText ? { detail: truncate(responseText, 180) } : {}),
+    ...(joinMeta([phase, resultStatus, agentType, agentId]) ? { meta: joinMeta([phase, resultStatus, agentType, agentId]) } : {}),
+  };
+}
+
+function buildWebTimelineItem(message: ToolCallMessage): AgentTimelineItem {
+  const result = toolResultRecord(message);
+  const title = recordString(result, 'query')
+    || recordString(result, 'url')
+    || firstRecordString(message.toolParams, ['query', 'url'])
+    || message.toolName;
+  const statusCode = typeof result?.statusCode === 'number' ? String(result.statusCode) : undefined;
+  const duration = formatDurationMs(result?.durationMs);
+
+  return {
+    id: message.id,
+    kind: 'web',
+    timestamp: message.timestamp,
+    title,
+    status: statusForMessage(message),
+    ...(joinMeta([statusCode, duration]) ? { meta: joinMeta([statusCode, duration]) } : {}),
+  };
+}
+
+function buildToolTimelineItem(message: ToolCallMessage): {
+  item?: AgentTimelineItem;
+  todos?: AgentTodoItem[];
+} {
+  if (message.status === 'error') {
+    return { item: buildIssueTimelineItem(message) };
+  }
+
+  const toolKind = getEffectiveToolKind(message);
+  switch (toolKind) {
+    case 'shell_command':
+      return { item: buildShellTimelineItem(message) };
+    case 'file_read':
+      return { item: buildReadTimelineItem(message) };
+    case 'search_grep':
+    case 'search_glob':
+      return { item: buildSearchTimelineItem(message) };
+    case 'file_edit':
+    case 'file_write':
+      return { item: buildEditTimelineItem(message) };
+    case 'todo_update': {
+      const todos = collectTodos(message);
+      return { item: buildTodoTimelineItem(message, todos), todos };
+    }
+    case 'subagent_task':
+    case 'task_output':
+    case 'task_stop':
+      return { item: buildTaskTimelineItem(message) };
+    case 'question_prompt':
+      return {};
+    case 'web_search':
+    case 'web_fetch':
+      return { item: buildWebTimelineItem(message) };
+    default:
+      return {
+        item: {
+          id: message.id,
+          kind: 'cmd',
+          timestamp: message.timestamp,
+          title: message.toolName,
+          status: statusForMessage(message),
+        },
+      };
+  }
+}
+
+function buildSystemIssueTimelineItem(message: Extract<EnhancedMessage, { type: 'system' }>): AgentTimelineItem | null {
+  if (message.severity !== 'warning' && message.severity !== 'error') return null;
+  return {
+    id: message.id,
+    kind: 'issue',
+    timestamp: message.timestamp,
+    title: message.severity,
+    detail: truncate(message.message, 180),
+    status: message.severity,
+  };
+}
+
+function buildIssueItemFromTimeline(item: AgentTimelineItem): AgentIssueItem {
+  return {
+    id: item.id,
+    label: item.title,
+    detail: item.detail,
+    tone: item.status === 'warning' ? 'warning' : 'error',
+    timestamp: item.timestamp,
+  };
+}
+
+function buildCommandItemFromTimeline(item: AgentTimelineItem): AgentCommandItem | null {
+  if (item.kind !== 'cmd' && !(item.kind === 'read' && item.command)) return null;
+  return {
+    id: item.id,
+    command: item.command || item.title,
+    status: item.status === 'error' ? 'error' : item.status === 'running' ? 'running' : 'completed',
+    timestamp: item.timestamp,
+    cwd: item.meta,
+    error: item.status === 'error' ? item.detail : undefined,
+    isVerification: false,
+  };
+}
+
+export function buildAgentPromptHistoryItem(
+  event: Extract<SessionReplayEvent, { type: 'interactive_prompt' }>,
+): AgentPromptHistoryItem {
+  const toolUseId = typeof event.data.toolUseId === 'string' && event.data.toolUseId
+    ? event.data.toolUseId
+    : event.timestamp;
+  const label = event.promptType.replace(/_/g, ' ');
+  const detail = typeof event.data.question === 'string'
+    ? event.data.question
+    : Array.isArray(event.data.questions) && typeof event.data.questions[0]?.question === 'string'
+      ? event.data.questions[0].question
+      : typeof event.data.toolName === 'string'
+        ? event.data.toolName
+        : typeof event.data.plan === 'string'
+          ? event.data.plan
+          : undefined;
+
+  return {
+    id: `prompt-${toolUseId}`,
+    label,
+    detail: detail ? truncate(detail, 180) : undefined,
+    timestamp: event.timestamp,
+    status: 'active',
+  };
+}
+
+export function buildAgentContextSummary(
+  messages: EnhancedMessage[],
+): AgentContextSummary {
+  const timeline: AgentTimelineItem[] = [];
+  const seenTimelineIds = new Set<string>();
+  let todos: AgentTodoItem[] = [];
+
+  function pushTimeline(item: AgentTimelineItem): void {
+    if (seenTimelineIds.has(item.id)) return;
+    seenTimelineIds.add(item.id);
+    timeline.push(item);
+  }
+
+  for (const message of messages) {
+    if (message.type === 'system') {
+      const issue = buildSystemIssueTimelineItem(message);
+      if (issue) pushTimeline(issue);
+      continue;
+    }
+
+    if (message.type !== 'tool_call') continue;
+
+    const result = buildToolTimelineItem(message);
+    if (result.item) {
+      pushTimeline(result.item);
+    }
+    if (result.todos) {
+      todos = result.todos;
+    }
+  }
+
+  const orderedTimeline = timeline
+    .map((item, index) => ({ index, item }))
+    .sort((left, right) => {
+      const byTimestamp = left.item.timestamp.localeCompare(right.item.timestamp);
+      return byTimestamp || left.index - right.index;
+    })
+    .map(({ item }) => item);
+
+  const commands = orderedTimeline.flatMap((item) => {
+    const command = buildCommandItemFromTimeline(item);
+    return command ? [command] : [];
+  });
+  const issuesAndPrompts = orderedTimeline.flatMap((item) =>
+    item.kind === 'issue' ? [buildIssueItemFromTimeline(item)] : [],
+  );
+
+  return {
+    referencedFiles: [],
+    commands,
+    verificationCommands: [],
+    issuesAndPrompts,
+    todos,
+    timeline: orderedTimeline,
+  };
+}

--- a/src/lib/agent-context-summary.ts
+++ b/src/lib/agent-context-summary.ts
@@ -104,7 +104,7 @@ const READ_LIKE_COMMANDS = new Set([
 ]);
 
 const WRITE_LIKE_SHELL_PATTERNS = [
-  /\bsed\b[\s\S]*?(?:^|\s)-i(?:\s|$|[A-Za-z0-9._=-])/,
+  /\bsed\b[\s\S]*?\s-i(?:\s|$|[A-Za-z0-9._=-])/,
   /(^|[^>])>>?($|[^>])/,
   /(^|[\s|;&])tee(\s|$)/,
 ];

--- a/src/lib/chat/apply-session-replay-events.ts
+++ b/src/lib/chat/apply-session-replay-events.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { buildAgentPromptHistoryItem } from '@/lib/agent-context-summary';
 import { useChatStore } from '@/stores/chat-store';
 import { useUsageStore } from '@/stores/usage-store';
 import {
@@ -245,11 +246,15 @@ function projectReplayStateTransition(
 
         if (existingToolCall) {
           chatStore.updateToolCall(sessionId, existingToolCall.id, {
+            toolName: nextTool.toolName,
             toolKind: nextTool.toolKind,
+            toolParams: nextTool.toolParams,
+            toolDisplay: nextTool.toolDisplay,
             status: nextTool.status,
             output: nextTool.output,
             error: nextTool.error,
             toolUseResult: nextTool.toolUseResult,
+            agentContext: nextTool.agentContext,
             hasOutput: nextTool.hasOutput,
           });
           return;
@@ -261,8 +266,19 @@ function projectReplayStateTransition(
     }
 
     case 'interactive_prompt':
+      chatStore.recordPromptHistoryItem(sessionId, buildAgentPromptHistoryItem(event));
+      syncPromptProjection(sessionId, nextState);
+      return;
+
     case 'interactive_prompt_response':
+      chatStore.resolvePromptHistoryItem(sessionId, `prompt-${event.toolUseId}`);
+      syncPromptProjection(sessionId, nextState);
+      return;
+
     case 'interactive_prompt_cleared':
+      if (event.toolUseId) {
+        chatStore.resolvePromptHistoryItem(sessionId, `prompt-${event.toolUseId}`);
+      }
       syncPromptProjection(sessionId, nextState);
       return;
 

--- a/src/lib/chat/server-message-to-replay-events.ts
+++ b/src/lib/chat/server-message-to-replay-events.ts
@@ -1,5 +1,6 @@
 import type { ServerMessage } from '@/lib/ws/message-types';
 import type { SessionReplayEvent } from '@/lib/session-replay-types';
+import { buildToolAgentContextEvents } from '@/lib/agent-context-events';
 
 const LIVE_EVENT_VERSION = 1;
 
@@ -64,20 +65,34 @@ export function serverMessageToReplayEvents(msg: ServerMessage): SessionReplayEv
       }];
 
     case 'tool_call':
-      return [{
-        v: LIVE_EVENT_VERSION,
-        type: 'tool_call',
-        timestamp: msg.timestamp,
-        toolName: msg.toolName,
-        toolKind: msg.toolKind,
-        toolParams: msg.toolParams,
-        toolDisplay: msg.toolDisplay,
-        status: msg.status,
-        output: msg.output,
-        error: msg.error,
-        toolUseResult: msg.toolUseResult,
-        toolUseId: msg.toolUseId,
-      }];
+      {
+        const agentContext = msg.agentContext ?? buildToolAgentContextEvents({
+          toolName: msg.toolName,
+          toolKind: msg.toolKind,
+          toolParams: msg.toolParams,
+          toolDisplay: msg.toolDisplay,
+          status: msg.status,
+          output: msg.output,
+          error: msg.error,
+          toolUseResult: msg.toolUseResult,
+        });
+
+        return [{
+          v: LIVE_EVENT_VERSION,
+          type: 'tool_call',
+          timestamp: msg.timestamp,
+          toolName: msg.toolName,
+          toolKind: msg.toolKind,
+          toolParams: msg.toolParams,
+          toolDisplay: msg.toolDisplay,
+          status: msg.status,
+          output: msg.output,
+          error: msg.error,
+          toolUseResult: msg.toolUseResult,
+          ...(agentContext.length > 0 ? { agentContext } : {}),
+          toolUseId: msg.toolUseId,
+        }];
+      }
 
     case 'system':
       return [{

--- a/src/lib/cli/protocol-adapter-tools.ts
+++ b/src/lib/cli/protocol-adapter-tools.ts
@@ -1,5 +1,6 @@
 import { buildToolDisplay } from '../tool-display';
 import type { SessionReplayEvent } from '../session-replay-types';
+import { buildToolAgentContextEvents } from '../agent-context-events';
 import { normalizeToolResult } from '../tool-results/normalize-tool-result';
 import {
   extractTodoSnapshot,
@@ -53,6 +54,14 @@ export function buildProtocolToolCallStart({
   const syntheticToolUseResult = synthesizeClaudeToolResult(toolKind, toolParams, {
     previousTodos,
   });
+  const agentContext = buildToolAgentContextEvents({
+    toolName,
+    toolKind,
+    toolParams,
+    toolDisplay,
+    status: 'running',
+    toolUseResult: syntheticToolUseResult,
+  });
 
   return {
     toolUseId,
@@ -72,6 +81,7 @@ export function buildProtocolToolCallStart({
       ...(toolDisplay !== undefined ? { toolDisplay } : {}),
       status: 'running',
       ...(syntheticToolUseResult !== undefined ? { toolUseResult: syntheticToolUseResult } : {}),
+      ...(agentContext.length > 0 ? { agentContext } : {}),
       toolUseId,
     },
   };
@@ -104,6 +114,16 @@ export function buildProtocolToolCallCompletion({
         isError,
         previousTodos,
       });
+  const agentContext = buildToolAgentContextEvents({
+    toolName: pendingTool.toolName,
+    toolKind: pendingTool.toolKind,
+    toolParams: pendingTool.toolParams,
+    toolDisplay: pendingTool.toolDisplay,
+    status: isError ? 'error' : 'completed',
+    output: isError ? undefined : output,
+    error: isError ? output : undefined,
+    toolUseResult,
+  });
 
   return {
     nextTodos: extractTodoSnapshot(pendingTool.toolKind, pendingTool.toolParams),
@@ -119,6 +139,7 @@ export function buildProtocolToolCallCompletion({
       output: isError ? undefined : output,
       error: isError ? output : undefined,
       ...(toolUseResult !== undefined ? { toolUseResult } : {}),
+      ...(agentContext.length > 0 ? { agentContext } : {}),
       toolUseId,
     },
   };

--- a/src/lib/session-history.ts
+++ b/src/lib/session-history.ts
@@ -201,6 +201,7 @@ class SessionHistoryStore {
           output: message.output,
           error: message.error,
           toolUseResult: message.toolUseResult,
+          agentContext: message.agentContext,
           toolUseId: message.toolUseId,
         });
         return;

--- a/src/lib/session-replay-reducer.ts
+++ b/src/lib/session-replay-reducer.ts
@@ -100,11 +100,18 @@ function upsertToolCallMessage(
 
     if (existingIdx !== -1) {
       const prev = state.messages[existingIdx] as ToolCallMessage;
+      const mergedToolParams = {
+        ...prev.toolParams,
+        ...event.toolParams,
+      };
       state.messages[existingIdx] = {
         ...prev,
         ...(event.toolUseId !== undefined ? { toolUseId: event.toolUseId } : {}),
+        toolName: event.toolName || prev.toolName,
         ...(event.toolKind !== undefined ? { toolKind: event.toolKind } : {}),
+        toolParams: mergedToolParams,
         ...(event.toolDisplay !== undefined ? { toolDisplay: event.toolDisplay } : {}),
+        ...(event.agentContext !== undefined ? { agentContext: event.agentContext } : {}),
         status: event.status,
         ...(output !== undefined ? { output } : {}),
         ...(error !== undefined ? { error } : {}),
@@ -125,6 +132,7 @@ function upsertToolCallMessage(
     ...(event.toolKind !== undefined ? { toolKind: event.toolKind } : {}),
     toolParams: event.toolParams,
     ...(event.toolDisplay !== undefined ? { toolDisplay: event.toolDisplay } : {}),
+    ...(event.agentContext !== undefined ? { agentContext: event.agentContext } : {}),
     status: event.status,
     ...(output !== undefined ? { output } : {}),
     ...(error !== undefined ? { error } : {}),

--- a/src/lib/session-replay-types.ts
+++ b/src/lib/session-replay-types.ts
@@ -1,5 +1,6 @@
 import type { ContentBlock, ModelUsageEntry } from './ws/message-types';
 import type { ToolCallKind } from '@/types/tool-call-kind';
+import type { AgentContextEvent } from '@/types/agent-context';
 import type { CanonicalToolResultValue } from '@/types/tool-result';
 import type { ToolDisplayMetadata } from '@/types/tool-display';
 import type { ToolUseResult } from '@/types/cli-jsonl-schemas';
@@ -59,6 +60,7 @@ export type SessionHistoryEvent =
       output?: string;
       error?: string;
       toolUseResult?: ToolUseResult | CanonicalToolResultValue;
+      agentContext?: AgentContextEvent[];
       toolUseId?: string;
     }
   | {

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -1,4 +1,5 @@
 import type { ToolCallKind } from '@/types/tool-call-kind';
+import type { AgentContextEvent } from '@/types/agent-context';
 import type { CanonicalToolResultValue } from '@/types/tool-result';
 import type { ToolDisplayMetadata } from '@/types/tool-display';
 import type { ToolUseResult } from '@/types/cli-jsonl-schemas';
@@ -99,6 +100,7 @@ export type ReplaySourceServerMessage =
       output?: string;
       error?: string;
       toolUseResult?: ToolUseResult | CanonicalToolResultValue;
+      agentContext?: AgentContextEvent[];
       toolUseId?: string;
       timestamp: string;
     }

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand';
+import type { AgentPromptHistoryItem } from '@/lib/agent-context-summary';
 import type { EnhancedMessage, ConnectionStatus, ActiveInteractivePrompt } from '@/types/chat';
+import type { AgentContextEvent } from '@/types/agent-context';
+import type { ToolCallKind } from '@/types/tool-call-kind';
+import type { ToolDisplayMetadata } from '@/types/tool-display';
 
 const STREAM_FLUSH_BASE_MS = 60;
 const STREAM_FLUSH_MEDIUM_MS = 110;
@@ -127,6 +131,9 @@ export interface ChatState {
   // Active interactive prompts (floating bar/panel, separate from message stream)
   activeInteractivePrompt: Map<string, ActiveInteractivePrompt>;
 
+  // Prompt history used by the live Agent Context right panel.
+  promptHistory: Map<string, AgentPromptHistoryItem[]>;
+
   // Tracks sessions whose JSONL history has been fully loaded via loadHistory().
   // Prevents race condition where WebSocket streaming messages create entries in
   // the messages Map before JSONL history is fetched, causing viewSession() to
@@ -146,6 +153,8 @@ export interface ChatState {
   setScrollPosition: (sessionId: string, position: number | ScrollPositionSnapshot) => void;
   getScrollPosition: (sessionId: string) => ScrollPositionSnapshot | undefined;
   setActiveInteractivePrompt: (sessionId: string, prompt: ActiveInteractivePrompt | null) => void;
+  recordPromptHistoryItem: (sessionId: string, item: AgentPromptHistoryItem) => void;
+  resolvePromptHistoryItem: (sessionId: string, promptId: string) => void;
   setTurnInFlight: (sessionId: string, inFlight: boolean) => void;
   setTurnsInFlight: (sessionIds: readonly string[]) => void;
   setError: (sessionId: string, message: string) => void;
@@ -161,7 +170,18 @@ export interface ChatState {
   clearSessionMessages: (sessionId: string) => void;
   resetForReload: (sessionId: string) => void;
   setLoading: (loading: boolean) => void;
-  updateToolCall: (sessionId: string, messageId: string, update: { status: 'running' | 'completed' | 'error'; output?: string; error?: string; toolUseResult?: any; hasOutput?: boolean; toolKind?: import('@/types/tool-call-kind').ToolCallKind }) => void;
+  updateToolCall: (sessionId: string, messageId: string, update: {
+    status: 'running' | 'completed' | 'error';
+    toolName?: string;
+    toolKind?: ToolCallKind;
+    toolParams?: Record<string, any>;
+    toolDisplay?: ToolDisplayMetadata;
+    output?: string;
+    error?: string;
+    toolUseResult?: any;
+    agentContext?: AgentContextEvent[];
+    hasOutput?: boolean;
+  }) => void;
   setReadOnlyPagination: (sessionId: string, pagination: {
     projectDir: string;
     hasMore: boolean;
@@ -248,6 +268,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   errors: new Map(),
   toolOutputCache: new Map(),
   activeInteractivePrompt: new Map(),
+  promptHistory: new Map(),
   historyLoaded: new Set(),
   draftInputs: new Map(),
   scrollPositions: new Map(),
@@ -288,6 +309,35 @@ export const useChatStore = create<ChatState>((set, get) => ({
         updated.set(sessionId, prompt);
       }
       return { activeInteractivePrompt: updated };
+    }),
+
+  recordPromptHistoryItem: (sessionId, item) =>
+    set((state) => {
+      const sessionItems = state.promptHistory.get(sessionId) || [];
+      const existingIndex = sessionItems.findIndex((current) => current.id === item.id);
+      const nextItems = existingIndex === -1
+        ? [...sessionItems, item]
+        : sessionItems.map((current, index) => index === existingIndex ? { ...current, ...item } : current);
+      const updated = new Map(state.promptHistory);
+      updated.set(sessionId, nextItems);
+      return { promptHistory: updated };
+    }),
+
+  resolvePromptHistoryItem: (sessionId, promptId) =>
+    set((state) => {
+      const sessionItems = state.promptHistory.get(sessionId);
+      if (!sessionItems?.some((item) => item.id === promptId && item.status === 'active')) {
+        return state;
+      }
+
+      const updated = new Map(state.promptHistory);
+      updated.set(
+        sessionId,
+        sessionItems.map((item) =>
+          item.id === promptId ? { ...item, status: 'resolved' as const } : item,
+        ),
+      );
+      return { promptHistory: updated };
     }),
 
   setTurnInFlight: (sessionId, inFlight) => {
@@ -552,10 +602,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
       updatedHistoryLoaded.delete(sessionId);
       const updatedPagination = new Map(state.readOnlyPagination);
       updatedPagination.delete(sessionId);
+      const updatedPromptHistory = new Map(state.promptHistory);
+      updatedPromptHistory.delete(sessionId);
       return {
         messages: updatedMessages,
         historyLoaded: updatedHistoryLoaded,
         readOnlyPagination: updatedPagination,
+        promptHistory: updatedPromptHistory,
       };
     }),
 
@@ -582,6 +635,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       const clearedPrompts = new Map(state.activeInteractivePrompt);
       clearedPrompts.delete(sessionId);
+      const clearedPromptHistory = new Map(state.promptHistory);
+      clearedPromptHistory.delete(sessionId);
 
       const clearedHistoryLoaded = new Set(state.historyLoaded);
       clearedHistoryLoaded.delete(sessionId);
@@ -609,6 +664,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         ),
         readOnlyPagination: clearedPagination,
         activeInteractivePrompt: clearedPrompts,
+        promptHistory: clearedPromptHistory,
         draftInputs: clearedDrafts,
         scrollPositions: clearedScrollPositions,
       };

--- a/src/types/agent-context.ts
+++ b/src/types/agent-context.ts
@@ -1,0 +1,30 @@
+export type AgentReferenceSource = 'read' | 'search' | 'inspect';
+
+export type AgentContextKind =
+  | 'reference'
+  | 'command'
+  | 'verification'
+  | 'issue'
+  | 'task'
+  | 'todo';
+
+export type AgentContextStatus =
+  | 'running'
+  | 'completed'
+  | 'error'
+  | 'pending'
+  | 'in_progress'
+  | 'resolved'
+  | 'active'
+  | 'warning';
+
+export interface AgentContextEvent {
+  kind: AgentContextKind;
+  title: string;
+  detail?: string;
+  meta?: string;
+  status?: AgentContextStatus;
+  source?: AgentReferenceSource;
+  path?: string;
+  command?: string;
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,4 +1,5 @@
 import type { ToolUseResult, AskUserQuestionItem } from './cli-jsonl-schemas';
+import type { AgentContextEvent } from './agent-context';
 import type { CanonicalToolResultValue } from './tool-result';
 import type { ToolCallKind } from './tool-call-kind';
 import type { ToolDisplayMetadata } from './tool-display';
@@ -41,6 +42,7 @@ export interface ToolCallMessage extends BaseEnhancedMessage {
   output?: string;
   error?: string;
   toolUseResult?: ToolUseResult | CanonicalToolResultValue;
+  agentContext?: AgentContextEvent[];
   /** True when output/toolUseResult were stripped for lazy loading (read-only sessions) */
   hasOutput?: boolean;
 }


### PR DESCRIPTION
## Summary
- Add an Agent tab in the right Git panel for the Session Brief timeline
- Normalize canonical tool calls into compact log kinds: CMD, READ, SEARCH, EDIT, ISSUE, TASK, TODO, WEB
- Preserve live/replay tool metadata so OpenCode, Codex, and Claude Code sessions show concrete commands, paths, and issue details

## Verification
- npx tsc --noEmit
- git diff --check
- git diff --cached --check