### PR TITLE
Fix Electron drag regions for All Projects

### DIFF
--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -58,13 +58,22 @@ export const AppHeader = memo(function AppHeader() {
           {shouldShowProjectContext ? (
             <>
               <div
-                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[0.6875rem] font-bold leading-none text-white shadow-sm"
+                className={cn(
+                  'flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[0.6875rem] font-bold leading-none text-white shadow-sm',
+                  isElectronTitlebar && 'electron-drag pointer-events-none',
+                )}
                 style={{ backgroundColor: getProjectColor(projectDisplayName) }}
                 aria-hidden="true"
               >
                 {projectInitial}
               </div>
-              <div className="min-w-0 flex-1" title={projectTitle}>
+              <div
+                className={cn(
+                  'min-w-0 flex-1',
+                  isElectronTitlebar && 'electron-drag pointer-events-none',
+                )}
+                title={projectTitle}
+              >
                 <div className="truncate text-[0.875rem] font-semibold leading-5 text-(--sidebar-text-active)">
                   {projectDisplayName}
                 </div>

--- a/src/components/tab/tab-bar.tsx
+++ b/src/components/tab/tab-bar.tsx
@@ -516,7 +516,7 @@ export const TabBar = memo(function TabBar() {
       {/* Spacer — keep this area draggable for frameless Electron windows. */}
       <div
         className={cn(
-          'flex-1 transition-colors',
+          'electron-drag flex-1 transition-colors',
           isCreateTabDragOver && 'bg-(--accent)/10',
         )}
         onDragOver={handleCreateTabDragOver}

--- a/tests/electron-drag-region-contract.test.mjs
+++ b/tests/electron-drag-region-contract.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const appHeaderSource = fs.readFileSync(
+  new URL('../src/components/layout/app-header.tsx', import.meta.url),
+  'utf8',
+);
+const tabBarSource = fs.readFileSync(
+  new URL('../src/components/tab/tab-bar.tsx', import.meta.url),
+  'utf8',
+);
+
+test('project header static content remains draggable in Electron titlebars', () => {
+  assert.match(appHeaderSource, /isElectronTitlebar && 'electron-drag pointer-events-none'/);
+});
+
+test('tab bar empty spacer remains an explicit Electron drag region', () => {
+  assert.match(tabBarSource, /'electron-drag flex-1 transition-colors'/);
+  assert.match(tabBarSource, /data-testid="tab-bar-new-tab-drop-zone"/);
+});


### PR DESCRIPTION
## Summary
- preserve Electron drag regions around All Projects header/static areas
- keep tab bar empty spacer draggable
- add contract coverage for drag region expectations

## Tests
- `node --test tests/electron-drag-region-contract.test.mjs`
- `npm run lint` (passes with existing warnings)
- `npm run electron:compile`
