### PR TITLE
fix(chat): translation UX — action-row placement, defer-on-stream, settings caret

### DIFF
--- a/src/components/chat/agent-message-group.tsx
+++ b/src/components/chat/agent-message-group.tsx
@@ -1,18 +1,21 @@
 'use client';
 
 import { memo, useCallback, useState } from 'react';
-import { Check, Copy, MessageSquarePlus } from 'lucide-react';
-import type { AgentMessageGroup as AgentMessageGroupModel, AgentSubGroup } from '@/lib/chat/group-messages';
+import { Check, Copy, Languages, MessageSquarePlus } from 'lucide-react';
+import type { AgentMessageGroup as AgentMessageGroupModel, AgentSubGroup, AssistantTextMessage } from '@/lib/chat/group-messages';
 import type { TextMessage, ToolCallMessage } from '@/types/chat';
 import type { AgentProgressData, McpProgressData } from '@/types/cli-jsonl-schemas';
 import { Tooltip } from '@/components/ui/tooltip';
 import { useI18n } from '@/lib/i18n';
+import { useChatStore } from '@/stores/chat-store';
+import { useSessionStore } from '@/stores/session-store';
+import { wsClient } from '@/lib/ws/client';
 import { ProviderLogoMark, getProviderBrand } from './provider-brand';
 import { ThinkingBlock } from './thinking-block';
 import { AgentProgress } from './progress/agent-progress';
 import { McpProgress } from './progress/mcp-progress';
 import { ToolCallGrid } from './tool-call-grid';
-import { AssistantTextBody, MessageTranslateButton, extractAssistantText, type ForkFromMessageHandler } from './message-bubble-content';
+import { AssistantTextBody, extractAssistantText, type ForkFromMessageHandler } from './message-bubble-content';
 import { MessageRowShell } from './message-row-shell';
 
 function formatMessageTime(timestamp: string) {
@@ -53,6 +56,9 @@ interface AgentSubGroupViewProps {
   onForkFromMessage?: ForkFromMessageHandler;
 }
 
+const MESSAGE_ACTIONS_CLASS =
+  'ml-auto inline-flex shrink-0 items-center gap-1 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto';
+
 const MESSAGE_ACTION_BUTTON_CLASS =
   'inline-flex h-5 shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded px-1.5 text-[10px] text-(--text-muted) transition-colors hover:bg-(--sidebar-hover) hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--accent)';
 
@@ -60,63 +66,67 @@ const MESSAGE_COPY_BUTTON_CLASS = `${MESSAGE_ACTION_BUTTON_CLASS} w-[4.75rem]`;
 const MESSAGE_FORK_BUTTON_CLASS = `${MESSAGE_ACTION_BUTTON_CLASS} w-[6.25rem]`;
 
 /**
- * One assistant text bubble in a group, with its OWN hover action row
- * (Copy · Translate · From here). Per-bubble so every message — including the
- * intermediate ones before tool calls — is individually copyable/translatable/forkable.
+ * Translate button for the subgroup header action row. Operates on EVERY assistant
+ * text bubble in the subgroup (the intermediate ones before tool calls and the final
+ * answer alike), so a single click translates the whole agent turn. Requests are
+ * auto-deferred while the turn is still streaming (see wsClient.translateMessage).
  */
-function GroupedAssistantText({
-  message,
-  onForkFromMessage,
+function SubgroupTranslateButton({
+  messages,
 }: {
-  message: TextMessage;
-  onForkFromMessage?: ForkFromMessageHandler;
+  messages: TextMessage[];
 }) {
   const { t } = useI18n();
-  const [copied, setCopied] = useState(false);
+  const activeSessionId = useSessionStore((state) => state.activeSessionId);
+  const overrides = useChatStore((state) => state.messageViewOverride);
+  const setMessageViewOverride = useChatStore((state) => state.setMessageViewOverride);
 
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(extractAssistantText(message.content));
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy:', err);
+  const hasAnyTranslation = messages.some(
+    (m) => typeof m.translatedContent === 'string' && m.translatedContent.length > 0,
+  );
+  const isAnyPending = messages.some((m) => m.translationStatus === 'pending');
+  // "Showing translation" if any already-translated bubble is currently in translation
+  // view (assistant bubbles default to 'translation').
+  const showingTranslation = messages.some((m) => {
+    const hasTranslation = typeof m.translatedContent === 'string' && m.translatedContent.length > 0;
+    return hasTranslation && (overrides.get(m.id) ?? 'translation') === 'translation';
+  });
+
+  const handleClick = useCallback(() => {
+    const sid = activeSessionId ?? '';
+    if (hasAnyTranslation) {
+      const next = showingTranslation ? 'original' : 'translation';
+      for (const m of messages) {
+        setMessageViewOverride(m.id, next);
+      }
+      return;
     }
-  }, [message.content]);
+    // No translation yet → request one for every text bubble and reveal it on arrival.
+    for (const m of messages) {
+      setMessageViewOverride(m.id, 'translation');
+      const already = typeof m.translatedContent === 'string' && m.translatedContent.length > 0;
+      if (!already && sid) wsClient.translateMessage(sid, m.id);
+    }
+  }, [activeSessionId, hasAnyTranslation, showingTranslation, messages, setMessageViewOverride]);
+
+  const label = isAnyPending
+    ? t('chat.translating')
+    : hasAnyTranslation
+      ? (showingTranslation ? t('chat.showOriginal') : t('chat.showTranslation'))
+      : t('chat.translate');
 
   return (
-    <div className="group/bubble relative">
-      <div className="absolute right-0 -top-3 z-10 opacity-0 transition-opacity group-hover/bubble:opacity-100">
-        <div className="inline-flex items-center gap-1 rounded-md bg-(--chat-bg) px-1 py-0.5 shadow-sm">
-          <button type="button" onClick={handleCopy} className={MESSAGE_COPY_BUTTON_CLASS}>
-            {copied ? (
-              <>
-                <Check className="w-3 h-3" />
-                <span>{t('chat.copied')}</span>
-              </>
-            ) : (
-              <>
-                <Copy className="w-3 h-3" />
-                <span>{t('chat.copy')}</span>
-              </>
-            )}
-          </button>
-          <MessageTranslateButton message={message} />
-          {onForkFromMessage && (
-            <button
-              type="button"
-              onClick={(event) => onForkFromMessage(message, event.currentTarget)}
-              className={MESSAGE_FORK_BUTTON_CLASS}
-              title={t('chat.forkFromHereTooltip')}
-            >
-              <MessageSquarePlus className="w-3 h-3" />
-              <span>{t('chat.forkFromHere')}</span>
-            </button>
-          )}
-        </div>
-      </div>
-      <AssistantTextBody message={message} />
-    </div>
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isAnyPending}
+      data-testid="message-translate-btn"
+      className={MESSAGE_FORK_BUTTON_CLASS}
+      title={t('chat.translate')}
+    >
+      <Languages className="w-3 h-3" />
+      <span>{label}</span>
+    </button>
   );
 }
 
@@ -131,6 +141,32 @@ function AgentSubGroupView({
   const { t } = useI18n();
   const providerBrand = getProviderBrand(providerId);
   const timestamp = subgroup.messages[0]?.timestamp ?? new Date().toISOString();
+  const [copied, setCopied] = useState(false);
+
+  const textMessages = subgroup.items
+    .filter(
+      (item): item is { kind: 'message'; message: AssistantTextMessage } =>
+        item.kind === 'message' && item.message.type === 'text',
+    )
+    .map((item) => item.message);
+
+  const combinedText = textMessages
+    .map((message) => extractAssistantText(message.content))
+    .filter(Boolean)
+    .join('\n\n');
+
+  const handleCopy = useCallback(async () => {
+    if (!combinedText) return;
+    try {
+      await navigator.clipboard.writeText(combinedText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  }, [combinedText]);
+
+  const forkTargetMessage = subgroup.messages[subgroup.messages.length - 1];
 
   return (
     <MessageRowShell
@@ -158,6 +194,39 @@ function AgentSubGroupView({
               {formatMessageTime(timestamp)}
             </span>
           </Tooltip>
+          {combinedText && (
+            <div className={MESSAGE_ACTIONS_CLASS}>
+              <button
+                type="button"
+                onClick={handleCopy}
+                className={MESSAGE_COPY_BUTTON_CLASS}
+              >
+                {copied ? (
+                  <>
+                    <Check className="w-3 h-3" />
+                    <span>{t('chat.copied')}</span>
+                  </>
+                ) : (
+                  <>
+                    <Copy className="w-3 h-3" />
+                    <span>{t('chat.copy')}</span>
+                  </>
+                )}
+              </button>
+              <SubgroupTranslateButton messages={textMessages} />
+              {onForkFromMessage && forkTargetMessage && (
+                <button
+                  type="button"
+                  onClick={(event) => onForkFromMessage(forkTargetMessage, event.currentTarget)}
+                  className={MESSAGE_FORK_BUTTON_CLASS}
+                  title={t('chat.forkFromHereTooltip')}
+                >
+                  <MessageSquarePlus className="w-3 h-3" />
+                  <span>{t('chat.forkFromHere')}</span>
+                </button>
+              )}
+            </div>
+          )}
         </div>
 
         <div className="max-w-2xl">
@@ -187,10 +256,9 @@ function AgentSubGroupView({
 
             if (message.type === 'text') {
               return (
-                <GroupedAssistantText
+                <AssistantTextBody
                   key={message.id}
                   message={message}
-                  onForkFromMessage={onForkFromMessage}
                 />
               );
             }

--- a/src/components/settings/translate-settings.tsx
+++ b/src/components/settings/translate-settings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSettingsStore } from '@/stores/settings-store';
 import { useI18n } from '@/lib/i18n';
 import { useProviderSessionOptions } from '@/hooks/use-provider-session-options';
@@ -47,6 +47,69 @@ function Toggle({ checked, onChange }: { checked: boolean; onChange: (next: bool
         }`}
       />
     </button>
+  );
+}
+
+const PROMPT_COMMIT_DEBOUNCE_MS = 500;
+
+/**
+ * Prompt editor backed by local state.
+ *
+ * Two things used to throw the caret to the end mid-edit: (1) every keystroke wrote
+ * straight back into the async settings store, whose snapshot re-rendered the
+ * controlled <textarea> with a fresh value; and (2) the store also persists to the
+ * server on every change — fast typing raced those writes into a 500, after which
+ * `updateSettings` rolled the in-memory settings back, reverting the text.
+ *
+ * Fix: while the field is focused, `local` is authoritative — no async store update
+ * (echo, rollback, snapshot) can touch it — and we only push to the store on a debounce
+ * and on blur, so the per-keystroke save storm is gone. External changes (Reset, initial
+ * load, other tabs) are adopted during render, but only while not editing.
+ */
+function PromptTextarea({ value, onChange }: { value: string; onChange: (next: string) => void }) {
+  const [local, setLocal] = useState(value);
+  const [editing, setEditing] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  if (!editing && value !== local) {
+    setLocal(value);
+  }
+
+  useEffect(() => () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+  }, []);
+
+  const scheduleCommit = (next: string) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      onChange(next);
+    }, PROMPT_COMMIT_DEBOUNCE_MS);
+  };
+
+  const flushCommit = (next: string) => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    onChange(next);
+  };
+
+  return (
+    <textarea
+      value={local}
+      onFocus={() => setEditing(true)}
+      onChange={(e) => {
+        setLocal(e.target.value);
+        scheduleCommit(e.target.value);
+      }}
+      onBlur={(e) => {
+        flushCommit(e.target.value);
+        setEditing(false);
+      }}
+      rows={10}
+      className={TEXTAREA_CLASS}
+    />
   );
 }
 
@@ -164,11 +227,9 @@ function TranslateDirectionSettings({
             {t('settings.translate.promptReset')}
           </button>
         </div>
-        <textarea
+        <PromptTextarea
           value={value.promptTemplate || DEFAULT_TRANSLATE_PROMPT_TEMPLATE}
-          onChange={(e) => onChangePrompt(e.target.value)}
-          rows={10}
-          className={TEXTAREA_CLASS}
+          onChange={onChangePrompt}
         />
         <p className="text-[11px] text-(--text-tertiary)">{t('settings.translate.promptHint')}</p>
       </div>

--- a/src/components/theme-initializer.tsx
+++ b/src/components/theme-initializer.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import {
   SETTINGS_STORAGE_KEY,
   SETTINGS_SYNC_CHANNEL,
+  SETTINGS_SYNC_SENDER_ID,
   isSettingsSyncMessage,
   useSettingsStore,
 } from '@/stores/settings-store';
@@ -53,6 +54,9 @@ export default function ThemeInitializer() {
 
     function handleSettingsBroadcast(event: MessageEvent<unknown>) {
       if (!isSettingsSyncMessage(event.data)) return;
+      // Ignore our own broadcast — a same-window sibling BroadcastChannel still
+      // delivers it, and re-applying it mid-edit resets focused settings fields.
+      if (event.data.senderId === SETTINGS_SYNC_SENDER_ID) return;
       applyExternalSettings(event.data.settings);
     }
 

--- a/src/lib/chat/session-client-effects.ts
+++ b/src/lib/chat/session-client-effects.ts
@@ -43,6 +43,18 @@ export function finalizeInFlightTurn(sessionId: string, options: { clearPrompt?:
   stopTurnInFlight(sessionId);
   chatStore.flushAndClearAssistantText(sessionId);
 
+  // Streaming is done: fire any translate requests that were deferred while the
+  // turn was in flight (now the messages are fully streamed and persisted).
+  // turn-in-flight is already false above, so translateMessage sends immediately.
+  const queuedTranslations = chatStore.drainTranslateQueue(sessionId);
+  if (queuedTranslations.length > 0) {
+    void import('@/lib/ws/client').then(({ wsClient }) => {
+      for (const messageId of queuedTranslations) {
+        wsClient.translateMessage(sessionId, messageId);
+      }
+    });
+  }
+
   if (options.clearPrompt) {
     clearInteractivePromptState(sessionId);
   }

--- a/src/lib/ws/client.ts
+++ b/src/lib/ws/client.ts
@@ -10,7 +10,7 @@ import type { CliStatusEntry } from '@/lib/cli/connection-checker';
 import type { ProviderRuntimeControls } from '@/lib/session/session-control-types';
 import type { SessionGoalUpdate } from '@/types/session-goal';
 import { v4 as uuidv4 } from 'uuid';
-import { useChatStore } from '@/stores/chat-store';
+import { useChatStore, isTurnInFlight } from '@/stores/chat-store';
 import { useProvidersStore } from '@/stores/providers-store';
 import { useSettingsStore } from '@/stores/settings-store';
 import {
@@ -165,6 +165,15 @@ export class WebSocketClient {
 
   /** Request on-demand translation of a specific assistant message. */
   translateMessage(sessionId: string, messageId: string) {
+    const chat = useChatStore.getState();
+    // If the turn is still streaming, the message text isn't final (nor persisted
+    // server-side) yet. Queue the request and show a "translating…" hint; the turn
+    // finalizer drains the queue once streaming completes (session-client-effects).
+    if (isTurnInFlight(chat, sessionId)) {
+      chat.enqueueTranslateOnStreamEnd(sessionId, messageId);
+      chat.attachMessageTranslation(sessionId, messageId, { translationStatus: 'pending' });
+      return;
+    }
     if (!this.sendRequest('translate_message', { sessionId, messageId })) {
       console.error('WebSocket not connected');
     }

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -154,6 +154,12 @@ export interface ChatState {
   // session-wide translationView for that one message (set by the per-message button).
   messageViewOverride: Map<string, 'original' | 'translation'>;
 
+  // Translate requests deferred until the turn finishes streaming, keyed by
+  // session → set of messageIds. Pressing "translate" while a message is still
+  // streaming would otherwise translate the partial text; we queue and fire once
+  // the turn completes (the message is then fully streamed and persisted).
+  translateQueue: Map<string, Set<string>>;
+
   // Actions
   isHistoryLoaded: (sessionId: string) => boolean;
   setDraftInput: (sessionId: string, text: string) => void;
@@ -162,6 +168,8 @@ export interface ChatState {
   setTranslationView: (sessionId: string, view: 'original' | 'translation') => void;
   toggleTranslationView: (sessionId: string) => void;
   setMessageViewOverride: (messageId: string, view: 'original' | 'translation') => void;
+  enqueueTranslateOnStreamEnd: (sessionId: string, messageId: string) => void;
+  drainTranslateQueue: (sessionId: string) => string[];
   setScrollPosition: (sessionId: string, position: number | ScrollPositionSnapshot) => void;
   getScrollPosition: (sessionId: string) => ScrollPositionSnapshot | undefined;
   setActiveInteractivePrompt: (sessionId: string, prompt: ActiveInteractivePrompt | null) => void;
@@ -292,6 +300,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   draftInputs: new Map(),
   translationView: new Map(),
   messageViewOverride: new Map(),
+  translateQueue: new Map(),
   scrollPositions: new Map(),
 
   isHistoryLoaded: (sessionId) => get().historyLoaded.has(sessionId),
@@ -329,6 +338,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
       updated.set(messageId, view);
       return { messageViewOverride: updated };
     }),
+
+  enqueueTranslateOnStreamEnd: (sessionId, messageId) =>
+    set((state) => {
+      const updated = new Map(state.translateQueue);
+      const ids = new Set(updated.get(sessionId) ?? []);
+      ids.add(messageId);
+      updated.set(sessionId, ids);
+      return { translateQueue: updated };
+    }),
+
+  drainTranslateQueue: (sessionId) => {
+    const ids = get().translateQueue.get(sessionId);
+    if (!ids || ids.size === 0) return [];
+    set((state) => {
+      const updated = new Map(state.translateQueue);
+      updated.delete(sessionId);
+      return { translateQueue: updated };
+    });
+    return [...ids];
+  },
 
   setScrollPosition: (sessionId, position) =>
     set((state) => {
@@ -689,9 +718,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const clearedScrollPositions = new Map(state.scrollPositions);
       clearedScrollPositions.delete(sessionId);
 
+      const clearedTranslateQueue = new Map(state.translateQueue);
+      clearedTranslateQueue.delete(sessionId);
+
       return {
         messages: updatedMessages,
         historyLoaded: clearedHistoryLoaded,
+        translateQueue: clearedTranslateQueue,
         assistantTextBuffers: clearedBuffers,
         assistantTextFlushTimers: clearedTimers,
         activeAssistantTextBySession: updateActiveAssistantTextMap(

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -92,7 +92,21 @@ function syncI18nLanguage(language: UserSettings['language']): void {
 interface SettingsSyncMessage {
   type: 'settings-updated';
   settings: UserSettings;
+  /** Identifies the originating tab so it can ignore its own broadcast (see below). */
+  senderId: string;
 }
+
+/**
+ * Unique per-tab id. Two BroadcastChannel objects in the SAME window still receive
+ * each other's messages (only the exact sender object is excluded), so without this
+ * a tab would re-apply its own settings snapshot asynchronously — replacing the
+ * settings object mid-edit and resetting the caret in any focused settings field.
+ * Receivers drop messages carrying this id; cross-tab sync (different id) still works.
+ */
+export const SETTINGS_SYNC_SENDER_ID =
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
 
 let settingsSyncChannel: BroadcastChannel | null = null;
 
@@ -109,6 +123,7 @@ function broadcastSettingsSnapshot(settings: UserSettings): void {
     getSettingsSyncChannel()?.postMessage({
       type: 'settings-updated',
       settings,
+      senderId: SETTINGS_SYNC_SENDER_ID,
     } satisfies SettingsSyncMessage);
   } catch {
     // Best effort only. Other windows can still pick up persisted settings.
@@ -120,7 +135,8 @@ export function isSettingsSyncMessage(message: unknown): message is SettingsSync
   const value = message as Partial<SettingsSyncMessage>;
   return value.type === 'settings-updated'
     && Boolean(value.settings)
-    && typeof value.settings === 'object';
+    && typeof value.settings === 'object'
+    && typeof value.senderId === 'string';
 }
 
 interface SettingsState {


### PR DESCRIPTION
Follow-up fixes to the KO↔EN translation layer, all reported during live testing.

## 1. Action buttons back in their original position
The per-bubble action row had become a floating box (`absolute -top-3 right-0`) that overlapped message content. Restored the original right-aligned **Copy · Translate · From here** row in the subgroup header. The Translate button now operates on **every** assistant text bubble in the turn (intermediate answers + final), so one click translates the whole turn.

## 2. Translate waits for streaming to finish
Pressing Translate mid-stream translated the partial text (and the server reads the message from persisted history, which only exists after the turn ends). `wsClient.translateMessage` now queues the request while the turn is in flight and `finalizeInFlightTurn` drains the queue once streaming completes — so the full final text is translated.

## 3. Translation-prompt textarea caret no longer jumps to the end
Two root causes, both fixed:
- **Same-window settings echo** — `settings-store` posted on one `BroadcastChannel` while `theme-initializer` listened on a sibling channel with the same name; same-window siblings still receive each other's messages, so the tab re-applied its own snapshot async mid-edit. Broadcasts now carry a per-tab sender id and receivers ignore their own.
- **Per-keystroke save storm** — a full `PUT /api/settings` fired on every keystroke; fast typing raced the atomic temp-file writes into 500s, after which `updateSettings` rolled settings back and reverted the text. The prompt field is now local-state authoritative while focused and only commits on debounce (500ms) / blur.

## Verification
- `tsc --noEmit` ✓ · `eslint` ✓ · translation reducer tests (6/6) ✓ · `next build` ✓
- Playwright against a live server: 0-delay 20-char burst typed into the middle of the prompt → caret stayed exactly at +20, text inserted at the caret, **0 save errors**. Action-row position confirmed via screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)