### PR TITLE
Add setup CLI smoke telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development tsx server.ts",
     "build": "cross-env TURBOPACK= __NEXT_DEV_SERVER= __NEXT_PROCESSED_ENV= NODE_ENV=production next build --webpack",
+    "build:telemetry": "node scripts/with-posthog-telemetry-build.mjs npm run build",
     "start": "cross-env NODE_ENV=production tsx server.ts",
     "lint": "eslint .",
     "server:compile": "node -e \"require('fs').rmSync('dist-server',{recursive:true,force:true})\" && tsc -p tsconfig.server.json",
@@ -60,7 +61,9 @@
     "electron:prepare-runtime": "node scripts/prepare-electron-runtime.mjs",
     "electron:dev": "npm run electron:compile && concurrently -k -n SERVER,ELECTRON -c cyan,yellow \"cross-env NODE_ENV=development PORT=3100 TESSERA_ELECTRON_AUTH_BYPASS=1 npx tsx server.ts\" \"wait-on http://localhost:3100 && cross-env TESSERA_DEV_PORT=3100 electron dist-electron/electron/main.js\"",
     "electron:prebuild": "npm run build && npm run electron:compile && npm run electron:prepare-runtime",
+    "electron:prebuild:telemetry": "node scripts/with-posthog-telemetry-build.mjs npm run electron:prebuild",
     "electron:build:win": "npm run electron:prebuild && electron-builder --win portable --x64 --publish never",
+    "electron:build:win:telemetry": "node scripts/with-posthog-telemetry-build.mjs npm run electron:build:win",
     "electron:build:linux": "npm run electron:prebuild && electron-builder --linux AppImage deb --x64 --publish never",
     "electron:build:mac-x64": "npm run electron:prebuild && electron-builder --mac --x64 --publish never",
     "electron:build:mac-arm64": "npm run electron:prebuild && electron-builder --mac --arm64 --publish never",

--- a/scripts/with-posthog-telemetry-build.mjs
+++ b/scripts/with-posthog-telemetry-build.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+import fs from 'fs';
+
+const ENV_FILES = ['.env', '.env.local', '.env.production.local'];
+const DEFAULT_POSTHOG_HOST = 'https://us.posthog.com';
+
+function loadEnvFiles() {
+  for (const filePath of ENV_FILES) {
+    if (!fs.existsSync(filePath)) continue;
+
+    const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+
+      const separatorIndex = trimmed.indexOf('=');
+      if (separatorIndex <= 0) continue;
+
+      const key = trimmed.slice(0, separatorIndex).trim();
+      const value = stripEnvQuotes(trimmed.slice(separatorIndex + 1).trim());
+      if (!process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function stripEnvQuotes(value) {
+  if (value.length < 2) return value;
+  const first = value[0];
+  const last = value[value.length - 1];
+  if ((first === '"' && last === '"') || (first === '\'' && last === '\'')) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+async function resolvePostHogProjectToken() {
+  if (process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) {
+    return {
+      token: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
+      source: 'NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN',
+    };
+  }
+
+  const personalApiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  if (!personalApiKey || !projectId) {
+    throw new Error(
+      'Telemetry build requires NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, or POSTHOG_PERSONAL_API_KEY + POSTHOG_PROJECT_ID.',
+    );
+  }
+
+  const host = (process.env.POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_UI_HOST || DEFAULT_POSTHOG_HOST)
+    .replace(/\/$/, '');
+  const response = await fetch(`${host}/api/projects/${projectId}/`, {
+    headers: { Authorization: `Bearer ${personalApiKey}` },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Could not resolve PostHog project token (${response.status}).`);
+  }
+
+  const project = await response.json();
+  if (typeof project.api_token !== 'string' || !project.api_token) {
+    throw new Error('PostHog project response did not include api_token.');
+  }
+
+  return {
+    token: project.api_token,
+    source: 'PostHog project api_token',
+  };
+}
+
+function runCommand(command, args, env) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      env,
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+    });
+
+    child.on('close', (code, signal) => {
+      if (signal) {
+        resolve(128);
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+}
+
+async function main() {
+  loadEnvFiles();
+
+  const [command, ...args] = process.argv.slice(2);
+  if (!command) {
+    throw new Error('Usage: node scripts/with-posthog-telemetry-build.mjs <command> [...args]');
+  }
+
+  const { token, source } = await resolvePostHogProjectToken();
+  const env = {
+    ...process.env,
+    NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: token,
+    TESSERA_TELEMETRY_LOCAL: '1',
+  };
+
+  console.log(`[telemetry-build] enabled using ${source} (token length=${token.length})`);
+  const exitCode = await runCommand(command, args, env);
+  process.exit(exitCode);
+}
+
+main().catch((error) => {
+  console.error(`[telemetry-build] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/src/app/api/diagnostics/cli/route.ts
+++ b/src/app/api/diagnostics/cli/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
-import { runCliDiagnostics } from '@/lib/cli/diagnostics';
+import { runCliDiagnostics, stripTelemetryRawLogs } from '@/lib/cli/diagnostics';
+import { isServerTelemetryCaptureAllowed } from '@/lib/telemetry/server';
+import {
+  captureCliDiagnosticsTelemetry,
+  parseSetupTelemetryTrigger,
+} from '@/lib/telemetry/setup';
 import logger from '@/lib/logger';
 
 export async function POST(request: NextRequest) {
@@ -10,8 +15,29 @@ export async function POST(request: NextRequest) {
       return auth.response;
     }
 
-    const report = await runCliDiagnostics(auth.userId);
-    return NextResponse.json({ report });
+    const source = request.nextUrl.searchParams.get('telemetry_source');
+    const trigger = parseSetupTelemetryTrigger(
+      request.nextUrl.searchParams.get('telemetry_trigger'),
+    );
+    const isSetupTelemetryRun = source === 'setup' && Boolean(trigger);
+
+    if (isSetupTelemetryRun && !isServerTelemetryCaptureAllowed(request)) {
+      return NextResponse.json({ skipped: true });
+    }
+
+    const report = await runCliDiagnostics(auth.userId, {
+      storeLatest: !isSetupTelemetryRun,
+      writeRawLogs: !isSetupTelemetryRun,
+      captureTelemetryRawLog: false,
+    });
+
+    if (isSetupTelemetryRun && trigger) {
+      await captureCliDiagnosticsTelemetry(report, { source: 'setup', trigger, request });
+    } else {
+      await captureCliDiagnosticsTelemetry(report, { source: 'settings', request });
+    }
+
+    return NextResponse.json({ report: stripTelemetryRawLogs(report) });
   } catch (error) {
     logger.error({ error }, 'POST /api/diagnostics/cli error');
     return NextResponse.json(

--- a/src/app/api/setup/status/route.ts
+++ b/src/app/api/setup/status/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import { SettingsManager } from '@/lib/settings/manager';
 import { buildSetupStatus } from '@/lib/setup/setup-status';
+import {
+  captureSetupStatusTelemetry,
+  parseSetupTelemetryTrigger,
+} from '@/lib/telemetry/setup';
 import logger from '@/lib/logger';
 
 export async function GET(request: NextRequest) {
@@ -13,6 +17,14 @@ export async function GET(request: NextRequest) {
 
     const settings = await SettingsManager.load(auth.userId);
     const status = await buildSetupStatus(settings, { userId: auth.userId });
+    const source = request.nextUrl.searchParams.get('telemetry_source');
+    const trigger = parseSetupTelemetryTrigger(
+      request.nextUrl.searchParams.get('telemetry_trigger'),
+    );
+
+    if (source === 'setup' && trigger) {
+      void captureSetupStatusTelemetry(status, { trigger, request });
+    }
 
     return NextResponse.json(status);
   } catch (error) {

--- a/src/components/setup/setup-client.tsx
+++ b/src/components/setup/setup-client.tsx
@@ -36,6 +36,12 @@ const TOOL_ORDER = ['git', 'gh'] as const;
 type ToolKey = typeof TOOL_ORDER[number];
 type SetupSuggestionTool = SetupStatusResponse['suggestions'][number]['tool'];
 type ProviderStatus = SetupProviderState['status'];
+type SetupTelemetryTrigger =
+  | 'initial'
+  | 'manual_refresh'
+  | 'environment_switch'
+  | 'command_override_saved'
+  | 'account_created';
 
 const SUPPORTED_PROVIDERS = [
   {
@@ -79,12 +85,40 @@ export function SetupClient({ initialNeedsAccountSetup = null }: SetupClientProp
   const [accountError, setAccountError] = useState<string | null>(null);
   const [isCreatingAccount, setIsCreatingAccount] = useState(false);
   const [switchingEnvironment, setSwitchingEnvironment] = useState<AgentEnvironment | null>(null);
+  const diagnosticsRunKeysRef = useRef<Set<string>>(new Set());
 
-  const refreshStatus = useCallback(async () => {
+  const startSetupDiagnostics = useCallback((
+    trigger: SetupTelemetryTrigger,
+    activeEnvironment: AgentEnvironment,
+  ) => {
+    if (telemetryDisabledByEnv) return;
+
+    const runKey = `${trigger}:${activeEnvironment}`;
+    if (diagnosticsRunKeysRef.current.has(runKey)) return;
+    diagnosticsRunKeysRef.current.add(runKey);
+
+    const params = new URLSearchParams({
+      telemetry_source: 'setup',
+      telemetry_trigger: trigger,
+    });
+
+    void fetch(`/api/diagnostics/cli?${params.toString()}`, {
+      method: 'POST',
+      cache: 'no-store',
+    }).catch(() => {
+      diagnosticsRunKeysRef.current.delete(runKey);
+    });
+  }, [telemetryDisabledByEnv]);
+
+  const refreshStatus = useCallback(async (trigger: SetupTelemetryTrigger = 'manual_refresh') => {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await fetch('/api/setup/status');
+      const params = new URLSearchParams({
+        telemetry_source: 'setup',
+        telemetry_trigger: trigger,
+      });
+      const response = await fetch(`/api/setup/status?${params.toString()}`);
       if (response.status === 401) {
         router.replace('/login');
         return;
@@ -92,13 +126,15 @@ export function SetupClient({ initialNeedsAccountSetup = null }: SetupClientProp
       if (!response.ok) {
         throw new Error('Could not check setup status.');
       }
-      setStatus(await response.json() as SetupStatusResponse);
+      const nextStatus = await response.json() as SetupStatusResponse;
+      setStatus(nextStatus);
+      startSetupDiagnostics(trigger, nextStatus.activeEnvironment);
     } catch (nextError) {
       setError(nextError instanceof Error ? nextError.message : 'Could not check setup status.');
     } finally {
       setIsLoading(false);
     }
-  }, [router]);
+  }, [router, startSetupDiagnostics]);
 
   useEffect(() => {
     let cancelled = false;
@@ -135,7 +171,7 @@ export function SetupClient({ initialNeedsAccountSetup = null }: SetupClientProp
           setIsLoading(false);
           return;
         }
-        await refreshStatus();
+        await refreshStatus('initial');
       } catch (nextError) {
         if (cancelled) return;
         setError(nextError instanceof Error ? nextError.message : 'Could not check setup status.');
@@ -207,7 +243,7 @@ export function SetupClient({ initialNeedsAccountSetup = null }: SetupClientProp
       setAccountPassword('');
       await checkAuth();
       await loadSettings();
-      await refreshStatus();
+      await refreshStatus('account_created');
       setNeedsAccountSetup(false);
     } catch (nextError) {
       setAccountError(nextError instanceof Error ? nextError.message : 'Could not create account.');
@@ -228,7 +264,7 @@ export function SetupClient({ initialNeedsAccountSetup = null }: SetupClientProp
       setError(null);
       try {
         await updateSettings({ agentEnvironment });
-        await refreshStatus();
+        await refreshStatus('environment_switch');
       } catch (nextError) {
         setError(nextError instanceof Error ? nextError.message : 'Could not change setup environment.');
         setIsLoading(false);
@@ -353,7 +389,7 @@ export function SetupClient({ initialNeedsAccountSetup = null }: SetupClientProp
               <div className="rounded-lg border border-(--divider) bg-(--sidebar-bg) px-4 py-3">
                 <CliCommandOverrideSettings
                   environments={status.availableEnvironments}
-                  onSaved={refreshStatus}
+                  onSaved={() => void refreshStatus('command_override_saved')}
                 />
               </div>
 
@@ -374,7 +410,7 @@ export function SetupClient({ initialNeedsAccountSetup = null }: SetupClientProp
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={refreshStatus}
+                  onClick={() => void refreshStatus('manual_refresh')}
                   disabled={isLoading}
                 >
                   <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />

--- a/src/lib/cli/cli-exec.ts
+++ b/src/lib/cli/cli-exec.ts
@@ -10,6 +10,9 @@ export interface ExecResult {
   exitCode: number | null;
   stdout: string;
   stderr: string;
+  timedOut: boolean;
+  durationMs: number;
+  spawnErrorCode?: string;
 }
 
 export type CliEnvironment = 'native' | 'wsl';
@@ -62,6 +65,7 @@ export async function execCli(
   timeoutMs: number,
 ): Promise<ExecResult> {
   return new Promise((resolve) => {
+    const startedAt = Date.now();
     const proc = spawnCliProcess(command, args, {
       windowsHide: true,
       env: process.env,
@@ -80,11 +84,19 @@ export async function execCli(
       try { proc.kill('SIGTERM'); } catch { /* ignore */ }
     }, timeoutMs);
 
-    const finish = (exitCode: number | null, ok: boolean) => {
+    const finish = (exitCode: number | null, ok: boolean, spawnErrorCode?: string) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      resolve({ ok, exitCode, stdout, stderr });
+      resolve({
+        ok,
+        exitCode,
+        stdout,
+        stderr,
+        timedOut,
+        durationMs: Date.now() - startedAt,
+        ...(spawnErrorCode ? { spawnErrorCode } : {}),
+      });
     };
 
     proc.stdout?.on('data', (chunk: Buffer | string) => {
@@ -94,9 +106,9 @@ export async function execCli(
       stderr += chunk.toString();
     });
 
-    proc.on('error', (err) => {
+    proc.on('error', (err: NodeJS.ErrnoException) => {
       stderr += `\n[execCli] spawn error: ${err.message}`;
-      finish(null, false);
+      finish(null, false, err.code);
     });
 
     proc.on('close', (code) => {

--- a/src/lib/cli/diagnostic-types.ts
+++ b/src/lib/cli/diagnostic-types.ts
@@ -1,4 +1,10 @@
-import type { CliConnectionStatus } from './providers/provider-contract';
+import type {
+  CliCommandShape,
+  CliCommandSource,
+  CliConnectionStatus,
+  CliDetectionReason,
+  CliProbeSummary,
+} from './providers/provider-contract';
 import type { AgentEnvironment } from '@/lib/settings/types';
 
 export type CliDiagnosticStepStatus = 'passed' | 'failed' | 'skipped' | 'timeout';
@@ -16,6 +22,11 @@ export interface CliDiagnosticProviderResult {
   environment: AgentEnvironment;
   connectionStatus: CliConnectionStatus;
   version?: string;
+  detectionReason?: CliDetectionReason;
+  commandSource?: CliCommandSource;
+  commandShape?: CliCommandShape;
+  versionProbe?: CliProbeSummary;
+  authProbe?: CliProbeSummary;
   outcome: CliDiagnosticOutcome;
   steps: {
     statusCheck: CliDiagnosticStep;
@@ -26,7 +37,14 @@ export interface CliDiagnosticProviderResult {
   };
   durationMs: number;
   assistantPreview?: string;
+  spawnErrorMessage?: string;
+  smokeTraceJsonl?: string;
+  smokeTraceEventCount?: number;
   rawLogPath?: string;
+  rawLogJsonl?: string;
+  rawLogBytes?: number;
+  rawLogEventCount?: number;
+  rawLogTruncated?: boolean;
 }
 
 export interface CliDiagnosticReport {
@@ -35,7 +53,7 @@ export interface CliDiagnosticReport {
   generatedAt: string;
   environment: AgentEnvironment;
   prompt: string;
-  rawLogDir: string;
+  rawLogDir?: string;
   summary: {
     passed: number;
     failed: number;

--- a/src/lib/cli/diagnostics.ts
+++ b/src/lib/cli/diagnostics.ts
@@ -27,6 +27,7 @@ const DEFAULT_STARTUP_TIMEOUT_MS = 15_000;
 const DEFAULT_RESPONSE_TIMEOUT_MS = 45_000;
 const ASSISTANT_PREVIEW_LIMIT = 240;
 const ERROR_PREVIEW_LIMIT = 500;
+const TELEMETRY_RAW_LOG_MAX_REPORT_BYTES = 12 * 1024 * 1024;
 const REPORTS_KEY = Symbol.for('tessera.cliDiagnostics.latestReports');
 
 type KillProcess = typeof gracefulKillProcess;
@@ -42,6 +43,8 @@ interface RunCliDiagnosticsOptions {
   killProcess?: KillProcess;
   now?: () => Date;
   storeLatest?: boolean;
+  writeRawLogs?: boolean;
+  captureTelemetryRawLog?: boolean;
 }
 
 interface DiagnosticTurnResult {
@@ -49,17 +52,37 @@ interface DiagnosticTurnResult {
   receiveStep: CliDiagnosticStep;
   outcome: CliDiagnosticStepStatus;
   assistantPreview?: string;
+  assistantMessageChars?: number;
   processExited: boolean;
 }
 
 interface RawLogWriter {
-  path: string;
+  path?: string;
   sink: CliRawLogSink;
   close: () => Promise<void>;
+  getTelemetryLog?: () => RawLogTelemetryLog;
+}
+
+interface RawLogTelemetryLog {
+  jsonl: string;
+  bytes: number;
+  eventCount: number;
+  truncated: boolean;
+}
+
+interface RawLogTelemetryBudget {
+  remainingBytes: number;
+  isTruncated: boolean;
 }
 
 interface LatestReportStore {
   byUserId: Map<string, CliDiagnosticReport>;
+}
+
+interface SmokeTraceRecorder {
+  record: (event: Record<string, unknown>) => void;
+  toJsonl: () => string;
+  count: () => number;
 }
 
 function getLatestReportStore(): LatestReportStore {
@@ -100,6 +123,54 @@ function sanitizeDiagnosticMessage(message: string): string {
 function buildAssistantPreview(content: string): string | undefined {
   const preview = content.replace(/\s+/g, ' ').trim().slice(0, ASSISTANT_PREVIEW_LIMIT);
   return preview || undefined;
+}
+
+function createSmokeTraceRecorder(
+  providerId: string,
+  environment: AgentEnvironment,
+): SmokeTraceRecorder {
+  const lines: string[] = [];
+  let seq = 0;
+
+  return {
+    record: (event) => {
+      seq += 1;
+      lines.push(`${JSON.stringify(removeUndefinedProperties({
+        schema_version: 1,
+        seq,
+        provider_id: providerId,
+        environment,
+        ...event,
+      }))}\n`);
+    },
+    toJsonl: () => lines.join(''),
+    count: () => seq,
+  };
+}
+
+function removeUndefinedProperties(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, item]) => item !== undefined),
+  );
+}
+
+function recordSmokeTraceStep(
+  trace: SmokeTraceRecorder,
+  step: string,
+  result: CliDiagnosticStep,
+  extra: Record<string, unknown> = {},
+): void {
+  trace.record({
+    event: 'step_completed',
+    step,
+    status: result.status,
+    duration_ms: result.durationMs,
+    ...extra,
+  });
+}
+
+function getDiagnosticPromptKind(prompt: string): 'fixed_hi' | 'custom' {
+  return prompt === DEFAULT_DIAGNOSTIC_PROMPT ? 'fixed_hi' : 'custom';
 }
 
 function getAssistantContent(message: ParsedMessage): string {
@@ -200,6 +271,131 @@ function createRawLogWriter(filePath: string): RawLogWriter {
   };
 }
 
+function createNoopRawLogWriter(): RawLogWriter {
+  return {
+    sink: () => {},
+    close: async () => {},
+  };
+}
+
+function createCompositeRawLogWriter(writers: RawLogWriter[]): RawLogWriter {
+  return {
+    path: writers.find((writer) => writer.path)?.path,
+    sink: (event) => {
+      for (const writer of writers) {
+        writer.sink(event);
+      }
+    },
+    close: async () => {
+      await Promise.all(writers.map((writer) => writer.close()));
+    },
+    getTelemetryLog: () => writers.find((writer) => writer.getTelemetryLog)?.getTelemetryLog?.() ?? {
+      jsonl: '',
+      bytes: 0,
+      eventCount: 0,
+      truncated: false,
+    },
+  };
+}
+
+function createTelemetryRawLogWriter(budget: RawLogTelemetryBudget): RawLogWriter {
+  const lines: string[] = [];
+  let totalLength = 0;
+  let eventCount = 0;
+  let truncated = false;
+
+  return {
+    sink: (event) => {
+      eventCount += 1;
+
+      const line = `${JSON.stringify({
+        direction: event.direction,
+        phase: event.phase,
+        byteLength: Buffer.byteLength(event.data),
+        data: sanitizeRawLogTelemetryData(event),
+      })}\n`;
+      const lineLength = Buffer.byteLength(line);
+
+      if (lineLength > budget.remainingBytes) {
+        truncated = true;
+        budget.isTruncated = true;
+        return;
+      }
+
+      lines.push(line);
+      totalLength += lineLength;
+      budget.remainingBytes -= lineLength;
+    },
+    close: async () => {},
+    getTelemetryLog: () => ({
+      jsonl: lines.join(''),
+      bytes: totalLength,
+      eventCount,
+      truncated: truncated || budget.isTruncated,
+    }),
+  };
+}
+
+function sanitizeRawLogTelemetryData(event: CliRawLogEvent): string {
+  if (event.direction === 'event' && event.phase === 'spawn') {
+    return sanitizeSpawnMetadata(event.data);
+  }
+
+  return redactSensitiveRawLogText(event.data);
+}
+
+function sanitizeSpawnMetadata(data: string): string {
+  try {
+    const raw = JSON.parse(data) as Record<string, unknown>;
+    const sanitized = {
+      providerId: typeof raw.providerId === 'string' ? raw.providerId : undefined,
+      args: Array.isArray(raw.args)
+        ? raw.args.filter((item): item is string => typeof item === 'string')
+        : undefined,
+      cwd: raw.cwd ? '[path]' : undefined,
+      requestedCwd: raw.requestedCwd ? '[path]' : undefined,
+      agentEnv: typeof raw.agentEnv === 'string' ? raw.agentEnv : undefined,
+      commandShape: typeof raw.command === 'string' ? getRawLogCommandShape(raw.command) : undefined,
+    };
+    return redactSensitiveRawLogText(JSON.stringify(sanitized));
+  } catch {
+    return redactSensitiveRawLogText(data);
+  }
+}
+
+function getRawLogCommandShape(command: string): string {
+  const trimmed = command.trim();
+  if (!trimmed) return 'other';
+  if (
+    trimmed.startsWith('/')
+    || /^[A-Za-z]:[\\/]/.test(trimmed)
+    || /^\\\\[^\\]+\\[^\\]+/.test(trimmed)
+    || /^\/\/[^/]+\/[^/]+/.test(trimmed)
+  ) {
+    return 'absolute_path';
+  }
+  if (trimmed.includes('/') || trimmed.includes('\\')) return 'relative_path';
+  if (/^[A-Za-z0-9._-]+$/.test(trimmed)) return 'bare_command';
+  return 'other';
+}
+
+function redactSensitiveRawLogText(value: string): string {
+  return value
+    .replace(/\x1b\[[0-9;]*m/g, '')
+    .replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, '[email]')
+    .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi, '[uuid]')
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{20,})\b/g, '[token]')
+    .replace(/\bAKIA[0-9A-Z]{16}\b/g, '[token]')
+    .replace(/("?(?:api[_-]?key|token|secret|password|authorization)"?\s*[:=]\s*)["']?[^"',\s}]+/gi, '$1[token]')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{20,}\b/gi, 'Bearer [token]')
+    .replace(/\\\\[^\s"']+(?:\\[^\s"']+)*/g, '[path]')
+    .replace(/\b[A-Za-z]:\\[^\s"']+/g, '[path]')
+    .replace(/(?:^|[\s"'(:])\/(?:Users|home|var|tmp|private|mnt|opt|usr|Volumes)\/[^\s"')]+/g, (match) => (
+      `${match[0] === '/' ? '' : match[0]}[path]`
+    ))
+    .replace(/\b[A-Za-z0-9+/=_-]{48,}\b/g, '[token]');
+}
+
 async function resolveDiagnosticWorkDir(workDir?: string): Promise<string> {
   const resolved = workDir ?? getTesseraDataPath('diagnostics', 'workspace');
   await fs.mkdir(resolved, { recursive: true, mode: 0o700 });
@@ -235,6 +431,7 @@ function executeDiagnosticTurn(
         receiveStep: makeStep('timeout', receiveStartedAt, `No assistant response within ${responseTimeoutMs}ms`),
         outcome: 'timeout',
         assistantPreview: buildAssistantPreview(assistantContent),
+        assistantMessageChars: assistantContent.trim().length,
         processExited,
       });
     }, responseTimeoutMs);
@@ -271,6 +468,7 @@ function executeDiagnosticTurn(
             receiveStep: makeStep('failed', receiveStartedAt, `Parser error: ${(error as Error).message}`),
             outcome: 'failed',
             assistantPreview: buildAssistantPreview(assistantContent),
+            assistantMessageChars: assistantContent.trim().length,
             processExited,
           });
           return;
@@ -284,6 +482,7 @@ function executeDiagnosticTurn(
               receiveStep: makeStep('passed', receiveStartedAt),
               outcome: 'passed',
               assistantPreview: buildAssistantPreview(assistantContent),
+              assistantMessageChars: assistantContent.trim().length,
               processExited,
             });
             return;
@@ -298,6 +497,7 @@ function executeDiagnosticTurn(
         receiveStep: makeStep('failed', receiveStartedAt, `Process error: ${error.message}`),
         outcome: 'failed',
         assistantPreview: buildAssistantPreview(assistantContent),
+        assistantMessageChars: assistantContent.trim().length,
         processExited,
       });
     };
@@ -309,6 +509,7 @@ function executeDiagnosticTurn(
         receiveStep: makeStep('failed', receiveStartedAt, `Process closed before response (code=${code ?? 'unknown'})`),
         outcome: 'failed',
         assistantPreview: buildAssistantPreview(assistantContent),
+        assistantMessageChars: assistantContent.trim().length,
         processExited,
       });
     };
@@ -336,6 +537,7 @@ function executeDiagnosticTurn(
           receiveStep: makeStaticStep('skipped', 'Message was not sent'),
           outcome: 'failed',
           assistantPreview: undefined,
+          assistantMessageChars: 0,
           processExited,
         });
       }
@@ -345,6 +547,7 @@ function executeDiagnosticTurn(
         receiveStep: makeStaticStep('skipped', 'Message was not sent'),
         outcome: 'failed',
         assistantPreview: undefined,
+        assistantMessageChars: 0,
         processExited,
       });
     }
@@ -379,7 +582,9 @@ async function runProviderDiagnostic(options: {
   startupTimeoutMs: number;
   responseTimeoutMs: number;
   killProcess: KillProcess;
-  rawLogDir: string;
+  rawLogDir?: string;
+  captureTelemetryRawLog?: boolean;
+  telemetryRawLogBudget: RawLogTelemetryBudget;
 }): Promise<CliDiagnosticProviderResult> {
   const {
     provider,
@@ -401,32 +606,73 @@ async function runProviderDiagnostic(options: {
     receiveResponse: makeStaticStep('skipped'),
     cleanup: makeStaticStep('skipped'),
   };
+  const smokeTrace = createSmokeTraceRecorder(status.providerId, status.environment);
+  recordSmokeTraceStep(smokeTrace, 'status_check', baseSteps.statusCheck, {
+    connection_status: status.status,
+    provider_version: status.version ?? '',
+  });
 
   if (status.status !== 'connected') {
+    const skippedSpawnStep = makeStaticStep('skipped', `Connection status is ${status.status}`);
+    recordSmokeTraceStep(smokeTrace, 'spawn', skippedSpawnStep, {
+      connection_status: status.status,
+    });
+    recordSmokeTraceStep(smokeTrace, 'send_message', baseSteps.sendMessage, {
+      prompt_kind: getDiagnosticPromptKind(prompt),
+      prompt_chars: prompt.length,
+    });
+    recordSmokeTraceStep(smokeTrace, 'receive_assistant_message', baseSteps.receiveResponse, {
+      assistant_message_chars: 0,
+      process_exited: false,
+    });
+    recordSmokeTraceStep(smokeTrace, 'cleanup', baseSteps.cleanup);
+    smokeTrace.record({
+      event: 'run_completed',
+      final_status: 'skipped',
+      can_continue: false,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return {
       providerId: status.providerId,
       displayName,
       environment: status.environment,
       connectionStatus: status.status,
       ...(status.version ? { version: status.version } : {}),
+      ...(status.detectionReason ? { detectionReason: status.detectionReason } : {}),
+      ...(status.commandSource ? { commandSource: status.commandSource } : {}),
+      ...(status.commandShape ? { commandShape: status.commandShape } : {}),
+      ...(status.versionProbe ? { versionProbe: status.versionProbe } : {}),
+      ...(status.authProbe ? { authProbe: status.authProbe } : {}),
       outcome: 'skipped',
       steps: {
         ...baseSteps,
-        spawn: makeStaticStep('skipped', `Connection status is ${status.status}`),
+        spawn: skippedSpawnStep,
       },
       durationMs: Date.now() - startedAt,
+      smokeTraceJsonl: smokeTrace.toJsonl(),
+      smokeTraceEventCount: smokeTrace.count(),
     };
   }
 
   const sessionId = randomUUID();
   let proc: ChildProcess | null = null;
-  const rawLogPath = path.join(
-    rawLogDir,
-    `${sanitizeFilePart(status.providerId)}-${sanitizeFilePart(status.environment)}.jsonl`,
-  );
-  const rawLog = createRawLogWriter(rawLogPath);
+  const rawLogPath = rawLogDir
+    ? path.join(
+      rawLogDir,
+      `${sanitizeFilePart(status.providerId)}-${sanitizeFilePart(status.environment)}.jsonl`,
+    )
+    : undefined;
+  const rawLogWriters = [
+    ...(rawLogPath ? [createRawLogWriter(rawLogPath)] : []),
+    ...(options.captureTelemetryRawLog ? [createTelemetryRawLogWriter(options.telemetryRawLogBudget)] : []),
+  ];
+  const rawLog = rawLogWriters.length > 0
+    ? createCompositeRawLogWriter(rawLogWriters)
+    : createNoopRawLogWriter();
   const spawnStartedAt = Date.now();
   let spawnStep: CliDiagnosticStep;
+  let spawnErrorMessage: string | undefined;
   let turnResult: DiagnosticTurnResult | null = null;
   let cleanupStep = makeStaticStep('skipped');
 
@@ -447,7 +693,8 @@ async function runProviderDiagnostic(options: {
 
     proc = spawnResult.process;
     if (!spawnResult.ok) {
-      spawnStep = makeStep('failed', spawnStartedAt, spawnResult.error?.message ?? 'Provider spawn failed');
+      spawnErrorMessage = spawnResult.error?.message ?? 'Provider spawn failed';
+      spawnStep = makeStep('failed', spawnStartedAt, spawnErrorMessage);
     } else {
       spawnStep = makeStep('passed', spawnStartedAt);
       turnResult = await executeDiagnosticTurn(
@@ -459,7 +706,8 @@ async function runProviderDiagnostic(options: {
       );
     }
   } catch (error) {
-    spawnStep = makeStep('failed', spawnStartedAt, `Spawn failed: ${(error as Error).message}`);
+    spawnErrorMessage = error instanceof Error ? error.message : String(error);
+    spawnStep = makeStep('failed', spawnStartedAt, `Spawn failed: ${spawnErrorMessage}`);
   } finally {
     if (proc) {
       cleanupStep = await cleanupDiagnosticProcess(
@@ -474,6 +722,28 @@ async function runProviderDiagnostic(options: {
   }
 
   const outcome = turnResult?.outcome ?? 'failed';
+  const telemetryRawLog = rawLog.getTelemetryLog?.();
+  const sendStep = turnResult?.sendStep ?? makeStaticStep(spawnStep.status === 'passed' ? 'failed' : 'skipped');
+  const receiveStep = turnResult?.receiveStep ?? makeStaticStep('skipped');
+
+  recordSmokeTraceStep(smokeTrace, 'spawn', spawnStep, {
+    ...(spawnErrorMessage ? { error_message: spawnErrorMessage } : {}),
+  });
+  recordSmokeTraceStep(smokeTrace, 'send_message', sendStep, {
+    prompt_kind: getDiagnosticPromptKind(prompt),
+    prompt_chars: prompt.length,
+  });
+  recordSmokeTraceStep(smokeTrace, 'receive_assistant_message', receiveStep, {
+    assistant_message_chars: turnResult?.assistantMessageChars ?? 0,
+    process_exited: turnResult?.processExited ?? false,
+  });
+  recordSmokeTraceStep(smokeTrace, 'cleanup', cleanupStep);
+  smokeTrace.record({
+    event: 'run_completed',
+    final_status: outcome,
+    can_continue: outcome === 'passed',
+    duration_ms: Date.now() - startedAt,
+  });
 
   return {
     providerId: status.providerId,
@@ -481,17 +751,29 @@ async function runProviderDiagnostic(options: {
     environment: status.environment,
     connectionStatus: status.status,
     ...(status.version ? { version: status.version } : {}),
+    ...(status.detectionReason ? { detectionReason: status.detectionReason } : {}),
+    ...(status.commandSource ? { commandSource: status.commandSource } : {}),
+    ...(status.commandShape ? { commandShape: status.commandShape } : {}),
+    ...(status.versionProbe ? { versionProbe: status.versionProbe } : {}),
+    ...(status.authProbe ? { authProbe: status.authProbe } : {}),
     outcome,
     steps: {
       statusCheck: baseSteps.statusCheck,
       spawn: spawnStep,
-      sendMessage: turnResult?.sendStep ?? makeStaticStep(spawnStep.status === 'passed' ? 'failed' : 'skipped'),
-      receiveResponse: turnResult?.receiveStep ?? makeStaticStep('skipped'),
+      sendMessage: sendStep,
+      receiveResponse: receiveStep,
       cleanup: cleanupStep,
     },
     durationMs: Date.now() - startedAt,
-    rawLogPath,
+    ...(rawLogPath ? { rawLogPath } : {}),
     ...(turnResult?.assistantPreview ? { assistantPreview: turnResult.assistantPreview } : {}),
+    ...(spawnErrorMessage ? { spawnErrorMessage } : {}),
+    smokeTraceJsonl: smokeTrace.toJsonl(),
+    smokeTraceEventCount: smokeTrace.count(),
+    ...(telemetryRawLog?.jsonl ? { rawLogJsonl: telemetryRawLog.jsonl } : {}),
+    ...(telemetryRawLog ? { rawLogBytes: telemetryRawLog.bytes } : {}),
+    ...(telemetryRawLog ? { rawLogEventCount: telemetryRawLog.eventCount } : {}),
+    ...(telemetryRawLog ? { rawLogTruncated: telemetryRawLog.truncated } : {}),
   };
 }
 
@@ -506,7 +788,13 @@ export async function runCliDiagnostics(
   const prompt = options.prompt ?? DEFAULT_DIAGNOSTIC_PROMPT;
   const reportId = randomUUID();
   const generatedAt = (options.now?.() ?? new Date()).toISOString();
-  const rawLogDir = await resolveRawLogDir(reportId, generatedAt);
+  const rawLogDir = options.writeRawLogs === false
+    ? undefined
+    : await resolveRawLogDir(reportId, generatedAt);
+  const telemetryRawLogBudget: RawLogTelemetryBudget = {
+    remainingBytes: TELEMETRY_RAW_LOG_MAX_REPORT_BYTES,
+    isTruncated: false,
+  };
   const providers: CliDiagnosticProviderResult[] = [];
 
   for (const providerId of registry.getProviderIds()) {
@@ -522,6 +810,8 @@ export async function runCliDiagnostics(
       responseTimeoutMs: options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS,
       killProcess: options.killProcess ?? gracefulKillProcess,
       rawLogDir,
+      captureTelemetryRawLog: options.captureTelemetryRawLog,
+      telemetryRawLogBudget,
     }));
   }
 
@@ -531,16 +821,32 @@ export async function runCliDiagnostics(
     generatedAt,
     environment,
     prompt,
-    rawLogDir,
+    ...(rawLogDir ? { rawLogDir } : {}),
     summary: summarizeProviders(providers),
     providers,
   };
 
   if (options.storeLatest !== false) {
-    getLatestReportStore().byUserId.set(userId, report);
+    getLatestReportStore().byUserId.set(userId, stripTelemetryRawLogs(report));
   }
 
   return report;
+}
+
+export function stripTelemetryRawLogs(report: CliDiagnosticReport): CliDiagnosticReport {
+  return {
+    ...report,
+    providers: report.providers.map((provider) => {
+      const {
+        rawLogJsonl: _rawLogJsonl,
+        rawLogBytes: _rawLogBytes,
+        rawLogEventCount: _rawLogEventCount,
+        rawLogTruncated: _rawLogTruncated,
+        ...safeProvider
+      } = provider;
+      return safeProvider;
+    }),
+  };
 }
 
 export function getLatestCliDiagnosticReport(userId: string): CliDiagnosticReport | null {
@@ -573,7 +879,7 @@ export function renderCliDiagnosticMarkdown(report: CliDiagnosticReport): string
     `- Prompt: ${report.prompt}`,
     `- Summary: ${report.summary.passed} passed, ${report.summary.failed} failed, ${report.summary.timeout} timeout, ${report.summary.skipped} skipped`,
     '',
-    `- Raw log directory: ${report.rawLogDir}`,
+    `- Raw log directory: ${report.rawLogDir ?? 'not captured'}`,
     '',
     '| Provider | Environment | CLI Status | Outcome | Duration | Raw Log | Message |',
     '| --- | --- | --- | --- | ---: | --- | --- |',
@@ -601,7 +907,7 @@ export async function exportCliDiagnosticReport(
     reportId: report.id,
     jsonPath,
     markdownPath,
-    rawLogDir: report.rawLogDir,
+    rawLogDir: report.rawLogDir ?? '',
   };
 }
 

--- a/src/lib/cli/provider-command.ts
+++ b/src/lib/cli/provider-command.ts
@@ -1,5 +1,10 @@
 import { SettingsManager } from '@/lib/settings/manager';
 import type { AgentEnvironment, UserSettings } from '@/lib/settings/types';
+import type { CliCommandShape, CliCommandSource, CliCommandTelemetry } from './providers/provider-contract';
+
+export interface ResolvedProviderCliCommand extends CliCommandTelemetry {
+  command: string;
+}
 
 export function getProviderCliCommandFromSettings(
   settings: Pick<UserSettings, 'cliCommandOverrides'>,
@@ -16,10 +21,52 @@ export async function resolveProviderCliCommand(
   environment: AgentEnvironment,
   userId?: string,
 ): Promise<string> {
+  const resolved = await resolveProviderCliCommandWithMetadata(
+    providerId,
+    fallbackCommand,
+    environment,
+    userId,
+  );
+  return resolved.command;
+}
+
+export async function resolveProviderCliCommandWithMetadata(
+  providerId: string,
+  fallbackCommand: string,
+  environment: AgentEnvironment,
+  userId?: string,
+): Promise<ResolvedProviderCliCommand> {
   if (!userId) {
-    return fallbackCommand;
+    return {
+      command: fallbackCommand,
+      commandSource: 'default',
+      commandShape: getCommandShape(fallbackCommand),
+    };
   }
 
   const settings = await SettingsManager.load(userId, { silent: true });
-  return getProviderCliCommandFromSettings(settings, providerId, environment, fallbackCommand);
+  const override = settings.cliCommandOverrides?.[providerId]?.[environment];
+  const command = override || fallbackCommand;
+
+  return {
+    command,
+    commandSource: override ? 'override' : 'default',
+    commandShape: getCommandShape(command),
+  };
+}
+
+function getCommandShape(command: string): CliCommandShape {
+  const trimmed = command.trim();
+  if (!trimmed) return 'other';
+  if (isAbsoluteExecutablePath(trimmed)) return 'absolute_path';
+  if (trimmed.includes('/') || trimmed.includes('\\')) return 'relative_path';
+  if (/^[A-Za-z0-9._-]+$/.test(trimmed)) return 'bare_command';
+  return 'other';
+}
+
+function isAbsoluteExecutablePath(value: string): boolean {
+  return value.startsWith('/')
+    || /^[A-Za-z]:[\\/]/.test(value)
+    || /^\\\\[^\\]+\\[^\\]+/.test(value)
+    || /^\/\/[^/]+\/[^/]+/.test(value);
 }

--- a/src/lib/cli/providers/claude-code/adapter.ts
+++ b/src/lib/cli/providers/claude-code/adapter.ts
@@ -27,7 +27,15 @@ import { claudeCodeProtocolParser } from './protocol-parser';
 import { isBinaryAvailable } from '../registry';
 import { getAgentEnvironment, spawnCli } from '../../spawn-cli';
 import { execCli, parseVersion, probeBinaryAvailable } from '../../cli-exec';
-import { resolveProviderCliCommand } from '../../provider-command';
+import {
+  resolveProviderCliCommand,
+  resolveProviderCliCommandWithMetadata,
+} from '../../provider-command';
+import {
+  classifyAuthFailure,
+  classifyVersionFailure,
+  summarizeExecProbe,
+} from '../../status-detection';
 import { getRuntimePlatform } from '@/lib/system/runtime-platform';
 import logger from '@/lib/logger';
 
@@ -97,12 +105,13 @@ export class ClaudeCodeAdapter implements CliProvider {
    * does not make provider pickers wait for both commands serially.
    */
   async checkStatus(options: CheckStatusOptions): Promise<CliStatusResult> {
-    const command = await resolveProviderCliCommand(
+    const commandMetadata = await resolveProviderCliCommandWithMetadata(
       PROVIDER_ID,
       DEFAULT_COMMAND,
       options.environment,
       options.userId,
     );
+    const command = commandMetadata.command;
     const [versionResult, authResult] = await Promise.all([
       execCli(
         command,
@@ -117,16 +126,31 @@ export class ClaudeCodeAdapter implements CliProvider {
         STATUS_CHECK_TIMEOUT_MS,
       ),
     ]);
+    const versionProbe = summarizeExecProbe(versionResult);
+    const authProbe = summarizeExecProbe(authResult);
+    const baseTelemetry = {
+      commandSource: commandMetadata.commandSource,
+      commandShape: commandMetadata.commandShape,
+      versionProbe,
+      authProbe,
+    };
 
     if (!versionResult.ok) {
-      return { status: 'not_installed' };
+      return {
+        status: 'not_installed',
+        detectionReason: classifyVersionFailure(versionResult, commandMetadata.commandSource),
+        ...baseTelemetry,
+      };
     }
 
     const version = parseVersion(versionResult.stdout);
+    const connected = authResult.ok;
 
     return {
-      status: authResult.ok ? 'connected' : 'needs_login',
+      status: connected ? 'connected' : 'needs_login',
+      detectionReason: connected ? 'connected' : classifyAuthFailure(authResult),
       ...(version ? { version } : {}),
+      ...baseTelemetry,
     };
   }
 

--- a/src/lib/cli/providers/codex/adapter.ts
+++ b/src/lib/cli/providers/codex/adapter.ts
@@ -46,7 +46,15 @@ import { buildCodexSandboxPolicy, getCodexPermissionMapping } from './session-co
 import { isBinaryAvailable } from '../registry';
 import { getAgentEnvironment, normalizeCwdForCliEnvironment, spawnCli } from '../../spawn-cli';
 import { execCli, parseVersion, probeBinaryAvailable } from '../../cli-exec';
-import { resolveProviderCliCommand } from '../../provider-command';
+import {
+  resolveProviderCliCommand,
+  resolveProviderCliCommandWithMetadata,
+} from '../../provider-command';
+import {
+  classifyAuthFailure,
+  classifyVersionFailure,
+  summarizeExecProbe,
+} from '../../status-detection';
 import { updateProviderStateWithRetry } from '../../process-manager-side-effects';
 import { getRuntimePlatform } from '@/lib/system/runtime-platform';
 import logger from '@/lib/logger';
@@ -258,12 +266,13 @@ export class CodexAdapter implements CliProvider {
    * by serial CLI startup costs on Windows.
    */
   async checkStatus(options: CheckStatusOptions): Promise<CliStatusResult> {
-    const command = await resolveProviderCliCommand(
+    const commandMetadata = await resolveProviderCliCommandWithMetadata(
       PROVIDER_ID,
       DEFAULT_COMMAND,
       options.environment,
       options.userId,
     );
+    const command = commandMetadata.command;
     const [versionResult, loginResult] = await Promise.all([
       execCli(
         command,
@@ -278,16 +287,31 @@ export class CodexAdapter implements CliProvider {
         STATUS_CHECK_TIMEOUT_MS,
       ),
     ]);
+    const versionProbe = summarizeExecProbe(versionResult);
+    const authProbe = summarizeExecProbe(loginResult);
+    const baseTelemetry = {
+      commandSource: commandMetadata.commandSource,
+      commandShape: commandMetadata.commandShape,
+      versionProbe,
+      authProbe,
+    };
 
     if (!versionResult.ok) {
-      return { status: 'not_installed' };
+      return {
+        status: 'not_installed',
+        detectionReason: classifyVersionFailure(versionResult, commandMetadata.commandSource),
+        ...baseTelemetry,
+      };
     }
 
     const version = parseVersion(versionResult.stdout);
+    const connected = loginResult.ok;
 
     return {
-      status: loginResult.ok ? 'connected' : 'needs_login',
+      status: connected ? 'connected' : 'needs_login',
+      detectionReason: connected ? 'connected' : classifyAuthFailure(loginResult),
       ...(version ? { version } : {}),
+      ...baseTelemetry,
     };
   }
 

--- a/src/lib/cli/providers/opencode/adapter.ts
+++ b/src/lib/cli/providers/opencode/adapter.ts
@@ -14,7 +14,15 @@ import type { ProviderRuntimeControls } from '@/lib/session/session-control-type
 import { isBinaryAvailable } from '../registry';
 import { execCli, parseVersion, probeBinaryAvailable } from '../../cli-exec';
 import { getAgentEnvironment, normalizeCwdForCliEnvironment, spawnCli } from '../../spawn-cli';
-import { resolveProviderCliCommand } from '../../provider-command';
+import {
+  resolveProviderCliCommand,
+  resolveProviderCliCommandWithMetadata,
+} from '../../provider-command';
+import {
+  classifyAuthFailure,
+  classifyVersionFailure,
+  summarizeExecProbe,
+} from '../../status-detection';
 import { updateProviderStateWithRetry } from '../../process-manager-side-effects';
 import { getRuntimePlatform } from '@/lib/system/runtime-platform';
 import logger from '@/lib/logger';
@@ -110,25 +118,41 @@ export class OpenCodeAdapter implements CliProvider {
   }
 
   async checkStatus(options: CheckStatusOptions): Promise<CliStatusResult> {
-    const command = await resolveProviderCliCommand(
+    const commandMetadata = await resolveProviderCliCommandWithMetadata(
       PROVIDER_ID,
       DEFAULT_COMMAND,
       options.environment,
       options.userId,
     );
+    const command = commandMetadata.command;
     const [versionResult, modelsResult] = await Promise.all([
       execCli(command, ['--version'], options.environment, STATUS_CHECK_TIMEOUT_MS),
       execCli(command, ['models'], options.environment, STATUS_CHECK_TIMEOUT_MS),
     ]);
+    const versionProbe = summarizeExecProbe(versionResult);
+    const authProbe = summarizeExecProbe(modelsResult);
+    const baseTelemetry = {
+      commandSource: commandMetadata.commandSource,
+      commandShape: commandMetadata.commandShape,
+      versionProbe,
+      authProbe,
+    };
 
     if (!versionResult.ok) {
-      return { status: 'not_installed' };
+      return {
+        status: 'not_installed',
+        detectionReason: classifyVersionFailure(versionResult, commandMetadata.commandSource),
+        ...baseTelemetry,
+      };
     }
 
     const version = parseVersion(versionResult.stdout);
+    const connected = modelsResult.ok;
     return {
-      status: modelsResult.ok ? 'connected' : 'needs_login',
+      status: connected ? 'connected' : 'needs_login',
+      detectionReason: connected ? 'connected' : classifyAuthFailure(modelsResult),
       ...(version ? { version } : {}),
+      ...baseTelemetry,
     };
   }
 

--- a/src/lib/cli/providers/provider-contract.ts
+++ b/src/lib/cli/providers/provider-contract.ts
@@ -13,6 +13,37 @@ import type { SkillSource } from './skill-types';
  */
 export type CliConnectionStatus = 'connected' | 'needs_login' | 'not_installed';
 
+export type CliDetectionReason =
+  | 'connected'
+  | 'auth_failed'
+  | 'auth_timeout'
+  | 'binary_missing'
+  | 'permission_denied'
+  | 'version_timeout'
+  | 'version_nonzero'
+  | 'override_failed'
+  | 'wrong_environment'
+  | 'unknown';
+
+export type CliProbeFailureKind = 'ok' | 'spawn_error' | 'timeout' | 'nonzero_exit' | 'unknown';
+
+export type CliCommandSource = 'default' | 'override';
+export type CliCommandShape = 'bare_command' | 'absolute_path' | 'relative_path' | 'other';
+
+export interface CliProbeSummary {
+  ok: boolean;
+  failureKind: CliProbeFailureKind;
+  exitCode: number | null;
+  timedOut: boolean;
+  durationMs: number;
+  spawnErrorCode?: string;
+}
+
+export interface CliCommandTelemetry {
+  commandSource: CliCommandSource;
+  commandShape: CliCommandShape;
+}
+
 /**
  * Result of a single connection check for one CLI × environment.
  */
@@ -20,6 +51,11 @@ export interface CliStatusResult {
   status: CliConnectionStatus;
   /** CLI version string when available (omitted when not_installed). */
   version?: string;
+  detectionReason?: CliDetectionReason;
+  commandSource?: CliCommandSource;
+  commandShape?: CliCommandShape;
+  versionProbe?: CliProbeSummary;
+  authProbe?: CliProbeSummary;
 }
 
 /**

--- a/src/lib/cli/status-detection.ts
+++ b/src/lib/cli/status-detection.ts
@@ -1,0 +1,47 @@
+import type { ExecResult } from './cli-exec';
+import type {
+  CliCommandSource,
+  CliDetectionReason,
+  CliProbeFailureKind,
+  CliProbeSummary,
+} from './providers/provider-contract';
+
+export function summarizeExecProbe(result: ExecResult): CliProbeSummary {
+  return {
+    ok: result.ok,
+    failureKind: getProbeFailureKind(result),
+    exitCode: result.exitCode,
+    timedOut: result.timedOut,
+    durationMs: result.durationMs,
+    ...(result.spawnErrorCode ? { spawnErrorCode: result.spawnErrorCode } : {}),
+  };
+}
+
+export function classifyVersionFailure(
+  result: ExecResult,
+  commandSource: CliCommandSource,
+): CliDetectionReason {
+  if (result.ok) return 'connected';
+  if (commandSource === 'override') return 'override_failed';
+  if (result.timedOut) return 'version_timeout';
+  if (result.spawnErrorCode === 'EACCES' || result.spawnErrorCode === 'EPERM') {
+    return 'permission_denied';
+  }
+  if (result.spawnErrorCode === 'ENOENT') return 'binary_missing';
+  if (result.exitCode !== null) return 'version_nonzero';
+  return 'unknown';
+}
+
+export function classifyAuthFailure(result: ExecResult): CliDetectionReason {
+  if (result.ok) return 'connected';
+  if (result.timedOut) return 'auth_timeout';
+  return 'auth_failed';
+}
+
+function getProbeFailureKind(result: ExecResult): CliProbeFailureKind {
+  if (result.ok) return 'ok';
+  if (result.timedOut) return 'timeout';
+  if (result.spawnErrorCode) return 'spawn_error';
+  if (result.exitCode !== null) return 'nonzero_exit';
+  return 'unknown';
+}

--- a/src/lib/setup/setup-status.ts
+++ b/src/lib/setup/setup-status.ts
@@ -2,6 +2,12 @@ import '@/lib/cli/providers/bootstrap';
 import { checkAllCliStatuses, type CliStatusEntry } from '@/lib/cli/connection-checker';
 import { execCli, isRunningInWsl, type CliEnvironment, type ExecResult } from '@/lib/cli/cli-exec';
 import { cliProviderRegistry } from '@/lib/cli/providers/registry';
+import type {
+  CliCommandShape,
+  CliCommandSource,
+  CliDetectionReason,
+  CliProbeSummary,
+} from '@/lib/cli/providers/provider-contract';
 import type { AgentEnvironment, UserSettings } from '@/lib/settings/types';
 
 export type SetupToolStatus = 'ready' | 'missing' | 'needs_login' | 'needs_config';
@@ -19,6 +25,11 @@ export interface SetupProviderState {
   displayName: string;
   status: 'connected' | 'needs_login' | 'not_installed';
   version?: string;
+  detectionReason?: CliDetectionReason;
+  commandSource?: CliCommandSource;
+  commandShape?: CliCommandShape;
+  versionProbe?: CliProbeSummary;
+  authProbe?: CliProbeSummary;
 }
 
 export interface SetupToolState {
@@ -158,6 +169,11 @@ function buildProviderStates(
         ?? entry.providerId,
       status: entry.status,
       ...(entry.version ? { version: entry.version } : {}),
+      ...(entry.detectionReason ? { detectionReason: entry.detectionReason } : {}),
+      ...(entry.commandSource ? { commandSource: entry.commandSource } : {}),
+      ...(entry.commandShape ? { commandShape: entry.commandShape } : {}),
+      ...(entry.versionProbe ? { versionProbe: entry.versionProbe } : {}),
+      ...(entry.authProbe ? { authProbe: entry.authProbe } : {}),
     }));
 }
 

--- a/src/lib/telemetry/server.ts
+++ b/src/lib/telemetry/server.ts
@@ -1,0 +1,153 @@
+import type { NextRequest } from 'next/server';
+import { getServerHostInfo } from '@/lib/system/server-host';
+import { getTelemetryBootstrapInfo } from './server-state';
+import logger from '@/lib/logger';
+
+export type ServerTelemetryEventName =
+  | 'setup_cli_detection_summary'
+  | 'setup_cli_provider_status'
+  | 'setup_cli_smoke_provider_result'
+  | 'setup_cli_smoke_raw_log'
+  | 'setup_cli_smoke_run_completed'
+  | 'settings_cli_diagnostics_provider_result'
+  | 'settings_cli_diagnostics_raw_log'
+  | 'settings_cli_diagnostics_run_completed';
+
+export type ServerTelemetryProperties = Record<string, unknown>;
+
+const MAX_STRING_LENGTH = 100;
+const MAX_ERROR_MESSAGE_LENGTH = 1_000;
+const MAX_ARRAY_LENGTH = 30;
+const MAX_RAW_LOG_JSONL_LENGTH = 512 * 1024;
+const MAX_SMOKE_TRACE_JSONL_LENGTH = 32 * 1024;
+const CAPTURE_TIMEOUT_MS = 2_000;
+
+const allowedEvents = new Set<ServerTelemetryEventName>([
+  'setup_cli_detection_summary',
+  'setup_cli_provider_status',
+  'setup_cli_smoke_provider_result',
+  'setup_cli_smoke_raw_log',
+  'setup_cli_smoke_run_completed',
+  'settings_cli_diagnostics_provider_result',
+  'settings_cli_diagnostics_raw_log',
+  'settings_cli_diagnostics_run_completed',
+]);
+
+export function isServerTelemetryCaptureAllowed(request?: NextRequest): boolean {
+  const hostInfo = getServerHostInfo();
+  return Boolean(
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+      && !hostInfo.telemetryDisabledByEnv
+      && !isRequestPrivacyOptOut(request),
+  );
+}
+
+export async function captureServerTelemetryEvent(
+  eventName: ServerTelemetryEventName,
+  properties: ServerTelemetryProperties = {},
+  request?: NextRequest,
+): Promise<void> {
+  if (!allowedEvents.has(eventName) || !isServerTelemetryCaptureAllowed(request)) {
+    return;
+  }
+
+  const projectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+  if (!projectToken) return;
+
+  const hostInfo = getServerHostInfo();
+  const bootstrap = await getTelemetryBootstrapInfo(hostInfo);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CAPTURE_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${getPostHogCaptureHost()}/capture/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        api_key: projectToken,
+        event: eventName,
+        properties: {
+          distinct_id: bootstrap.installId,
+          install_id: bootstrap.installId,
+          app_version: hostInfo.appVersion,
+          platform: hostInfo.platform,
+          arch: hostInfo.arch,
+          channel: hostInfo.channel,
+          $geoip_disable: true,
+          $process_person_profile: false,
+          ...sanitizeTelemetryProperties(properties),
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      logger.warn({ eventName, status: response.status }, 'server telemetry capture failed');
+    }
+  } catch (error) {
+    logger.warn({ eventName, error }, 'server telemetry capture error');
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function getPostHogCaptureHost(): string {
+  const explicitHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+  if (explicitHost) return explicitHost.replace(/\/$/, '');
+
+  const apiHost = process.env.NEXT_PUBLIC_POSTHOG_API_HOST;
+  if (apiHost?.startsWith('http://') || apiHost?.startsWith('https://')) {
+    return apiHost.replace(/\/$/, '');
+  }
+
+  return 'https://us.i.posthog.com';
+}
+
+function isRequestPrivacyOptOut(request?: NextRequest): boolean {
+  if (!request) return false;
+  const dnt = request.headers.get('dnt') || request.headers.get('DNT');
+  const gpc = request.headers.get('sec-gpc') || request.headers.get('Sec-GPC');
+  return dnt === '1' || dnt === 'yes' || gpc === '1';
+}
+
+function sanitizeTelemetryProperties(
+  properties: ServerTelemetryProperties,
+): ServerTelemetryProperties {
+  const sanitized: ServerTelemetryProperties = {};
+
+  for (const [key, value] of Object.entries(properties)) {
+    if (typeof value === 'string') {
+      sanitized[key] = value.slice(
+        0,
+        getMaxStringLengthForProperty(key),
+      );
+      continue;
+    }
+
+    if (typeof value === 'number') {
+      if (Number.isFinite(value)) sanitized[key] = value;
+      continue;
+    }
+
+    if (typeof value === 'boolean') {
+      sanitized[key] = value;
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      sanitized[key] = value
+        .filter((item): item is string => typeof item === 'string')
+        .slice(0, MAX_ARRAY_LENGTH)
+        .map((item) => item.slice(0, MAX_STRING_LENGTH));
+    }
+  }
+
+  return sanitized;
+}
+
+function getMaxStringLengthForProperty(key: string): number {
+  if (key === 'raw_log_jsonl') return MAX_RAW_LOG_JSONL_LENGTH;
+  if (key === 'smoke_trace_jsonl') return MAX_SMOKE_TRACE_JSONL_LENGTH;
+  if (key.endsWith('_error_message')) return MAX_ERROR_MESSAGE_LENGTH;
+  return MAX_STRING_LENGTH;
+}

--- a/src/lib/telemetry/setup.ts
+++ b/src/lib/telemetry/setup.ts
@@ -1,0 +1,346 @@
+import type { NextRequest } from 'next/server';
+import type {
+  SetupProviderState,
+  SetupStatusResponse,
+} from '@/lib/setup/setup-status';
+import type { CliDiagnosticProviderResult, CliDiagnosticReport } from '@/lib/cli/diagnostic-types';
+import { captureServerTelemetryEvent } from './server';
+import type { ServerTelemetryEventName } from './server';
+
+export type SetupTelemetryTrigger =
+  | 'initial'
+  | 'manual_refresh'
+  | 'environment_switch'
+  | 'command_override_saved'
+  | 'account_created';
+
+interface SetupTelemetryOptions {
+  trigger: SetupTelemetryTrigger;
+  request?: NextRequest;
+}
+
+export type CliDiagnosticsTelemetrySource = 'setup' | 'settings';
+
+interface CliDiagnosticsTelemetryOptions {
+  source: CliDiagnosticsTelemetrySource;
+  trigger?: SetupTelemetryTrigger;
+  request?: NextRequest;
+}
+
+type DiagnosticFailureStage =
+  | 'status_check'
+  | 'spawn'
+  | 'send_message'
+  | 'receive_response'
+  | 'cleanup'
+  | 'none';
+
+const RAW_LOG_CHUNK_BYTES = 512 * 1024;
+
+export function parseSetupTelemetryTrigger(value: unknown): SetupTelemetryTrigger | null {
+  if (
+    value === 'initial'
+    || value === 'manual_refresh'
+    || value === 'environment_switch'
+    || value === 'command_override_saved'
+    || value === 'account_created'
+  ) {
+    return value;
+  }
+  return null;
+}
+
+export async function captureSetupStatusTelemetry(
+  status: SetupStatusResponse,
+  options: SetupTelemetryOptions,
+): Promise<void> {
+  const active = status.environments[status.activeEnvironment];
+  const providers = Object.entries(status.environments)
+    .flatMap(([environment, environmentState]) => (
+      environmentState?.providers.map((provider) => ({
+        environment,
+        provider,
+      })) ?? []
+    ));
+
+  await captureServerTelemetryEvent(
+    'setup_cli_detection_summary',
+    {
+      source: 'setup',
+      setup_trigger: options.trigger,
+      active_environment: status.activeEnvironment,
+      available_environments: status.availableEnvironments,
+      is_windows_ecosystem: status.isWindowsEcosystem,
+      is_fully_ready: status.isFullyReady,
+      can_use_core_features: status.canUseCoreFeatures,
+      ai_cli_status: active?.aiCli.status ?? 'unknown',
+      git_status: active?.git.status ?? 'unknown',
+      gh_status: active?.gh.status ?? 'unknown',
+      connected_provider_ids: active?.providers
+        .filter((provider) => provider.status === 'connected')
+        .map((provider) => provider.providerId) ?? [],
+      needs_login_provider_ids: active?.providers
+        .filter((provider) => provider.status === 'needs_login')
+        .map((provider) => provider.providerId) ?? [],
+      missing_provider_ids: active?.providers
+        .filter((provider) => provider.status === 'not_installed')
+        .map((provider) => provider.providerId) ?? [],
+      active_missing_but_other_environment_connected: hasOtherEnvironmentProviderStatus(
+        status,
+        'connected',
+      ),
+      active_missing_but_other_environment_needs_login: hasOtherEnvironmentProviderStatus(
+        status,
+        'needs_login',
+      ),
+      suggestion_tools: status.suggestions.map((suggestion) => suggestion.tool),
+      suggestion_available_environments: status.suggestions.map((suggestion) => suggestion.availableEnvironment),
+    },
+    options.request,
+  );
+
+  await Promise.all(providers.map(({ environment, provider }) => captureProviderStatusTelemetry(
+    status,
+    environment,
+    provider,
+    options,
+  )));
+}
+
+export async function captureCliDiagnosticsTelemetry(
+  report: CliDiagnosticReport,
+  options: CliDiagnosticsTelemetryOptions,
+): Promise<void> {
+  await Promise.all(report.providers.map((provider) => captureDiagnosticProviderTelemetry(
+    report,
+    provider,
+    options,
+  )));
+
+  const firstSuccess = report.providers.find((provider) => provider.outcome === 'passed');
+  const providersWithRawLog = report.providers.filter((provider) => provider.rawLogJsonl);
+  const providersWithSmokeTrace = report.providers.filter((provider) => provider.smokeTraceJsonl);
+
+  await captureServerTelemetryEvent(
+    getDiagnosticsEventName(options.source, 'run_completed'),
+    {
+      source: options.source,
+      ...(options.trigger ? { setup_trigger: options.trigger } : {}),
+      run_id: report.id,
+      active_environment: report.environment,
+      tested_provider_count: report.providers.length,
+      passed_provider_count: report.summary.passed,
+      failed_provider_count: report.summary.failed,
+      timeout_provider_count: report.summary.timeout,
+      skipped_provider_count: report.summary.skipped,
+      first_success_provider_id: firstSuccess?.providerId ?? '',
+      first_success_environment: firstSuccess?.environment ?? '',
+      can_continue: report.summary.passed > 0,
+      raw_log_provider_count: providersWithRawLog.length,
+      raw_log_total_bytes: providersWithRawLog.reduce(
+        (total, provider) => total + (provider.rawLogBytes ?? 0),
+        0,
+      ),
+      raw_log_truncated: report.providers.some((provider) => provider.rawLogTruncated === true),
+      smoke_trace_provider_count: providersWithSmokeTrace.length,
+      smoke_trace_event_count: providersWithSmokeTrace.reduce(
+        (total, provider) => total + (provider.smokeTraceEventCount ?? 0),
+        0,
+      ),
+    },
+    options.request,
+  );
+}
+
+async function captureProviderStatusTelemetry(
+  status: SetupStatusResponse,
+  environment: string,
+  provider: SetupProviderState,
+  options: SetupTelemetryOptions,
+): Promise<void> {
+  const isActiveEnvironment = environment === status.activeEnvironment;
+
+  await captureServerTelemetryEvent(
+    'setup_cli_provider_status',
+    {
+      source: 'setup',
+      setup_trigger: options.trigger,
+      provider_id: provider.providerId,
+      environment,
+      is_active_environment: isActiveEnvironment,
+      provider_status: provider.status,
+      provider_version: provider.version ?? '',
+      command_source: provider.commandSource ?? 'default',
+      command_shape: provider.commandShape ?? 'bare_command',
+      version_failure_kind: provider.versionProbe?.failureKind ?? '',
+      version_exit_code: provider.versionProbe?.exitCode,
+      version_duration_ms: provider.versionProbe?.durationMs,
+      auth_failure_kind: provider.authProbe?.failureKind ?? '',
+      auth_exit_code: provider.authProbe?.exitCode,
+      auth_duration_ms: provider.authProbe?.durationMs,
+    },
+    options.request,
+  );
+}
+
+async function captureDiagnosticProviderTelemetry(
+  report: CliDiagnosticReport,
+  provider: CliDiagnosticProviderResult,
+  options: CliDiagnosticsTelemetryOptions,
+): Promise<void> {
+  const failureStage = classifyDiagnosticFailureStage(provider);
+
+  await captureServerTelemetryEvent(
+    getDiagnosticsEventName(options.source, 'provider_result'),
+    {
+      source: options.source,
+      ...(options.trigger ? { setup_trigger: options.trigger } : {}),
+      run_id: report.id,
+      provider_id: provider.providerId,
+      environment: provider.environment,
+      is_active_environment: provider.environment === report.environment,
+      provider_status: provider.connectionStatus,
+      provider_version: provider.version ?? '',
+      command_source: provider.commandSource ?? 'default',
+      command_shape: provider.commandShape ?? 'bare_command',
+      status_check_status: provider.steps.statusCheck.status,
+      spawn_status: provider.steps.spawn.status,
+      send_status: provider.steps.sendMessage.status,
+      response_status: provider.steps.receiveResponse.status,
+      cleanup_status: provider.steps.cleanup.status,
+      final_status: provider.outcome,
+      failure_stage: failureStage,
+      duration_ms: provider.durationMs,
+      version_failure_kind: provider.versionProbe?.failureKind ?? '',
+      version_exit_code: provider.versionProbe?.exitCode,
+      version_duration_ms: provider.versionProbe?.durationMs,
+      auth_failure_kind: provider.authProbe?.failureKind ?? '',
+      auth_exit_code: provider.authProbe?.exitCode,
+      auth_duration_ms: provider.authProbe?.durationMs,
+      spawn_duration_ms: provider.steps.spawn.durationMs,
+      spawn_error_message: provider.steps.spawn.status === 'failed'
+        ? provider.spawnErrorMessage ?? provider.steps.spawn.message ?? ''
+        : '',
+      response_duration_ms: provider.steps.receiveResponse.durationMs,
+      smoke_trace_jsonl: provider.smokeTraceJsonl ?? '',
+      smoke_trace_event_count: provider.smokeTraceEventCount ?? 0,
+    },
+    options.request,
+  );
+
+  await captureDiagnosticRawLogTelemetry(report, provider, options);
+}
+
+function hasOtherEnvironmentProviderStatus(
+  status: SetupStatusResponse,
+  providerStatus: SetupProviderState['status'],
+): boolean {
+  const active = status.environments[status.activeEnvironment];
+  if (!active) return false;
+
+  return active.providers.some((provider) => {
+    if (provider.status === 'connected') return false;
+    return Object.entries(status.environments).some(([environment, environmentState]) => {
+      if (environment === status.activeEnvironment) return false;
+      return environmentState?.providers.some((candidate) => (
+        candidate.providerId === provider.providerId
+        && candidate.status === providerStatus
+      ));
+    });
+  });
+}
+
+async function captureDiagnosticRawLogTelemetry(
+  report: CliDiagnosticReport,
+  provider: CliDiagnosticProviderResult,
+  options: CliDiagnosticsTelemetryOptions,
+): Promise<void> {
+  const rawLogJsonl = provider.rawLogJsonl;
+  if (!rawLogJsonl) return;
+
+  const chunks = chunkRawLogJsonl(rawLogJsonl, RAW_LOG_CHUNK_BYTES);
+  await Promise.all(chunks.map((chunk, index) => captureServerTelemetryEvent(
+    getDiagnosticsEventName(options.source, 'raw_log'),
+    {
+      source: options.source,
+      ...(options.trigger ? { setup_trigger: options.trigger } : {}),
+      run_id: report.id,
+      report_id: report.id,
+      provider_id: provider.providerId,
+      environment: provider.environment,
+      final_status: provider.outcome,
+      chunk_index: index,
+      chunk_count: chunks.length,
+      raw_log_jsonl: chunk,
+      raw_log_total_bytes: provider.rawLogBytes ?? Buffer.byteLength(rawLogJsonl),
+      raw_log_chunk_bytes: Buffer.byteLength(chunk),
+      raw_log_event_count: provider.rawLogEventCount,
+      raw_log_truncated: provider.rawLogTruncated ?? false,
+    },
+    options.request,
+  )));
+}
+
+function classifyDiagnosticFailureStage(provider: CliDiagnosticProviderResult): DiagnosticFailureStage {
+  if (provider.outcome === 'passed') {
+    return 'none';
+  }
+
+  if (provider.connectionStatus !== 'connected') {
+    return 'status_check';
+  }
+
+  if (provider.steps.spawn.status !== 'passed') {
+    return 'spawn';
+  }
+
+  if (provider.steps.sendMessage.status !== 'passed') {
+    return 'send_message';
+  }
+
+  if (provider.steps.receiveResponse.status !== 'passed') {
+    return 'receive_response';
+  }
+
+  if (provider.steps.cleanup.status !== 'passed') {
+    return 'cleanup';
+  }
+
+  return 'none';
+}
+
+function getDiagnosticsEventName(
+  source: CliDiagnosticsTelemetrySource,
+  event: 'provider_result' | 'raw_log' | 'run_completed',
+): ServerTelemetryEventName {
+  if (source === 'settings') {
+    if (event === 'provider_result') return 'settings_cli_diagnostics_provider_result';
+    if (event === 'raw_log') return 'settings_cli_diagnostics_raw_log';
+    return 'settings_cli_diagnostics_run_completed';
+  }
+
+  if (event === 'provider_result') return 'setup_cli_smoke_provider_result';
+  if (event === 'raw_log') return 'setup_cli_smoke_raw_log';
+  return 'setup_cli_smoke_run_completed';
+}
+
+function chunkRawLogJsonl(value: string, maxBytes: number): string[] {
+  const chunks: string[] = [];
+  let current = '';
+  let currentBytes = 0;
+
+  for (const char of value) {
+    const charBytes = Buffer.byteLength(char);
+    if (currentBytes + charBytes > maxBytes) {
+      if (current) chunks.push(current);
+      current = char;
+      currentBytes = charBytes;
+      continue;
+    }
+    current += char;
+    currentBytes += charBytes;
+  }
+
+  if (current) chunks.push(current);
+  return chunks;
+}


### PR DESCRIPTION
## Summary
- add server-side setup/settings CLI diagnostics telemetry for provider detection and smoke-test results
- record sanitized smoke trace JSONL for spawn/send/assistant-response outcomes without raw CLI stdout/stderr
- add telemetry-enabled local build scripts for validating PostHog capture in packaged Electron builds

## Tests
- npm run lint (passes with existing warnings in preview-markdown.tsx and use-virtual-message-list.ts)
- npx tsc --noEmit
- git diff --check