### PR TITLE
fix(sidebar): stabilize Recent Work ordering for running sessions

### DIFF
--- a/src/lib/chat/recent-work.ts
+++ b/src/lib/chat/recent-work.ts
@@ -38,6 +38,17 @@ function timeValue(value: string | undefined): number {
   return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
+/**
+ * 정렬 anchor로 쓰는 불변 생성 시각.
+ * task 항목은 TaskEntity.createdAt(DB 값)을 쓴다 — 어떤 세션이 "가장 최근"인지에 따라
+ * item.session이 바뀌어도 흔들리지 않기 때문이다(taskToRecentItem의 liveSession,
+ * fallbackTaskItemsFromSessions의 recentSession 모두 최신 세션을 따라 바뀔 수 있다).
+ * chat 항목은 세션이 하나뿐이라 session.createdAt이 곧 불변 anchor다.
+ */
+function sortAnchorTime(item: RecentWorkItem): number {
+  return timeValue(item.type === 'task' ? item.task.createdAt : item.session.createdAt);
+}
+
 function getMostRecentTaskSession(sessions: TaskSession[]): TaskSession | null {
   let recent: TaskSession | null = null;
   for (const session of sessions) {
@@ -115,6 +126,14 @@ function fallbackTaskItemsFromSessions(
   return Array.from(grouped.entries()).map(([taskId, sessions]) => {
     const sortedSessions = sortSessionsByLastActivity(sessions);
     const recentSession = sortedSessions[0];
+    // 그룹의 정렬 anchor는 "가장 먼저 생성된 세션"의 createdAt으로 고정한다.
+    // recentSession.createdAt을 쓰면 동시 실행 중인 세션끼리 최신 자리가 바뀔 때
+    // anchor도 따라 바뀌어 정렬이 흔들린다.
+    const earliestCreatedAt = sortedSessions.reduce(
+      (earliest, session) =>
+        timeValue(session.createdAt) < timeValue(earliest) ? session.createdAt : earliest,
+      recentSession.createdAt,
+    );
     const taskSessions: TaskSession[] = sortedSessions.map((session) => ({
       id: session.id,
       title: session.title,
@@ -133,7 +152,7 @@ function fallbackTaskItemsFromSessions(
       archived: false,
       sortOrder: recentSession.sortOrder,
       sessions: taskSessions,
-      createdAt: recentSession.createdAt,
+      createdAt: earliestCreatedAt,
       updatedAt: recentSession.lastModified,
       diffStats: recentSession.diffStats,
     };
@@ -203,6 +222,26 @@ export function buildRecentWorkItems({
   }
 
   return items
-    .sort((left, right) => timeValue(right.lastActivityAt) - timeValue(left.lastActivityAt))
+    .sort((left, right) => {
+      // 1) 실행 중 항목을 위로 (사용자가 주시하는 라이브 작업).
+      const runDiff = (right.isRunning ? 1 : 0) - (left.isRunning ? 1 : 0);
+      if (runDiff !== 0) return runDiff;
+
+      // 2) 같은 그룹 안에서는 키를 다르게 고른다.
+      //    실행 중 세션은 스트리밍 청크마다 lastModified가 갱신되므로
+      //    (touchSessionActivity, session-store.ts), lastActivityAt로 정렬하면
+      //    동시에 스트리밍 중인 세션끼리 텍스트 델타마다 자리를 맞바꾼다.
+      //    createdAt은 불변이라 실행 중 그룹의 순서가 흔들리지 않는다.
+      //    완료된 항목은 lastActivityAt로 정렬해 실제 "최근 작업" 순서를 유지한다.
+      //    (이 부분을 lastActivityAt로 되돌리면 정렬 흔들림 버그가 재발한다.)
+      const leftKey = left.isRunning ? sortAnchorTime(left) : timeValue(left.lastActivityAt);
+      const rightKey = right.isRunning ? sortAnchorTime(right) : timeValue(right.lastActivityAt);
+      if (rightKey !== leftKey) return rightKey - leftKey;
+
+      // 3) 키가 같을 때도 순서가 절대 뒤섞이지 않도록 결정적 tie-break.
+      const createdDiff = sortAnchorTime(right) - sortAnchorTime(left);
+      if (createdDiff !== 0) return createdDiff;
+      return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+    })
     .slice(0, limit);
 }

--- a/tests/recent-work-sort.test.ts
+++ b/tests/recent-work-sort.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildRecentWorkItems } from '../src/lib/chat/recent-work';
+import type { ProjectGroup, UnifiedSession } from '../src/types/chat';
+
+function makeSession(overrides: Partial<UnifiedSession> & Pick<UnifiedSession, 'id'>): UnifiedSession {
+  return {
+    title: `session ${overrides.id}`,
+    projectDir: 'proj',
+    isRunning: false,
+    status: 'completed',
+    lastModified: '2026-06-13T10:00:00.000Z',
+    createdAt: '2026-06-13T09:00:00.000Z',
+    archived: false,
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+function makeProject(sessions: UnifiedSession[]): ProjectGroup {
+  return {
+    encodedDir: 'proj',
+    displayName: 'proj',
+    decodedPath: '/proj',
+    isCurrent: true,
+    sessions,
+    totalSessions: sessions.length,
+    allLoaded: true,
+    loadedCount: sessions.length,
+    nextCursor: null,
+    loadBatchIndex: 0,
+  };
+}
+
+function build(sessions: UnifiedSession[]) {
+  return buildRecentWorkItems({
+    projects: [makeProject(sessions)],
+    tasksByProject: {},
+    limit: 8,
+  });
+}
+
+function idsOf(sessions: UnifiedSession[]): string[] {
+  return build(sessions).map((item) => item.id);
+}
+
+test('two running sessions keep a stable order while their lastModified keeps advancing', () => {
+  // A was created before B. Both are streaming, so their lastModified bumps on every chunk.
+  const a = makeSession({
+    id: 'a',
+    isRunning: true,
+    status: 'running',
+    createdAt: '2026-06-13T09:00:00.000Z',
+    lastModified: '2026-06-13T10:00:00.001Z',
+  });
+  const b = makeSession({
+    id: 'b',
+    isRunning: true,
+    status: 'running',
+    createdAt: '2026-06-13T09:00:05.000Z',
+    lastModified: '2026-06-13T10:00:00.002Z',
+  });
+
+  // createdAt desc => newer-created B first, then A.
+  const initial = idsOf([a, b]);
+  assert.deepEqual(initial, ['b', 'a']);
+
+  // Simulate several streaming ticks where A and B alternately become "most recent".
+  const ticks: UnifiedSession[][] = [
+    [{ ...a, lastModified: '2026-06-13T10:00:00.050Z' }, b],
+    [a, { ...b, lastModified: '2026-06-13T10:00:00.099Z' }],
+    [{ ...a, lastModified: '2026-06-13T10:00:01.500Z' }, b],
+    [a, { ...b, lastModified: '2026-06-13T10:00:02.700Z' }],
+  ];
+
+  for (const tick of ticks) {
+    assert.deepEqual(idsOf(tick), initial, 'running order must not change as lastModified advances');
+  }
+});
+
+test('completed sessions still sort by most recent activity (lastActivityAt desc)', () => {
+  const older = makeSession({ id: 'old', lastModified: '2026-06-13T08:00:00.000Z' });
+  const newer = makeSession({ id: 'new', lastModified: '2026-06-13T11:00:00.000Z' });
+  const mid = makeSession({ id: 'mid', lastModified: '2026-06-13T09:30:00.000Z' });
+
+  assert.deepEqual(idsOf([older, newer, mid]), ['new', 'mid', 'old']);
+});
+
+test('a running session ranks above a more-recently-active completed session', () => {
+  const running = makeSession({
+    id: 'run',
+    isRunning: true,
+    status: 'running',
+    createdAt: '2026-06-13T07:00:00.000Z',
+    // Note: its activity is OLDER than the completed one, yet it must still win.
+    lastModified: '2026-06-13T09:00:00.000Z',
+  });
+  const completed = makeSession({
+    id: 'done',
+    isRunning: false,
+    lastModified: '2026-06-13T12:00:00.000Z',
+  });
+
+  assert.deepEqual(idsOf([completed, running]), ['run', 'done']);
+});
+
+test('items with identical keys fall back to id and never reshuffle', () => {
+  const shared = {
+    isRunning: false as const,
+    createdAt: '2026-06-13T09:00:00.000Z',
+    lastModified: '2026-06-13T10:00:00.000Z',
+  };
+  const x = makeSession({ id: 'x', ...shared });
+  const y = makeSession({ id: 'y', ...shared });
+  const z = makeSession({ id: 'z', ...shared });
+
+  const expected = ['x', 'y', 'z']; // id ascending tie-break
+  assert.deepEqual(idsOf([x, y, z]), expected);
+  // Input order must not matter once all sort keys are equal.
+  assert.deepEqual(idsOf([z, y, x]), expected);
+  assert.deepEqual(idsOf([y, z, x]), expected);
+});
+
+test('fallback task groups (orphaned task sessions) keep stable order while running', () => {
+  // taskId가 있지만 tasksByProject에 없는 세션들은 fallbackTaskItemsFromSessions 경로를 탄다.
+  // 같은 그룹 안에서 두 세션이 동시에 스트리밍하며 lastModified가 번갈아 최신이 되어도,
+  // 그룹(task 항목)의 정렬 anchor는 그룹의 가장 이른 createdAt으로 고정되어야 한다.
+  const t1s1 = makeSession({
+    id: 't1s1', taskId: 'T1', isRunning: true, status: 'running',
+    createdAt: '2026-06-13T09:00:00.000Z', lastModified: '2026-06-13T10:00:00.010Z',
+  });
+  const t1s2 = makeSession({
+    id: 't1s2', taskId: 'T1', isRunning: true, status: 'running',
+    createdAt: '2026-06-13T09:00:01.000Z', lastModified: '2026-06-13T10:00:00.020Z',
+  });
+  const t2s1 = makeSession({
+    id: 't2s1', taskId: 'T2', isRunning: true, status: 'running',
+    createdAt: '2026-06-13T09:00:05.000Z', lastModified: '2026-06-13T10:00:00.030Z',
+  });
+
+  // anchor: T1 earliest=09:00:00, T2 earliest=09:00:05 => createdAt desc로 T2가 먼저.
+  // (fallback 항목의 RecentWorkItem.id는 taskId 이다.)
+  const initial = idsOf([t1s1, t1s2, t2s1]);
+  assert.deepEqual(initial, ['T2', 'T1']);
+
+  // 어느 세션이 "가장 최근"이 되든(= recentSession이 flip 되든) 그룹 순서는 그대로여야 한다.
+  const ticks: UnifiedSession[][] = [
+    [{ ...t1s1, lastModified: '2026-06-13T10:00:05.000Z' }, t1s2, t2s1],
+    [t1s1, { ...t1s2, lastModified: '2026-06-13T10:00:09.000Z' }, t2s1],
+    [t1s1, t1s2, { ...t2s1, lastModified: '2026-06-13T10:00:01.000Z' }],
+  ];
+  for (const tick of ticks) {
+    assert.deepEqual(idsOf(tick), initial, 'fallback task group order must stay stable');
+  }
+});
+
+test('mixed running + completed: running tier (createdAt desc) above completed tier (activity desc)', () => {
+  const runA = makeSession({
+    id: 'runA',
+    isRunning: true,
+    status: 'running',
+    createdAt: '2026-06-13T08:00:00.000Z',
+    lastModified: '2026-06-13T10:00:01.000Z',
+  });
+  const runB = makeSession({
+    id: 'runB',
+    isRunning: true,
+    status: 'running',
+    createdAt: '2026-06-13T08:00:10.000Z',
+    lastModified: '2026-06-13T10:00:00.500Z',
+  });
+  const doneOld = makeSession({ id: 'doneOld', lastModified: '2026-06-13T09:50:00.000Z' });
+  const doneNew = makeSession({ id: 'doneNew', lastModified: '2026-06-13T09:59:00.000Z' });
+
+  // running tier first (runB created later => first), then completed tier by activity desc.
+  assert.deepEqual(idsOf([doneOld, runA, doneNew, runB]), ['runB', 'runA', 'doneNew', 'doneOld']);
+});


### PR DESCRIPTION
## Summary
- keep running Recent Work items sorted by stable createdAt anchors
- preserve activity-based ordering for completed items
- add node:test coverage for running, completed, fallback task ordering

## Tests
- npx tsx --test tests/recent-work-sort.test.ts