### PR TITLE
Add Monaco workspace file viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "i18next": "^25.8.13",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.563.0",
+        "monaco-editor": "^0.55.1",
         "next": "^16.2.3",
         "node-pty": "^1.1.0",
         "pino": "^8.18.0",
@@ -7399,14 +7400,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -10950,6 +10951,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -12142,6 +12155,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/motion-dom": {
@@ -14999,9 +15031,9 @@
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "i18next": "^25.8.13",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.563.0",
+    "monaco-editor": "^0.55.1",
     "next": "^16.2.3",
     "node-pty": "^1.1.0",
     "pino": "^8.18.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -627,37 +627,6 @@ body {
   line-height: inherit;
 }
 
-/* Workspace file code view */
-.workspace-code-lines {
-  min-width: max-content;
-  padding: 0.625rem 0;
-  font-family: 'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', monospace;
-  font-size: 0.8125rem;
-  line-height: 1.25rem;
-}
-
-.workspace-code-line {
-  display: grid;
-  grid-template-columns: 4rem minmax(0, 1fr);
-  min-height: 1.25rem;
-  font: inherit;
-}
-
-.workspace-code-line-number {
-  border-right: 1px solid var(--divider);
-  color: var(--text-muted);
-  opacity: 0.7;
-  padding: 0 0.75rem;
-  text-align: right;
-  user-select: none;
-}
-
-.workspace-code-line-content {
-  padding: 0 1rem;
-  font: inherit;
-  white-space: pre;
-}
-
 /* Message enter animation */
 @keyframes message-in {
   from {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -627,6 +627,37 @@ body {
   line-height: inherit;
 }
 
+/* Workspace file code view */
+.workspace-code-lines {
+  min-width: max-content;
+  padding: 0.625rem 0;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', monospace;
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+}
+
+.workspace-code-line {
+  display: grid;
+  grid-template-columns: 4rem minmax(0, 1fr);
+  min-height: 1.25rem;
+  font: inherit;
+}
+
+.workspace-code-line-number {
+  border-right: 1px solid var(--divider);
+  color: var(--text-muted);
+  opacity: 0.7;
+  padding: 0 0.75rem;
+  text-align: right;
+  user-select: none;
+}
+
+.workspace-code-line-content {
+  padding: 0 1rem;
+  font: inherit;
+  white-space: pre;
+}
+
 /* Message enter animation */
 @keyframes message-in {
   from {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import ThemeInitializer from '@/components/theme-initializer';
 import '@xterm/xterm/css/xterm.css';
+import 'monaco-editor/min/vs/editor/editor.main.css';
 import './globals.css';
 import { I18nHtmlLang } from '@/components/i18n-html-lang';
 import { Agentation } from 'agentation';

--- a/src/components/chat/code-block.tsx
+++ b/src/components/chat/code-block.tsx
@@ -4,61 +4,15 @@ import { useState, useEffect, useMemo, memo, useCallback } from 'react';
 import type { Highlighter } from 'shiki';
 import { useI18n } from '@/lib/i18n';
 import { useIsDark } from '@/hooks/use-is-dark';
+import {
+  getHighlighterInstance,
+  highlightCodeToHtml,
+} from '@/lib/code-highlighting';
 
 interface CodeBlockProps {
   code: string;
   language: string;
   filename?: string;
-}
-
-// Singleton highlighter instance
-let highlighterInstance: Highlighter | null = null;
-let highlighterPromise: Promise<Highlighter | null> | null = null;
-
-async function getHighlighterInstance(): Promise<Highlighter | null> {
-  if (highlighterInstance) {
-    return highlighterInstance;
-  }
-
-  if (!highlighterPromise) {
-    highlighterPromise = (async () => {
-      try {
-        const shiki = await import('shiki');
-        const highlighter = await shiki.createHighlighter({
-          themes: ['github-dark', 'github-light'],
-          langs: [
-            'javascript',
-            'typescript',
-            'python',
-            'bash',
-            'shell',
-            'json',
-            'markdown',
-            'html',
-            'css',
-            'yaml',
-            'sql',
-            'rust',
-            'go',
-            'java',
-            'cpp',
-            'c',
-            'tsx',
-            'jsx',
-          ],
-        });
-        highlighterInstance = highlighter;
-        return highlighter;
-      } catch {
-        // Shiki dynamic import fails in custom server dev mode (webpack chunk issue)
-        // Gracefully fallback to plain text rendering
-        highlighterPromise = null;
-        return null;
-      }
-    })();
-  }
-
-  return highlighterPromise;
 }
 
 export const CodeBlock = memo(function CodeBlock({ code, language, filename }: CodeBlockProps) {
@@ -68,9 +22,15 @@ export const CodeBlock = memo(function CodeBlock({ code, language, filename }: C
   const isDark = useIsDark();
 
   useEffect(() => {
+    let cancelled = false;
+
     getHighlighterInstance().then(h => {
-      if (h) setHighlighter(h);
+      if (!cancelled && h) setHighlighter(h);
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const shikiTheme = isDark ? 'github-dark' : 'github-light';
@@ -79,25 +39,9 @@ export const CodeBlock = memo(function CodeBlock({ code, language, filename }: C
     if (!highlighter) return code;
 
     try {
-      let normalizedLang = language.toLowerCase();
-      if (normalizedLang === 'sh') normalizedLang = 'bash';
-      if (normalizedLang === 'ts') normalizedLang = 'typescript';
-      if (normalizedLang === 'js') normalizedLang = 'javascript';
-      if (normalizedLang === 'py') normalizedLang = 'python';
-
-      return highlighter.codeToHtml(code, {
-        lang: normalizedLang || 'text',
-        theme: shikiTheme,
-      });
+      return highlightCodeToHtml(highlighter, code, language, shikiTheme);
     } catch {
-      try {
-        return highlighter.codeToHtml(code, {
-          lang: 'text',
-          theme: shikiTheme,
-        });
-      } catch {
-        return code;
-      }
+      return code;
     }
   }, [highlighter, code, language, shikiTheme]);
 

--- a/src/components/workspace/workspace-code-view.tsx
+++ b/src/components/workspace/workspace-code-view.tsx
@@ -1,24 +1,25 @@
 "use client";
 
-import { AlertCircle, Binary, Copy, FileCode2, FileText, GitCompare, LoaderCircle, X } from "lucide-react";
-import { type CSSProperties, useCallback, useEffect, useMemo, useState } from "react";
-import type { Highlighter, ThemedToken } from "shiki";
+import { AlertCircle, Binary, Code2, Copy, ExternalLink, Eye, FileCode2, FileText, GitCompare, LoaderCircle, X } from "lucide-react";
+import { useCallback, useState, useSyncExternalStore } from "react";
 import { PreviewMarkdown } from "@/components/chat/preview-markdown";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { WorkspaceFileContextMenu } from "@/components/workspace/workspace-file-context-menu";
-import { useIsDark } from "@/hooks/use-is-dark";
+import { WorkspaceMonacoEditor } from "@/components/workspace/workspace-monaco-editor";
 import {
-  getHighlighterInstance,
-  highlightCodeToTokens,
-} from "@/lib/code-highlighting";
-import {
+  canUseElectronFileActions,
   copyText,
+  openFilePathOnHost,
   toAbsoluteWorkspacePath,
 } from "@/lib/workspace-tabs/file-path-actions";
-import { cn } from "@/lib/utils";
 import type { GitDiffData } from "@/types/git";
 import type { WorkspaceFileData } from "@/types/workspace-file";
+
+type MarkdownViewMode = "preview" | "source";
+
+const subscribeToStaticClientValue = () => () => {};
+const getNoElectronFileActions = () => false;
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -85,94 +86,55 @@ function buildWorkspaceRawFileUrl(sessionId: string, filePath: string): string {
   return `/api/sessions/${encodeURIComponent(sessionId)}/file?path=${encodeURIComponent(filePath)}&raw=1`;
 }
 
-function getDiffLineClassName(line: string): string {
-  if (line.startsWith("+") && !line.startsWith("+++")) {
-    return "bg-[#2f8753]/8 text-[#2f8753]";
-  }
-  if (line.startsWith("-") && !line.startsWith("---")) {
-    return "bg-[#c94c4c]/8 text-[#c94c4c]";
-  }
-  if (line.startsWith("@@")) {
-    return "bg-[#4a8cd6]/10 text-[#4a8cd6]";
-  }
-  if (line.startsWith("diff --git") || line.startsWith("index ")) {
-    return "text-(--text-primary)";
-  }
-  if (line.startsWith("---") || line.startsWith("+++")) {
-    return "text-[#9b7f35]";
-  }
-  return "text-(--text-secondary)";
-}
-
-function CodeLines({
-  content,
-  highlightedLines,
-  mode,
-}: {
-  content: string;
-  highlightedLines?: ThemedToken[][] | null;
-  mode: "file" | "diff";
-}) {
-  if (mode === "file" && highlightedLines) {
-    return <HighlightedCodeLines lines={highlightedLines} />;
-  }
-
-  const lines = content.split("\n");
-  return (
-    <div className="workspace-code-lines">
-      {lines.map((line, index) => (
-        <div
-          key={`${index}-${line.slice(0, 16)}`}
-          className={cn(
-            "workspace-code-line",
-            mode === "diff" ? getDiffLineClassName(line) : "text-(--text-secondary)",
-          )}
-        >
-          <span className="workspace-code-line-number">{index + 1}</span>
-          <code className="workspace-code-line-content">{line || " "}</code>
-        </div>
-      ))}
-    </div>
+function useCanUseElectronFileActions(): boolean {
+  return useSyncExternalStore(
+    subscribeToStaticClientValue,
+    canUseElectronFileActions,
+    getNoElectronFileActions,
   );
 }
 
-function getTokenStyle(token: ThemedToken): CSSProperties | undefined {
-  if (token.htmlStyle) {
-    return token.htmlStyle;
-  }
+function MarkdownModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: MarkdownViewMode;
+  onChange: (mode: MarkdownViewMode) => void;
+}) {
+  const buttonClassName = (value: MarkdownViewMode) =>
+    [
+      "inline-flex h-7 items-center gap-1.5 rounded px-2 text-[11px] font-medium transition-colors",
+      mode === value
+        ? "bg-(--chat-bg) text-(--text-primary) shadow-sm"
+        : "text-(--text-muted) hover:text-(--text-primary)",
+    ].join(" ");
 
-  const style: CSSProperties = {};
-  if (token.color) style.color = token.color;
-  if (token.bgColor) style.backgroundColor = token.bgColor;
-
-  const fontStyle = token.fontStyle ?? 0;
-  if ((fontStyle & 1) !== 0) style.fontStyle = "italic";
-  if ((fontStyle & 2) !== 0) style.fontWeight = 700;
-  if ((fontStyle & 4) !== 0) style.textDecoration = "underline";
-
-  return Object.keys(style).length > 0 ? style : undefined;
-}
-
-function HighlightedCodeLines({ lines }: { lines: ThemedToken[][] }) {
   return (
-    <div className="workspace-code-lines">
-      {lines.map((tokens, lineIndex) => (
-        <div className="workspace-code-line" key={lineIndex}>
-          <span className="workspace-code-line-number">{lineIndex + 1}</span>
-          <code className="workspace-code-line-content">
-            {tokens.length > 0
-              ? tokens.map((token, tokenIndex) => (
-                <span
-                  key={`${token.offset}-${tokenIndex}`}
-                  style={getTokenStyle(token)}
-                >
-                  {token.content}
-                </span>
-              ))
-              : " "}
-          </code>
-        </div>
-      ))}
+    <div
+      className="flex shrink-0 items-center rounded-md border border-(--divider) bg-(--sidebar-hover) p-0.5"
+      role="tablist"
+      aria-label="Markdown view mode"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === "preview"}
+        className={buttonClassName("preview")}
+        onClick={() => onChange("preview")}
+      >
+        <Eye className="h-3.5 w-3.5" />
+        <span>Preview</span>
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === "source"}
+        className={buttonClassName("source")}
+        onClick={() => onChange("source")}
+      >
+        <Code2 className="h-3.5 w-3.5" />
+        <span>Source</span>
+      </button>
     </div>
   );
 }
@@ -218,8 +180,10 @@ export function WorkspaceCodeView({
   sourceSessionId?: string;
 }) {
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
-  const [highlighter, setHighlighter] = useState<Highlighter | null>(null);
-  const isDark = useIsDark();
+  const [markdownModeState, setMarkdownModeState] = useState<{ mode: MarkdownViewMode; path: string }>({
+    mode: "preview",
+    path: "",
+  });
   const content =
     mode === "diff"
       ? (data as GitDiffData | null)?.diff ?? ""
@@ -232,36 +196,20 @@ export function WorkspaceCodeView({
   );
   const copied = copiedKey === `${mode}:${path}`;
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const canOpenOnHost = useCanUseElectronFileActions();
   const isMarkdownFile = mode === "file" && fileData?.language === "markdown";
-  const shikiTheme = isDark ? "github-dark" : "github-light";
+  const markdownViewMode = isMarkdownFile && markdownModeState.path === path ? markdownModeState.mode : "preview";
+  const shouldRenderMarkdownPreview = isMarkdownFile && markdownViewMode === "preview";
+  const showOpenButton = canOpenOnHost && Boolean(absolutePath);
   const resolveMarkdownImageSrc = useCallback((src: string): string | null => {
     if (!sourceSessionId || isBrowserImageSrc(src)) return src;
     const assetPath = normalizeWorkspaceAssetPath(path, src);
     if (!assetPath) return null;
     return buildWorkspaceRawFileUrl(sourceSessionId, assetPath);
   }, [path, sourceSessionId]);
-  useEffect(() => {
-    if (mode !== "file" || isMarkdownFile || fileData?.binary) return undefined;
-
-    let cancelled = false;
-    getHighlighterInstance().then((h) => {
-      if (!cancelled && h) setHighlighter(h);
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [fileData?.binary, isMarkdownFile, mode]);
-
-  const highlightedLines = useMemo(() => {
-    if (mode !== "file" || isMarkdownFile || !highlighter) return null;
-
-    try {
-      return highlightCodeToTokens(highlighter, content, fileData?.language, shikiTheme);
-    } catch {
-      return null;
-    }
-  }, [content, fileData?.language, highlighter, isMarkdownFile, mode, shikiTheme]);
+  const handleMarkdownViewModeChange = useCallback((nextMode: MarkdownViewMode) => {
+    setMarkdownModeState({ mode: nextMode, path });
+  }, [path]);
 
   async function copyContent() {
     try {
@@ -326,6 +274,24 @@ export function WorkspaceCodeView({
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          {isMarkdownFile ? (
+            <MarkdownModeToggle mode={markdownViewMode} onChange={handleMarkdownViewModeChange} />
+          ) : null}
+          {showOpenButton ? (
+            <Tooltip content="Open">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8 shrink-0 px-2.5"
+                onClick={() => openFilePathOnHost(absolutePath)}
+                aria-label={`Open ${path}`}
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                <span>Open</span>
+              </Button>
+            </Tooltip>
+          ) : null}
           <Tooltip content={copied ? "Copied" : "Copy"}>
             <Button
               type="button"
@@ -368,16 +334,18 @@ export function WorkspaceCodeView({
           ) : null}
         </div>
       </div>
-      <div className="min-h-0 flex-1 overflow-auto">
-        {isMarkdownFile ? (
+      <div className={shouldRenderMarkdownPreview ? "min-h-0 flex-1 overflow-auto" : "min-h-0 flex-1 overflow-hidden"}>
+        {shouldRenderMarkdownPreview ? (
           <div className="mx-auto w-full max-w-4xl px-6 py-5 text-sm">
             <PreviewMarkdown content={content} resolveImageSrc={resolveMarkdownImageSrc} />
           </div>
         ) : (
-          <CodeLines
+          <WorkspaceMonacoEditor
             content={content}
-            highlightedLines={highlightedLines}
+            language={mode === "diff" ? "git-diff" : fileData?.language}
             mode={mode}
+            path={path}
+            readOnly
           />
         )}
       </div>

--- a/src/components/workspace/workspace-code-view.tsx
+++ b/src/components/workspace/workspace-code-view.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { AlertCircle, Binary, Copy, FileCode2, FileText, GitCompare, LoaderCircle, X } from "lucide-react";
-import { useCallback, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useMemo, useState } from "react";
+import type { Highlighter, ThemedToken } from "shiki";
 import { PreviewMarkdown } from "@/components/chat/preview-markdown";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { WorkspaceFileContextMenu } from "@/components/workspace/workspace-file-context-menu";
+import { useIsDark } from "@/hooks/use-is-dark";
+import {
+  getHighlighterInstance,
+  highlightCodeToTokens,
+} from "@/lib/code-highlighting";
 import {
   copyText,
   toAbsoluteWorkspacePath,
@@ -100,26 +106,71 @@ function getDiffLineClassName(line: string): string {
 
 function CodeLines({
   content,
+  highlightedLines,
   mode,
 }: {
   content: string;
+  highlightedLines?: ThemedToken[][] | null;
   mode: "file" | "diff";
 }) {
+  if (mode === "file" && highlightedLines) {
+    return <HighlightedCodeLines lines={highlightedLines} />;
+  }
+
   const lines = content.split("\n");
   return (
-    <div className="min-w-max py-3">
+    <div className="workspace-code-lines">
       {lines.map((line, index) => (
         <div
           key={`${index}-${line.slice(0, 16)}`}
           className={cn(
-            "grid grid-cols-[4rem_minmax(0,1fr)] font-mono text-xs leading-5",
+            "workspace-code-line",
             mode === "diff" ? getDiffLineClassName(line) : "text-(--text-secondary)",
           )}
         >
-          <span className="select-none border-r border-(--divider) px-3 text-right text-(--text-muted) opacity-70">
-            {index + 1}
-          </span>
-          <code className="whitespace-pre px-4">{line || " "}</code>
+          <span className="workspace-code-line-number">{index + 1}</span>
+          <code className="workspace-code-line-content">{line || " "}</code>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function getTokenStyle(token: ThemedToken): CSSProperties | undefined {
+  if (token.htmlStyle) {
+    return token.htmlStyle;
+  }
+
+  const style: CSSProperties = {};
+  if (token.color) style.color = token.color;
+  if (token.bgColor) style.backgroundColor = token.bgColor;
+
+  const fontStyle = token.fontStyle ?? 0;
+  if ((fontStyle & 1) !== 0) style.fontStyle = "italic";
+  if ((fontStyle & 2) !== 0) style.fontWeight = 700;
+  if ((fontStyle & 4) !== 0) style.textDecoration = "underline";
+
+  return Object.keys(style).length > 0 ? style : undefined;
+}
+
+function HighlightedCodeLines({ lines }: { lines: ThemedToken[][] }) {
+  return (
+    <div className="workspace-code-lines">
+      {lines.map((tokens, lineIndex) => (
+        <div className="workspace-code-line" key={lineIndex}>
+          <span className="workspace-code-line-number">{lineIndex + 1}</span>
+          <code className="workspace-code-line-content">
+            {tokens.length > 0
+              ? tokens.map((token, tokenIndex) => (
+                <span
+                  key={`${token.offset}-${tokenIndex}`}
+                  style={getTokenStyle(token)}
+                >
+                  {token.content}
+                </span>
+              ))
+              : " "}
+          </code>
         </div>
       ))}
     </div>
@@ -167,6 +218,8 @@ export function WorkspaceCodeView({
   sourceSessionId?: string;
 }) {
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const [highlighter, setHighlighter] = useState<Highlighter | null>(null);
+  const isDark = useIsDark();
   const content =
     mode === "diff"
       ? (data as GitDiffData | null)?.diff ?? ""
@@ -180,12 +233,35 @@ export function WorkspaceCodeView({
   const copied = copiedKey === `${mode}:${path}`;
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const isMarkdownFile = mode === "file" && fileData?.language === "markdown";
+  const shikiTheme = isDark ? "github-dark" : "github-light";
   const resolveMarkdownImageSrc = useCallback((src: string): string | null => {
     if (!sourceSessionId || isBrowserImageSrc(src)) return src;
     const assetPath = normalizeWorkspaceAssetPath(path, src);
     if (!assetPath) return null;
     return buildWorkspaceRawFileUrl(sourceSessionId, assetPath);
   }, [path, sourceSessionId]);
+  useEffect(() => {
+    if (mode !== "file" || isMarkdownFile || fileData?.binary) return undefined;
+
+    let cancelled = false;
+    getHighlighterInstance().then((h) => {
+      if (!cancelled && h) setHighlighter(h);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fileData?.binary, isMarkdownFile, mode]);
+
+  const highlightedLines = useMemo(() => {
+    if (mode !== "file" || isMarkdownFile || !highlighter) return null;
+
+    try {
+      return highlightCodeToTokens(highlighter, content, fileData?.language, shikiTheme);
+    } catch {
+      return null;
+    }
+  }, [content, fileData?.language, highlighter, isMarkdownFile, mode, shikiTheme]);
 
   async function copyContent() {
     try {
@@ -298,7 +374,11 @@ export function WorkspaceCodeView({
             <PreviewMarkdown content={content} resolveImageSrc={resolveMarkdownImageSrc} />
           </div>
         ) : (
-          <CodeLines content={content} mode={mode} />
+          <CodeLines
+            content={content}
+            highlightedLines={highlightedLines}
+            mode={mode}
+          />
         )}
       </div>
     </div>

--- a/src/components/workspace/workspace-monaco-editor.tsx
+++ b/src/components/workspace/workspace-monaco-editor.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { LoaderCircle } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useIsDark } from "@/hooks/use-is-dark";
+import { cn } from "@/lib/utils";
+
+interface WorkspaceMonacoEditorProps {
+  className?: string;
+  content: string;
+  language?: string | null;
+  mode: "file" | "diff";
+  path: string;
+  readOnly?: boolean;
+}
+
+type MonacoApi = typeof import("monaco-editor");
+type MonacoEditor = import("monaco-editor").editor.IStandaloneCodeEditor;
+type MonacoModel = import("monaco-editor").editor.ITextModel;
+
+const LANGUAGE_ALIASES: Record<string, string> = {
+  bash: "shell",
+  cjs: "javascript",
+  h: "c",
+  hpp: "cpp",
+  js: "javascript",
+  jsx: "javascript",
+  md: "markdown",
+  mjs: "javascript",
+  py: "python",
+  sh: "shell",
+  makefile: "plaintext",
+  text: "plaintext",
+  ts: "typescript",
+  tsx: "typescript",
+  txt: "plaintext",
+  yml: "yaml",
+};
+
+const LANGUAGE_BY_EXTENSION: Record<string, string> = {
+  bash: "shell",
+  c: "c",
+  cc: "cpp",
+  cjs: "javascript",
+  cpp: "cpp",
+  css: "css",
+  dockerfile: "dockerfile",
+  go: "go",
+  h: "c",
+  hpp: "cpp",
+  html: "html",
+  js: "javascript",
+  json: "json",
+  jsx: "javascript",
+  md: "markdown",
+  makefile: "plaintext",
+  mjs: "javascript",
+  py: "python",
+  rs: "rust",
+  sh: "shell",
+  sql: "sql",
+  ts: "typescript",
+  tsx: "typescript",
+  txt: "plaintext",
+  yaml: "yaml",
+  yml: "yaml",
+};
+
+const SUPPORTED_MONACO_LANGUAGES = new Set([
+  "c",
+  "cpp",
+  "css",
+  "dockerfile",
+  "git-diff",
+  "go",
+  "html",
+  "javascript",
+  "json",
+  "markdown",
+  "plaintext",
+  "python",
+  "rust",
+  "shell",
+  "sql",
+  "typescript",
+  "yaml",
+]);
+
+let monacoExtensionsRegistered = false;
+let monacoEnvironmentConfigured = false;
+
+function extensionFromPath(filePath: string): string {
+  const name = filePath.split("/").pop()?.toLowerCase() ?? "";
+  if (name === "dockerfile") return "dockerfile";
+  if (name === "makefile") return "makefile";
+  const dotIndex = name.lastIndexOf(".");
+  return dotIndex >= 0 ? name.slice(dotIndex + 1) : "";
+}
+
+function normalizeMonacoLanguage(mode: "file" | "diff", language: string | null | undefined, filePath: string): string {
+  if (mode === "diff") return "git-diff";
+
+  const normalized = (language ?? "").trim().toLowerCase();
+  const fromLanguage = LANGUAGE_ALIASES[normalized] ?? normalized;
+  if (SUPPORTED_MONACO_LANGUAGES.has(fromLanguage)) return fromLanguage;
+
+  const ext = extensionFromPath(filePath);
+  return LANGUAGE_BY_EXTENSION[ext] ?? "plaintext";
+}
+
+function buildModelUri(monaco: MonacoApi, mode: "file" | "diff", filePath: string) {
+  const encodedPath = filePath
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+  return monaco.Uri.parse(`inmemory://workspace/${mode}/${encodedPath || "untitled"}`);
+}
+
+function registerMonacoExtensions(monaco: MonacoApi): void {
+  if (monacoExtensionsRegistered) return;
+  monacoExtensionsRegistered = true;
+
+  monaco.languages.register({ id: "git-diff" });
+  monaco.languages.setMonarchTokensProvider("git-diff", {
+    tokenizer: {
+      root: [
+        [/^diff --git.*$/, "diff.header"],
+        [/^index .*$/, "diff.header"],
+        [/^@@.*@@.*$/, "diff.hunk"],
+        [/^\+\+\+.*$/, "diff.meta"],
+        [/^---.*$/, "diff.meta"],
+        [/^\+.*/, "diff.inserted"],
+        [/^-.*/, "diff.deleted"],
+      ],
+    },
+  });
+
+  monaco.editor.defineTheme("tessera-light", {
+    base: "vs",
+    inherit: true,
+    rules: [
+      { token: "diff.header", foreground: "1a1a1a", fontStyle: "bold" },
+      { token: "diff.hunk", foreground: "4a8cd6" },
+      { token: "diff.meta", foreground: "9b7f35" },
+      { token: "diff.inserted", foreground: "2f8753" },
+      { token: "diff.deleted", foreground: "c94c4c" },
+    ],
+    colors: {
+      "editor.background": "#fafaf9",
+    },
+  });
+
+  monaco.editor.defineTheme("tessera-dark", {
+    base: "vs-dark",
+    inherit: true,
+    rules: [
+      { token: "diff.header", foreground: "d7dde3", fontStyle: "bold" },
+      { token: "diff.hunk", foreground: "79aee8" },
+      { token: "diff.meta", foreground: "c2a15a" },
+      { token: "diff.inserted", foreground: "66c98b" },
+      { token: "diff.deleted", foreground: "e27777" },
+    ],
+    colors: {
+      "editor.background": "#17191c",
+    },
+  });
+}
+
+function configureMonacoEnvironment(): void {
+  if (monacoEnvironmentConfigured || typeof window === "undefined") return;
+  monacoEnvironmentConfigured = true;
+
+  window.MonacoEnvironment = {
+    getWorker(_workerId: string, label: string): Worker {
+      if (label === "json") {
+        return new Worker(new URL("monaco-editor/esm/vs/language/json/json.worker.js", import.meta.url));
+      }
+      if (label === "css" || label === "scss" || label === "less") {
+        return new Worker(new URL("monaco-editor/esm/vs/language/css/css.worker.js", import.meta.url));
+      }
+      if (label === "html" || label === "handlebars" || label === "razor") {
+        return new Worker(new URL("monaco-editor/esm/vs/language/html/html.worker.js", import.meta.url));
+      }
+      if (label === "typescript" || label === "javascript") {
+        return new Worker(new URL("monaco-editor/esm/vs/language/typescript/ts.worker.js", import.meta.url));
+      }
+      return new Worker(new URL("monaco-editor/esm/vs/editor/editor.worker.js", import.meta.url));
+    },
+  };
+}
+
+export function WorkspaceMonacoEditor({
+  className,
+  content,
+  language,
+  mode,
+  path,
+  readOnly = true,
+}: WorkspaceMonacoEditorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<MonacoEditor | null>(null);
+  const modelRef = useRef<MonacoModel | null>(null);
+  const monacoRef = useRef<MonacoApi | null>(null);
+  const latestPropsRef = useRef({ content, language, mode, path, readOnly });
+  const latestThemeRef = useRef("tessera-light");
+  const [isReady, setIsReady] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const isDark = useIsDark();
+  const monacoLanguage = useMemo(
+    () => normalizeMonacoLanguage(mode, language, path),
+    [language, mode, path],
+  );
+  const theme = isDark ? "tessera-dark" : "tessera-light";
+
+  useEffect(() => {
+    latestPropsRef.current = { content, language, mode, path, readOnly };
+  }, [content, language, mode, path, readOnly]);
+
+  useEffect(() => {
+    latestThemeRef.current = theme;
+  }, [theme]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    configureMonacoEnvironment();
+    import("monaco-editor")
+      .then((monaco) => {
+        if (cancelled || !containerRef.current) return;
+
+        registerMonacoExtensions(monaco);
+        const latest = latestPropsRef.current;
+        const initialLanguage = normalizeMonacoLanguage(latest.mode, latest.language, latest.path);
+        const model = monaco.editor.createModel(
+          latest.content,
+          initialLanguage,
+          buildModelUri(monaco, latest.mode, latest.path),
+        );
+        const editor = monaco.editor.create(containerRef.current, {
+          automaticLayout: true,
+          contextmenu: true,
+          cursorBlinking: "smooth",
+          domReadOnly: latest.readOnly,
+          fixedOverflowWidgets: true,
+          fontFamily: "'JetBrains Mono', 'Fira Code', Monaco, Consolas, monospace",
+          fontSize: 13,
+          largeFileOptimizations: true,
+          lineHeight: 20,
+          lineNumbers: "on",
+          minimap: { enabled: false },
+          model,
+          overviewRulerBorder: false,
+          readOnly: latest.readOnly,
+          renderFinalNewline: "off",
+          renderLineHighlight: "line",
+          renderWhitespace: "selection",
+          scrollBeyondLastLine: false,
+          smoothScrolling: false,
+          stickyScroll: { enabled: false },
+          theme: latestThemeRef.current,
+          wordWrap: "off",
+        });
+
+        monacoRef.current = monaco;
+        modelRef.current = model;
+        editorRef.current = editor;
+        setIsReady(true);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setLoadError(error instanceof Error ? error.message : "Editor failed to load.");
+      });
+
+    return () => {
+      cancelled = true;
+      editorRef.current?.dispose();
+      modelRef.current?.dispose();
+      editorRef.current = null;
+      modelRef.current = null;
+      monacoRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const monaco = monacoRef.current;
+    const editor = editorRef.current;
+    if (!monaco || !editor) return;
+
+    const nextUri = buildModelUri(monaco, mode, path);
+    const currentModel = modelRef.current;
+    const shouldReplaceModel =
+      !currentModel
+      || currentModel.uri.toString() !== nextUri.toString()
+      || currentModel.getLanguageId() !== monacoLanguage;
+
+    if (shouldReplaceModel) {
+      const nextModel = monaco.editor.createModel(content, monacoLanguage, nextUri);
+      modelRef.current = nextModel;
+      editor.setModel(nextModel);
+      currentModel?.dispose();
+      return;
+    }
+
+    if (currentModel.getValue() !== content) {
+      currentModel.setValue(content);
+    }
+  }, [content, mode, monacoLanguage, path]);
+
+  useEffect(() => {
+    monacoRef.current?.editor.setTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    editorRef.current?.updateOptions({
+      domReadOnly: readOnly,
+      readOnly,
+    });
+  }, [readOnly]);
+
+  return (
+    <div className={cn("relative h-full min-h-0 w-full", className)}>
+      <div ref={containerRef} className="h-full min-h-0 w-full" />
+      {!isReady && !loadError ? (
+        <div className="absolute inset-0 flex items-center justify-center bg-(--chat-bg)">
+          <LoaderCircle className="h-5 w-5 animate-spin text-(--text-muted)" />
+        </div>
+      ) : null}
+      {loadError ? (
+        <div className="absolute inset-0 flex items-center justify-center bg-(--chat-bg) p-6 text-center text-xs text-(--text-muted)">
+          {loadError}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/code-highlighting.ts
+++ b/src/lib/code-highlighting.ts
@@ -1,0 +1,118 @@
+import type { Highlighter, ThemedToken } from "shiki";
+
+const SHIKI_THEMES = ["github-dark", "github-light"] as const;
+
+const SHIKI_LANGS = [
+  "bash",
+  "c",
+  "cpp",
+  "css",
+  "dockerfile",
+  "go",
+  "html",
+  "java",
+  "javascript",
+  "json",
+  "jsx",
+  "makefile",
+  "markdown",
+  "python",
+  "rust",
+  "shell",
+  "sql",
+  "tsx",
+  "typescript",
+  "yaml",
+] as const;
+
+export type ShikiTheme = (typeof SHIKI_THEMES)[number];
+type ShikiLanguage = (typeof SHIKI_LANGS)[number] | "text";
+
+const SHIKI_LANG_SET: ReadonlySet<string> = new Set([...SHIKI_LANGS, "text"]);
+
+let highlighterInstance: Highlighter | null = null;
+let highlighterPromise: Promise<Highlighter | null> | null = null;
+
+export async function getHighlighterInstance(): Promise<Highlighter | null> {
+  if (highlighterInstance) {
+    return highlighterInstance;
+  }
+
+  if (!highlighterPromise) {
+    highlighterPromise = (async () => {
+      try {
+        const shiki = await import("shiki");
+        const highlighter = await shiki.createHighlighter({
+          themes: [...SHIKI_THEMES],
+          langs: [...SHIKI_LANGS],
+        });
+        highlighterInstance = highlighter;
+        return highlighter;
+      } catch {
+        // Shiki dynamic import can fail in custom server dev mode (webpack chunk issue).
+        // Callers should fall back to plain text rendering.
+        highlighterPromise = null;
+        return null;
+      }
+    })();
+  }
+
+  return highlighterPromise;
+}
+
+export function normalizeShikiLanguage(language: string | null | undefined): ShikiLanguage {
+  const normalizedLang = (language ?? "").trim().toLowerCase();
+
+  if (normalizedLang === "c++") return "cpp";
+  if (normalizedLang === "docker") return "dockerfile";
+  if (normalizedLang === "dockerfile") return "dockerfile";
+  if (normalizedLang === "h") return "c";
+  if (normalizedLang === "hpp") return "cpp";
+  if (normalizedLang === "js") return "javascript";
+  if (normalizedLang === "md") return "markdown";
+  if (normalizedLang === "py") return "python";
+  if (normalizedLang === "sh") return "bash";
+  if (normalizedLang === "ts") return "typescript";
+  if (normalizedLang === "yml") return "yaml";
+
+  if (!normalizedLang) return "text";
+  return SHIKI_LANG_SET.has(normalizedLang) ? (normalizedLang as ShikiLanguage) : "text";
+}
+
+export function highlightCodeToHtml(
+  highlighter: Highlighter,
+  code: string,
+  language: string | null | undefined,
+  theme: ShikiTheme,
+): string {
+  try {
+    return highlighter.codeToHtml(code, {
+      lang: normalizeShikiLanguage(language),
+      theme,
+    });
+  } catch {
+    return highlighter.codeToHtml(code, {
+      lang: "text",
+      theme,
+    });
+  }
+}
+
+export function highlightCodeToTokens(
+  highlighter: Highlighter,
+  code: string,
+  language: string | null | undefined,
+  theme: ShikiTheme,
+): ThemedToken[][] {
+  try {
+    return highlighter.codeToTokens(code, {
+      lang: normalizeShikiLanguage(language),
+      theme,
+    }).tokens;
+  } catch {
+    return highlighter.codeToTokens(code, {
+      lang: "text",
+      theme,
+    }).tokens;
+  }
+}


### PR DESCRIPTION
Summary:
- Adds shared syntax highlighting for workspace code previews.
- Adds a Monaco-based workspace file viewer with editor loading wired into layout.
- Updates package metadata for the Monaco editor dependency.

Tests:
- `npx eslint src/components/chat/code-block.tsx src/components/workspace/workspace-code-view.tsx src/components/workspace/workspace-monaco-editor.tsx src/lib/code-highlighting.ts src/app/layout.tsx`
- `npx tsc --noEmit`