### PR TITLE
fix(ui): show provider icon before task icon for task items

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -844,8 +844,39 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
       >
         {/* Main row: icon + content */}
         <div className="flex items-start gap-2.5">
-          {/* Worktree/status icon first when present, provider mark otherwise leads */}
+          {/* Provider mark leads; worktree/status icon follows when present */}
           <span className="mt-[3px] flex shrink-0 items-center gap-1">
+            {showProviderIcons ? (
+              <span className="relative flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+                <ProviderLogoMark
+                  providerId={task.sessions[0]?.provider}
+                  className={KANBAN_PROVIDER_MARK_CLASS}
+                  iconClassName={KANBAN_PROVIDER_ICON_CLASS}
+                  data-testid={`kanban-task-agent-icon-${task.id}`}
+                />
+                {!task.worktreeBranch && (
+                  <ItemStatusIndicator
+                    isProcessing={hasProcessingSession}
+                    isAwaitingUser={hasAwaitingUserSession}
+                    hasUnread={hasUnreadSession}
+                    isRunning={hasRunningSession}
+                    placement="corner"
+                    surface="board"
+                  />
+                )}
+              </span>
+            ) : !task.worktreeBranch && hasTaskStatus ? (
+              <span className="relative flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+                <ItemStatusIndicator
+                  isProcessing={hasProcessingSession}
+                  isAwaitingUser={hasAwaitingUserSession}
+                  hasUnread={hasUnreadSession}
+                  isRunning={hasRunningSession}
+                  placement="inline"
+                  surface="board"
+                />
+              </span>
+            ) : null}
             {task.worktreeBranch ? (
               <span
                 title={
@@ -895,37 +926,6 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                     />
                   </span>
                 )}
-              </span>
-            ) : null}
-            {showProviderIcons ? (
-              <span className="relative flex h-3.5 w-3.5 shrink-0 items-center justify-center">
-                <ProviderLogoMark
-                  providerId={task.sessions[0]?.provider}
-                  className={KANBAN_PROVIDER_MARK_CLASS}
-                  iconClassName={KANBAN_PROVIDER_ICON_CLASS}
-                  data-testid={`kanban-task-agent-icon-${task.id}`}
-                />
-                {!task.worktreeBranch && (
-                  <ItemStatusIndicator
-                    isProcessing={hasProcessingSession}
-                    isAwaitingUser={hasAwaitingUserSession}
-                    hasUnread={hasUnreadSession}
-                    isRunning={hasRunningSession}
-                    placement="corner"
-                    surface="board"
-                  />
-                )}
-              </span>
-            ) : !task.worktreeBranch && hasTaskStatus ? (
-              <span className="relative flex h-3.5 w-3.5 shrink-0 items-center justify-center">
-                <ItemStatusIndicator
-                  isProcessing={hasProcessingSession}
-                  isAwaitingUser={hasAwaitingUserSession}
-                  hasUnread={hasUnreadSession}
-                  isRunning={hasRunningSession}
-                  placement="inline"
-                  surface="board"
-                />
               </span>
             ) : null}
             {prMismatch && !task.worktreeBranch && (

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -863,6 +863,37 @@ export function TaskItemRow({
         data-testid={`collection-task-${task.id}`}
       >
         <span className="flex shrink-0 items-center gap-1">
+          {showProviderIcons ? (
+            <span className="relative flex shrink-0 items-center">
+              <ProviderLogoMark
+                providerId={task.sessions[0]?.provider}
+                className={COLLECTION_PROVIDER_MARK_CLASS}
+                iconClassName={COLLECTION_PROVIDER_ICON_CLASS}
+                data-testid={`collection-task-agent-icon-${task.id}`}
+              />
+              {!task.worktreeBranch && (
+                <ItemStatusIndicator
+                  isProcessing={hasProcessingSession}
+                  isAwaitingUser={hasAwaitingUserSession}
+                  hasUnread={hasUnreadSession}
+                  isRunning={hasRunningSession}
+                  placement="corner"
+                  surface="sidebar"
+                />
+              )}
+            </span>
+          ) : !task.worktreeBranch && hasTaskStatus ? (
+            <span className="relative flex w-3.5 shrink-0 items-center justify-center">
+              <ItemStatusIndicator
+                isProcessing={hasProcessingSession}
+                isAwaitingUser={hasAwaitingUserSession}
+                hasUnread={hasUnreadSession}
+                isRunning={hasRunningSession}
+                placement="inline"
+                surface="sidebar"
+              />
+            </span>
+          ) : null}
           {task.worktreeBranch ? (
             <span
               title={task.worktreeMissing ? t('task.worktree.missing', { branch: task.worktreeBranch }) : task.worktreeBranch}
@@ -912,37 +943,6 @@ export function TaskItemRow({
                   className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-(--status-error-text) ring-1 ring-(--sidebar-bg)"
                 />
               )}
-            </span>
-          ) : null}
-          {showProviderIcons ? (
-            <span className="relative flex shrink-0 items-center">
-              <ProviderLogoMark
-                providerId={task.sessions[0]?.provider}
-                className={COLLECTION_PROVIDER_MARK_CLASS}
-                iconClassName={COLLECTION_PROVIDER_ICON_CLASS}
-                data-testid={`collection-task-agent-icon-${task.id}`}
-              />
-              {!task.worktreeBranch && (
-                <ItemStatusIndicator
-                  isProcessing={hasProcessingSession}
-                  isAwaitingUser={hasAwaitingUserSession}
-                  hasUnread={hasUnreadSession}
-                  isRunning={hasRunningSession}
-                  placement="corner"
-                  surface="sidebar"
-                />
-              )}
-            </span>
-          ) : !task.worktreeBranch && hasTaskStatus ? (
-            <span className="relative flex w-3.5 shrink-0 items-center justify-center">
-              <ItemStatusIndicator
-                isProcessing={hasProcessingSession}
-                isAwaitingUser={hasAwaitingUserSession}
-                hasUnread={hasUnreadSession}
-                isRunning={hasRunningSession}
-                placement="inline"
-                surface="sidebar"
-              />
             </span>
           ) : null}
         </span>


### PR DESCRIPTION
## What

Swap the icon display order for **task** items so they render `[provider][task]` instead of `[task][provider]`, in both the list view (sidebar) and the kanban board.

## Where

- `src/components/chat/collection-group-sections.tsx` — `TaskItemRow`
- `src/components/board/kanban-card.tsx` — `KanbanTaskCard` (also removed a duplicate status-only fallback block introduced during the reorder, and updated the now-stale leading-icon comment)

## Notes

- Purely a visual reorder. The `ItemStatusIndicator` and PR-mismatch badge still attach to the same icon under the same conditions (keyed off `task.worktreeBranch`, not document order).
- Sub-session rows are unchanged — they only ever rendered the provider icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)