### PR TITLE
Ignore rate_limit_event in Claude Code provider parser

### DIFF
--- a/src/lib/cli/protocol-adapter-routing.ts
+++ b/src/lib/cli/protocol-adapter-routing.ts
@@ -1,9 +1,8 @@
 import logger from '../logger';
 import type { SessionReplayEvent } from '../session-replay-types';
 import { buildProtocolSystemReplayEvent } from './protocol-adapter-events';
+import { KNOWN_IGNORED_MESSAGE_TYPES } from './protocol-message-types';
 import type { CliMessage } from './types';
-
-const KNOWN_IGNORED_MESSAGE_TYPES = new Set(['rate_limit_event']);
 
 type ProtocolMessageHandler = (sessionId: string, userId: string, msg: CliMessage) => void;
 

--- a/src/lib/cli/protocol-message-types.ts
+++ b/src/lib/cli/protocol-message-types.ts
@@ -72,3 +72,13 @@ export type CliMessage = {
   event?: CliStreamEventPayload;
   parent_tool_use_id?: string | null;
 };
+
+/**
+ * Top-level CLI stdout message types that tessera intentionally ignores rather
+ * than rendering. These are benign telemetry/status pushes (e.g. the CLI's
+ * `rate_limit_event`, emitted when unified usage-limit info changes) that have no
+ * chat representation. Shared by every stdout parsing path so a new benign type
+ * only needs to be listed once — otherwise an unmodeled type falls through to a
+ * generic "Unhandled Claude Code message type" warning in the transcript.
+ */
+export const KNOWN_IGNORED_MESSAGE_TYPES = new Set<string>(['rate_limit_event']);

--- a/src/lib/cli/providers/claude-code/protocol-parser.ts
+++ b/src/lib/cli/providers/claude-code/protocol-parser.ts
@@ -15,6 +15,7 @@
 
 import type { ParsedMessage } from '../types';
 import type { CliCommandInfo, CliMessage } from '../../types';
+import { KNOWN_IGNORED_MESSAGE_TYPES } from '../../protocol-message-types';
 import { buildModelUsageEntries, pickPrimaryModelName } from '../../protocol-adapter-events';
 import { parseContentBlocks, extractToolResultOutput, extractOutputString } from '../../message-parser';
 import { hookHandler } from '../../hook-handler';
@@ -206,6 +207,11 @@ export class ClaudeCodeProtocolParser {
         results = this.handleStreamEvent(sessionId, msg);
         break;
       default: {
+        if (KNOWN_IGNORED_MESSAGE_TYPES.has(msg.type)) {
+          logger.debug('Ignoring known benign CLI message type', { sessionId, type: msg.type });
+          results = [];
+          break;
+        }
         logger.warn('Unknown CLI message type', { sessionId, type: msg.type });
         results = [buildClaudeSystemWarning(
           sessionId,

--- a/tests/claude-code-rate-limit-event.test.ts
+++ b/tests/claude-code-rate-limit-event.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { claudeCodeProtocolParser } from '../src/lib/cli/providers/claude-code/protocol-parser';
+
+// The Claude Code CLI (>= v2.1.x) emits a top-level `rate_limit_event` stdout
+// message carrying unified usage-limit status. Tessera does not model it, so the
+// active provider parser must ignore it silently rather than fall through to the
+// `default` branch and surface a generic "Unhandled Claude Code message type"
+// warning in the chat transcript. The ignore list previously lived only on the
+// separate routeProtocolMessage path and never reached this parser.
+
+const SESSION = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+function systemWarnings(messages: ReturnType<typeof claudeCodeProtocolParser.parseStdout>) {
+  return messages.filter((m) => m.serverMessage && (m.serverMessage as any).type === 'system');
+}
+
+test('rate_limit_event is ignored, not surfaced as an unhandled-type chat warning', () => {
+  const line = JSON.stringify({
+    type: 'rate_limit_event',
+    session_id: SESSION,
+    uuid: '00000000-0000-0000-0000-000000000000',
+    rate_limit_info: {
+      status: 'allowed_warning',
+      rateLimitType: 'five_hour',
+      resetsAt: 1777980453,
+    },
+  });
+
+  const result = claudeCodeProtocolParser.parseStdout(SESSION, line);
+
+  assert.equal(
+    result.length,
+    0,
+    `rate_limit_event must produce no parsed messages; got: ${JSON.stringify(result)}`,
+  );
+  assert.equal(
+    systemWarnings(result).length,
+    0,
+    'rate_limit_event must not emit a system warning to the chat',
+  );
+});
+
+test('a genuinely unknown message type still surfaces the unhandled-type warning', () => {
+  const line = JSON.stringify({
+    type: 'totally_unknown_future_type',
+    session_id: SESSION,
+    uuid: '00000000-0000-0000-0000-000000000001',
+  });
+
+  const result = claudeCodeProtocolParser.parseStdout(SESSION, line);
+  const warnings = systemWarnings(result);
+
+  assert.equal(warnings.length, 1, 'unknown types must still warn so real gaps stay visible');
+  const sm = warnings[0].serverMessage as { type: string; severity: string; message: string };
+  assert.equal(sm.severity, 'warning');
+  assert.match(sm.message, /Unhandled Claude Code message type: totally_unknown_future_type/);
+});


### PR DESCRIPTION
## Problem

After updating the Claude Code CLI, a warning shows up in the chat transcript:

> Unhandled Claude Code message type: rate_limit_event

## Root cause

The updated CLI (>= v2.1.x) emits a new top-level `rate_limit_event` stdout message carrying unified usage-limit status (`rate_limit_info`). For Claude Code sessions the live stdout path is the **provider parser** (`ClaudeCodeProtocolParser.handleMessage`), which had no `case` for `rate_limit_event`, so it fell through to the `default` branch and emitted a `severity: 'warning'` system message — rendered verbatim in chat.

The ignore list that *would* silence it (`KNOWN_IGNORED_MESSAGE_TYPES` with `rate_limit_event`) lived only in `protocol-adapter-routing.ts` → `routeProtocolMessage`, which is the **legacy/fallback** path. Claude Code provides `parseSessionStdout`, so the fallback (and its ignore-set) is never reached. The suppression was simply never carried over to the active parser.

## Fix

- Extract `KNOWN_IGNORED_MESSAGE_TYPES` into `protocol-message-types.ts` (the canonical wire-format module) so **every** stdout-parsing path shares one list.
- Consult it in `ClaudeCodeProtocolParser`'s `default` branch before warning, so benign telemetry types are swallowed quietly while genuinely unknown types still surface a warning.
- `protocol-adapter-routing.ts` now imports the shared constant instead of declaring its own — a new benign type only needs to be listed once, preventing this kind of drift in the future.

## Tests

Added `tests/claude-code-rate-limit-event.test.ts`:

- `rate_limit_event` produces no chat message (the bug).
- A genuinely unknown message type still surfaces the `Unhandled Claude Code message type` warning (guards against over-suppression).

```
# tests 2
# pass 2
# fail 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
