### PR TITLE
워크플로 카드 행 오버플로 수정

### DIFF
--- a/src/components/chat/workflow/workflow-card.tsx
+++ b/src/components/chat/workflow/workflow-card.tsx
@@ -113,26 +113,39 @@ const WorkflowAgentRow = memo(function WorkflowAgentRow({
       : lifecycle === 'done' || lifecycle === 'failed' || lifecycle === 'skipped'
         ? formatSeconds(agent.durationMs)
         : null;
+  const hasDetail = Boolean(
+    (lifecycle === 'done' && agent.resultPreview) || lifecycle === 'failed' || agent.promptPreview,
+  );
 
   return (
-    <div className="group/agent flex items-center gap-2 rounded-md py-1 pl-2 pr-1 text-[11px] transition-colors hover:bg-(--sidebar-hover)">
+    <div className="group/agent flex min-w-0 items-center gap-2 overflow-hidden rounded-md py-1 pl-2 pr-1 text-[11px] transition-colors hover:bg-(--sidebar-hover)">
       <span className="shrink-0">{AGENT_ICON[lifecycle]}</span>
-      <span className="shrink-0 font-medium text-(--text-secondary)">{agent.label}</span>
+      <span className="flex min-w-0 flex-1 items-center gap-1.5">
+        <span
+          className={cn(
+            'shrink-0 truncate font-medium text-(--text-secondary)',
+            hasDetail ? 'max-w-[45%]' : 'max-w-full',
+          )}
+          title={agent.label}
+        >
+          {agent.label}
+        </span>
 
-      {lifecycle === 'done' && agent.resultPreview ? (
-        <span className="flex min-w-0 items-center gap-1">
-          <span className="text-(--text-muted)">→</span>
-          <span className="truncate font-mono text-(--status-success-text)" title={agent.resultPreview}>
-            {agent.resultPreview}
+        {lifecycle === 'done' && agent.resultPreview ? (
+          <span className="flex min-w-0 flex-1 items-center gap-1">
+            <span className="shrink-0 text-(--text-muted)">→</span>
+            <span className="min-w-0 flex-1 truncate font-mono text-(--status-success-text)" title={agent.resultPreview}>
+              {agent.resultPreview}
+            </span>
           </span>
-        </span>
-      ) : lifecycle === 'failed' ? (
-        <span className="truncate text-(--status-error-text)">failed{agent.attempt && agent.attempt > 1 ? ` · ${agent.attempt} tries` : ''}</span>
-      ) : agent.promptPreview ? (
-        <span className="truncate italic text-(--text-muted)" title={agent.promptPreview}>
-          {agent.promptPreview}
-        </span>
-      ) : null}
+        ) : lifecycle === 'failed' ? (
+          <span className="min-w-0 flex-1 truncate text-(--status-error-text)">failed{agent.attempt && agent.attempt > 1 ? ` · ${agent.attempt} tries` : ''}</span>
+        ) : agent.promptPreview ? (
+          <span className="min-w-0 flex-1 truncate italic text-(--text-muted)" title={agent.promptPreview}>
+            {agent.promptPreview}
+          </span>
+        ) : null}
+      </span>
 
       <span className="ml-auto flex shrink-0 items-center gap-2.5 text-[10px] text-(--text-muted)">
         {model && <span className="font-mono opacity-80">{model}</span>}
@@ -250,7 +263,7 @@ export const WorkflowCard = memo(function WorkflowCard({
       >
         {collapsed ? <ChevronRight className="h-3 w-3 shrink-0 text-(--text-muted)" /> : <ChevronDown className="h-3 w-3 shrink-0 text-(--text-muted)" />}
         <WorkflowIcon className="h-3.5 w-3.5 shrink-0 text-(--text-muted)" />
-        <span className="truncate text-xs font-semibold text-(--text-primary)">{workflowName}</span>
+        <span className="min-w-0 flex-1 truncate text-xs font-semibold text-(--text-primary)">{workflowName}</span>
 
         <span className={cn('inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium', statusPill.cls)}>
           {statusPill.icon}

--- a/tests/workflow-card-layout-contract.test.mjs
+++ b/tests/workflow-card-layout-contract.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const source = fs.readFileSync(
+  new URL('../src/components/chat/workflow/workflow-card.tsx', import.meta.url),
+  'utf8',
+);
+
+test('workflow card header truncates the title before status metadata', () => {
+  assert.match(source, /min-w-0 flex-1 truncate text-xs font-semibold text-\(--text-primary\)/);
+});
+
+test('workflow agent rows keep long previews inside a bounded flex track', () => {
+  assert.match(source, /group\/agent flex min-w-0 items-center gap-2 overflow-hidden/);
+  assert.match(source, /flex min-w-0 flex-1 items-center gap-1\.5/);
+  assert.match(source, /hasDetail \? 'max-w-\[45%\]' : 'max-w-full'/);
+  assert.match(source, /min-w-0 flex-1 truncate italic text-\(--text-muted\)/);
+  assert.match(source, /min-w-0 flex-1 truncate font-mono text-\(--status-success-text\)/);
+});


### PR DESCRIPTION
## 변경 내용

- 워크플로 카드의 agent row 본문을 `min-w-0 flex-1` 트랙으로 묶어 긴 label/result/prompt가 메타 영역을 밀어내지 않게 했습니다.
- 긴 label은 상세 preview가 있을 때만 최대 45%로 제한하고, preview/result는 남은 폭 안에서 ellipsis 처리되게 했습니다.
- 카드 헤더의 workflow 이름도 메타 앞에서 줄어들도록 `min-w-0 flex-1`을 적용했습니다.
- 레이아웃 계약 테스트를 추가해 같은 회귀가 다시 들어오지 않도록 했습니다.

## 원인

flex row에서 `agent.label`이 `shrink-0`으로 고정되고 preview 영역이 명시적인 bounded flex track을 갖지 않아, 긴 한국어/영문 혼합 텍스트가 카드 오른쪽의 model/duration/token 메타 영역까지 밀어내는 구조였습니다.

## 검증

- `node --test tests/workflow-card-layout-contract.test.mjs`
- `npx eslint src/components/chat/workflow/workflow-card.tsx tests/workflow-card-layout-contract.test.mjs`
- 로컬 dev 서버 `http://127.0.0.1:3210/chat`에서 `foxden-impl-roadmap` 실제 workflow card를 펼쳐 Chrome headless로 측정
  - agent row 10개
  - `maxVisualOverflowPx: 0`
  - `maxInternalScrollOverflowPx: 0`
- `git diff --check`

참고: `npm run lint -- ...`는 스크립트가 `eslint .`로 고정되어 전체 저장소를 검사하며, 이번 변경과 무관한 기존 React compiler/react-hooks 오류 33건으로 실패합니다. 변경 파일만 직접 대상으로 한 ESLint는 통과했습니다.
