### PR TITLE
Release v0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@horang-labs/tessera",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@horang-labs/tessera",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@horang-labs/tessera",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Open-source web and desktop workspace for AI coding agents",
   "private": false,
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- merge dev into main for v0.1.8
- includes package version bump to 0.1.8

## Merge requirement
Use a merge commit, not squash, so dev/main history stays aligned.

## Validation
- `npm run server:compile`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`
