### PR TITLE
Add workspace file path actions

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,6 +43,74 @@ const WINDOWS_TITLEBAR_DIMMED_THEME = {
   },
 } satisfies Record<TitlebarTheme, { color: string; symbolColor: string }>;
 const TESSERA_HOMEPAGE = 'https://github.com/horang-labs/tessera';
+const MAX_SHELL_PATH_LENGTH = 32768;
+
+function isWindowsStylePath(filesystemPath: string): boolean {
+  return (
+    /^[a-zA-Z]:[\\/]/.test(filesystemPath)
+    || /^[a-zA-Z]:$/.test(filesystemPath)
+    || filesystemPath.startsWith('\\\\')
+    || filesystemPath.startsWith('//')
+  );
+}
+
+function getShellPathModule(filesystemPath: string): typeof path.win32 | typeof path.posix {
+  return isWindowsStylePath(filesystemPath) || process.platform === 'win32'
+    ? path.win32
+    : path.posix;
+}
+
+function convertWslPathWithWslpath(filesystemPath: string): string | null {
+  try {
+    const result = spawnSync('wsl.exe', ['-e', 'wslpath', '-w', filesystemPath], {
+      encoding: 'utf8',
+      timeout: 4000,
+      windowsHide: true,
+    });
+    const converted = result.stdout?.trim();
+    return result.status === 0 && converted ? converted : null;
+  } catch {
+    return null;
+  }
+}
+
+function convertPosixPathForWindowsShell(filesystemPath: string): string {
+  if (filesystemPath.startsWith('//')) return filesystemPath.replace(/\//g, '\\');
+  if (process.platform !== 'win32' || !filesystemPath.startsWith('/')) return filesystemPath;
+
+  const converted = convertWslPathWithWslpath(filesystemPath);
+  if (converted) return converted;
+
+  const mountedDriveMatch = filesystemPath.match(/^\/mnt\/([a-zA-Z])(?:\/(.*))?$/);
+  if (mountedDriveMatch) {
+    const drive = mountedDriveMatch[1].toUpperCase();
+    const rest = mountedDriveMatch[2]?.replace(/\//g, '\\') ?? '';
+    return rest ? `${drive}:\\${rest}` : `${drive}:\\`;
+  }
+
+  const distro = process.env.WSL_DISTRO_NAME;
+  if (distro) {
+    return `\\\\wsl.localhost\\${distro}${filesystemPath.replace(/\//g, '\\')}`;
+  }
+
+  return filesystemPath;
+}
+
+function resolveShellPath(rawPath: unknown): string | null {
+  if (typeof rawPath !== 'string') return null;
+  const trimmed = rawPath.trim();
+  if (!trimmed || trimmed.length > MAX_SHELL_PATH_LENGTH || trimmed.includes('\0')) {
+    return null;
+  }
+  return convertPosixPathForWindowsShell(trimmed);
+}
+
+function getExistingParentDirectory(filesystemPath: string): string | null {
+  const pathModule = getShellPathModule(filesystemPath);
+  const parent = pathModule.dirname(filesystemPath);
+  if (!parent || parent === filesystemPath) return null;
+  return fs.existsSync(parent) ? parent : null;
+}
 
 function getTitlebarOverlayOptions(theme: TitlebarTheme, options: TitlebarThemeOptions = {}) {
   const palette = options.dimmed ? WINDOWS_TITLEBAR_DIMMED_THEME[theme] : WINDOWS_TITLEBAR_THEME[theme];
@@ -709,6 +777,31 @@ function broadcastPopoutState(): void {
 
 // ── IPC ────────────────────────────────────────────────────────────────────
 ipcMain.handle('get-server-port', () => serverPort);
+ipcMain.handle('shell-open-path', async (_event, rawPath: unknown) => {
+  const targetPath = resolveShellPath(rawPath);
+  if (!targetPath) return { ok: false, error: 'invalid_path' };
+
+  const error = await shell.openPath(targetPath);
+  return error ? { ok: false, error } : { ok: true };
+});
+ipcMain.handle('shell-show-item-in-folder', async (_event, rawPath: unknown) => {
+  const targetPath = resolveShellPath(rawPath);
+  if (!targetPath) return { ok: false, error: 'invalid_path' };
+
+  if (fs.existsSync(targetPath)) {
+    shell.showItemInFolder(targetPath);
+    return { ok: true };
+  }
+
+  const parentDirectory = getExistingParentDirectory(targetPath);
+  if (parentDirectory) {
+    const error = await shell.openPath(parentDirectory);
+    return error ? { ok: false, error } : { ok: true };
+  }
+
+  shell.showItemInFolder(targetPath);
+  return { ok: true };
+});
 ipcMain.handle('open-board-window', (_event, payload?: unknown) => {
   if (!serverPort) return { ok: false };
   const params = new URLSearchParams();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -30,6 +30,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('open-board-window', payload),
   closeBoardPopouts: () => ipcRenderer.invoke('close-board-popouts'),
   getPopoutState: () => ipcRenderer.invoke('get-popout-state'),
+  openFilePath: (path: string) => ipcRenderer.invoke('shell-open-path', path),
+  revealFilePath: (path: string) => ipcRenderer.invoke('shell-show-item-in-folder', path),
   onPopoutStateChanged: (callback: (count: number) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: { count?: number }) => {
       if (typeof payload?.count === 'number') {

--- a/src/app/api/sessions/[id]/file/route.ts
+++ b/src/app/api/sessions/[id]/file/route.ts
@@ -186,6 +186,7 @@ export async function GET(
 
     return NextResponse.json({
       sessionId: id,
+      workDir: root,
       path: relativePath,
       content: binary ? "" : contentBuffer.toString("utf8"),
       language: inferLanguage(relativePath),

--- a/src/app/api/sessions/[id]/files/route.ts
+++ b/src/app/api/sessions/[id]/files/route.ts
@@ -119,6 +119,7 @@ export async function GET(
       tasks: refs.tasks,
       truncated: false,
       reason: 'no-root',
+      workDir: null,
     });
   }
 
@@ -131,6 +132,7 @@ export async function GET(
         tasks: refs.tasks,
         truncated: false,
         reason: 'not-a-directory',
+        workDir: root,
       });
     }
   } catch {
@@ -140,6 +142,7 @@ export async function GET(
       tasks: refs.tasks,
       truncated: false,
       reason: 'unreadable',
+      workDir: root,
     });
   }
 
@@ -150,6 +153,7 @@ export async function GET(
       chats: refs.chats,
       tasks: refs.tasks,
       truncated: result.truncated,
+      workDir: root,
     });
   } catch {
     return NextResponse.json({
@@ -158,6 +162,7 @@ export async function GET(
       tasks: refs.tasks,
       truncated: false,
       reason: 'walk-failed',
+      workDir: root,
     });
   }
 }

--- a/src/components/git/git-diff-drawer.tsx
+++ b/src/components/git/git-diff-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronLeft, ChevronRight, GitBranch } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Copy, GitBranch } from 'lucide-react';
 import { BottomDrawer } from '@/components/ui/bottom-drawer';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
@@ -20,6 +20,7 @@ interface GitDiffDrawerProps {
   onClose: () => void;
   onMoveSelection: (direction: -1 | 1) => void;
   onResize?: (height: number) => void;
+  onCopyFilePath?: (relativePath: string) => void;
 }
 
 export function GitDiffDrawer({
@@ -33,6 +34,7 @@ export function GitDiffDrawer({
   onClose,
   onMoveSelection,
   onResize,
+  onCopyFilePath,
 }: GitDiffDrawerProps) {
   const stateMeta = selectedFile ? FILE_STATE_META[selectedFile.state] : null;
   const position =
@@ -61,6 +63,19 @@ export function GitDiffDrawer({
 
   const headerActions = (
     <div className="flex shrink-0 items-center gap-1">
+      {selectedFile && onCopyFilePath ? (
+        <Tooltip content="Copy absolute path">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => onCopyFilePath(selectedFile.path)}
+            aria-label={`Copy absolute path for ${selectedFile.path}`}
+          >
+            <Copy className="h-4 w-4" />
+          </Button>
+        </Tooltip>
+      ) : null}
       <Tooltip content="Previous file">
         <Button
           variant="ghost"

--- a/src/components/git/git-panel-sections.tsx
+++ b/src/components/git/git-panel-sections.tsx
@@ -26,8 +26,10 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tooltip } from "@/components/ui/tooltip";
+import { WorkspaceFileContextMenu } from "@/components/workspace/workspace-file-context-menu";
 import { setWorkspaceFileDragData } from "@/lib/dnd/panel-session-drag";
 import { useI18n } from "@/lib/i18n";
+import { toAbsoluteWorkspacePath } from "@/lib/workspace-tabs/file-path-actions";
 import { cn } from "@/lib/utils";
 import type { GitChangedFile, GitDiffData, GitPanelData } from "@/types/git";
 import {
@@ -332,12 +334,14 @@ export function DiffPreview({
   diffLoading,
   selectedFile,
   hideFileHeader = false,
+  onCopyFilePath,
 }: {
   diffData: GitDiffData | null;
   diffError: string | null;
   diffLoading: boolean;
   selectedFile: GitChangedFile | null;
   hideFileHeader?: boolean;
+  onCopyFilePath?: (relativePath: string) => void;
 }) {
   const { t } = useI18n();
 
@@ -391,7 +395,21 @@ export function DiffPreview({
               {diffData.truncated ? " · truncated" : ""}
             </p>
           </div>
-          <FileBadge file={selectedFile} />
+          <div className="flex shrink-0 items-center gap-1">
+            {onCopyFilePath ? (
+              <Tooltip content="Copy absolute path" side="top">
+                <button
+                  type="button"
+                  onClick={() => onCopyFilePath(selectedFile.path)}
+                  className="rounded-md p-1 text-(--text-muted) hover:bg-(--chat-bg) hover:text-(--text-primary)"
+                  aria-label={`Copy absolute path for ${selectedFile.path}`}
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </button>
+              </Tooltip>
+            ) : null}
+            <FileBadge file={selectedFile} />
+          </div>
         </div>
       ) : null}
       <div className="py-2">
@@ -593,6 +611,7 @@ export function GitPanelContentSection({
   selectedPath,
   sessionId,
   setSelectedPath,
+  onCopyFilePath,
   onOpenDiffFile,
   onPinDiffFile,
   onOpenReadOnlyFile,
@@ -604,13 +623,20 @@ export function GitPanelContentSection({
   selectedPath: string | null;
   sessionId: string | null;
   setSelectedPath: (path: string | null) => void;
+  onCopyFilePath: (relativePath: string) => void;
   onOpenDiffFile: (file: GitChangedFile) => void;
   onPinDiffFile: (file: GitChangedFile) => void;
   onOpenReadOnlyFile: (file: GitChangedFile) => void;
 }) {
   const { t } = useI18n();
+  const [contextMenu, setContextMenu] = useState<{
+    absolutePath: string;
+    canOpenFile: boolean;
+    position: { x: number; y: number };
+  } | null>(null);
 
   return (
+    <>
     <div className="flex-1 overflow-hidden p-3">
       {!sessionId && !loading ? (
         <EmptyPanelMessage
@@ -641,6 +667,7 @@ export function GitPanelContentSection({
                 {data.changedFiles.map((file) => {
                   const isSelected = file.path === selectedPath;
                   const canOpenReadOnly = file.state !== "deleted";
+                  const absolutePath = toAbsoluteWorkspacePath(data.worktreePath, file.path);
                   return (
                     <div
                       key={file.path}
@@ -657,6 +684,17 @@ export function GitPanelContentSection({
                           : "border-l-transparent text-(--text-secondary) hover:bg-(--sidebar-hover) hover:text-(--text-primary)",
                       )}
                       data-testid={`git-panel-file-row-${file.path}`}
+                      onContextMenu={(event) => {
+                        if (!absolutePath) return;
+                        event.preventDefault();
+                        event.stopPropagation();
+                        setSelectedPath(file.path);
+                        setContextMenu({
+                          absolutePath,
+                          canOpenFile: canOpenReadOnly,
+                          position: { x: event.clientX, y: event.clientY },
+                        });
+                      }}
                     >
                       <button
                         type="button"
@@ -722,6 +760,19 @@ export function GitPanelContentSection({
                             <FileText className="h-3.5 w-3.5" />
                           </button>
                         </Tooltip>
+                        <Tooltip content="Copy absolute path">
+                          <button
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onCopyFilePath(file.path);
+                            }}
+                            className="inline-flex rounded-md p-1 text-(--text-muted) hover:bg-(--chat-bg) hover:text-(--text-primary)"
+                            aria-label={`Copy absolute path for ${file.path}`}
+                          >
+                            <Copy className="h-3.5 w-3.5" />
+                          </button>
+                        </Tooltip>
                       </div>
                     </div>
                   );
@@ -732,6 +783,15 @@ export function GitPanelContentSection({
         )
       )}
     </div>
+    {contextMenu ? (
+      <WorkspaceFileContextMenu
+        absolutePath={contextMenu.absolutePath}
+        canOpenFile={contextMenu.canOpenFile}
+        onClose={() => setContextMenu(null)}
+        position={contextMenu.position}
+      />
+    ) : null}
+    </>
   );
 }
 

--- a/src/components/git/git-panel.tsx
+++ b/src/components/git/git-panel.tsx
@@ -260,6 +260,7 @@ export function GitPanel({
             changedFileCount={controller.changedFileCount}
             selectedPath={controller.selectedPath}
             setSelectedPath={controller.setSelectedPath}
+            onCopyFilePath={controller.copyFilePath}
             onOpenDiffFile={openDiffFile}
             onPinDiffFile={pinDiffFile}
             onOpenReadOnlyFile={openReadOnlyFile}

--- a/src/components/git/use-git-panel-controller.ts
+++ b/src/components/git/use-git-panel-controller.ts
@@ -9,6 +9,7 @@ import { useSessionStore } from "@/stores/session-store";
 import { useSessionPrStore } from "@/stores/session-pr-store";
 import { useTaskStore } from "@/stores/task-store";
 import { captureTelemetryEvent } from "@/lib/telemetry/client";
+import { toAbsoluteWorkspacePath } from "@/lib/workspace-tabs/file-path-actions";
 import type {
   GitChangedFilesData,
   GitDiffData,
@@ -477,6 +478,27 @@ export function useGitPanelController(sessionId: string | null) {
     panelData?.prStatus,
   ]);
 
+  const copyFilePath = useCallback(
+    async (relativePath: string) => {
+      const absolutePath = toAbsoluteWorkspacePath(data?.worktreePath, relativePath);
+      await writeClipboardText(absolutePath);
+      void captureTelemetryEvent("git_action_triggered", {
+        source: "git_panel",
+        action: "copy_file_path",
+        target: "file_path",
+        has_worktree: Boolean(data?.worktreePath),
+        has_changes: Boolean(panelData?.changedFiles.length),
+        has_pr: Boolean(panelData?.prStatus || panelData?.github.pullRequest),
+      });
+    },
+    [
+      data?.worktreePath,
+      panelData?.changedFiles.length,
+      panelData?.github.pullRequest,
+      panelData?.prStatus,
+    ],
+  );
+
   const openExternal = useCallback((url: string | null | undefined) => {
     if (!url || typeof window === "undefined") return;
     void captureTelemetryEvent("git_action_triggered", {
@@ -839,6 +861,7 @@ export function useGitPanelController(sessionId: string | null) {
     checksUrl,
     closeAction,
     copyBranch,
+    copyFilePath,
     copyWorktreePath,
     data: panelData,
     diffData,

--- a/src/components/workspace/workspace-code-view.tsx
+++ b/src/components/workspace/workspace-code-view.tsx
@@ -5,6 +5,11 @@ import { useCallback, useState } from "react";
 import { PreviewMarkdown } from "@/components/chat/preview-markdown";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
+import { WorkspaceFileContextMenu } from "@/components/workspace/workspace-file-context-menu";
+import {
+  copyText,
+  toAbsoluteWorkspacePath,
+} from "@/lib/workspace-tabs/file-path-actions";
 import { cn } from "@/lib/utils";
 import type { GitDiffData } from "@/types/git";
 import type { WorkspaceFileData } from "@/types/workspace-file";
@@ -168,7 +173,12 @@ export function WorkspaceCodeView({
       : (data as WorkspaceFileData | null)?.content ?? "";
   const fileData = mode === "file" ? (data as WorkspaceFileData | null) : null;
   const diffData = mode === "diff" ? (data as GitDiffData | null) : null;
+  const absolutePath = toAbsoluteWorkspacePath(
+    mode === "diff" ? diffData?.workDir : fileData?.workDir,
+    path,
+  );
   const copied = copiedKey === `${mode}:${path}`;
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const isMarkdownFile = mode === "file" && fileData?.language === "markdown";
   const resolveMarkdownImageSrc = useCallback((src: string): string | null => {
     if (!sourceSessionId || isBrowserImageSrc(src)) return src;
@@ -211,6 +221,7 @@ export function WorkspaceCodeView({
   }
 
   return (
+    <>
     <div className="flex h-full min-h-0 flex-col bg-(--chat-bg)">
       <div className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-(--chat-header-border) px-4">
         <div className="flex min-w-0 items-center gap-2">
@@ -221,7 +232,15 @@ export function WorkspaceCodeView({
           ) : (
             <FileCode2 className="h-4 w-4 shrink-0 text-(--text-muted)" />
           )}
-          <div className="min-w-0">
+          <div
+            className="min-w-0"
+            onContextMenu={(event) => {
+              if (!absolutePath) return;
+              event.preventDefault();
+              event.stopPropagation();
+              setContextMenu({ x: event.clientX, y: event.clientY });
+            }}
+          >
             <p className="truncate font-mono text-sm text-(--text-primary)">{path}</p>
             <p className="truncate text-[10px] uppercase tracking-[0.14em] text-(--text-muted)">
               {mode === "diff" ? "Diff" : fileData?.language || "text"}
@@ -240,6 +259,19 @@ export function WorkspaceCodeView({
               onClick={copyContent}
               disabled={!content}
               aria-label="Copy file content"
+            >
+              <Copy className="h-4 w-4" />
+            </Button>
+          </Tooltip>
+          <Tooltip content="Copy absolute path">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              onClick={() => copyText(absolutePath)}
+              disabled={!absolutePath}
+              aria-label={`Copy absolute path for ${path}`}
             >
               <Copy className="h-4 w-4" />
             </Button>
@@ -270,5 +302,13 @@ export function WorkspaceCodeView({
         )}
       </div>
     </div>
+    {contextMenu && absolutePath ? (
+      <WorkspaceFileContextMenu
+        absolutePath={absolutePath}
+        onClose={() => setContextMenu(null)}
+        position={contextMenu}
+      />
+    ) : null}
+    </>
   );
 }

--- a/src/components/workspace/workspace-file-context-menu.tsx
+++ b/src/components/workspace/workspace-file-context-menu.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
+import { Copy, ExternalLink, FolderOpen } from "lucide-react";
+import { useCloseOnEscape } from "@/hooks/use-close-on-escape";
+import { useMenuNavigation } from "@/hooks/use-menu-navigation";
+import {
+  canUseElectronFileActions,
+  copyText,
+  getElectronPlatform,
+  getRevealFileLabel,
+  openFilePathOnHost,
+  revealFilePathOnHost,
+} from "@/lib/workspace-tabs/file-path-actions";
+import { cn } from "@/lib/utils";
+
+interface WorkspaceFileContextMenuProps {
+  absolutePath: string;
+  canOpenFile?: boolean;
+  onClose: () => void;
+  position: { x: number; y: number };
+}
+
+const MENU_WIDTH = 220;
+const ITEM_HEIGHT = 32;
+const PADDING = 6;
+
+export function WorkspaceFileContextMenu({
+  absolutePath,
+  canOpenFile = true,
+  onClose,
+  position,
+}: WorkspaceFileContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const hasElectronFileActions = canUseElectronFileActions();
+  const revealLabel = getRevealFileLabel(getElectronPlatform());
+  const itemCount = hasElectronFileActions ? 3 : 1;
+
+  useCloseOnEscape(onClose, { capture: true });
+
+  const menuPos = useMemo(() => {
+    if (typeof window === "undefined") return null;
+
+    const menuHeight = ITEM_HEIGHT * itemCount + PADDING * 2 + (hasElectronFileActions ? 1 : 0);
+    let top = position.y;
+    let left = position.x;
+
+    if (top + menuHeight > window.innerHeight - 8) {
+      top = window.innerHeight - menuHeight - 8;
+    }
+    if (left + MENU_WIDTH > window.innerWidth - 8) {
+      left = window.innerWidth - MENU_WIDTH - 8;
+    }
+
+    return {
+      left: Math.max(8, left),
+      top: Math.max(8, top),
+    };
+  }, [hasElectronFileActions, itemCount, position.x, position.y]);
+
+  useEffect(() => {
+    function onMouseDown(event: MouseEvent) {
+      if (!menuRef.current?.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+
+    document.addEventListener("mousedown", onMouseDown, true);
+    return () => document.removeEventListener("mousedown", onMouseDown, true);
+  }, [onClose]);
+
+  useEffect(() => {
+    const firstItem = menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]:not(:disabled)');
+    firstItem?.focus();
+  }, []);
+
+  const handleMenuKeyDown = useMenuNavigation(menuRef, '[role="menuitem"]:not(:disabled)');
+
+  const handleOpen = useCallback(() => {
+    if (!canOpenFile) return;
+    openFilePathOnHost(absolutePath);
+    onClose();
+  }, [absolutePath, canOpenFile, onClose]);
+
+  const handleReveal = useCallback(() => {
+    revealFilePathOnHost(absolutePath);
+    onClose();
+  }, [absolutePath, onClose]);
+
+  const handleCopyPath = useCallback(() => {
+    copyText(absolutePath);
+    onClose();
+  }, [absolutePath, onClose]);
+
+  const menuItemClassName = cn(
+    "flex h-8 w-full cursor-default items-center gap-2 rounded-md px-3 text-left text-[12px]",
+    "text-(--sidebar-text-active) transition-colors",
+    "hover:bg-(--sidebar-hover) focus:bg-(--sidebar-hover) focus:outline-none",
+  );
+  const disabledItemClassName = cn(
+    "flex h-8 w-full cursor-default items-center gap-2 rounded-md px-3 text-left text-[12px]",
+    "text-(--text-muted) opacity-50",
+  );
+
+  if (typeof document === "undefined" || !menuPos) return null;
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="File options"
+      className={cn(
+        "fixed z-[9999] rounded-lg border border-(--divider) bg-(--sidebar-bg) p-1.5",
+        "shadow-[0_8px_32px_rgba(0,0,0,0.24),0_2px_8px_rgba(0,0,0,0.16)]",
+      )}
+      style={{ top: menuPos.top, left: menuPos.left, width: MENU_WIDTH }}
+      onKeyDown={handleMenuKeyDown}
+      data-testid="workspace-file-context-menu"
+    >
+      {hasElectronFileActions ? (
+        <>
+          <button
+            type="button"
+            role="menuitem"
+            className={canOpenFile ? menuItemClassName : disabledItemClassName}
+            onClick={canOpenFile ? handleOpen : undefined}
+            disabled={!canOpenFile}
+          >
+            <ExternalLink className="h-3.5 w-3.5 shrink-0 text-(--text-muted)" />
+            <span>Open</span>
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className={menuItemClassName}
+            onClick={handleReveal}
+          >
+            <FolderOpen className="h-3.5 w-3.5 shrink-0 text-(--text-muted)" />
+            <span>{revealLabel}</span>
+          </button>
+          <div className="my-1 h-px bg-(--divider) opacity-40" />
+        </>
+      ) : null}
+      <button
+        type="button"
+        role="menuitem"
+        className={menuItemClassName}
+        onClick={handleCopyPath}
+      >
+        <Copy className="h-3.5 w-3.5 shrink-0 text-(--text-muted)" />
+        <span>Copy absolute path</span>
+      </button>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -3,6 +3,7 @@
 import {
   AlertCircle,
   ChevronRight,
+  Copy,
   FileText,
   Folder,
   FolderOpen,
@@ -12,16 +13,23 @@ import {
 } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tooltip } from "@/components/ui/tooltip";
 import {
   openWorkspaceFileTab,
   previewWorkspaceFileTab,
 } from "@/lib/workspace-tabs/open-workspace-tab";
 import { setWorkspaceFileDragData } from "@/lib/dnd/panel-session-drag";
+import {
+  copyText,
+  toAbsoluteWorkspacePath,
+} from "@/lib/workspace-tabs/file-path-actions";
+import { WorkspaceFileContextMenu } from "@/components/workspace/workspace-file-context-menu";
 import { cn } from "@/lib/utils";
 
 interface WorkspaceFilesResponse {
   files?: string[];
   truncated?: boolean;
+  workDir?: string | null;
 }
 
 interface WorkspaceFilePanelState {
@@ -45,6 +53,12 @@ interface WorkspaceDirectoryNode {
 }
 
 type WorkspaceTreeNode = WorkspaceDirectoryNode | WorkspaceFileNode;
+
+interface FileContextMenuState {
+  absolutePath: string;
+  canOpenFile: boolean;
+  position: { x: number; y: number };
+}
 
 interface MutableDirectoryNode {
   name: string;
@@ -147,6 +161,8 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
   const [query, setQuery] = useState("");
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
+  const [workDir, setWorkDir] = useState<string | null>(null);
+  const [contextMenu, setContextMenu] = useState<FileContextMenuState | null>(null);
   const [state, setState] = useState<WorkspaceFilePanelState>(() => ({
     loading: Boolean(sessionId),
     error: null,
@@ -154,9 +170,13 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
   }));
 
   useEffect(() => {
-    if (!sessionId) return;
+    if (!sessionId) {
+      setWorkDir(null);
+      return;
+    }
 
     const abortController = new AbortController();
+    setWorkDir(null);
 
     const loadFiles = async () => {
       try {
@@ -167,6 +187,7 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
         const payload = (await response.json().catch(() => null)) as WorkspaceFilesResponse | null;
         if (!response.ok) throw new Error("Failed to load files.");
         setFiles(Array.isArray(payload?.files) ? payload.files : []);
+        setWorkDir(payload?.workDir ?? null);
         setState({
           loading: false,
           error: null,
@@ -243,41 +264,75 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
     }
 
     const isSelected = node.path === selectedPath;
+    const absolutePath = toAbsoluteWorkspacePath(workDir, node.path);
+
     return (
-      <button
+      <div
         key={`file:${node.path}`}
-        type="button"
-        onClick={() => {
-          if (!sessionId) return;
-          setSelectedPath(node.path);
-          previewWorkspaceFileTab(sessionId, "file", node.path);
-        }}
-        onDoubleClick={() => {
-          if (!sessionId) return;
-          setSelectedPath(node.path);
-          openWorkspaceFileTab(sessionId, "file", node.path);
-        }}
-        onDragStart={(event) => {
-          if (!sessionId) return;
-          setSelectedPath(node.path);
-          setWorkspaceFileDragData(event.dataTransfer, sessionId, "file", node.path);
-        }}
-        draggable={Boolean(sessionId)}
         className={cn(
-          "group flex min-w-0 items-center gap-2 border-l-2 py-1.5 pr-2 text-left transition-colors",
+          "group relative border-l-2 transition-colors",
           isSelected
             ? "border-l-(--accent) bg-(--accent)/10 text-(--text-primary)"
             : "border-l-transparent text-(--text-secondary) hover:bg-(--sidebar-hover) hover:text-(--text-primary)",
         )}
         style={{ paddingLeft: paddingLeft + 19 }}
-        title={node.path}
-        data-testid={`workspace-file-row-${node.path}`}
+        onContextMenu={(event) => {
+          if (!absolutePath) return;
+          event.preventDefault();
+          event.stopPropagation();
+          setSelectedPath(node.path);
+          setContextMenu({
+            absolutePath,
+            canOpenFile: true,
+            position: { x: event.clientX, y: event.clientY },
+          });
+        }}
       >
-        <FileText className="h-3.5 w-3.5 shrink-0 text-(--text-muted) group-hover:text-(--text-primary)" />
-        <span className="min-w-0 flex-1 truncate font-mono text-[11px]">
-          {node.name}
-        </span>
-      </button>
+        <button
+          type="button"
+          onClick={() => {
+            if (!sessionId) return;
+            setSelectedPath(node.path);
+            previewWorkspaceFileTab(sessionId, "file", node.path);
+          }}
+          onDoubleClick={() => {
+            if (!sessionId) return;
+            setSelectedPath(node.path);
+            openWorkspaceFileTab(sessionId, "file", node.path);
+          }}
+          onDragStart={(event) => {
+            if (!sessionId) return;
+            setSelectedPath(node.path);
+            setWorkspaceFileDragData(event.dataTransfer, sessionId, "file", node.path);
+          }}
+          draggable={Boolean(sessionId)}
+          className="flex min-w-0 items-center gap-2 border-l-transparent py-1.5 pr-2 text-left transition-colors"
+          title={node.path}
+          data-testid={`workspace-file-row-${node.path}`}
+        >
+          <FileText className="h-3.5 w-3.5 shrink-0 text-(--text-muted) group-hover:text-(--text-primary)" />
+          <span className="min-w-0 flex-1 truncate font-mono text-[11px]">
+            {node.name}
+          </span>
+        </button>
+        <div className="pointer-events-none absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 rounded-md bg-(--sidebar-hover)/95 opacity-0 shadow-sm transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+          <Tooltip content="Copy absolute path">
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                if (!absolutePath || !node.path) return;
+                copyText(absolutePath);
+              }}
+              disabled={!absolutePath}
+              className="inline-flex rounded-md p-1 text-(--text-muted) hover:bg-(--chat-bg) hover:text-(--text-primary) disabled:pointer-events-none disabled:opacity-35"
+              aria-label={`Copy absolute path for ${absolutePath || node.path}`}
+            >
+              <Copy className="h-3.5 w-3.5" />
+            </button>
+          </Tooltip>
+        </div>
+      </div>
     );
   }
 
@@ -346,6 +401,14 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
           </ScrollArea>
         </div>
       )}
+      {contextMenu ? (
+        <WorkspaceFileContextMenu
+          absolutePath={contextMenu.absolutePath}
+          canOpenFile={contextMenu.canOpenFile}
+          onClose={() => setContextMenu(null)}
+          position={contextMenu.position}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/lib/git/git-panel.ts
+++ b/src/lib/git/git-panel.ts
@@ -629,6 +629,7 @@ export async function getGitDiffData(
     const diff = await buildSyntheticUntrackedDiff(repoRoot, relativePath, workDir);
     return {
       sessionId,
+      workDir,
       path: relativePath,
       diff,
       truncated: diff.includes("diff truncated for preview"),
@@ -652,6 +653,7 @@ export async function getGitDiffData(
 
   return {
     sessionId,
+    workDir,
     path: relativePath,
     diff: diff || `No textual diff available for ${relativePath}.`,
     truncated: false,

--- a/src/lib/workspace-tabs/file-path-actions.ts
+++ b/src/lib/workspace-tabs/file-path-actions.ts
@@ -1,0 +1,70 @@
+"use client";
+
+interface ElectronFileApi {
+  isElectron?: boolean;
+  platform?: string;
+  openFilePath?: (path: string) => Promise<{ ok: boolean; error?: string }>;
+  revealFilePath?: (path: string) => Promise<{ ok: boolean; error?: string }>;
+}
+
+function getElectronFileApi(): ElectronFileApi | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as Window & { electronAPI?: ElectronFileApi }).electronAPI;
+}
+
+export function toAbsoluteWorkspacePath(
+  workDir: string | null | undefined,
+  relativePath: string,
+): string | null {
+  const trimmedBase = workDir?.trim();
+  const trimmedPath = relativePath.trim();
+
+  if (!trimmedPath) return trimmedBase ?? null;
+  if (!trimmedBase) return null;
+
+  const separator = trimmedBase.includes("\\") ? "\\" : "/";
+  const normalizedRelativePath = trimmedPath.replace(/^[\\/]+/, "").replace(/[\\/]/g, separator);
+
+  return trimmedBase.endsWith(separator)
+    ? `${trimmedBase}${normalizedRelativePath}`
+    : `${trimmedBase}${separator}${normalizedRelativePath}`;
+}
+
+export function getElectronPlatform(): string | null {
+  const electronApi = getElectronFileApi();
+  return electronApi?.isElectron ? (electronApi.platform ?? null) : null;
+}
+
+export function canUseElectronFileActions(): boolean {
+  const electronApi = getElectronFileApi();
+  return Boolean(
+    electronApi?.isElectron
+    && electronApi.openFilePath
+    && electronApi.revealFilePath,
+  );
+}
+
+export function getRevealFileLabel(platform: string | null | undefined): string {
+  if (platform === "darwin") return "Show in Finder";
+  if (platform === "win32") return "Show in Explorer";
+  return "Show in folder";
+}
+
+export function copyText(value: string | null | undefined) {
+  if (!value || typeof navigator === "undefined" || !navigator.clipboard) return;
+  void navigator.clipboard.writeText(value);
+}
+
+export function openFilePathOnHost(path: string | null | undefined) {
+  if (!path) return;
+  const electronApi = getElectronFileApi();
+  if (!electronApi?.isElectron || !electronApi.openFilePath) return;
+  void electronApi.openFilePath(path);
+}
+
+export function revealFilePathOnHost(path: string | null | undefined) {
+  if (!path) return;
+  const electronApi = getElectronFileApi();
+  if (!electronApi?.isElectron || !electronApi.revealFilePath) return;
+  void electronApi.revealFilePath(path);
+}

--- a/src/types/git.ts
+++ b/src/types/git.ts
@@ -96,6 +96,7 @@ export interface GitPanelData {
 
 export interface GitDiffData {
   sessionId: string;
+  workDir?: string | null;
   path: string;
   diff: string;
   truncated: boolean;

--- a/src/types/workspace-file.ts
+++ b/src/types/workspace-file.ts
@@ -1,5 +1,6 @@
 export interface WorkspaceFileData {
   sessionId: string;
+  workDir?: string | null;
   path: string;
   content: string;
   language: string;


### PR DESCRIPTION
## Summary
- add workspace file context menu and host path actions
- expose file path actions through Electron IPC/preload
- add file path actions to workspace and git panels

## Tests
- `npm run lint` (passes with existing warnings)
- `npm run electron:compile`
