### PR TITLE
fix(chat): keep read position fixed when scrolled up during streaming

### DIFF
--- a/src/hooks/use-virtual-message-list.ts
+++ b/src/hooks/use-virtual-message-list.ts
@@ -383,7 +383,22 @@ export function useVirtualMessageList({
     };
     const scrollOffset = virtualizerState.getScrollOffset?.() ?? virtualizerState.scrollOffset ?? 0;
     const scrollAdjustments = virtualizerState.scrollAdjustments ?? 0;
-    return item.start < scrollOffset + scrollAdjustments;
+    const anchor = scrollOffset + scrollAdjustments;
+
+    // Following the live tail: keep the bottom pinned by compensating for any
+    // item above the offset as new content streams in.
+    if (autoScroll) {
+      return item.start < anchor;
+    }
+
+    // Parked away from the bottom — the user is reading. Only compensate when the
+    // changed item sits ENTIRELY above the viewport top (genuine re-layout of
+    // already-read content: images decoding, code highlighting). A streaming
+    // message that straddles the viewport top grows at its tail, below the read
+    // position; adjusting scroll there would shove the read text upward out of
+    // view. `item` carries the pre-growth measurement, so `item.end` is the old
+    // bottom edge — leave straddling (and below-viewport) items untouched.
+    return item.end <= anchor;
   };
 
   const totalSize = virtualizer.getTotalSize();


### PR DESCRIPTION
## Summary

- 스트리밍 응답 중 스크롤을 위로 올려 읽을 때, 읽던 텍스트가 계속 위로 밀려 사라지던 문제 수정. 의도: 하단에 있으면 자동 추적, 위로 올리면 읽는 위치 고정.
- **원인**: 가상화 리스트(`@tanstack/react-virtual`)의 `shouldAdjustScrollPositionOnItemSizeChange`가 스트리밍 메시지(뷰포트 상단을 가로지르며 꼬리에서 성장)에 대해 `item.start < scrollOffset`을 반환 → TanStack이 성장분(delta)만큼 `scrollAdjustments`를 더해 뷰포트를 아래로 밀어 읽던 콘텐츠를 밀어냄. 기존 가드(`isUserScrolling`)는 능동 스크롤 ~180ms만 보호하고 "멈춰서 읽는 중"은 무방비였음.
- **수정**: 하단 자동추적(`autoScroll`)이 아닐 때는 뷰포트 상단보다 **완전히 위**(`item.end <= anchor`)인 항목만 스크롤 보정(이미지 디코딩·코드 하이라이팅 등 이미 읽은 영역의 재레이아웃). 뷰포트를 가로지르며 꼬리에서 자라는 스트리밍 메시지는 그대로 둬 읽기 위치 고정. `autoScroll`(하단) 분기는 불변이라 자동 흐름 거동 그대로.
- 변경: `src/hooks/use-virtual-message-list.ts` 1파일 (+16/-1)

## Testing

- [ ] `npm run lint` — 미실행 (이 워크트리는 dev 툴링 미설치, eslint 바이너리 없음)
- [ ] `npx tsc --noEmit` — 미실행. 단, 타입 수동 검증: `VirtualItem.end: number` 존재, 콜백 모든 분기 boolean 반환 → 타입 안전
- [ ] `NODE_ENV=production npm run build` — 미실행
- [x] Manual test: dev 서버(:3100) 기동 후 `/chat` 정상 컴파일·HTTP 200 확인. 브라우저상 스크롤 거동 최종 확인은 진행 중
- [x] 근본원인·회귀 검증: 멀티에이전트 적대적 리뷰(독립 진단 3 + 회귀 리뷰 4). straddle 케이스/위쪽 재레이아웃 = safe, at-bottom·load-more의 우려는 기존 코드와 동일 동작이라 본 수정이 도입한 회귀 아님

## Screenshots or Recordings

UI 동작(스크롤 앵커링) 변경. 재현: 긴 응답 스트리밍 중 위로 스크롤 → 읽기 위치 고정, 맨 아래로 내리면 자동 추적.

## Notes

버그 수정, 단일 파일 변경. 이슈 선행 불필요.
