### PR TITLE
Persist Codex goal commands in chat history

### DIFF
--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -110,18 +110,6 @@ function formatGoalStatusMessage(goal: SessionGoal | null | undefined): string {
   ].filter(Boolean).join(' | ');
 }
 
-function formatGoalMutationMessage(command: ReturnType<typeof parseCodexGoalCommand>): string | null {
-  if (!command) return null;
-  if (command.kind === 'inspect') return null;
-  if (command.kind === 'clear') return 'Goal cleared';
-
-  if (command.update.status === 'paused') return 'Goal paused';
-  if (command.update.status === 'active' && !command.update.objective) return 'Goal resumed';
-  if (command.update.objective) return `Goal active  Objective: ${command.update.objective}`;
-
-  return null;
-}
-
 function goalStatusLabel(
   goal: SessionGoal,
   t: (key: string, vars?: Record<string, string>) => string,
@@ -688,7 +676,15 @@ export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isS
       return false;
     }
 
-    const mutationMessage = formatGoalMutationMessage(command);
+    const displayContent = commandInput.trim();
+    addMessage(sessionId, {
+      id: `temp-goal-${uuidv4()}`,
+      type: 'text',
+      role: 'user',
+      content: displayContent,
+      timestamp: new Date().toISOString(),
+    });
+
     if (command.kind === 'inspect') {
       addMessage(sessionId, {
         id: `system-goal-${uuidv4()}`,
@@ -697,29 +693,11 @@ export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isS
         content: formatGoalStatusMessage(session?.goal),
         timestamp: new Date().toISOString(),
       });
-      refreshSessionGoal(sessionId, buildSpawnConfigForCurrentSession());
+      refreshSessionGoal(sessionId, buildSpawnConfigForCurrentSession(), displayContent);
     } else if (command.kind === 'clear') {
-      if (mutationMessage) {
-        addMessage(sessionId, {
-          id: `system-goal-${uuidv4()}`,
-          type: 'text',
-          role: 'system',
-          content: mutationMessage,
-          timestamp: new Date().toISOString(),
-        });
-      }
-      clearSessionGoal(sessionId, buildSpawnConfigForCurrentSession());
+      clearSessionGoal(sessionId, buildSpawnConfigForCurrentSession(), displayContent);
     } else {
-      if (mutationMessage) {
-        addMessage(sessionId, {
-          id: `system-goal-${uuidv4()}`,
-          type: 'text',
-          role: 'system',
-          content: mutationMessage,
-          timestamp: new Date().toISOString(),
-        });
-      }
-      setSessionGoal(sessionId, command.update, buildSpawnConfigForCurrentSession());
+      setSessionGoal(sessionId, command.update, buildSpawnConfigForCurrentSession(), displayContent);
     }
 
     clearInput();

--- a/src/hooks/use-websocket.ts
+++ b/src/hooks/use-websocket.ts
@@ -67,16 +67,29 @@ export function useWebSocket() {
     wsClient.cancelGeneration(sessionId);
   }, []);
 
-  const setSessionGoal = useCallback((sessionId: string, update: SessionGoalUpdate, spawnConfig?: SessionSpawnConfig) => {
-    wsClient.setSessionGoal(sessionId, update, spawnConfig);
+  const setSessionGoal = useCallback((
+    sessionId: string,
+    update: SessionGoalUpdate,
+    spawnConfig?: SessionSpawnConfig,
+    displayContent?: string,
+  ) => {
+    wsClient.setSessionGoal(sessionId, update, spawnConfig, displayContent);
   }, []);
 
-  const refreshSessionGoal = useCallback((sessionId: string, spawnConfig?: SessionSpawnConfig) => {
-    wsClient.refreshSessionGoal(sessionId, spawnConfig);
+  const refreshSessionGoal = useCallback((
+    sessionId: string,
+    spawnConfig?: SessionSpawnConfig,
+    displayContent?: string,
+  ) => {
+    wsClient.refreshSessionGoal(sessionId, spawnConfig, displayContent);
   }, []);
 
-  const clearSessionGoal = useCallback((sessionId: string, spawnConfig?: SessionSpawnConfig) => {
-    wsClient.clearSessionGoal(sessionId, spawnConfig);
+  const clearSessionGoal = useCallback((
+    sessionId: string,
+    spawnConfig?: SessionSpawnConfig,
+    displayContent?: string,
+  ) => {
+    wsClient.clearSessionGoal(sessionId, spawnConfig, displayContent);
   }, []);
 
   const stopSession = useCallback((sessionId: string) => {

--- a/src/lib/ws/client.ts
+++ b/src/lib/ws/client.ts
@@ -217,25 +217,33 @@ export class WebSocketClient {
     this.sendRequest('cancel_generation', { sessionId });
   }
 
-  setSessionGoal(sessionId: string, update: SessionGoalUpdate, spawnConfig?: SessionSpawnConfig) {
+  setSessionGoal(
+    sessionId: string,
+    update: SessionGoalUpdate,
+    spawnConfig?: SessionSpawnConfig,
+    displayContent?: string,
+  ) {
     this.sendRequest('set_session_goal', {
       sessionId,
       update,
       ...(spawnConfig && { spawnConfig }),
+      ...(displayContent && { displayContent }),
     });
   }
 
-  refreshSessionGoal(sessionId: string, spawnConfig?: SessionSpawnConfig) {
+  refreshSessionGoal(sessionId: string, spawnConfig?: SessionSpawnConfig, displayContent?: string) {
     this.sendRequest('refresh_session_goal', {
       sessionId,
       ...(spawnConfig && { spawnConfig }),
+      ...(displayContent && { displayContent }),
     });
   }
 
-  clearSessionGoal(sessionId: string, spawnConfig?: SessionSpawnConfig) {
+  clearSessionGoal(sessionId: string, spawnConfig?: SessionSpawnConfig, displayContent?: string) {
     this.sendRequest('clear_session_goal', {
       sessionId,
       ...(spawnConfig && { spawnConfig }),
+      ...(displayContent && { displayContent }),
     });
   }
 

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -72,9 +72,9 @@ export type ClientMessage =
   | { type: 'interactive_response'; requestId: string; sessionId: string; toolUseId: string; response: string }
   | { type: 'mark_as_read'; requestId: string; sessionId: string } // NEW - for FEAT-002
   | { type: 'cancel_generation'; requestId: string; sessionId: string }
-  | { type: 'set_session_goal'; requestId: string; sessionId: string; update: SessionGoalUpdate; spawnConfig?: SessionSpawnConfig }
-  | { type: 'refresh_session_goal'; requestId: string; sessionId: string; spawnConfig?: SessionSpawnConfig }
-  | { type: 'clear_session_goal'; requestId: string; sessionId: string; spawnConfig?: SessionSpawnConfig }
+  | { type: 'set_session_goal'; requestId: string; sessionId: string; update: SessionGoalUpdate; spawnConfig?: SessionSpawnConfig; displayContent?: string }
+  | { type: 'refresh_session_goal'; requestId: string; sessionId: string; spawnConfig?: SessionSpawnConfig; displayContent?: string }
+  | { type: 'clear_session_goal'; requestId: string; sessionId: string; spawnConfig?: SessionSpawnConfig; displayContent?: string }
   | ({ type: 'set_permission_mode'; requestId: string; sessionId: string; mode?: PermissionMode } & ProviderRuntimeControls)
   | { type: 'set_model'; requestId: string; sessionId: string; model: string }
   | { type: 'set_reasoning_effort'; requestId: string; sessionId: string; reasoningEffort: string | null }

--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -205,6 +205,7 @@ export async function routeClientTransportMessage({
         sessionId: message.sessionId,
         spawnConfig: message.spawnConfig,
         update: message.update,
+        displayContent: message.displayContent,
       });
       return;
 
@@ -214,6 +215,7 @@ export async function routeClientTransportMessage({
         sendToUser,
         sessionId: message.sessionId,
         spawnConfig: message.spawnConfig,
+        displayContent: message.displayContent,
       });
       return;
 
@@ -223,6 +225,7 @@ export async function routeClientTransportMessage({
         sendToUser,
         sessionId: message.sessionId,
         spawnConfig: message.spawnConfig,
+        displayContent: message.displayContent,
       });
       return;
 

--- a/src/lib/ws/server-session-actions.ts
+++ b/src/lib/ws/server-session-actions.ts
@@ -100,6 +100,7 @@ interface InteractiveResponseActionOptions extends SessionActionOptions {
 }
 
 interface SessionGoalActionOptions extends SessionActionOptions {
+  displayContent?: string;
   sessionId: string;
   spawnConfig?: SessionSpawnConfig;
   update?: SessionGoalUpdate;
@@ -298,6 +299,7 @@ export async function sendSessionMessageFromWebSocket({
 }
 
 export async function setSessionGoalFromWebSocket({
+  displayContent,
   sendToUser,
   sessionId,
   spawnConfig,
@@ -308,6 +310,7 @@ export async function setSessionGoalFromWebSocket({
     const ok = await ensureSessionProcess({ sessionId, userId, sendToUser, spawnConfig });
     if (!ok) return;
 
+    recordGoalCommandDisplayContent(sessionId, displayContent);
     const goal = await processManager.setSessionGoal(sessionId, update ?? {});
     if (!goal) {
       sendToUser(userId, {
@@ -337,6 +340,7 @@ export async function setSessionGoalFromWebSocket({
 }
 
 export async function refreshSessionGoalFromWebSocket({
+  displayContent,
   sendToUser,
   sessionId,
   spawnConfig,
@@ -346,6 +350,7 @@ export async function refreshSessionGoalFromWebSocket({
     const ok = await ensureSessionProcess({ sessionId, userId, sendToUser, spawnConfig });
     if (!ok) return;
 
+    recordGoalCommandDisplayContent(sessionId, displayContent);
     const goal = await processManager.refreshSessionGoal(sessionId);
     sendToUser(userId, goal
       ? {
@@ -370,6 +375,7 @@ export async function refreshSessionGoalFromWebSocket({
 }
 
 export async function clearSessionGoalFromWebSocket({
+  displayContent,
   sendToUser,
   sessionId,
   spawnConfig,
@@ -379,6 +385,7 @@ export async function clearSessionGoalFromWebSocket({
     const ok = await ensureSessionProcess({ sessionId, userId, sendToUser, spawnConfig });
     if (!ok) return;
 
+    recordGoalCommandDisplayContent(sessionId, displayContent);
     const cleared = await processManager.clearSessionGoal(sessionId);
     if (!cleared) {
       sendToUser(userId, {
@@ -404,6 +411,15 @@ export async function clearSessionGoalFromWebSocket({
       message: `Failed to clear goal: ${(err as Error).message}`,
     });
   }
+}
+
+function recordGoalCommandDisplayContent(sessionId: string, displayContent?: string): void {
+  const trimmed = displayContent?.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  sessionHistory.recordUserMessage(sessionId, trimmed);
 }
 
 /**

--- a/tests/board-popout-live-sync-contract.test.mjs
+++ b/tests/board-popout-live-sync-contract.test.mjs
@@ -71,8 +71,7 @@ test('live replay events mark background popout cards as processing', () => {
   assert.match(clientMessageHandlersSource, /startTurnInFlight/);
   assert.match(clientMessageHandlersSource, /function replayEventsIndicateActiveTurn/);
   assert.match(clientMessageHandlersSource, /case 'replay_events':\s*if \(replayEventsIndicateActiveTurn\(msg\.events\)\) \{\s*startTurnInFlight\(msg\.sessionId\);/);
-  assert.match(clientMessageHandlersSource, /function containsTurnStartProgress/);
-  assert.match(clientMessageHandlersSource, /event\.progressType === 'waiting_for_task' \|\| event\.hookEvent === 'waiting_for_task'/);
+  assert.match(clientMessageHandlersSource, /event\.hookEvent === 'waiting_for_task' \|\| event\.progressType === 'waiting_for_task'/);
   assert.match(clientMessageHandlersSource, /case 'tool_call':\s*return event\.status === 'running';/);
   assert.match(clientMessageHandlersSource, /case 'interactive_prompt_response':\s*return true;/);
 });

--- a/tests/codex-goal-contract.test.mjs
+++ b/tests/codex-goal-contract.test.mjs
@@ -111,18 +111,23 @@ test('Codex parser persists and broadcasts goal updates and clears', () => {
 test('goal controls are routed through websocket client and server actions', () => {
   assert.match(wsMessageTypesSource, /type: 'set_session_goal'/);
   assert.match(wsMessageTypesSource, /spawnConfig\?: SessionSpawnConfig/);
+  assert.match(wsMessageTypesSource, /displayContent\?: string/);
   assert.match(wsMessageTypesSource, /type: 'refresh_session_goal'/);
   assert.match(wsMessageTypesSource, /type: 'clear_session_goal'/);
   assert.match(wsMessageTypesSource, /type: 'session_goal_updated'/);
   assert.match(wsMessageTypesSource, /type: 'session_goal_cleared'/);
-  assert.match(wsClientSource, /setSessionGoal\(sessionId: string, update: SessionGoalUpdate, spawnConfig\?: SessionSpawnConfig\)/);
+  assert.match(wsClientSource, /setSessionGoal\([\s\S]*displayContent\?: string[\s\S]*'set_session_goal'/);
   assert.match(wsHookSource, /setSessionGoal/);
+  assert.match(wsHookSource, /displayContent\?: string/);
   assert.match(wsRoutingSource, /case 'set_session_goal':/);
   assert.match(wsRoutingSource, /spawnConfig: message\.spawnConfig/);
+  assert.match(wsRoutingSource, /displayContent: message\.displayContent/);
   assert.match(wsRoutingSource, /case 'refresh_session_goal':/);
   assert.match(wsRoutingSource, /case 'clear_session_goal':/);
   assert.match(wsActionsSource, /processManager\.getProcess\(sessionId\)\?\.status === 'running'/);
   assert.match(wsActionsSource, /ensureSessionProcess\(\{ sessionId, userId, sendToUser, spawnConfig \}\)/);
+  assert.match(wsActionsSource, /recordGoalCommandDisplayContent\(sessionId, displayContent\)/);
+  assert.match(wsActionsSource, /sessionHistory\.recordUserMessage\(sessionId, trimmed\)/);
   assert.match(wsActionsSource, /processManager\.setSessionGoal\(sessionId, update \?\? \{\}\)/);
 });
 
@@ -141,7 +146,9 @@ test('/goal is intercepted by the composer and exposed in UI affordances', () =>
   assert.doesNotMatch(messageInputSource, /const \[goalDraft, setGoalDraft\]/);
   assert.doesNotMatch(messageInputSource, /submitGoalMode/);
   assert.match(messageInputSource, /value=\{inputValue\}/);
-  assert.match(messageInputSource, /setSessionGoal\(sessionId, command\.update, buildSpawnConfigForCurrentSession\(\)\)/);
+  assert.match(messageInputSource, /id: `temp-goal-\$\{uuidv4\(\)\}`/);
+  assert.match(messageInputSource, /role: 'user'/);
+  assert.match(messageInputSource, /setSessionGoal\(sessionId, command\.update, buildSpawnConfigForCurrentSession\(\), displayContent\)/);
   assert.match(messageInputSource, /<SessionGoalControl[\s\S]*variant="composer"/);
   assert.match(headerSource, /<SessionGoalControl sessionId=\{sessionId\} variant="header" \/>/);
   assert.match(goalCommandEventSource, /SESSION_GOAL_COMMAND_INSERT_EVENT/);
@@ -159,7 +166,7 @@ test('/goal is intercepted by the composer and exposed in UI affordances', () =>
 });
 
 test('goal auto turns use the normal running composer lifecycle', () => {
-  assert.match(wsClientHandlersSource, /containsTurnStartProgress/);
+  assert.match(wsClientHandlersSource, /replayEventsIndicateActiveTurn/);
   assert.match(wsClientHandlersSource, /startTurnInFlight\(msg\.sessionId\)/);
   assert.match(wsClientHandlersSource, /event\.progressType === 'waiting_for_task'/);
   assert.match(messageInputSource, /const isGoalRunning = Boolean/);


### PR DESCRIPTION
## Summary
- route goal commands through websocket session actions
- persist Codex goal commands in chat history
- update goal command contract coverage

## Tests
- `node --test tests/codex-goal-contract.test.mjs tests/board-popout-live-sync-contract.test.mjs`
- `npm run lint` (passes with existing warnings)
