### PR TITLE
fix(opencode): treat a runnable binary as connected, drop models login-gate

### DIFF
--- a/src/lib/cli/providers/opencode/adapter.ts
+++ b/src/lib/cli/providers/opencode/adapter.ts
@@ -19,8 +19,7 @@ import {
   resolveProviderCliCommandWithMetadata,
 } from '../../provider-command';
 import {
-  classifyAuthStatus,
-  classifyVersionFailure,
+  classifyOpenCodeStatus,
   summarizeExecProbe,
 } from '../../status-detection';
 import { updateProviderStateWithRetry } from '../../process-manager-side-effects';
@@ -125,34 +124,29 @@ export class OpenCodeAdapter implements CliProvider {
       options.userId,
     );
     const command = commandMetadata.command;
-    const [versionResult, modelsResult] = await Promise.all([
-      execCli(command, ['--version'], options.environment, STATUS_CHECK_TIMEOUT_MS),
-      execCli(command, ['models'], options.environment, STATUS_CHECK_TIMEOUT_MS),
-    ]);
-    const versionProbe = summarizeExecProbe(versionResult);
-    const authProbe = summarizeExecProbe(modelsResult);
-    const baseTelemetry = {
+    // OpenCode needs no login, so we only probe `--version` to confirm the
+    // binary runs. We deliberately skip `opencode models`: it never detects a
+    // missing login (free models always list, even offline) and its ~2s boot
+    // used to time out and mislabel a healthy install as "needs_login".
+    const versionResult = await execCli(
+      command,
+      ['--version'],
+      options.environment,
+      STATUS_CHECK_TIMEOUT_MS,
+    );
+    const { status, detectionReason } = classifyOpenCodeStatus(
+      versionResult,
+      commandMetadata.commandSource,
+    );
+    const version = parseVersion(versionResult.stdout);
+
+    return {
+      status,
+      detectionReason,
+      ...(version ? { version } : {}),
       commandSource: commandMetadata.commandSource,
       commandShape: commandMetadata.commandShape,
-      versionProbe,
-      authProbe,
-    };
-
-    if (!versionResult.ok) {
-      return {
-        status: 'not_installed',
-        detectionReason: classifyVersionFailure(versionResult, commandMetadata.commandSource),
-        ...baseTelemetry,
-      };
-    }
-
-    const version = parseVersion(versionResult.stdout);
-    const authStatus = classifyAuthStatus(modelsResult);
-    return {
-      status: authStatus.status,
-      detectionReason: authStatus.detectionReason,
-      ...(version ? { version } : {}),
-      ...baseTelemetry,
+      versionProbe: summarizeExecProbe(versionResult),
     };
   }
 

--- a/src/lib/cli/status-detection.ts
+++ b/src/lib/cli/status-detection.ts
@@ -53,6 +53,30 @@ export function classifyAuthStatus(result: ExecResult): {
   return { status: 'not_installed', detectionReason };
 }
 
+/**
+ * Resolves OpenCode's connection status from the version probe alone.
+ *
+ * Unlike Claude Code (`auth status`) and Codex (`login status`), OpenCode has
+ * no dedicated auth-status command and never gates on login: its free hosted
+ * models are always available, so `opencode models` exits 0 even with zero
+ * credentials. Probing `models` therefore measures OpenCode's ~2s runtime boot,
+ * not auth — and on a slow boot it timed out and was mislabeled "needs_login".
+ *
+ * A runnable binary is "connected"; only a failed version probe is a problem.
+ */
+export function classifyOpenCodeStatus(
+  versionResult: ExecResult,
+  commandSource: CliCommandSource,
+): { status: CliConnectionStatus; detectionReason: CliDetectionReason } {
+  if (!versionResult.ok) {
+    return {
+      status: 'not_installed',
+      detectionReason: classifyVersionFailure(versionResult, commandSource),
+    };
+  }
+  return { status: 'connected', detectionReason: 'connected' };
+}
+
 function getProbeFailureKind(result: ExecResult): CliProbeFailureKind {
   if (result.ok) return 'ok';
   if (result.timedOut) return 'timeout';

--- a/tests/opencode-status-no-login-gate.test.ts
+++ b/tests/opencode-status-no-login-gate.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { classifyOpenCodeStatus } from '../src/lib/cli/status-detection';
+import type { ExecResult } from '../src/lib/cli/cli-exec';
+
+function execResult(overrides: Partial<ExecResult>): ExecResult {
+  return {
+    ok: false,
+    exitCode: null,
+    stdout: '',
+    stderr: '',
+    timedOut: false,
+    durationMs: 0,
+    ...overrides,
+  };
+}
+
+test('OpenCode is connected as soon as the version probe succeeds', () => {
+  const versionOk = execResult({ ok: true, exitCode: 0, stdout: '1.14.39' });
+
+  const result = classifyOpenCodeStatus(versionOk, 'default');
+
+  assert.equal(result.status, 'connected');
+  assert.equal(result.detectionReason, 'connected');
+});
+
+test('OpenCode never reports needs_login when the binary runs', () => {
+  // Regression: OpenCode needs no login (free zen models are always available),
+  // yet a slow `opencode models` probe used to time out and surface a
+  // misleading "needs_login". A runnable binary must read as connected.
+  const versionOk = execResult({ ok: true, exitCode: 0, stdout: '1.14.39' });
+
+  const result = classifyOpenCodeStatus(versionOk, 'default');
+
+  assert.notEqual(result.status, 'needs_login');
+});
+
+test('OpenCode is not_installed when the version probe times out', () => {
+  const versionTimeout = execResult({ ok: false, exitCode: null, timedOut: true });
+
+  const result = classifyOpenCodeStatus(versionTimeout, 'default');
+
+  assert.equal(result.status, 'not_installed');
+  assert.equal(result.detectionReason, 'version_timeout');
+});
+
+test('OpenCode is not_installed when the binary is missing', () => {
+  const missing = execResult({ ok: false, exitCode: null, spawnErrorCode: 'ENOENT' });
+
+  const result = classifyOpenCodeStatus(missing, 'default');
+
+  assert.equal(result.status, 'not_installed');
+  assert.equal(result.detectionReason, 'binary_missing');
+});


### PR DESCRIPTION
## What

OpenCode's CLI status was driven by the exit code of `opencode models`, used as a stand-in for "logged in". This PR resolves OpenCode status from `opencode --version` alone and removes the `models` login-gate.

A new pure helper `classifyOpenCodeStatus(versionResult, commandSource)` returns `connected` whenever the binary runs, and `not_installed` only when the version probe fails. Claude Code and Codex are unchanged — they keep `classifyAuthStatus`, since their subscription login is a real binary state.

## Why (fixes #93)

Unlike Claude Code (`auth status`) and Codex (`login status`), OpenCode has no single mandatory login. Its `auth` command manages per-provider credentials, and free hosted/local models run with zero credentials — verified locally: `opencode auth list` shows 0 credentials, yet `opencode models` exits 0 (even offline) and lists the free `opencode/*` models.

Using `opencode models` as a login probe was wrong on two counts:

- It can't detect a missing login (it exits 0 without one).
- It boots OpenCode's full ~2s runtime, so on a slow host it exceeded the 5s probe timeout and surfaced as a misleading **"needs login"** — exactly what the issue reports. The same slow probe also fed the **"Provider check is taking too long"** message in the composer.

Dropping the probe removes both the misdiagnosis and the slow call from the status path.

## Measurements (local)

- `opencode --version` ~1.9s · `opencode models` ~2.5s (vs `claude --version` 0.24s, `codex --version` 0.5s) — OpenCode boots a full runtime for any subcommand.

## Tests

- New `tests/opencode-status-no-login-gate.test.ts` (4 cases): connected on version-ok; never needs_login when the binary runs; not_installed on version timeout / missing binary.
- Verified on this branch: unit tests 4/4 pass, `eslint` clean, `tsc --noEmit` 0 errors.
- Run: `npx tsx --test tests/opencode-status-no-login-gate.test.ts`

## Reviewer notes

- Based on `origin/dev`. Minimal diff: opencode adapter + one new helper + test. `classifyAuthStatus` is intentionally preserved for Claude Code / Codex.
- Behavior change: a slow (>5s) OpenCode boot now reads `not_installed` instead of `needs_login`. If field boot times are a concern, bumping `STATUS_CHECK_TIMEOUT_MS` for OpenCode is an orthogonal follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
