### PR TITLE
fix(providers): avoid needs-login for transient status failures

### DIFF
--- a/src/lib/cli/providers/claude-code/adapter.ts
+++ b/src/lib/cli/providers/claude-code/adapter.ts
@@ -32,7 +32,7 @@ import {
   resolveProviderCliCommandWithMetadata,
 } from '../../provider-command';
 import {
-  classifyAuthFailure,
+  classifyAuthStatus,
   classifyVersionFailure,
   summarizeExecProbe,
 } from '../../status-detection';
@@ -144,11 +144,11 @@ export class ClaudeCodeAdapter implements CliProvider {
     }
 
     const version = parseVersion(versionResult.stdout);
-    const connected = authResult.ok;
+    const authStatus = classifyAuthStatus(authResult);
 
     return {
-      status: connected ? 'connected' : 'needs_login',
-      detectionReason: connected ? 'connected' : classifyAuthFailure(authResult),
+      status: authStatus.status,
+      detectionReason: authStatus.detectionReason,
       ...(version ? { version } : {}),
       ...baseTelemetry,
     };

--- a/src/lib/cli/providers/codex/adapter.ts
+++ b/src/lib/cli/providers/codex/adapter.ts
@@ -53,7 +53,7 @@ import {
   resolveProviderCliCommandWithMetadata,
 } from '../../provider-command';
 import {
-  classifyAuthFailure,
+  classifyAuthStatus,
   classifyVersionFailure,
   summarizeExecProbe,
 } from '../../status-detection';
@@ -338,11 +338,11 @@ export class CodexAdapter implements CliProvider {
     }
 
     const version = parseVersion(versionResult.stdout);
-    const connected = loginResult.ok;
+    const authStatus = classifyAuthStatus(loginResult);
 
     return {
-      status: connected ? 'connected' : 'needs_login',
-      detectionReason: connected ? 'connected' : classifyAuthFailure(loginResult),
+      status: authStatus.status,
+      detectionReason: authStatus.detectionReason,
       ...(version ? { version } : {}),
       ...baseTelemetry,
     };

--- a/src/lib/cli/providers/opencode/adapter.ts
+++ b/src/lib/cli/providers/opencode/adapter.ts
@@ -19,7 +19,7 @@ import {
   resolveProviderCliCommandWithMetadata,
 } from '../../provider-command';
 import {
-  classifyAuthFailure,
+  classifyAuthStatus,
   classifyVersionFailure,
   summarizeExecProbe,
 } from '../../status-detection';
@@ -147,10 +147,10 @@ export class OpenCodeAdapter implements CliProvider {
     }
 
     const version = parseVersion(versionResult.stdout);
-    const connected = modelsResult.ok;
+    const authStatus = classifyAuthStatus(modelsResult);
     return {
-      status: connected ? 'connected' : 'needs_login',
-      detectionReason: connected ? 'connected' : classifyAuthFailure(modelsResult),
+      status: authStatus.status,
+      detectionReason: authStatus.detectionReason,
       ...(version ? { version } : {}),
       ...baseTelemetry,
     };

--- a/src/lib/cli/status-detection.ts
+++ b/src/lib/cli/status-detection.ts
@@ -1,6 +1,7 @@
 import type { ExecResult } from './cli-exec';
 import type {
   CliCommandSource,
+  CliConnectionStatus,
   CliDetectionReason,
   CliProbeFailureKind,
   CliProbeSummary,
@@ -36,6 +37,20 @@ export function classifyAuthFailure(result: ExecResult): CliDetectionReason {
   if (result.ok) return 'connected';
   if (result.timedOut) return 'auth_timeout';
   return 'auth_failed';
+}
+
+export function classifyAuthStatus(result: ExecResult): {
+  status: CliConnectionStatus;
+  detectionReason: CliDetectionReason;
+} {
+  const detectionReason = classifyAuthFailure(result);
+  if (result.ok) {
+    return { status: 'connected', detectionReason };
+  }
+  if (!result.timedOut && result.exitCode !== null) {
+    return { status: 'needs_login', detectionReason };
+  }
+  return { status: 'not_installed', detectionReason };
 }
 
 function getProbeFailureKind(result: ExecResult): CliProbeFailureKind {

--- a/tests/provider-status-auth-classification.test.ts
+++ b/tests/provider-status-auth-classification.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ExecResult } from '../src/lib/cli/cli-exec';
+import { classifyAuthStatus } from '../src/lib/cli/status-detection';
+
+function execResult(overrides: Partial<ExecResult>): ExecResult {
+  return {
+    ok: false,
+    exitCode: 1,
+    stdout: '',
+    stderr: '',
+    timedOut: false,
+    durationMs: 25,
+    ...overrides,
+  };
+}
+
+test('auth status keeps nonzero auth probe failures as needs_login', () => {
+  assert.deepEqual(
+    classifyAuthStatus(execResult({ exitCode: 1 })),
+    {
+      status: 'needs_login',
+      detectionReason: 'auth_failed',
+    },
+  );
+});
+
+test('auth status maps timeout auth probe failures away from needs_login', () => {
+  assert.deepEqual(
+    classifyAuthStatus(execResult({ exitCode: null, timedOut: true })),
+    {
+      status: 'not_installed',
+      detectionReason: 'auth_timeout',
+    },
+  );
+});
+
+test('auth status maps spawn-error auth probe failures away from needs_login', () => {
+  assert.deepEqual(
+    classifyAuthStatus(execResult({ exitCode: null, spawnErrorCode: 'ENOENT' })),
+    {
+      status: 'not_installed',
+      detectionReason: 'auth_failed',
+    },
+  );
+});
+
+test('auth status maps unknown auth probe failures away from needs_login', () => {
+  assert.deepEqual(
+    classifyAuthStatus(execResult({ exitCode: null })),
+    {
+      status: 'not_installed',
+      detectionReason: 'auth_failed',
+    },
+  );
+});
+
+test('auth status preserves connected probes', () => {
+  assert.deepEqual(
+    classifyAuthStatus(execResult({ ok: true, exitCode: 0 })),
+    {
+      status: 'connected',
+      detectionReason: 'connected',
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Fixes #33 by avoiding `needs_login` for transient provider auth/model probe failures.
- Added shared auth-status classification so Claude Code, Codex, and OpenCode keep true nonzero auth failures as `needs_login` while mapping timeout/spawn/unknown probe failures away from login prompts.
- Added focused `node:test` coverage for connected, nonzero, timeout, spawn-error, and unknown auth probe outcomes.

## Testing

- [x] `node --import tsx --test tests/provider-status-auth-classification.test.ts`
- [x] `npm run lint` (passes with existing warnings in unrelated files)
- [x] `npx tsc --noEmit`
- [x] `NODE_ENV=production npm run build` (passes; Next.js warns about workspace-root inference because another lockfile exists above this checkout)
- [x] Manual test: synthetic status-classification cases cover the auth/model probe outcomes described above.
- [x] Not tested: live Windows/Electron/WSL provider status reproduction was not available locally.

## Screenshots or Recordings

N/A; no UI changes.

## Notes

The public provider status enum is unchanged. Version probe failures still use the existing version-failure path, and auth/model probe metadata remains in `authProbe` / `detectionReason` for diagnostics.

Note: I used Codex to help inspect the provider-status code path and draft the focused regression test, then reviewed the final diff and ran the listed verification commands locally.

Fixes #33
