### PR TITLE
feat: add Opus 4.8 models and a custom model override

### DIFF
--- a/src/components/chat/composer-session-control-sections.tsx
+++ b/src/components/chat/composer-session-control-sections.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { Gauge, Square } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type {
@@ -36,6 +37,11 @@ interface ComposerModelMenuProps {
   selectedModel: string;
   loadingLabel: string;
   onSelectModel: (model: string) => void;
+  allowCustomModel?: boolean;
+  customLabel?: string;
+  customPlaceholder?: string;
+  customApplyLabel?: string;
+  customHint?: string;
 }
 
 interface ComposerReasoningEffortMenuProps {
@@ -134,7 +140,39 @@ export function ComposerModelMenu({
   selectedModel,
   loadingLabel,
   onSelectModel,
+  allowCustomModel = false,
+  customLabel,
+  customPlaceholder,
+  customApplyLabel,
+  customHint,
 }: ComposerModelMenuProps) {
+  const isListedModel = modelOptions.some((option) => option.value === selectedModel);
+  // Seed the field with the active model when it isn't one of the listed options,
+  // so opening the menu shows (and lets you edit) the current custom selection.
+  const [customValue, setCustomValue] = useState(() =>
+    !isListedModel && selectedModel ? selectedModel : '',
+  );
+
+  const submitCustomModel = () => {
+    const trimmed = customValue.trim();
+    if (trimmed) {
+      onSelectModel(trimmed);
+    }
+  };
+
+  const handleCustomKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      submitCustomModel();
+      return;
+    }
+    // Let Escape bubble to close the menu; keep every other key (typing, arrows,
+    // Home/End) inside the input instead of triggering menu arrow-navigation.
+    if (event.key !== 'Escape') {
+      event.stopPropagation();
+    }
+  };
+
   return (
     <>
       {modelOptions.map((option) => (
@@ -158,6 +196,38 @@ export function ComposerModelMenu({
       {isLoading && (
         <div className="px-3 py-2 text-[10px] text-(--text-muted)">
           {loadingLabel}
+        </div>
+      )}
+      {allowCustomModel && (
+        <div className="mt-1 border-t border-(--chat-header-border) px-3 py-2">
+          {customLabel && (
+            <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-(--text-muted)">
+              {customLabel}
+            </div>
+          )}
+          <div className="flex items-center gap-1.5">
+            <input
+              type="text"
+              value={customValue}
+              spellCheck={false}
+              autoComplete="off"
+              placeholder={customPlaceholder}
+              onChange={(event) => setCustomValue(event.target.value)}
+              onKeyDown={handleCustomKeyDown}
+              className="h-7 min-w-0 flex-1 rounded-md border border-(--divider) bg-(--input-bg) px-2 text-xs text-(--text-primary) outline-none focus:border-(--accent)/50"
+            />
+            <button
+              type="button"
+              onClick={submitCustomModel}
+              disabled={customValue.trim().length === 0}
+              className="h-7 shrink-0 rounded-md border border-(--divider) px-2.5 text-[11px] text-(--text-secondary) transition-colors hover:border-(--accent)/40 hover:bg-(--sidebar-hover) hover:text-(--text-primary) disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {customApplyLabel}
+            </button>
+          </div>
+          {customHint && (
+            <div className="mt-1.5 text-[10px] leading-snug text-(--text-muted)">{customHint}</div>
+          )}
         </div>
       )}
     </>

--- a/src/components/chat/composer-session-controls.tsx
+++ b/src/components/chat/composer-session-controls.tsx
@@ -853,6 +853,11 @@ function ComposerSessionControlsInner({
               modelOptions={sessionOptions?.modelOptions ?? []}
               selectedModel={model}
               loadingLabel={t('settings.model.loadingOptions')}
+              allowCustomModel={providerIdForSticky === 'claude-code'}
+              customLabel={t('settings.model.customLabel')}
+              customPlaceholder={t('settings.model.customPlaceholder')}
+              customApplyLabel={t('settings.model.customApply')}
+              customHint={t('settings.model.customHint')}
               onSelectModel={(nextModel) => {
                 handleModelChange(nextModel);
                 close();

--- a/src/lib/cli/provider-session-option-definitions.ts
+++ b/src/lib/cli/provider-session-option-definitions.ts
@@ -139,11 +139,30 @@ const CLAUDE_EFFORT_WITH_MAX: ProviderReasoningEffortOption[] = [
 
 const CLAUDE_EFFORT_WITH_XHIGH_MAX: ProviderReasoningEffortOption[] = [
   ...CLAUDE_EFFORT_COMMON,
-  { value: 'xhigh', label: 'Extra High', description: 'Deeper reasoning, just below maximum (Opus 4.7 only)' },
+  { value: 'xhigh', label: 'Extra High', description: 'Deeper reasoning, just below maximum' },
   { value: 'max', label: 'Max', description: 'Maximum reasoning depth' },
 ];
 
+const CLAUDE_EFFORT_WITH_ULTRACODE: ProviderReasoningEffortOption[] = [
+  ...CLAUDE_EFFORT_WITH_XHIGH_MAX,
+  { value: 'ultracode', label: 'Ultracode', description: 'Above maximum — most exhaustive effort' },
+];
+
 export const CLAUDE_MODELS: ProviderModelOption[] = [
+  {
+    value: 'claude-opus-4-8',
+    label: 'claude-opus-4-8',
+    isDefault: false,
+    defaultReasoningEffort: 'auto',
+    supportedReasoningEfforts: CLAUDE_EFFORT_WITH_ULTRACODE,
+  },
+  {
+    value: 'claude-opus-4-8[1m]',
+    label: 'claude-opus-4-8[1m]',
+    isDefault: true,
+    defaultReasoningEffort: 'auto',
+    supportedReasoningEfforts: CLAUDE_EFFORT_WITH_ULTRACODE,
+  },
   {
     value: 'claude-opus-4-7',
     label: 'claude-opus-4-7',
@@ -154,7 +173,7 @@ export const CLAUDE_MODELS: ProviderModelOption[] = [
   {
     value: 'claude-opus-4-7[1m]',
     label: 'claude-opus-4-7[1m]',
-    isDefault: true,
+    isDefault: false,
     defaultReasoningEffort: 'auto',
     supportedReasoningEfforts: CLAUDE_EFFORT_WITH_XHIGH_MAX,
   },

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -150,6 +150,10 @@ export const en: I18nMessages = {
       label: 'Default Model',
       reasoningEffortLabel: 'Thinking Intensity',
       loadingOptions: 'Loading provider options...',
+      customLabel: 'Custom model',
+      customPlaceholder: 'Enter model identifier',
+      customApply: 'Use',
+      customHint: 'Use any model the Claude Code CLI accepts, even if it’s not listed.',
     },
     effort: {
       readOnlyTooltip: 'Cannot change while a session is running. Stop the session to change.',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -150,6 +150,10 @@ export const ja: I18nMessages = {
       label: 'デフォルトモデル',
       reasoningEffortLabel: 'Thinking 強度',
       loadingOptions: 'プロバイダー設定を読み込み中...',
+      customLabel: 'カスタムモデル',
+      customPlaceholder: 'モデル識別子を入力',
+      customApply: '使用',
+      customHint: 'リストにないモデルでも、Claude Code CLI が受け付けるモデルを指定できます。',
     },
     effort: {
       readOnlyTooltip: 'セッション実行中は変更できません。停止してから変更してください',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -150,6 +150,10 @@ export const ko: I18nMessages = {
       label: '기본 모델',
       reasoningEffortLabel: 'Thinking 강도',
       loadingOptions: '프로바이더 옵션을 불러오는 중...',
+      customLabel: '사용자 지정 모델',
+      customPlaceholder: '모델 식별자 입력',
+      customApply: '사용',
+      customHint: '목록에 없어도 Claude Code CLI가 허용하는 모든 모델을 사용할 수 있습니다.',
     },
     effort: {
       readOnlyTooltip: '세션 실행 중에는 변경할 수 없습니다. 중지 후 변경하세요',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -148,6 +148,10 @@ export interface I18nMessages {
       label: string;
       reasoningEffortLabel: string;
       loadingOptions: string;
+      customLabel: string;
+      customPlaceholder: string;
+      customApply: string;
+      customHint: string;
     };
     effort: {
       readOnlyTooltip: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -150,6 +150,10 @@ export const zh: I18nMessages = {
       label: '默认模型',
       reasoningEffortLabel: 'Thinking 强度',
       loadingOptions: '正在加载 Provider 选项...',
+      customLabel: '自定义模型',
+      customPlaceholder: '输入模型标识符',
+      customApply: '使用',
+      customHint: '可使用 Claude Code CLI 接受的任何模型，即使未在列表中。',
     },
     effort: {
       readOnlyTooltip: '会话运行中无法更改，请停止会话后再更改',

--- a/src/lib/settings/provider-defaults.ts
+++ b/src/lib/settings/provider-defaults.ts
@@ -71,7 +71,7 @@ export function normalizeClaudeModel(model?: string): string | undefined {
 
   switch (model) {
     case 'opus':
-      return 'claude-opus-4-7[1m]';
+      return 'claude-opus-4-8[1m]';
     case 'sonnet':
       return 'claude-sonnet-4-6';
     case 'haiku':
@@ -136,6 +136,21 @@ export function getProviderSessionDefaultsWithOptions(
   };
 }
 
+/**
+ * Build a synthetic model option for a Claude model the user typed that isn't in
+ * the curated list. No reasoning-effort tiers are claimed (we can't know what an
+ * arbitrary model supports), so the CLI uses its own --effort default.
+ */
+function buildCustomClaudeModelOption(model: string): ProviderModelOption {
+  return {
+    value: model,
+    label: model,
+    isDefault: false,
+    defaultReasoningEffort: null,
+    supportedReasoningEfforts: [],
+  };
+}
+
 export function resolveProviderModelOption(
   providerId: string,
   sessionOptions: ProviderSessionOptions | null | undefined,
@@ -152,6 +167,16 @@ export function resolveProviderModelOption(
     const selected = sessionOptions.modelOptions.find((option) => option.value === normalizedRequestedModel);
     if (selected) {
       return selected;
+    }
+
+    // Claude Code passes --model straight to the CLI, so it accepts any model the
+    // CLI understands — including ones not in the curated list (e.g. a new release
+    // that ships before Tessera updates CLAUDE_MODELS). Preserve the custom value
+    // as a synthetic option instead of snapping back to the default, so it survives
+    // round-trips through the sticky session defaults. Codex/OpenCode model lists are
+    // probed from the CLI, so an unknown model there is invalid and falls through.
+    if (providerId === 'claude-code' && normalizedRequestedModel && normalizedRequestedModel.trim().length > 0) {
+      return buildCustomClaudeModelOption(normalizedRequestedModel);
     }
   }
 
@@ -481,10 +506,10 @@ export function normalizeUserSettings(raw: Partial<UserSettings> | null | undefi
     fontSize: DEFAULT_FONT_SCALE,
     enterKeyBehavior: 'send',
     defaultPermissionMode: 'default',
-    defaultModel: 'claude-opus-4-7[1m]',
+    defaultModel: 'claude-opus-4-8[1m]',
     providerDefaults: {
       'claude-code': {
-        model: 'claude-opus-4-7[1m]',
+        model: 'claude-opus-4-8[1m]',
         reasoningEffort: null,
         sessionMode: 'work',
         accessMode: 'default',


### PR DESCRIPTION
## Summary

Two related improvements to Claude Code model selection in the composer.

### Opus 4.8
- Add `claude-opus-4-8` and `claude-opus-4-8[1m]` to the curated `CLAUDE_MODELS` list (top of the list).
- Make `claude-opus-4-8[1m]` the new default — `isDefault`, the `normalizeClaudeModel('opus')` alias, and the `defaultModel` / `providerDefaults['claude-code'].model` settings defaults.
- 4.8 exposes the full reasoning-effort ladder: auto / low / medium / high / xhigh / max / ultracode (new `ultracode` tier).
- Drop the outdated "Opus 4.7 only" note from `xhigh`, since 4.7 and 4.8 both support it.

### Custom model override (escape hatch)
The Claude Code model list is static (unlike Codex/OpenCode, which probe the CLI), so a brand-new model is not selectable until Tessera ships an update. This adds a free-text field at the bottom of the model dropdown (Claude Code only) to use any model the CLI accepts.

- `resolveProviderModelOption` now preserves a non-empty custom claude-code model as a synthetic option instead of snapping back to the default, so it survives as a sticky session default.
- Custom models already flowed through verbatim server-side (`resolveRuntimeModelDefaults` skips claude-code), at runtime (`sendSetModel`), and at spawn (`--model`); this fixes the one client-side spot that discarded them.
- Codex/OpenCode are intentionally unaffected — their lists are CLI-probed, so an unknown model there is genuinely invalid.

## Notes for reviewers
- **4.8 is now the default model**, not just an added option. Happy to revert to keeping 4.7 as default if preferred.
- New i18n keys (`customLabel`, `customPlaceholder`, `customApply`, `customHint`) added to en/ja/ko/zh + `types.ts`.

## Test plan
- `tsc --noEmit`: pass
- `eslint` (changed files): pass
- Manual: ran `npm run dev`, opened a Claude Code session — 4.8 entries show at the top, 4.8[1m] is the default, the effort ladder includes `ultracode`; the custom-model field applies an arbitrary id and it sticks.
