### PR TITLE
fix(chat): open local file-path links on the host instead of the browser

### DIFF
--- a/src/components/chat/markdown-link.tsx
+++ b/src/components/chat/markdown-link.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { MouseEvent, ReactNode } from "react";
+import {
+  openFilePathOnHost,
+  parseLocalFileHref,
+} from "@/lib/workspace-tabs/file-path-actions";
+
+/**
+ * Anchor renderer shared by the chat markdown surfaces. Web URLs open in the
+ * system browser as before; links that point at a local filesystem path are
+ * opened on the host (the default app via Electron's shell) instead of being
+ * treated as a navigation, which would otherwise resolve against the app
+ * origin and load a broken `http://localhost/<path>` page.
+ */
+export function MarkdownLink({
+  href,
+  className,
+  children,
+}: {
+  href?: string;
+  className?: string;
+  children?: ReactNode;
+}) {
+  const filePath = parseLocalFileHref(href);
+
+  if (filePath) {
+    const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      openFilePathOnHost(filePath);
+    };
+    return (
+      <a
+        href={href}
+        onClick={handleClick}
+        className={className}
+        title={filePath}
+        data-file-link="true"
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+      {children}
+    </a>
+  );
+}

--- a/src/components/chat/message-bubble-content.tsx
+++ b/src/components/chat/message-bubble-content.tsx
@@ -31,6 +31,7 @@ import {
 import { ImageLightbox } from './image-lightbox';
 import { ProviderLogoMark, getProviderBrand } from './provider-brand';
 import { renderMarkdownCode, renderMarkdownPre } from './markdown-code';
+import { MarkdownLink } from './markdown-link';
 import { MessageRowShell } from './message-row-shell';
 
 type TextMessage = Extract<EnhancedMessage, { type: 'text' }>;
@@ -131,14 +132,9 @@ const MARKDOWN_COMPONENTS: Components = {
   },
   a({ href, children }) {
     return (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-(--accent-light) hover:underline"
-      >
+      <MarkdownLink href={href} className="text-(--accent-light) hover:underline">
         {children}
-      </a>
+      </MarkdownLink>
     );
   },
   strong({ children }) {

--- a/src/components/chat/preview-markdown.tsx
+++ b/src/components/chat/preview-markdown.tsx
@@ -10,6 +10,7 @@ import type { Schema } from 'hast-util-sanitize';
 import remarkGfm from 'remark-gfm';
 import type { PluggableList } from 'unified';
 import { renderMarkdownCode, renderMarkdownPre } from './markdown-code';
+import { MarkdownLink } from './markdown-link';
 
 const PREVIEW_MARKDOWN_REMARK_PLUGINS: PluggableList = [[remarkGfm, { singleTilde: false }]];
 type PreviewMarkdownCodeProps = ComponentProps<'code'> & { node?: unknown };
@@ -114,14 +115,12 @@ const BASE_PREVIEW_MARKDOWN_COMPONENTS: Components = {
   },
   a({ href, children }) {
     return (
-      <a
+      <MarkdownLink
         href={href}
-        target="_blank"
-        rel="noopener noreferrer"
         className="font-medium text-(--accent-light) underline-offset-2 hover:underline"
       >
         {children}
-      </a>
+      </MarkdownLink>
     );
   },
   strong({ children }) {

--- a/src/lib/workspace-tabs/file-path-actions.ts
+++ b/src/lib/workspace-tabs/file-path-actions.ts
@@ -30,6 +30,42 @@ export function toAbsoluteWorkspacePath(
     : `${trimmedBase}${separator}${normalizedRelativePath}`;
 }
 
+const WINDOWS_ABSOLUTE_PATH = /^[A-Za-z]:[\\/]/;
+
+/**
+ * Detects whether a markdown link href points at a local file on the host
+ * filesystem (rather than a web URL, mail/tel link, or in-page anchor) and
+ * returns the normalized filesystem path. Returns null for anything that is
+ * not an openable local path.
+ *
+ * Recognizes: `file://` URLs (incl. `file:///C:/...`), Windows absolute paths
+ * (`C:\...` / `C:/...`), and POSIX absolute paths (`/...`, excluding
+ * protocol-relative `//host`). Web schemes, relative paths, and `#anchors`
+ * are intentionally left as normal links.
+ */
+export function parseLocalFileHref(href: string | null | undefined): string | null {
+  if (!href) return null;
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+
+  if (/^file:\/\//i.test(trimmed)) {
+    try {
+      const decoded = decodeURIComponent(new URL(trimmed).pathname);
+      // `file:///C:/path` decodes to `/C:/path`; drop the leading slash so the
+      // OS receives a valid drive path.
+      return (/^\/[A-Za-z]:/.test(decoded) ? decoded.slice(1) : decoded) || null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (WINDOWS_ABSOLUTE_PATH.test(trimmed)) return trimmed;
+
+  if (trimmed.startsWith("/") && !trimmed.startsWith("//")) return trimmed;
+
+  return null;
+}
+
 export function getElectronPlatform(): string | null {
   const electronApi = getElectronFileApi();
   return electronApi?.isElectron ? (electronApi.platform ?? null) : null;

--- a/tests/markdown-file-link.test.ts
+++ b/tests/markdown-file-link.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseLocalFileHref } from '../src/lib/workspace-tabs/file-path-actions';
+
+test('treats POSIX absolute paths as local files', () => {
+  assert.equal(parseLocalFileHref('/Users/rs/source/foxden/doc.md'), '/Users/rs/source/foxden/doc.md');
+  assert.equal(parseLocalFileHref('/tmp/output.html'), '/tmp/output.html');
+});
+
+test('treats Windows absolute paths as local files', () => {
+  assert.equal(parseLocalFileHref('C:\\Users\\rs\\doc.md'), 'C:\\Users\\rs\\doc.md');
+  assert.equal(parseLocalFileHref('D:/projects/app/file.ts'), 'D:/projects/app/file.ts');
+});
+
+test('decodes file:// URLs into filesystem paths', () => {
+  assert.equal(parseLocalFileHref('file:///Users/rs/a%20b.md'), '/Users/rs/a b.md');
+  // Windows file URL keeps the drive letter, drops the spurious leading slash.
+  assert.equal(parseLocalFileHref('file:///C:/Users/rs/doc.md'), 'C:/Users/rs/doc.md');
+});
+
+test('leaves web URLs and non-file links as normal links', () => {
+  assert.equal(parseLocalFileHref('https://example.com/path'), null);
+  assert.equal(parseLocalFileHref('http://localhost:4173/foo'), null);
+  assert.equal(parseLocalFileHref('mailto:a@b.com'), null);
+  assert.equal(parseLocalFileHref('#section'), null);
+  assert.equal(parseLocalFileHref('//cdn.example.com/x.js'), null); // protocol-relative
+  assert.equal(parseLocalFileHref('./relative/path.md'), null);
+  assert.equal(parseLocalFileHref('relative/path.md'), null);
+});
+
+test('handles empty and missing hrefs', () => {
+  assert.equal(parseLocalFileHref(undefined), null);
+  assert.equal(parseLocalFileHref(null), null);
+  assert.equal(parseLocalFileHref(''), null);
+  assert.equal(parseLocalFileHref('   '), null);
+});


### PR DESCRIPTION
## 문제
채팅 마크다운에서 href가 로컬 파일 경로인 링크(예: `[문서](/Users/rs/...절대경로)`)가 `target="_blank"` 앵커로 렌더돼서, 클릭하면 `http://localhost/<path>`로 이동 → 브라우저로 떠서 파일이 안 열렸습니다.

## 변경
- `parseLocalFileHref(href)` 추가 — POSIX 절대경로 / 윈도우 드라이브 경로 / `file://` URL을 파일 경로로 판별 (http·mailto·앵커·상대경로는 일반 링크 유지).
- 공유 컴포넌트 `MarkdownLink` 추가 — 파일 경로면 클릭 시 `openFilePathOnHost`(`shell.openPath`)로 OS 기본 앱에서 열고, 그 외에는 기존 `target="_blank"` 동작 유지.
- 채팅(`message-bubble-content`)·프리뷰(`preview-markdown`) 두 렌더러의 `a()`를 `MarkdownLink`로 교체.

## 검증
- 단위 테스트 추가 (`parseLocalFileHref` 5 케이스) — 통과
- `tsc --noEmit` 0 에러, `eslint` 0 에러
- 실제 Electron 앱에서 POSIX 절대경로 링크 클릭 → `shell.openPath` 호출·파일 열림 확인. http/anchor 링크는 가로채지 않음(회귀 없음).

## 알려진 제약
- 윈도우 절대경로(`C:\...`)·`file://` 링크는 react-markdown의 `urlTransform`이 스킴을 제거해 채팅에서 아직 안 열림. macOS/Linux의 POSIX 절대경로는 정상. (후속으로 커스텀 `urlTransform` 추가 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)