### PR TITLE
Refresh remote model config

### DIFF
--- a/electron/server-child.ts
+++ b/electron/server-child.ts
@@ -19,6 +19,8 @@ import { installTaskPrStatusBroadcast, uninstallTaskPrStatusBroadcast } from '..
 import { installSessionPrStatusBroadcast, uninstallSessionPrStatusBroadcast } from '../src/lib/github/session-pr-broadcast';
 import { prewarmCliStatusSnapshot } from '../src/lib/cli/provider-status-prewarm';
 import { snapshotTelemetryStartupDataState } from '../src/lib/telemetry/server-state';
+import { setModelConfigBroadcast, triggerModelConfigRefresh } from '../src/lib/model-config/refresh';
+import { ensureRemoteModelConfigLoaded } from '../src/lib/model-config/remote-config';
 import logger from '../src/lib/logger';
 import { getTesseraDataPath } from '../src/lib/tessera-data-dir';
 
@@ -111,7 +113,10 @@ if (isElectronChild) {
 logStartup('debug', `Server child starting (cwd=${process.cwd()}, dir=${dir}, port=${port})`);
 
 initDatabase().then(() => {
-  logStartup('debug', 'DB initialized, calling ensureRSAKeys...');
+  logStartup('debug', 'DB initialized, loading model config cache...');
+  return ensureRemoteModelConfigLoaded();
+}).then(() => {
+  logStartup('debug', 'Model config cache loaded, calling ensureRSAKeys...');
   return ensureRSAKeys();
 }).then(async () => {
   logStartup('debug', 'RSA keys ensured, creating server and calling app.prepare...');
@@ -138,6 +143,11 @@ initDatabase().then(() => {
       return getAgentEnvironment(userId);
     });
     rateLimitPoller.start();
+
+    // Model config: packaged Electron uses this child process instead of server.ts,
+    // so it must run the same startup refresh path.
+    setModelConfigBroadcast((msg) => wsServer.broadcast(msg));
+    void triggerModelConfigRefresh('launch');
 
     // Wire PR sync broadcasts and start the background PR poller. Without
     // these the in-process subscribe callbacks on syncTaskPr/syncSessionPr

--- a/tests/electron-model-config-launch-contract.test.mjs
+++ b/tests/electron-model-config-launch-contract.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const serverChildSource = fs.readFileSync(
+  path.join(root, 'electron', 'server-child.ts'),
+  'utf8',
+);
+
+test('Electron server child refreshes remote model config on app launch', () => {
+  assert.match(
+    serverChildSource,
+    /import \{ setModelConfigBroadcast, triggerModelConfigRefresh \} from '\.\.\/src\/lib\/model-config\/refresh';/,
+  );
+  assert.match(
+    serverChildSource,
+    /import \{ ensureRemoteModelConfigLoaded \} from '\.\.\/src\/lib\/model-config\/remote-config';/,
+  );
+  assert.match(serverChildSource, /return ensureRemoteModelConfigLoaded\(\);/);
+  assert.match(serverChildSource, /setModelConfigBroadcast\(\(msg\) => wsServer\.broadcast\(msg\)\);/);
+  assert.match(serverChildSource, /void triggerModelConfigRefresh\('launch'\);/);
+});


### PR DESCRIPTION
## Summary

-

## Testing

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] `NODE_ENV=production npm run build`
- [ ] Manual test:
- [ ] Not tested:

## Screenshots or Recordings

Add screenshots or a short recording for UI changes.

## Notes

Large features, new provider integrations, workflow changes, and architecture changes should have an issue first.
