### PR TITLE
[codex] Enable opening workspace folders

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -250,10 +250,6 @@ function buildWebContentsContextMenuTemplate(
     ];
   }
 
-  if (editFlags.canSelectAll) {
-    return [{ role: 'selectAll' }];
-  }
-
   return [];
 }
 

--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -55,7 +55,7 @@ interface WorkspaceDirectoryNode {
 
 type WorkspaceTreeNode = WorkspaceDirectoryNode | WorkspaceFileNode;
 
-interface FileContextMenuState {
+interface PathContextMenuState {
   absolutePath: string;
   canOpenFile: boolean;
   position: { x: number; y: number };
@@ -163,7 +163,7 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
   const [workDir, setWorkDir] = useState<string | null>(null);
-  const [contextMenu, setContextMenu] = useState<FileContextMenuState | null>(null);
+  const [contextMenu, setContextMenu] = useState<PathContextMenuState | null>(null);
   const [state, setState] = useState<WorkspaceFilePanelState>(() => ({
     loading: Boolean(sessionId),
     error: null,
@@ -237,11 +237,22 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
     if (node.type === "directory") {
       const expanded = isSearching || expandedPaths.has(node.path);
       const FolderIcon = expanded ? FolderOpen : Folder;
+      const absolutePath = toAbsoluteWorkspacePath(workDir, node.path);
       return (
         <div key={`dir:${node.path}`} className="flex flex-col">
           <button
             type="button"
             onClick={() => toggleDirectory(node.path)}
+            onContextMenu={(event) => {
+              if (!absolutePath) return;
+              event.preventDefault();
+              event.stopPropagation();
+              setContextMenu({
+                absolutePath,
+                canOpenFile: true,
+                position: { x: event.clientX, y: event.clientY },
+              });
+            }}
             className="group flex min-w-0 items-center gap-1.5 border-l-2 border-l-transparent py-1.5 pr-2 text-left text-(--text-secondary) transition-colors hover:bg-(--sidebar-hover) hover:text-(--text-primary)"
             style={{ paddingLeft }}
             title={node.path}

--- a/tests/electron-context-menu-contract.test.mjs
+++ b/tests/electron-context-menu-contract.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const electronMainSource = fs.readFileSync(
+  new URL('../electron/main.ts', import.meta.url),
+  'utf8',
+);
+
+test('Electron context menu does not show Select All for inert app chrome', () => {
+  assert.match(electronMainSource, /if \(params\.isEditable\) \{/);
+  assert.match(electronMainSource, /if \(params\.selectionText\.length > 0\) \{/);
+  assert.doesNotMatch(
+    electronMainSource,
+    /if \(editFlags\.canSelectAll\) \{\s*return \[\{ role: 'selectAll' \}\];\s*\}/,
+  );
+});

--- a/tests/workspace-folder-open-contract.test.mjs
+++ b/tests/workspace-folder-open-contract.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const filePanelSource = fs.readFileSync(
+  new URL('../src/components/workspace/workspace-file-panel.tsx', import.meta.url),
+  'utf8',
+);
+
+test('workspace folder rows expose the Electron open path context menu', () => {
+  const directoryBranchStart = filePanelSource.indexOf('if (node.type === "directory")');
+  const fileBranchStart = filePanelSource.indexOf('const isSelected = node.path === selectedPath');
+  assert.notEqual(directoryBranchStart, -1);
+  assert.notEqual(fileBranchStart, -1);
+
+  const directoryBranch = filePanelSource.slice(directoryBranchStart, fileBranchStart);
+  assert.match(directoryBranch, /const absolutePath = toAbsoluteWorkspacePath\(workDir, node\.path\);/);
+  assert.match(directoryBranch, /onContextMenu=\{\(event\) => \{/);
+  assert.match(directoryBranch, /event\.preventDefault\(\);/);
+  assert.match(directoryBranch, /setContextMenu\(\{\s*absolutePath,\s*canOpenFile: true,/);
+});


### PR DESCRIPTION
## Summary

- Add the existing Electron file-path context menu to workspace folder rows so folders can be opened on the host from the Files tab.
- Keep folder expansion on normal click while using right-click for host actions.
- Remove the Electron global `Select All` fallback for inert app chrome so file and folder right-clicks do not show a meaningless native menu item.
- Add contract tests for folder context-menu behavior and the Electron context-menu fallback.

## Impact

Users of the Electron app can now right-click a folder in the Files tab and choose `Open` to open that folder in the host file manager. File behavior remains unchanged.

## Validation

- `node --test tests/file-read-timeout-contract.test.mjs tests/electron-context-menu-contract.test.mjs tests/workspace-folder-open-contract.test.mjs`
- `npm run lint -- --quiet` fails on the current `dev` baseline with existing React Hooks/Compiler lint errors, including `react-hooks/set-state-in-effect` and `react-hooks/refs` findings outside this change.
