### PR TITLE
feat(models): register claude-fable-5 in the model list

### DIFF
--- a/src/lib/cli/provider-session-option-definitions.ts
+++ b/src/lib/cli/provider-session-option-definitions.ts
@@ -155,6 +155,17 @@ const CLAUDE_EFFORT_WITH_ULTRACODE: ProviderReasoningEffortOption[] = [
 
 export const CLAUDE_MODELS: ProviderModelOption[] = [
   {
+    // Fable 5 has a 1M context window by default (no separate [1m] variant) and
+    // does not support fast mode (Opus 4.8/4.7 only) — so no supportsFastMode.
+    // Thinking is always on; effort is the only depth control, and xhigh support
+    // means ultracode is exposed.
+    value: 'claude-fable-5',
+    label: 'claude-fable-5',
+    isDefault: false,
+    defaultReasoningEffort: 'auto',
+    supportedReasoningEfforts: CLAUDE_EFFORT_WITH_ULTRACODE,
+  },
+  {
     value: 'claude-opus-4-8',
     label: 'claude-opus-4-8',
     isDefault: false,


### PR DESCRIPTION
## What
Register `claude-fable-5` in `CLAUDE_MODELS` so it shows up in the claude-code provider's model dropdown.

## Details
- **effort**: `CLAUDE_EFFORT_WITH_ULTRACODE` (auto/low/medium/high/xhigh/max + ultracode) — Fable supports xhigh
- **fast mode**: intentionally omitted (`supportsFastMode` left off) → the UI toggle is auto-hidden
- **1M context by default**: no separate `[1m]` variant, unlike the opus entries
- **default model**: unchanged (`claude-opus-4-8[1m]`)

## Verification
- CLI 2.1.198 binary contains the `claude-fable-5` string → `--model claude-fable-5` is accepted
- e2e with the exact args tessera spawns: the model responds and self-identifies as Claude Fable 5, `model: claude-fable-5`
- **fast unsupported, measured**: with `fastMode` on, the CLI reports `speed: standard` / `fast_mode_state: off` — it silently ignores fast mode on Fable, which is why the toggle is omitted
- model contract tests pass 8/8

🤖 Generated with [Claude Code](https://claude.com/claude-code)