### PR TITLE
Stop building Linux AppImage

### DIFF
--- a/.github/workflows/desktop-preflight.yml
+++ b/.github/workflows/desktop-preflight.yml
@@ -200,66 +200,18 @@ jobs:
         run: |
           set -euo pipefail
           version="$(node -p "require('./package.json').version")"
-          appimage="release/Tessera-${version}.AppImage"
           deb="release/Tessera-${version}-linux-amd64.deb"
 
-          test -f "$appimage"
           test -f "$deb"
-          file "$appimage" "$deb"
+          file "$deb"
           dpkg-deb --info "$deb"
           dpkg-deb --contents "$deb" | grep -F '/usr/share/applications/tessera.desktop'
-
-      - name: Smoke test AppImage startup
-        run: |
-          set -euo pipefail
-          version="$(node -p "require('./package.json').version")"
-          appimage="release/Tessera-${version}.AppImage"
-          smoke_dir="$RUNNER_TEMP/tessera-linux-smoke"
-          stdout_log="$RUNNER_TEMP/tessera-appimage-smoke.out"
-          devtools_json="$RUNNER_TEMP/tessera-devtools.json"
-
-          rm -rf "$smoke_dir"
-          xvfb-run -a env \
-            TESSERA_DATA_DIR="$smoke_dir" \
-            TESSERA_ELECTRON_LOG_LEVEL=debug \
-            TESSERA_DISABLE_GPU=1 \
-            "$appimage" \
-            --appimage-extract-and-run \
-            --no-sandbox \
-            --disable-gpu \
-            --remote-debugging-port=9333 \
-            >"$stdout_log" 2>&1 &
-          app_pid=$!
-
-          cleanup() {
-            kill "$app_pid" 2>/dev/null || true
-            wait "$app_pid" 2>/dev/null || true
-            cat "$smoke_dir/tessera-main.log" 2>/dev/null || true
-            cat "$smoke_dir/startup.log" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-
-          for _ in {1..60}; do
-            if curl -fsS http://127.0.0.1:9333/json/list > "$devtools_json" 2>/dev/null && grep -q '"title": "Tessera"' "$devtools_json"; then
-              break
-            fi
-            sleep 1
-          done
-
-          grep -q '"title": "Tessera"' "$devtools_json"
-          app_url="$(node -e "const fs=require('fs'); const pages=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(pages[0]?.url || '')" "$devtools_json")"
-          echo "Loaded URL: $app_url"
-          port="$(printf '%s\n' "$app_url" | sed -n 's#^http://localhost:\([0-9][0-9]*\)/.*#\1#p')"
-          test -n "$port"
-          curl -fsS "http://127.0.0.1:${port}/api/setup/status" | grep -q '"canUseCoreFeatures"'
 
       - name: Upload desktop artifact
         uses: actions/upload-artifact@v4
         with:
           name: tessera-preflight-linux-x64
           path: |
-            release/Tessera-*.AppImage
             release/Tessera-*-linux-amd64.deb
-            release/latest-linux.yml
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
         default: false
       build_linux:
-        description: Build and upload Linux AppImage and .deb assets
+        description: Build and upload the Linux .deb asset
         required: true
         type: boolean
         default: false
@@ -236,67 +236,19 @@ jobs:
         run: |
           set -euo pipefail
           version="$(node -p "require('./package.json').version")"
-          appimage="release/Tessera-${version}.AppImage"
           deb="release/Tessera-${version}-linux-amd64.deb"
 
-          test -f "$appimage"
           test -f "$deb"
-          file "$appimage" "$deb"
+          file "$deb"
           dpkg-deb --info "$deb"
           dpkg-deb --contents "$deb" | grep -F '/usr/share/applications/tessera.desktop'
-
-      - name: Smoke test AppImage startup
-        run: |
-          set -euo pipefail
-          version="$(node -p "require('./package.json').version")"
-          appimage="release/Tessera-${version}.AppImage"
-          smoke_dir="$RUNNER_TEMP/tessera-linux-smoke"
-          stdout_log="$RUNNER_TEMP/tessera-appimage-smoke.out"
-          devtools_json="$RUNNER_TEMP/tessera-devtools.json"
-
-          rm -rf "$smoke_dir"
-          xvfb-run -a env \
-            TESSERA_DATA_DIR="$smoke_dir" \
-            TESSERA_ELECTRON_LOG_LEVEL=debug \
-            TESSERA_DISABLE_GPU=1 \
-            "$appimage" \
-            --appimage-extract-and-run \
-            --no-sandbox \
-            --disable-gpu \
-            --remote-debugging-port=9333 \
-            >"$stdout_log" 2>&1 &
-          app_pid=$!
-
-          cleanup() {
-            kill "$app_pid" 2>/dev/null || true
-            wait "$app_pid" 2>/dev/null || true
-            cat "$smoke_dir/tessera-main.log" 2>/dev/null || true
-            cat "$smoke_dir/startup.log" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-
-          for _ in {1..60}; do
-            if curl -fsS http://127.0.0.1:9333/json/list > "$devtools_json" 2>/dev/null && grep -q '"title": "Tessera"' "$devtools_json"; then
-              break
-            fi
-            sleep 1
-          done
-
-          grep -q '"title": "Tessera"' "$devtools_json"
-          app_url="$(node -e "const fs=require('fs'); const pages=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(pages[0]?.url || '')" "$devtools_json")"
-          echo "Loaded URL: $app_url"
-          port="$(printf '%s\n' "$app_url" | sed -n 's#^http://localhost:\([0-9][0-9]*\)/.*#\1#p')"
-          test -n "$port"
-          curl -fsS "http://127.0.0.1:${port}/api/setup/status" | grep -q '"canUseCoreFeatures"'
 
       - name: Upload desktop artifact
         uses: actions/upload-artifact@v4
         with:
           name: tessera-linux-x64
           path: |
-            release/Tessera-*.AppImage
             release/Tessera-*-linux-amd64.deb
-            release/latest-linux.yml
           if-no-files-found: error
           retention-days: 1
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Download from [GitHub Releases](https://github.com/horang-labs/tessera/releases)
 |----------|-------|
 | Windows, including WSL | Portable `.exe` |
 | macOS | `.dmg` for Apple Silicon or Intel |
-| Linux beta | `.deb` or `.AppImage` |
+| Linux beta | `.deb` |
 
 Windows builds are not code-signed yet, so SmartScreen may show an unknown-publisher warning. macOS builds are signed and notarized with Apple Developer ID.
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "electron:prebuild:telemetry": "node scripts/with-posthog-telemetry-build.mjs npm run electron:prebuild",
     "electron:build:win": "npm run electron:prebuild && electron-builder --win portable --x64 --publish never",
     "electron:build:win:telemetry": "node scripts/with-posthog-telemetry-build.mjs npm run electron:build:win",
-    "electron:build:linux": "npm run electron:prebuild && electron-builder --linux AppImage deb --x64 --publish never",
+    "electron:build:linux": "npm run electron:prebuild && electron-builder --linux deb --x64 --publish never",
     "electron:build:mac-x64": "npm run electron:prebuild && electron-builder --mac --x64 --publish never",
     "electron:build:mac-arm64": "npm run electron:prebuild && electron-builder --mac --arm64 --publish never",
     "electron:build:mac-x64:signed": "npm run electron:prebuild && TESSERA_MAC_DISTRIBUTION=1 electron-builder --mac dmg --x64 --publish never --config.forceCodeSigning=true --config.mac.notarize=false && node scripts/notarize-mac-dmg.cjs x64",
@@ -171,7 +171,6 @@
     },
     "linux": {
       "target": [
-        "AppImage",
         "deb"
       ],
       "category": "Development",


### PR DESCRIPTION
## Summary
- build Linux desktop releases as .deb only
- remove AppImage verification, smoke test, and upload paths from desktop workflows
- update README Linux asset docs to .deb only

## Verification
- rg AppImage/latest-linux references under tracked release config/docs
- package.json Linux build target check
- git diff --check