### PR TITLE
feat(chat): render Codex view_image & Claude Code image reads inline

### DIFF
--- a/src/app/api/sessions/[id]/tool-image/route.ts
+++ b/src/app/api/sessions/[id]/tool-image/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import * as fs from 'fs/promises';
+import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
+import { jsonError } from '@/lib/http/json-error';
+import logger from '@/lib/logger';
+import * as dbSessions from '@/lib/db/sessions';
+import { sessionHistory } from '@/lib/session-history';
+import { inferImageMime, isImagePath } from '@/lib/tool-results/tool-image';
+
+// Codex screenshots / large reads can be a few MB; cap to avoid serving huge files.
+const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Serves the image bytes for an image-producing tool call (Codex `view_image`,
+ * Claude Code image `Read`). The on-disk path is re-derived server-side from the
+ * session's recorded tool call by `toolUseId`, so no client-supplied filesystem
+ * path is trusted. Only image files are served.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  try {
+    const auth = await requireAuthenticatedUserId(request, {
+      error: { code: 'unauthorized', message: 'Unauthorized' },
+    });
+    if ('response' in auth) return auth.response;
+
+    const toolUseId = request.nextUrl.searchParams.get('toolUseId');
+    if (!toolUseId || !toolUseId.trim()) {
+      return jsonError('invalid_params', 'toolUseId is required', 400);
+    }
+
+    if (!dbSessions.getSession(id)) {
+      return jsonError('not_found', 'Session not found', 404);
+    }
+
+    const toolParams = await sessionHistory.readToolCallParams(id, toolUseId);
+    if (!toolParams) {
+      return jsonError('not_found', 'Tool call not found', 404);
+    }
+
+    // `path` for Codex view_image, `file_path` for Claude Code Read.
+    const rawPath = typeof toolParams.path === 'string'
+      ? toolParams.path
+      : typeof toolParams.file_path === 'string'
+        ? toolParams.file_path
+        : '';
+
+    if (!rawPath.trim() || rawPath.includes('\0')) {
+      return jsonError('invalid_file_path', 'Tool call has no image path', 422);
+    }
+    if (!isImagePath(rawPath)) {
+      return jsonError('unsupported_media', 'Tool call path is not an image', 415);
+    }
+
+    let stat;
+    try {
+      stat = await fs.stat(rawPath);
+    } catch {
+      return jsonError('file_not_found', 'Image file not found', 404);
+    }
+    if (!stat.isFile()) {
+      return jsonError('invalid_file_path', 'Path is not a file', 400);
+    }
+    if (stat.size > MAX_IMAGE_BYTES) {
+      return jsonError('file_too_large', 'Image is too large to preview', 413);
+    }
+
+    const buffer = await fs.readFile(rawPath);
+    return new NextResponse(buffer, {
+      headers: {
+        'Content-Type': inferImageMime(rawPath) ?? 'application/octet-stream',
+        'Cache-Control': 'private, max-age=30',
+        'Content-Length': String(buffer.byteLength),
+      },
+    });
+  } catch (error) {
+    logger.error({ error, sessionId: id }, 'Failed to serve tool image');
+    return jsonError('internal_error', 'Failed to serve tool image', 500);
+  }
+}

--- a/src/components/chat/tool-call-block-utils.tsx
+++ b/src/components/chat/tool-call-block-utils.tsx
@@ -273,7 +273,7 @@ export function renderToolCallResult({
     case 'command_execution':
       return <BashResult result={normalizedResult as CommandExecutionToolResult} />;
     case 'file_read':
-      return <ReadResult result={normalizedResult as FileReadToolResult} filePath={toolParams.file_path} />;
+      return <ReadResult result={normalizedResult as FileReadToolResult} filePath={toolParams.file_path ?? toolParams.path} />;
     case 'file_change': {
       const result = normalizedResult as FileChangeToolResult;
       const diffToolName = result.operation === 'create'

--- a/src/components/chat/tool-call-grid.tsx
+++ b/src/components/chat/tool-call-grid.tsx
@@ -10,6 +10,8 @@ import { TOOL_STATUS_TEXT } from './tool-call-block-utils';
 import { ToolCallDetailPanel } from './tool-call-detail-panel';
 import { MESSAGE_BODY_OFFSET_CLASS } from './message-layout';
 import { MessageRowShell } from './message-row-shell';
+import { ImageLightbox } from './image-lightbox';
+import { buildToolImageUrl, isImagePath } from '@/lib/tool-results/tool-image';
 
 // --- Layout threshold ---
 const SUMMARY_BAR_MIN = 4;
@@ -87,6 +89,58 @@ async function prefetchToolOutput(tc: ToolCallMessage): Promise<boolean> {
     isError: false,
   });
   return false;
+}
+
+// --- Inline image tool calls ---
+
+/** An image-producing tool call (Codex `view_image`, Claude image `Read`). */
+function isImageToolCall(tc: ToolCallMessage): boolean {
+  if (tc.status === 'error') return false;
+  if (tc.toolKind !== 'file_read' && tc.toolName !== 'ViewImage') return false;
+  return isImagePath(tc.toolParams?.file_path ?? tc.toolParams?.path);
+}
+
+/** Renders the image inline in the chat flow (no click needed), with click-to-zoom. */
+function InlineToolImage({ toolCall, alignWithMessageBody }: {
+  toolCall: ToolCallMessage;
+  alignWithMessageBody: boolean;
+}) {
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const toolUseId = extractToolUseId(toolCall);
+  const sessionId = toolCall.sessionId;
+  if (!toolUseId || !sessionId) return null;
+
+  const url = buildToolImageUrl(sessionId, toolUseId);
+  const filePath = toolCall.toolParams?.file_path ?? toolCall.toolParams?.path;
+  const caption = typeof filePath === 'string' ? filePath : shortenToolName(toolCall.toolName);
+
+  const content = (
+    <div className={cn('my-2 max-w-2xl', alignWithMessageBody && MESSAGE_BODY_OFFSET_CLASS)}>
+      <div className="mb-1 flex items-center gap-1.5 text-[11px] text-(--text-muted)">
+        <span className="text-(--text-secondary)">{getToolIcon(toolCall.toolName, toolCall.toolKind)}</span>
+        <span className="truncate font-mono">{caption}</span>
+      </div>
+      <button
+        type="button"
+        onClick={() => setLightboxOpen(true)}
+        className="inline-block cursor-zoom-in overflow-hidden rounded-lg border border-(--tool-border) hover:border-(--accent) transition-colors"
+        title="Click to enlarge"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element -- dynamic local image, dimensions unknown */}
+        <img
+          src={url}
+          alt={typeof filePath === 'string' ? filePath : 'image'}
+          className="block max-h-[180px] max-w-[240px] w-auto h-auto object-contain"
+        />
+      </button>
+      {lightboxOpen && (
+        <ImageLightbox src={url} alt={typeof filePath === 'string' ? filePath : undefined} onClose={() => setLightboxOpen(false)} />
+      )}
+    </div>
+  );
+
+  if (!alignWithMessageBody) return content;
+  return <MessageRowShell>{content}</MessageRowShell>;
 }
 
 // --- Compact Row ---
@@ -333,11 +387,15 @@ export const ToolCallGrid = memo(function ToolCallGrid({
   const [localSelectedId, setLocalSelectedId] = useState<string | null>(null);
   const [loadingId, setLoadingId] = useState<string | null>(null);
 
+  // Image tool calls render inline as images; everything else uses the compact grid.
+  const imageToolCalls = useMemo(() => toolCalls.filter(isImageToolCall), [toolCalls]);
+  const gridToolCalls = useMemo(() => toolCalls.filter(tc => !isImageToolCall(tc)), [toolCalls]);
+
   const isExternallyManaged = onSelectToolCall !== undefined;
   const effectiveSelectedId = isExternallyManaged ? (selectedToolCallId ?? null) : localSelectedId;
 
   const selectedToolCall = effectiveSelectedId
-    ? toolCalls.find(tc => tc.id === effectiveSelectedId) ?? null
+    ? gridToolCalls.find(tc => tc.id === effectiveSelectedId) ?? null
     : null;
 
   // Commit selection (after prefetch or immediately)
@@ -381,7 +439,7 @@ export const ToolCallGrid = memo(function ToolCallGrid({
   const showInlinePanel = !isExternallyManaged;
 
   const commonProps = {
-    toolCalls,
+    toolCalls: gridToolCalls,
     selectedId: effectiveSelectedId,
     loadingId,
     onToggle: handleToggle,
@@ -390,8 +448,15 @@ export const ToolCallGrid = memo(function ToolCallGrid({
     alignWithMessageBody,
   };
 
-  if (toolCalls.length >= SUMMARY_BAR_MIN) {
-    return <SummaryBar {...commonProps} />;
-  }
-  return <CompactList {...commonProps} />;
+  const imagesBlock = imageToolCalls.map(tc => (
+    <InlineToolImage key={tc.id} toolCall={tc} alignWithMessageBody={alignWithMessageBody} />
+  ));
+
+  const gridBlock = gridToolCalls.length === 0
+    ? null
+    : gridToolCalls.length >= SUMMARY_BAR_MIN
+      ? <SummaryBar {...commonProps} />
+      : <CompactList {...commonProps} />;
+
+  return <>{imagesBlock}{gridBlock}</>;
 });

--- a/src/components/chat/tool-results/read-result.tsx
+++ b/src/components/chat/tool-results/read-result.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, memo } from 'react';
-import Image from 'next/image';
 import type { FileReadToolResult } from '@/types/tool-result';
+import { ImageLightbox } from '../image-lightbox';
 
 const MAX_DISPLAY_LINES = 50;
 
@@ -13,26 +13,39 @@ interface ReadResultProps {
 
 export const ReadResult = memo(function ReadResult({ result, filePath }: ReadResultProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
 
   if (result.contentType === 'image') {
-    const { base64, mimeType, dimensions } = result;
+    const src = result.url
+      ?? (result.base64 ? `data:${result.mimeType ?? 'image/png'};base64,${result.base64}` : null);
+
+    if (!src) return null;
+
     return (
       <div className="space-y-1">
         {filePath && (
           <div className="text-[10px] text-(--text-muted) font-mono">{filePath}</div>
         )}
-        <Image
-          src={`data:${mimeType};base64,${base64}`}
-          alt={filePath || 'Image'}
-          width={dimensions.displayWidth}
-          height={dimensions.displayHeight}
-          unoptimized
-          sizes={`${dimensions.displayWidth}px`}
-          className="rounded max-w-full h-auto"
-        />
-        <div className="text-[10px] text-(--text-muted)">
-          {dimensions.originalWidth}x{dimensions.originalHeight}
-        </div>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setLightboxSrc(src); }}
+          className="block cursor-zoom-in rounded overflow-hidden border border-(--divider) hover:border-(--accent) transition-colors"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element -- dynamic local/remote src, dimensions unknown */}
+          <img
+            src={src}
+            alt={filePath || 'Image'}
+            className="max-w-full h-auto max-h-[400px] object-contain"
+          />
+        </button>
+        {result.dimensions && (
+          <div className="text-[10px] text-(--text-muted)">
+            {result.dimensions.originalWidth}x{result.dimensions.originalHeight}
+          </div>
+        )}
+        {lightboxSrc && (
+          <ImageLightbox src={lightboxSrc} alt={filePath} onClose={() => setLightboxSrc(null)} />
+        )}
       </div>
     );
   }

--- a/src/lib/cli/providers/claude-code/protocol-parser.ts
+++ b/src/lib/cli/providers/claude-code/protocol-parser.ts
@@ -25,6 +25,7 @@ import logger from '../../../logger';
 import type { ToolCallKind } from '@/types/tool-call-kind';
 import type { ToolDisplayMetadata } from '@/types/tool-display';
 import { normalizeToolResult } from '@/lib/tool-results/normalize-tool-result';
+import { buildImageToolResult, isImagePath } from '@/lib/tool-results/tool-image';
 import { buildToolDisplay } from '@/lib/tool-display';
 
 // =============================================================================
@@ -780,7 +781,16 @@ export class ClaudeCodeProtocolParser {
       outputLength: output?.length || 0,
     });
 
-    const syntheticToolUseResult = synthesizeClaudeToolResult(pendingTool.toolKind, pendingTool.toolParams, {
+    // Image reads (e.g. Read of a .png) arrive on stdout as image content blocks
+    // with no text output, so synthesis yields nothing renderable. Serve the file
+    // lazily instead of dropping the image.
+    const imageToolUseResult = !isError
+      && pendingTool.toolKind === 'file_read'
+      && isImagePath(pendingTool.toolParams?.file_path)
+      ? buildImageToolResult(sessionId, toolUseId)
+      : undefined;
+
+    const effectiveToolUseResult = imageToolUseResult ?? synthesizeClaudeToolResult(pendingTool.toolKind, pendingTool.toolParams, {
       output,
       error: isError ? output : undefined,
       isError,
@@ -803,7 +813,7 @@ export class ClaudeCodeProtocolParser {
         status: isError ? 'error' : 'completed',
         output: isError ? undefined : output,
         error: isError ? output : undefined,
-        ...(syntheticToolUseResult !== undefined ? { toolUseResult: syntheticToolUseResult } : {}),
+        ...(effectiveToolUseResult !== undefined ? { toolUseResult: effectiveToolUseResult } : {}),
         toolUseId,
         timestamp: new Date().toISOString(),
       },
@@ -844,6 +854,10 @@ export class ClaudeCodeProtocolParser {
         continue;
       }
 
+      const isImageRead = !toolResult.isError
+        && pendingTool.toolKind === 'file_read'
+        && isImagePath(pendingTool.toolParams?.file_path);
+
       const toolUseResult = rawToolUseResult
         ? normalizeToolResult(
             pendingTool.toolKind,
@@ -852,12 +866,14 @@ export class ClaudeCodeProtocolParser {
               toolName: pendingTool.toolName,
             }),
           )
-        : synthesizeClaudeToolResult(pendingTool.toolKind, pendingTool.toolParams, {
-            output: toolResult.output,
-            error: toolResult.isError ? toolResult.output : undefined,
-            isError: toolResult.isError,
-            previousTodos: this.lastTodoSnapshots.get(sessionId),
-          });
+        : isImageRead
+          ? buildImageToolResult(sessionId, toolResult.toolUseId)
+          : synthesizeClaudeToolResult(pendingTool.toolKind, pendingTool.toolParams, {
+              output: toolResult.output,
+              error: toolResult.isError ? toolResult.output : undefined,
+              isError: toolResult.isError,
+              previousTodos: this.lastTodoSnapshots.get(sessionId),
+            });
 
       sessionPending!.delete(toolResult.toolUseId);
 

--- a/src/lib/cli/providers/codex/protocol-parser.ts
+++ b/src/lib/cli/providers/codex/protocol-parser.ts
@@ -31,6 +31,7 @@ import { CODEX_THREAD_ID_RE } from '../../../validation/path';
 import logger from '../../../logger';
 import { inferToolCallKindFromToolName, type ToolCallKind } from '@/types/tool-call-kind';
 import type { CommandExecutionToolResult } from '@/types/tool-result';
+import { buildImageToolResult, isImagePath } from '@/lib/tool-results/tool-image';
 import type { AskUserQuestionItem, AskUserQuestionOption } from '@/types/cli-jsonl-schemas';
 import { buildCodexRateLimitSnapshot } from '@/lib/status-display/rate-limit-snapshots';
 import { buildToolDisplay } from '@/lib/tool-display';
@@ -2091,6 +2092,14 @@ export class CodexProtocolParser {
     const { toolName, toolParams } = this.buildGenericCodexItemMetadata(item);
     const output = status === 'running' ? undefined : this.buildGenericCodexItemOutput(item);
 
+    // `view_image` (imageView) injects a local file into context with no image
+    // bytes in the result — render it inline by serving the file at `path`.
+    const isImageView = toolParams.itemType === 'imageView' || toolName === 'ViewImage';
+    const toolKind: ToolCallKind | undefined = isImageView ? 'file_read' : undefined;
+    const imageToolUseResult = isImageView && status === 'completed' && itemId && isImagePath(toolParams.path)
+      ? buildImageToolResult(sessionId, itemId)
+      : undefined;
+
     logger.info('Codex: generic item mapped to tool_call', {
       sessionId,
       itemId,
@@ -2105,10 +2114,12 @@ export class CodexProtocolParser {
         sessionId,
         toolUseId: itemId,
         toolName,
+        ...(toolKind !== undefined ? { toolKind } : {}),
         toolParams,
         status,
         output: status === 'error' ? undefined : output,
         error: status === 'error' ? output || `${toolName} failed` : undefined,
+        ...(imageToolUseResult !== undefined ? { toolUseResult: imageToolUseResult } : {}),
         timestamp,
       },
       sideEffect: addPending

--- a/src/lib/session-history.ts
+++ b/src/lib/session-history.ts
@@ -394,6 +394,19 @@ class SessionHistoryStore {
     return null;
   }
 
+  /** Returns the recorded toolParams for a tool call, used to re-derive on-disk paths server-side. */
+  async readToolCallParams(sessionId: string, toolUseId: string): Promise<Record<string, any> | null> {
+    this.flushSession(sessionId);
+    const events = await this.readEvents(sessionId);
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i];
+      if (event.type === 'tool_call' && event.toolUseId === toolUseId) {
+        return event.toolParams ?? null;
+      }
+    }
+    return null;
+  }
+
   async readUsage(sessionId: string): Promise<PersistedUsage | null> {
     const replayState = await this.readReplayState(sessionId, { lazyToolOutput: true });
     return replayState.usage;

--- a/src/lib/tool-results/tool-image.ts
+++ b/src/lib/tool-results/tool-image.ts
@@ -1,0 +1,60 @@
+import type { FileReadImageToolResult } from '@/types/tool-result';
+
+/** File extensions the chat renders as an inline image. */
+const IMAGE_EXTENSIONS = new Set([
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'svg',
+  'bmp',
+  'avif',
+]);
+
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+  avif: 'image/avif',
+  bmp: 'image/bmp',
+  gif: 'image/gif',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+};
+
+function extensionOf(filePath: string): string {
+  const clean = filePath.split(/[?#]/, 1)[0];
+  const dot = clean.lastIndexOf('.');
+  if (dot < 0) return '';
+  return clean.slice(dot + 1).toLowerCase();
+}
+
+/** True when the path looks like an image we can render inline. */
+export function isImagePath(filePath: unknown): boolean {
+  if (typeof filePath !== 'string' || !filePath.trim()) return false;
+  return IMAGE_EXTENSIONS.has(extensionOf(filePath));
+}
+
+/** Best-effort image MIME type from a file path; undefined when not an image. */
+export function inferImageMime(filePath: string): string | undefined {
+  return IMAGE_MIME_BY_EXT[extensionOf(filePath)];
+}
+
+/**
+ * Same-origin endpoint that serves the image bytes for a tool call. The server
+ * re-derives the on-disk path from the session's recorded tool call (by
+ * `toolUseId`), so no client-supplied filesystem path is trusted.
+ */
+export function buildToolImageUrl(sessionId: string, toolUseId: string): string {
+  return `/api/sessions/${encodeURIComponent(sessionId)}/tool-image?toolUseId=${encodeURIComponent(toolUseId)}`;
+}
+
+/** Canonical image read result that renders by serving the file lazily. */
+export function buildImageToolResult(sessionId: string, toolUseId: string): FileReadImageToolResult {
+  return {
+    kind: 'file_read',
+    contentType: 'image',
+    url: buildToolImageUrl(sessionId, toolUseId),
+  };
+}

--- a/src/types/tool-result.ts
+++ b/src/types/tool-result.ts
@@ -24,10 +24,16 @@ export interface FileReadImageToolResult {
   kind: 'file_read';
   contentType: 'image';
   path?: string;
-  base64: string;
-  mimeType: string;
-  originalSize: number;
-  dimensions: {
+  /**
+   * Same-origin URL that serves the image bytes lazily (e.g. Codex `view_image`
+   * and live Claude Code image reads, where the tool result carries no base64).
+   * When present the renderer fetches the image instead of decoding `base64`.
+   */
+  url?: string;
+  base64?: string;
+  mimeType?: string;
+  originalSize?: number;
+  dimensions?: {
     originalWidth: number;
     originalHeight: number;
     displayWidth: number;

--- a/tests/tool-image-rendering.test.ts
+++ b/tests/tool-image-rendering.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildImageToolResult,
+  buildToolImageUrl,
+  inferImageMime,
+  isImagePath,
+} from '../src/lib/tool-results/tool-image';
+import { codexProtocolParser } from '../src/lib/cli/providers/codex/protocol-parser';
+import { claudeCodeProtocolParser } from '../src/lib/cli/providers/claude-code/protocol-parser';
+
+// --- helper ---
+
+test('isImagePath recognizes image extensions (and rejects others)', () => {
+  for (const p of ['/tmp/a.png', '/x/y.JPG', 'shot.jpeg', 'a.gif', 'b.webp', 'c.svg', 'd.bmp', 'e.avif']) {
+    assert.equal(isImagePath(p), true, p);
+  }
+  for (const p of ['/tmp/a.txt', '/x/y', 'README.md', '', 42, null, undefined]) {
+    assert.equal(isImagePath(p as unknown as string), false, String(p));
+  }
+});
+
+test('inferImageMime maps extensions', () => {
+  assert.equal(inferImageMime('/tmp/a.png'), 'image/png');
+  assert.equal(inferImageMime('a.JPG'), 'image/jpeg');
+  assert.equal(inferImageMime('a.txt'), undefined);
+});
+
+test('buildToolImageUrl / buildImageToolResult encode session + toolUseId', () => {
+  assert.equal(
+    buildToolImageUrl('sess 1', 'call/2'),
+    '/api/sessions/sess%201/tool-image?toolUseId=call%2F2',
+  );
+  assert.deepEqual(buildImageToolResult('s', 'call_x'), {
+    kind: 'file_read',
+    contentType: 'image',
+    url: '/api/sessions/s/tool-image?toolUseId=call_x',
+  });
+});
+
+// --- codex view_image (imageView) end-to-end through the parser ---
+
+test('Codex imageView maps to a file_read tool call with an inline image result', () => {
+  const sid = 'codex-img-1';
+  const parsed = codexProtocolParser.parseStdout(
+    sid,
+    JSON.stringify({
+      method: 'item/completed',
+      params: {
+        item: { type: 'imageView', id: 'call_img1', path: '/tmp/shot.png', status: 'completed' },
+      },
+    }),
+  );
+
+  const toolCall = parsed
+    .map((p) => p.serverMessage)
+    .find((m) => m && (m as any).type === 'tool_call' && (m as any).toolUseId === 'call_img1') as any;
+
+  assert.ok(toolCall, 'expected a tool_call server message for the imageView item');
+  assert.equal(toolCall.toolName, 'ViewImage');
+  assert.equal(toolCall.toolKind, 'file_read');
+  assert.deepEqual(toolCall.toolUseResult, {
+    kind: 'file_read',
+    contentType: 'image',
+    url: `/api/sessions/${sid}/tool-image?toolUseId=call_img1`,
+  });
+});
+
+test('Codex imageView with a non-image path does not fabricate an image result', () => {
+  const sid = 'codex-img-2';
+  const parsed = codexProtocolParser.parseStdout(
+    sid,
+    JSON.stringify({
+      method: 'item/completed',
+      params: {
+        item: { type: 'imageView', id: 'call_txt1', path: '/tmp/notes.txt', status: 'completed' },
+      },
+    }),
+  );
+  const toolCall = parsed
+    .map((p) => p.serverMessage)
+    .find((m) => m && (m as any).type === 'tool_call' && (m as any).toolUseId === 'call_txt1') as any;
+
+  assert.ok(toolCall, 'expected a tool_call server message');
+  assert.equal(toolCall.toolUseResult, undefined);
+});
+
+// --- claude code Read of an image through the live tool_result path ---
+
+function lastToolCall(parsed: ReturnType<typeof claudeCodeProtocolParser.parseStdout>, toolUseId: string) {
+  return parsed
+    .map((p) => p.serverMessage)
+    .find((m) => m && (m as any).type === 'tool_call' && (m as any).toolUseId === toolUseId) as any;
+}
+
+test('Claude Code image Read emits an inline image result instead of empty text', () => {
+  const sid = 'claude-img-1';
+  // Register the pending Read tool call.
+  claudeCodeProtocolParser.parseStdout(
+    sid,
+    JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', id: 'toolu_img', name: 'Read', input: { file_path: '/tmp/a.png' } }] },
+    }),
+  );
+  // Image reads arrive as image content blocks with no text output.
+  const parsed = claudeCodeProtocolParser.parseStdout(
+    sid,
+    JSON.stringify({
+      type: 'tool_result',
+      tool_use_id: 'toolu_img',
+      message: {
+        is_error: false,
+        content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } }],
+      },
+    }),
+  );
+
+  const toolCall = lastToolCall(parsed, 'toolu_img');
+  assert.ok(toolCall, 'expected a tool_call server message for the image Read');
+  assert.equal(toolCall.toolKind, 'file_read');
+  assert.deepEqual(toolCall.toolUseResult, {
+    kind: 'file_read',
+    contentType: 'image',
+    url: `/api/sessions/${sid}/tool-image?toolUseId=toolu_img`,
+  });
+});
+
+test('Claude Code text Read is unaffected (no image result)', () => {
+  const sid = 'claude-img-2';
+  claudeCodeProtocolParser.parseStdout(
+    sid,
+    JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', id: 'toolu_txt', name: 'Read', input: { file_path: '/tmp/a.ts' } }] },
+    }),
+  );
+  const parsed = claudeCodeProtocolParser.parseStdout(
+    sid,
+    JSON.stringify({
+      type: 'tool_result',
+      tool_use_id: 'toolu_txt',
+      message: { is_error: false, content: [{ type: 'text', text: 'const x = 1;' }] },
+    }),
+  );
+
+  const toolCall = lastToolCall(parsed, 'toolu_txt');
+  assert.ok(toolCall, 'expected a tool_call server message');
+  assert.notEqual(toolCall.toolUseResult?.contentType, 'image');
+});


### PR DESCRIPTION
## What

Image-producing tool calls now render as **inline thumbnails in the chat** (click to enlarge), instead of an opaque tool-call row that hid the image:
- **Codex** `view_image` (`imageView`)
- **Claude Code** `Read` of an image file

## Why

Previously the live parser discarded the image (Claude image reads synthesized to empty text; Codex `view_image` mapped to a generic tool row), so neither rendered.

## How

- `claude-code` / `codex` protocol parsers tag image reads as `file_read` results carrying a served URL (built from `sessionId` + `toolUseId`).
- New `GET /api/sessions/[id]/tool-image?toolUseId=…` route serves the image bytes, re-deriving the on-disk path **server-side** from the recorded tool call (no client-supplied filesystem path is trusted; image MIME + 25MB cap).
- `ToolCallGrid` renders image tool calls as inline thumbnails + `ImageLightbox`; `ReadResult` / normalizer support the url-based image result.

## Verification

- tsc 0 errors, eslint clean, `tests/tool-image-rendering.test.ts` 7/7 (drives both real parsers).
- Manually verified in a **real Claude Code session** (real `claude` CLI spawned, real `toolu_…` id) and a Codex `view_image` flow: image renders inline + click-to-enlarge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)