### PR TITLE
fix(opencode): report accurate cache/context usage from ACP prompt results

### DIFF
--- a/src/lib/cli/providers/opencode/protocol-parser.ts
+++ b/src/lib/cli/providers/opencode/protocol-parser.ts
@@ -37,6 +37,15 @@ interface PendingToolCall {
   previousTodos?: TodoItem[];
 }
 
+interface ModelUsageTotals {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  costUsd: number;
+  contextWindow?: number;
+}
+
 interface SessionState {
   pendingRequests: Map<number | string, PendingRequest>;
   pendingToolCalls: Map<string, PendingToolCall>;
@@ -49,6 +58,12 @@ interface SessionState {
   } | null;
   currentModel: string | null;
   lastTodoSnapshots: TodoItem[];
+  // session/prompt result usage is per-turn, but the usage store expects
+  // modelUsage to be cumulative (as Claude Code reports it) — accumulate here.
+  modelUsageTotals: Map<string, ModelUsageTotals>;
+  // usage_update's cost is cumulative across the OpenCode session; per-model
+  // cost is apportioned from its per-turn delta against this baseline.
+  lastSessionCostUsd: number;
 }
 
 const MAX_ACCUMULATED_TEXT_LENGTH = 100;
@@ -487,6 +502,11 @@ export class OpenCodeProtocolParser {
       return [];
     }
 
+    // usage_update carries no cache breakdown: `used` is input + cache-read
+    // combined (and excludes cache-write), so this snapshot understates the
+    // context and shows zero cache activity. It is still emitted because for
+    // some flows (e.g. ACP commands like compact) it is the only usage signal;
+    // prompt completion overwrites it with the accurate split right after.
     return [{
       serverMessage: {
         type: 'context_usage',
@@ -694,6 +714,24 @@ export class OpenCodeProtocolParser {
       });
     }
 
+    // The prompt result carries the accurate per-turn token split (the
+    // usage_update snapshot lumps cache reads into `used` and drops cache
+    // writes entirely) — overwrite the context snapshot with it.
+    if (usage) {
+      messages.push({
+        serverMessage: {
+          type: 'context_usage',
+          sessionId,
+          inputTokens: usage.inputTokens,
+          cacheCreationTokens: usage.cacheCreationTokens,
+          cacheReadTokens: usage.cacheReadTokens,
+          ...(usage.contextWindowSize !== undefined
+            ? { contextWindowSize: usage.contextWindowSize }
+            : {}),
+        },
+      });
+    }
+
     messages.push(
       {
         serverMessage: {
@@ -749,6 +787,8 @@ export class OpenCodeProtocolParser {
         latestUsageUpdate: null,
         currentModel: null,
         lastTodoSnapshots: [],
+        modelUsageTotals: new Map(),
+        lastSessionCostUsd: 0,
       };
       this.sessionStates.set(sessionId, state);
     }
@@ -1208,7 +1248,42 @@ function buildCompletedUsage(
   const cacheReadTokens = toNumber(usage.cachedReadTokens) ?? 0;
   const cacheCreationTokens = toNumber(usage.cachedWriteTokens) ?? 0;
   const contextWindowSize = state.latestUsageUpdate?.size;
-  const costUsd = state.latestUsageUpdate?.cost ?? 0;
+  // Session-cumulative (OpenCode reports totalSessionCost). After a process
+  // respawn the accumulator restarts at 0, so the first turn's delta absorbs
+  // the pre-respawn cost — per-model split degrades but the total stays right.
+  const sessionCostUsd = state.latestUsageUpdate?.cost ?? state.lastSessionCostUsd;
+  const turnCostUsd = Math.max(0, sessionCostUsd - state.lastSessionCostUsd);
+  state.lastSessionCostUsd = sessionCostUsd;
+
+  if (state.currentModel) {
+    const totals = state.modelUsageTotals.get(state.currentModel) ?? {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUsd: 0,
+    };
+    totals.inputTokens += inputTokens;
+    totals.outputTokens += outputTokens;
+    totals.cacheReadTokens += cacheReadTokens;
+    totals.cacheCreationTokens += cacheCreationTokens;
+    totals.costUsd += turnCostUsd;
+    if (contextWindowSize !== undefined) {
+      totals.contextWindow = contextWindowSize;
+    }
+    state.modelUsageTotals.set(state.currentModel, totals);
+  }
+
+  const modelUsage = [...state.modelUsageTotals.entries()].map(([model, totals]) => ({
+    model,
+    inputTokens: totals.inputTokens,
+    outputTokens: totals.outputTokens,
+    cacheReadInputTokens: totals.cacheReadTokens,
+    cacheCreationInputTokens: totals.cacheCreationTokens,
+    webSearchRequests: 0,
+    costUSD: totals.costUsd,
+    ...(totals.contextWindow !== undefined ? { contextWindow: totals.contextWindow } : {}),
+  }));
 
   return {
     inputTokens,
@@ -1218,20 +1293,9 @@ function buildCompletedUsage(
     durationMs,
     durationApiMs: 0,
     numTurns: 0,
-    costUsd,
+    costUsd: sessionCostUsd,
     ...(contextWindowSize !== undefined ? { contextWindowSize } : {}),
-    ...(state.currentModel ? {
-      modelUsage: [{
-        model: state.currentModel,
-        inputTokens,
-        outputTokens,
-        cacheReadInputTokens: cacheReadTokens,
-        cacheCreationInputTokens: cacheCreationTokens,
-        webSearchRequests: 0,
-        costUSD: costUsd,
-        ...(contextWindowSize !== undefined ? { contextWindow: contextWindowSize } : {}),
-      }],
-    } : {}),
+    ...(modelUsage.length > 0 ? { modelUsage } : {}),
   };
 }
 


### PR DESCRIPTION
## Problem

A user reported that API prompt-cache hits appear to be ~0 when using the OpenCode backend through Tessera, while the same setup via the OpenCode CLI directly shows normal cache hits.

Investigation showed the cache actually works fine — the numbers Tessera displays are wrong, for three reasons:

1. **Cache activity shown as zero.** OpenCode's ACP `usage_update` notification carries no cache breakdown: `used` is input + cache-read combined, and cache-write is omitted entirely (`packages/opencode/src/acp/usage.ts`, `sendUpdate`). Tessera's parser hardcoded `cacheCreationTokens: 0, cacheReadTokens: 0` from it, so every OpenCode session looked cache-cold.
2. **Context bar understated.** Since `used` omits cache-write tokens, the context bar missed the entire freshly-written prefix — worst right after turn 1, where the whole system prompt + tool definitions are a cache write.
3. **modelUsage semantics mismatch.** The usage store expects `modelUsage` to be cumulative across the session (as Claude Code reports it), but the OpenCode path built it from the last turn's tokens combined with a whole-session cost — one tooltip row mixing two different scopes, and a mid-session model switch dropped the previous model's row.

## Verification against a real session (before writing the fix)

Drove a live `opencode acp` (v1.17.13) process with the exact JSON-RPC sequence Tessera uses (`initialize` → `session/new` → `session/set_model` → `session/prompt` ×2) and captured the wire traffic:

- Turn 2 `usage_update`: `{ used: 9518, size: 200000, cost: {...} }` — no cache fields
- Turn 2 `session/prompt` result: `{ inputTokens: 46, outputTokens: 2, cachedReadTokens: 9472 }` — `46 + 9472 = 9518`

So the accurate split exists only on the prompt *result*, and the cache was genuinely hitting (9472 tokens) while Tessera displayed 0.

## Fix (all in `src/lib/cli/providers/opencode/protocol-parser.ts`)

- Emit an accurate `context_usage` snapshot from the `session/prompt` result right after each turn, overwriting the lossy `usage_update`-based one. The `usage_update` emission is kept (it is the only usage signal for flows like ACP commands / compact) with a comment documenting its limits.
- Accumulate `modelUsage` per model in parser session state, so entries are cumulative and survive mid-session model switches.
- Apportion OpenCode's session-cumulative cost to models via per-turn deltas (total is preserved; after a process respawn the first turn's delta absorbs pre-respawn cost, noted in a comment).

Other providers are untouched — Claude Code and Codex have their own parsers, and no shared store/display code changed.

## Testing

- Replayed the captured wire messages through the patched parser: turn-2 context snapshot now reads `{inputTokens: 46, cacheRead: 9472, cacheCreation: 0}` (sum still 9518), modelUsage accumulates across turns (9505+46 input), model-switch scenario keeps both entries with cost split by delta (0.012 + 0.018 = 0.03 total).
- `tsc --noEmit` and `eslint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)