### PR TITLE
chore(release): bump version to 0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@horang-labs/tessera",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@horang-labs/tessera",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@horang-labs/tessera",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Open-source web and desktop workspace for AI coding agents",
   "private": false,
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- bump package version from 0.1.7 to 0.1.8
- update package-lock metadata for the release

## Validation
- `npm run server:compile`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`
