### PR TITLE
feat(session): runtime effort/ultracode changes for live Claude Code sessions

### DIFF
--- a/src/components/chat/composer-session-control-sections.tsx
+++ b/src/components/chat/composer-session-control-sections.tsx
@@ -48,6 +48,9 @@ interface ComposerReasoningEffortMenuProps {
   options: ProviderReasoningEffortOption[];
   selectedEffort: string | null;
   onSelect: (effort: string) => void;
+  /** Disable spawn-only options (requiresRestart) while the session is running. */
+  disableRestartRequired?: boolean;
+  restartRequiredTooltip?: string;
 }
 
 interface ComposerReadonlyReasoningBadgeProps {
@@ -238,25 +241,32 @@ export function ComposerReasoningEffortMenu({
   options,
   selectedEffort,
   onSelect,
+  disableRestartRequired,
+  restartRequiredTooltip,
 }: ComposerReasoningEffortMenuProps) {
   return (
     <>
-      {options.map((option) => (
-        <button
-          key={option.value}
-          type="button"
-          data-composer-menu-item
-          data-selected={selectedEffort === option.value ? 'true' : undefined}
-          onClick={() => onSelect(option.value)}
-          className={cn(
-            'w-full px-3 py-1.5 text-left text-xs transition-colors hover:bg-(--sidebar-hover) focus:bg-(--sidebar-hover) focus:outline-none',
-            selectedEffort === option.value ? 'text-(--accent)' : 'text-(--text-primary)',
-          )}
-        >
-          <div className="font-medium">{option.label}</div>
-          <div className="mt-0.5 text-[10px] text-(--text-muted)">{option.description}</div>
-        </button>
-      ))}
+      {options.map((option) => {
+        const isDisabled = disableRestartRequired === true && option.requiresRestart === true;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            data-composer-menu-item
+            data-selected={selectedEffort === option.value ? 'true' : undefined}
+            disabled={isDisabled}
+            title={isDisabled ? restartRequiredTooltip : undefined}
+            onClick={() => onSelect(option.value)}
+            className={cn(
+              'w-full px-3 py-1.5 text-left text-xs transition-colors hover:bg-(--sidebar-hover) focus:bg-(--sidebar-hover) focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent',
+              selectedEffort === option.value ? 'text-(--accent)' : 'text-(--text-primary)',
+            )}
+          >
+            <div className="font-medium">{option.label}</div>
+            <div className="mt-0.5 text-[10px] text-(--text-muted)">{option.description}</div>
+          </button>
+        );
+      })}
     </>
   );
 }

--- a/src/components/chat/composer-session-controls.tsx
+++ b/src/components/chat/composer-session-controls.tsx
@@ -647,10 +647,13 @@ function ComposerSessionControlsInner({
         sessionId,
         buildProviderModelControlValue(providerIdForSticky, nextModel, nextReasoningEffort),
       );
+      const nextEffortRequiresRestart = nextModelOption?.supportedReasoningEfforts
+        .find((option) => option.value === nextReasoningEffort)?.requiresRestart === true;
       if (
         !isOpenCodeProvider(providerIdForSticky)
         && sessionOptions?.supportsReasoningEffort
         && sessionOptions.runtimeEffortChange
+        && !nextEffortRequiresRestart
       ) {
         wsClient.setReasoningEffort(sessionId, nextReasoningEffort);
       }
@@ -679,12 +682,17 @@ function ComposerSessionControlsInner({
           buildProviderModelControlValue(providerIdForSticky, model, nextReasoningEffort),
         );
       } else if (sessionOptions?.runtimeEffortChange) {
-        // Only providers that declare runtimeEffortChange (codex) can apply an
-        // effort change to a live process. Claude Code declares it false — its
-        // adapter has no updateSessionConfig, so sending set_reasoning_effort
-        // here would fail with set_reasoning_effort_failed. We persist above and
-        // let the next spawn/resume pick it up, mirroring handleModelChange.
-        wsClient.setReasoningEffort(sessionId, nextReasoningEffort);
+        // Codex applies this via updateSessionConfig, Claude Code via an
+        // apply_flag_settings control_request on the live process. Spawn-only
+        // levels (Claude max) are disabled in the menu while running so they
+        // never reach here, but skip defensively instead of surfacing
+        // set_reasoning_effort_failed; the persisted value above still applies
+        // on the next spawn/resume.
+        const requiresRestart = reasoningOptions
+          .find((option) => option.value === nextReasoningEffort)?.requiresRestart === true;
+        if (!requiresRestart) {
+          wsClient.setReasoningEffort(sessionId, nextReasoningEffort);
+        }
       }
     }
     focusSessionInput(sessionId);
@@ -725,10 +733,18 @@ function ComposerSessionControlsInner({
   const canToggleFastMode = isCodexProvider(providerIdForSticky)
     || (isClaudeCodeProvider(providerIdForSticky) && currentModelSupportsFastMode);
   const fastModeToggleTitle = resolveFastModeToggleTitle(isFastModeEnabled, providerIdForSticky);
+  // A session spawned with a spawn-only effort (Claude max → --effort flag) can't
+  // change effort at runtime at all: the flag outranks apply_flag_settings for
+  // the process lifetime, so live changes would be silent no-ops. Those sessions
+  // keep the read-only badge until stopped.
+  const isEffortSpawnLocked = Boolean(
+    session?.isRunning
+    && reasoningOptions.find((option) => option.value === reasoningEffort)?.requiresRestart,
+  );
   const canOpenReasoningSelector = Boolean(
     sessionOptions?.supportsReasoningEffort
     && reasoningOptions.length > 0
-    && (sessionOptions.runtimeEffortChange || !session?.isRunning),
+    && ((sessionOptions.runtimeEffortChange && !isEffortSpawnLocked) || !session?.isRunning),
   );
 
   useEffect(() => {
@@ -888,7 +904,7 @@ function ComposerSessionControlsInner({
         </ComposerControlDropdown>
 
         {sessionOptions?.supportsReasoningEffort && reasoningOptions.length > 0 && (
-          sessionOptions.runtimeEffortChange || !session?.isRunning ? (
+          canOpenReasoningSelector ? (
             <ComposerControlDropdown
               icon={Gauge}
               label={reasoningLabel}
@@ -904,6 +920,8 @@ function ComposerSessionControlsInner({
                 <ComposerReasoningEffortMenu
                   options={reasoningOptions}
                   selectedEffort={reasoningEffort}
+                  disableRestartRequired={session?.isRunning === true}
+                  restartRequiredTooltip={t('settings.effort.requiresRestartTooltip')}
                   onSelect={(nextReasoningEffort) => {
                     handleReasoningEffortChange(nextReasoningEffort);
                     close();

--- a/src/lib/cli/process-manager.ts
+++ b/src/lib/cli/process-manager.ts
@@ -407,11 +407,44 @@ export class ProcessManager {
 
   /**
    * Update provider-side reasoning effort / thinking intensity for future turns.
+   * Providers implementing updateSessionConfig (Codex/OpenCode) receive the patch;
+   * Claude Code falls through to an apply_flag_settings control_request on stdin
+   * (no restart) — the same mechanism the CLI's own /effort command uses. A null
+   * settings value deletes the key, so 'auto'/null restores the model default.
+   *
+   * 'max' is rejected here: the CLI's effortLevel enum stops at xhigh and silently
+   * drops unknown values (the control_response still reports success), so sending
+   * it would leave the UI and the live process out of sync.
    */
   sendSetReasoningEffort(sessionId: string, reasoningEffort: string | null): boolean {
-    return this.tryUpdateProviderSessionConfig(
+    if (this.tryUpdateProviderSessionConfig(
       sessionId, { reasoningEffort }, 'reasoning effort', { reasoningEffort },
+    )) {
+      return true;
+    }
+    if (reasoningEffort === 'max') {
+      logger.warn({ sessionId }, 'effort "max" is spawn-only for Claude Code; not sending apply_flag_settings');
+      return false;
+    }
+    const settings = reasoningEffort === 'ultracode'
+      ? { ultracode: true, effortLevel: null }
+      : {
+        effortLevel: reasoningEffort && reasoningEffort !== 'auto' ? reasoningEffort : null,
+        ultracode: null,
+      };
+    const sent = this.writeControlRequest(
+      sessionId,
+      { subtype: 'apply_flag_settings', settings },
+      'apply_flag_settings',
     );
+    if (sent) {
+      const info = this.processes.get(sessionId);
+      if (info) {
+        info.reasoningEffort = reasoningEffort;
+      }
+      logger.info({ sessionId, reasoningEffort }, 'apply_flag_settings (effort) sent to CLI');
+    }
+    return sent;
   }
 
   /**

--- a/src/lib/cli/provider-session-option-definitions.ts
+++ b/src/lib/cli/provider-session-option-definitions.ts
@@ -145,7 +145,10 @@ export function buildClaudeSessionOptions(): ProviderSessionOptions {
     providerId: 'claude-code',
     displayName: 'Claude Code',
     supportsReasoningEffort: true,
-    runtimeEffortChange: false,
+    // Live changes ride the apply_flag_settings control_request (the same
+    // mechanism the CLI's own /effort command uses) — except `max`, which is
+    // spawn-only (stamped requiresRestart in remote-config normalization).
+    runtimeEffortChange: true,
     runtimeAccessChange: true,
     modelOptions: getClaudeModelOptions(),
     permissionMappings: buildClaudePermissionMappings(),

--- a/src/lib/cli/provider-session-option-types.ts
+++ b/src/lib/cli/provider-session-option-types.ts
@@ -5,6 +5,12 @@ export interface ProviderReasoningEffortOption {
   value: string;
   label: string;
   description: string;
+  /**
+   * Effort levels that only take effect at spawn (e.g. Claude `max`: the CLI's
+   * apply_flag_settings effortLevel enum stops at xhigh and silently drops
+   * unknown values). Shown disabled in the selector while the session runs.
+   */
+  requiresRestart?: boolean;
 }
 
 export interface ProviderServiceTierOption {

--- a/src/lib/cli/providers/claude-code/adapter.ts
+++ b/src/lib/cli/providers/claude-code/adapter.ts
@@ -199,18 +199,26 @@ export class ClaudeCodeAdapter implements CliProvider {
       args.push('--model', model);
     }
 
-    // Settings booleans (ultracode, fastMode) are session-scoped and merged into a
+    // Session-scoped settings (ultracode, effortLevel, fastMode) are merged into a
     // SINGLE --settings object — never pass --settings twice (the CLI would only honor
     // one). Ultracode is not an --effort value (the CLI rejects `--effort ultracode`)
     // and pairs xhigh effort with standing multi-agent orchestration. fastMode is
     // orthogonal to effort and enables Claude's high-speed serving on supported models;
     // the CLI silently ignores it on models without fast-mode support.
+    //
+    // Effort rides settings.effortLevel instead of the --effort flag: the flag
+    // outranks flag settings for the process lifetime, which would make later
+    // apply_flag_settings effort changes (sendSetReasoningEffort) silent no-ops.
+    // `max` is the exception — the effortLevel enum stops at xhigh, so max only
+    // exists as --effort; such sessions can't change effort until respawn.
     const settings: Record<string, unknown> = {};
     if (reasoningEffort === 'ultracode') {
       settings.ultracode = true;
-    } else if (reasoningEffort && reasoningEffort !== 'auto') {
-      // 'auto' or null → don't pass --effort, let CLI use its own default
+    } else if (reasoningEffort === 'max') {
       args.push('--effort', reasoningEffort);
+    } else if (reasoningEffort && reasoningEffort !== 'auto') {
+      // 'auto' or null → pass no effort, let CLI use its own default
+      settings.effortLevel = reasoningEffort;
     }
     if (fastMode === true) {
       settings.fastMode = true;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -178,6 +178,7 @@ export const en: I18nMessages = {
     },
     effort: {
       readOnlyTooltip: 'Cannot change while a session is running. Stop the session to change.',
+      requiresRestartTooltip: 'Only applies when a session starts. Stop the session and start again to use it.',
     },
     agentEnv: {
       label: 'Agent Environment',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -178,6 +178,7 @@ export const ja: I18nMessages = {
     },
     effort: {
       readOnlyTooltip: 'セッション実行中は変更できません。停止してから変更してください',
+      requiresRestartTooltip: 'セッション開始時にのみ適用されます。使用するにはセッションを停止して再開してください',
     },
     agentEnv: {
       label: 'エージェント環境',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -178,6 +178,7 @@ export const ko: I18nMessages = {
     },
     effort: {
       readOnlyTooltip: '세션 실행 중에는 변경할 수 없습니다. 중지 후 변경하세요',
+      requiresRestartTooltip: '세션 시작 시에만 적용됩니다. 사용하려면 세션을 중지한 뒤 다시 시작하세요',
     },
     agentEnv: {
       label: '에이전트 환경',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -176,6 +176,7 @@ export interface I18nMessages {
     };
     effort: {
       readOnlyTooltip: string;
+      requiresRestartTooltip: string;
     };
     agentEnv: {
       label: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -178,6 +178,7 @@ export const zh: I18nMessages = {
     },
     effort: {
       readOnlyTooltip: '会话运行中无法更改，请停止会话后再更改',
+      requiresRestartTooltip: '仅在会话启动时生效。如需使用，请停止会话后重新开始',
     },
     agentEnv: {
       label: '代理环境',

--- a/src/lib/model-config/remote-config.ts
+++ b/src/lib/model-config/remote-config.ts
@@ -57,11 +57,21 @@ function normalizeEffort(raw: unknown): ProviderReasoningEffortOption | null {
   const value = toTrimmedString(r.value);
   const label = toTrimmedString(r.label);
   if (!value || !label) return null;
-  return {
+  const effort: ProviderReasoningEffortOption = {
     value,
     label,
     description: typeof r.description === 'string' ? r.description : '',
   };
+  // Whether a level is spawn-only is a property of the CLI integration, not the
+  // remote catalog: `max` exists only as the --effort flag (the apply_flag_settings
+  // effortLevel enum stops at xhigh), so it can't change on a live process. Stamp
+  // it here, letting the Worker override if it ever starts sending the field.
+  if (typeof r.requiresRestart === 'boolean') {
+    effort.requiresRestart = r.requiresRestart;
+  } else if (value === 'max') {
+    effort.requiresRestart = true;
+  }
+  return effort;
 }
 
 function normalizeEfforts(raw: unknown): ProviderReasoningEffortOption[] | null {

--- a/tests/claude-code-fast-mode-args.test.ts
+++ b/tests/claude-code-fast-mode-args.test.ts
@@ -41,17 +41,18 @@ test('fastMode + ultracode merge into ONE --settings object', () => {
   assert.ok(!valuesOf(args, '--effort').includes('ultracode'));
 });
 
-test('fastMode + plain effort: --effort flag AND --settings fastMode', () => {
+test('fastMode + plain effort merge into ONE --settings object, no --effort flag', () => {
   const args = claudeCodeAdapter.getCliArgs({
     sessionId: '33333333-3333-3333-3333-333333333333',
     model: 'claude-opus-4-8',
     reasoningEffort: 'high',
     fastMode: true,
   });
-  assert.deepEqual(valuesOf(args, '--effort'), ['high']);
+  assert.equal(valuesOf(args, '--effort').length, 0, `plain effort must ride --settings; got: ${args.join(' ')}`);
   const settings = valuesOf(args, '--settings');
   assert.equal(settings.length, 1);
   assert.equal(JSON.parse(settings[0]).fastMode, true);
+  assert.equal(JSON.parse(settings[0]).effortLevel, 'high');
   assert.equal(JSON.parse(settings[0]).ultracode, undefined);
 });
 

--- a/tests/claude-code-ultracode-args.test.ts
+++ b/tests/claude-code-ultracode-args.test.ts
@@ -30,16 +30,35 @@ test('ultracode effort emits --settings ultracode, never --effort ultracode', ()
   assert.equal(settings.length, 1, `expected exactly one --settings; got: ${args.join(' ')}`);
   const parsed = JSON.parse(settings[0]);
   assert.equal(parsed.ultracode, true, `--settings JSON must set ultracode:true; got: ${settings[0]}`);
+  assert.equal(parsed.effortLevel, undefined, 'ultracode implies xhigh; effortLevel must stay unset');
 });
 
-test('ordinary effort levels still use the --effort flag', () => {
+test('ordinary effort levels ride --settings effortLevel, not the --effort flag', () => {
+  // The --effort flag outranks apply_flag_settings for the process lifetime,
+  // which would turn runtime effort changes into silent no-ops.
   const args = claudeCodeAdapter.getCliArgs({
     sessionId: '22222222-2222-2222-2222-222222222222',
     model: 'claude-opus-4-8',
     reasoningEffort: 'xhigh',
   });
-  assert.deepEqual(valuesOf(args, '--effort'), ['xhigh']);
-  assert.equal(valuesOf(args, '--settings').length, 0, 'plain effort must not inject --settings');
+  assert.equal(valuesOf(args, '--effort').length, 0, `plain effort must not use --effort; got: ${args.join(' ')}`);
+  const settings = valuesOf(args, '--settings');
+  assert.equal(settings.length, 1);
+  const parsed = JSON.parse(settings[0]);
+  assert.equal(parsed.effortLevel, 'xhigh');
+  assert.equal(parsed.ultracode, undefined);
+});
+
+test('max is the exception: spawn-only --effort flag, no effortLevel setting', () => {
+  // The CLI's effortLevel settings enum stops at xhigh; max only exists as
+  // --effort. Such sessions cannot change effort at runtime.
+  const args = claudeCodeAdapter.getCliArgs({
+    sessionId: '44444444-4444-4444-4444-444444444444',
+    model: 'claude-opus-4-8',
+    reasoningEffort: 'max',
+  });
+  assert.deepEqual(valuesOf(args, '--effort'), ['max']);
+  assert.equal(valuesOf(args, '--settings').length, 0, `max must not inject --settings; got: ${args.join(' ')}`);
 });
 
 test('auto effort passes neither --effort nor an ultracode --settings', () => {

--- a/tests/claude-effort-runtime-change-contract.test.mjs
+++ b/tests/claude-effort-runtime-change-contract.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const read = (p) => fs.readFileSync(new URL(`../${p}`, import.meta.url), 'utf8');
+
+// Claude Code effort/ultracode can change mid-session via the apply_flag_settings
+// control_request — the same mechanism the CLI's own /effort command uses. The
+// one exception is `max`: it only exists as the spawn-only --effort flag (the
+// settings effortLevel enum stops at xhigh and silently drops unknown values),
+// so it is disabled in the selector while a session runs.
+
+test('ProcessManager.sendSetReasoningEffort falls back to apply_flag_settings', () => {
+  const processManagerSource = read('src/lib/cli/process-manager.ts');
+
+  assert.match(processManagerSource, /sendSetReasoningEffort\(sessionId: string, reasoningEffort: string \| null\): boolean/);
+  // ultracode on → effortLevel cleared; plain effort → ultracode cleared; auto/null → both cleared
+  assert.match(processManagerSource, /\? \{ ultracode: true, effortLevel: null \}/);
+  assert.match(processManagerSource, /effortLevel: reasoningEffort && reasoningEffort !== 'auto' \? reasoningEffort : null/);
+  assert.match(processManagerSource, /ultracode: null/);
+  assert.match(processManagerSource, /\{ subtype: 'apply_flag_settings', settings \}/);
+  // max would be silently dropped by the CLI (success response, no effect) — reject before sending
+  assert.match(processManagerSource, /if \(reasoningEffort === 'max'\) \{\s*logger\.warn/);
+  assert.match(processManagerSource, /info\.reasoningEffort = reasoningEffort/);
+});
+
+test('claude-code declares runtime effort change with max as spawn-only', () => {
+  const definitionsSource = read('src/lib/cli/provider-session-option-definitions.ts');
+  const typesSource = read('src/lib/cli/provider-session-option-types.ts');
+  const remoteConfigSource = read('src/lib/model-config/remote-config.ts');
+
+  assert.match(typesSource, /requiresRestart\?: boolean/);
+  // the model catalog is remote (PR #123), so requiresRestart is stamped during
+  // effort normalization: max defaults to spawn-only, Worker value wins if sent
+  assert.match(remoteConfigSource, /typeof r\.requiresRestart === 'boolean'/);
+  assert.match(remoteConfigSource, /else if \(value === 'max'\) \{\s*effort\.requiresRestart = true;/);
+  // buildClaudeSessionOptions unlocks the runtime dropdown
+  assert.match(definitionsSource, /runtimeEffortChange: true,\s*runtimeAccessChange: true/);
+});
+
+test('spawn passes plain effort through settings.effortLevel so the flag cannot shadow runtime changes', () => {
+  const adapterSource = read('src/lib/cli/providers/claude-code/adapter.ts');
+
+  assert.match(adapterSource, /settings\.effortLevel = reasoningEffort/);
+  // max stays a --effort flag (spawn-only)
+  assert.match(adapterSource, /reasoningEffort === 'max'\) \{\s*args\.push\('--effort', reasoningEffort\)/);
+});
+
+test('composer disables spawn-only efforts while running and locks max-spawned sessions', () => {
+  const composer = read('src/components/chat/composer-session-controls.tsx');
+  const sections = read('src/components/chat/composer-session-control-sections.tsx');
+
+  // menu supports per-option disabling with a tooltip
+  assert.match(sections, /disableRestartRequired\?: boolean/);
+  assert.match(sections, /restartRequiredTooltip\?: string/);
+  assert.match(sections, /disableRestartRequired === true && option\.requiresRestart === true/);
+
+  // composer wires it to the running state + i18n tooltip
+  assert.match(composer, /disableRestartRequired=\{session\?\.isRunning === true\}/);
+  assert.match(composer, /restartRequiredTooltip=\{t\('settings\.effort\.requiresRestartTooltip'\)\}/);
+
+  // a session spawned with --effort max keeps the read-only badge (flag outranks runtime changes)
+  assert.match(composer, /const isEffortSpawnLocked = Boolean\(/);
+  assert.match(composer, /sessionOptions\.runtimeEffortChange && !isEffortSpawnLocked/);
+
+  // live change requests skip spawn-only levels instead of surfacing failures
+  assert.match(composer, /\?\.requiresRestart === true;\s*if \(!requiresRestart\) \{\s*wsClient\.setReasoningEffort\(sessionId, nextReasoningEffort\);/);
+});
+
+test('requiresRestart tooltip exists in every locale', () => {
+  for (const locale of ['en', 'ko', 'ja', 'zh']) {
+    const source = read(`src/lib/i18n/${locale}.ts`);
+    assert.match(source, /requiresRestartTooltip: '/, `${locale}.ts must define requiresRestartTooltip`);
+  }
+  assert.match(read('src/lib/i18n/types.ts'), /requiresRestartTooltip: string/);
+});

--- a/tests/model-config-remote.test.ts
+++ b/tests/model-config-remote.test.ts
@@ -69,6 +69,34 @@ test('extractClaudeModels parses a valid Worker document', () => {
   assert.equal(result.models[0].supportedReasoningEfforts.length, 2);
 });
 
+test('normalization stamps requiresRestart on max (spawn-only) unless the Worker overrides it', () => {
+  // `max` only exists as the spawn-only --effort flag (the apply_flag_settings
+  // effortLevel enum stops at xhigh), so the client stamps it during normalization
+  // rather than expecting the remote catalog to know about CLI transport limits.
+  const result = extractClaudeModels({
+    version: 3,
+    providers: {
+      'claude-code': {
+        models: [{
+          value: 'claude-opus-4-8',
+          label: 'claude-opus-4-8',
+          isDefault: false,
+          supportedReasoningEfforts: [
+            { value: 'high', label: 'High', description: '' },
+            { value: 'max', label: 'Max', description: '' },
+            { value: 'xhigh', label: 'Extra High', description: '', requiresRestart: false },
+          ],
+        }],
+      },
+    },
+  });
+  assert.ok(result);
+  const efforts = result.models[0].supportedReasoningEfforts;
+  assert.equal(efforts.find((e) => e.value === 'high')?.requiresRestart, undefined);
+  assert.equal(efforts.find((e) => e.value === 'max')?.requiresRestart, true);
+  assert.equal(efforts.find((e) => e.value === 'xhigh')?.requiresRestart, false);
+});
+
 test('extractClaudeModels rejects a missing/invalid version', () => {
   assert.equal(extractClaudeModels({ providers: { 'claude-code': { models: [] } } }), null);
   assert.equal(


### PR DESCRIPTION
## Summary

Effort (low–xhigh) and ultracode were locked once a Claude Code session started, while model changes already worked live via the `set_model` control_request. This unlocks runtime effort/ultracode changes using the `apply_flag_settings` control_request — the same mechanism the CLI's own `/effort` command uses internally, and the same fallback pattern `sendSetFastMode` already established.

**`max` is the one exception**: it only exists as the spawn-only `--effort` flag. The CLI's `effortLevel` settings enum stops at `xhigh` and silently drops unknown values (the control_response still reports success), so `max` is shown disabled in the selector while a session runs, with a tooltip telling the user to stop and restart the session.

## Changes

- **process-manager**: `sendSetReasoningEffort` falls back to an `apply_flag_settings` control_request on stdin for Claude Code (Codex/OpenCode keep the `updateSessionConfig` path). Effort sends `{effortLevel: v, ultracode: null}`, ultracode sends `{ultracode: true, effortLevel: null}`, auto sends both null (a null value deletes the key, restoring the model default). `max` is rejected before sending.
- **claude-code adapter**: spawn passes plain effort via `--settings '{"effortLevel":…}'` instead of the `--effort` flag. The flag outranks flag settings for the process lifetime, which would have turned every later runtime change into a silent no-op. `max` keeps `--effort max`.
- **UI**: the effort dropdown stays interactive on running sessions; `requiresRestart` options (max) render disabled with a tooltip. Sessions spawned at max keep the read-only badge, since the spawn flag shadows all runtime changes for that process.
- **i18n**: `settings.effort.requiresRestartTooltip` added to en/ko/ja/zh.
- **tests**: spawn-args tests updated for the new `--settings` shape (plus a max spawn-only case); new `claude-effort-runtime-change-contract.test.mjs` covers the fallback payloads, max rejection, UI wiring, and locale keys.

## Verification

- 29 tests pass (`tsx --test`), `tsc --noEmit` and `eslint` clean on touched files.
- Verified against claude CLI 2.1.198 in stream-json mode: spawning with `--settings '{"effortLevel":"high"}'` works, and `apply_flag_settings` requests with `effortLevel`/`ultracode` return success on the live process.
- CLI binary inspection confirmed `/effort` itself sends `{subtype:"apply_flag_settings", settings:{effortLevel, ultracode}}`, and that the settings schema documents ultracode as "set per session via --settings or apply_flag_settings".

🤖 Generated with [Claude Code](https://claude.com/claude-code)