### PR TITLE
Fix session tab activation and composer focus

### DIFF
--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -50,6 +50,7 @@ import {
   isSpecialSession,
 } from "@/lib/constants/special-sessions";
 import { resolveActiveWorkspaceSessionId } from "@/lib/session/active-workspace-session";
+import { activateSessionPanel } from "@/lib/session/focus-session-panel";
 
 const SIDEBAR_RESIZE_HANDLE_WIDTH = 1;
 const GIT_PANEL_RESIZE_HANDLE_WIDTH = 1;
@@ -394,7 +395,10 @@ export function ChatLayout() {
       } catch {
         return;
       }
-      if (location !== null) return;
+      if (location !== null) {
+        activateSessionPanel(activeSessionId, { location });
+        return;
+      }
 
       panelState.assignSession(activeTabData?.activePanelId ?? '', activeSessionId);
       useTabStore.getState().syncTabProjectFromSession(panelState.activeTabId, activeSessionId);
@@ -449,15 +453,13 @@ export function ChatLayout() {
       const location = tabStore.findSessionLocation(sessionId);
       if (action === 'pin') {
         if (location) {
-          tabStore.setActiveTab(location.tabId);
-          usePanelStore.getState().setActivePanelId(location.panelId);
+          activateSessionPanel(sessionId, { location });
           tabStore.pinTab(location.tabId);
         } else {
           tabStore.createTabWithSession(sessionId);
         }
       } else if (location) {
-        tabStore.setActiveTab(location.tabId);
-        usePanelStore.getState().setActivePanelId(location.panelId);
+        activateSessionPanel(sessionId, { location });
       } else {
         tabStore.openPreview(sessionId);
       }

--- a/src/components/layout/running-process-panel.tsx
+++ b/src/components/layout/running-process-panel.tsx
@@ -11,6 +11,7 @@ import { useTabStore } from '@/stores/tab-store';
 import { wsClient } from '@/lib/ws/client';
 import { Button } from '@/components/ui/button';
 import { useI18n } from '@/lib/i18n';
+import { activateSessionPanel } from '@/lib/session/focus-session-panel';
 
 interface RunningProcessPanelProps {
   /** Dropdown open direction: 'down' (header) or 'right' (vertical strip) */
@@ -106,13 +107,10 @@ export function RunningProcessPanel({ direction = 'down' }: RunningProcessPanelP
     const tabStore = useTabStore.getState();
     const existing = tabStore.findSessionLocation(sessionId);
     if (existing) {
-      tabStore.setActiveTab(existing.tabId);
+      activateSessionPanel(sessionId, { location: existing });
     } else {
       tabStore.createTab(sessionId);
     }
-
-    // Set as active session
-    useSessionStore.getState().setActiveSession(sessionId);
 
     setIsOpen(false);
   }, []);

--- a/src/components/notifications/notification-center.tsx
+++ b/src/components/notifications/notification-center.tsx
@@ -5,12 +5,12 @@ import { createPortal } from 'react-dom';
 import { CheckCircle, AlertTriangle, Inbox } from 'lucide-react';
 import { useNotificationStore } from '@/stores/notification-store';
 import { useSessionStore } from '@/stores/session-store';
-import { usePanelStore } from '@/stores/panel-store';
 import { useTabStore } from '@/stores/tab-store';
 import { useBoardStore } from '@/stores/board-store';
 import { wsClient } from '@/lib/ws/client';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
+import { activateSessionPanel } from '@/lib/session/focus-session-panel';
 
 interface NotificationCenterProps {
   isOpen: boolean;
@@ -97,10 +97,7 @@ function NotificationCenterContent({
 
     if (location) {
       // Session already open — switch to correct tab and focus panel
-      if (location.tabId !== tabStore.activeTabId) {
-        tabStore.setActiveTab(location.tabId);
-      }
-      usePanelStore.getState().setActivePanelId(location.panelId);
+      activateSessionPanel(sessionId, { location });
     } else {
       // Session not in any tab/panel — let bridge effect assign it
       setActiveSession(sessionId);

--- a/src/components/notifications/toast-container.tsx
+++ b/src/components/notifications/toast-container.tsx
@@ -6,7 +6,6 @@ import { CheckCircle, XCircle, AlertTriangle, Info, X } from 'lucide-react';
 import { useNotificationStore, type ActionToast } from '@/stores/notification-store';
 import { toast } from '@/stores/notification-store';
 import { useI18n } from '@/lib/i18n';
-import { usePanelStore } from '@/stores/panel-store';
 import { useTabStore } from '@/stores/tab-store';
 import { useSessionStore } from '@/stores/session-store';
 import { useBoardStore } from '@/stores/board-store';
@@ -15,6 +14,7 @@ import { NotificationSound } from './notification-sound';
 import { useSessionNavigation } from '@/hooks/use-session-navigation';
 import { wsClient } from '@/lib/ws/client';
 import { cn } from '@/lib/utils';
+import { activateSessionPanel } from '@/lib/session/focus-session-panel';
 
 const MAX_VISIBLE_TOASTS = 5;
 const ACTION_TOAST_DURATION = 3000;
@@ -127,10 +127,7 @@ export function ToastContainer() {
 
     if (location) {
       // Session already open — switch to correct tab and focus panel
-      if (location.tabId !== tabStore.activeTabId) {
-        tabStore.setActiveTab(location.tabId);
-      }
-      usePanelStore.getState().setActivePanelId(location.panelId);
+      activateSessionPanel(sessionId, { location });
       return;
     }
 

--- a/src/components/panel/panel-wrapper.tsx
+++ b/src/components/panel/panel-wrapper.tsx
@@ -13,6 +13,7 @@ import { PANEL_NODE_DRAG_MIME, SESSION_DRAG_MIME, TAB_DRAG_MIME, TAB_PANEL_TREE_
 import { useSettingsStore } from '@/stores/settings-store';
 import { useI18n } from '@/lib/i18n';
 import { parsePanelNodeDragData, parsePanelTitleDragData } from '@/lib/dnd/panel-session-drag';
+import { focusPanelControl } from '@/lib/session/focus-session-panel';
 
 /** Edge zone threshold — the outer 25% of each edge triggers a split. */
 const EDGE_THRESHOLD = 0.25;
@@ -54,7 +55,9 @@ interface PanelWrapperProps {
 export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: PanelWrapperProps) {
   const { t } = useI18n();
   const tabId = useContext(TabIdContext);
-  const isActive = usePanelStore((s) => s.tabPanels[tabId]?.activePanelId === panelId);
+  const isActive = usePanelStore((s) => (
+    s.activeTabId === tabId && s.tabPanels[tabId]?.activePanelId === panelId
+  ));
   const isSinglePanel = usePanelStore((s) => Object.keys(s.tabPanels[tabId]?.panels ?? EMPTY_PANELS).length <= 1);
   const setActivePanelId = usePanelStore((s) => s.setActivePanelId);
   const inactivePanelDimming = useSettingsStore((s) => s.settings.inactivePanelDimming);
@@ -89,22 +92,7 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
   // 패널 활성화 시 포커스 자동 이동
   useEffect(() => {
     if (!isActive) return;
-    requestAnimationFrame(() => {
-      const panelEl = document.querySelector(`[data-panel-id="${panelId}"]`);
-      if (!panelEl) return;
-      const prompt = panelEl.querySelector<HTMLElement>('[data-interactive-prompt]');
-      if (prompt) {
-        prompt.focus();
-        return;
-      }
-      const textarea = panelEl.querySelector('textarea');
-      if (textarea) {
-        textarea.focus();
-        return;
-      }
-      const createBtn = panelEl.querySelector<HTMLElement>('[data-testid="empty-panel-create-session"]');
-      createBtn?.focus();
-    });
+    focusPanelControl(panelId);
   }, [isActive, panelId, sessionId]);
 
   const handleMouseDown = useCallback(() => {

--- a/src/components/tab/tab-bar.tsx
+++ b/src/components/tab/tab-bar.tsx
@@ -16,6 +16,7 @@ import { TabContextMenu } from './tab-context-menu';
 import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
 import { parsePanelNodeDragData, parsePanelTitleDragData } from '@/lib/dnd/panel-session-drag';
 import { ElectronWindowControls } from '@/components/layout/electron-window-controls';
+import { focusPanelControl } from '@/lib/session/focus-session-panel';
 
 const TAB_SCROLL_MIN_STEP = 180;
 const TAB_SCROLL_EDGE_EPSILON = 1;
@@ -255,8 +256,14 @@ export const TabBar = memo(function TabBar() {
 
   const handleTabActivate = useCallback(function handleTabActivate(tabId: string) {
     const tabStore = useTabStore.getState();
-    if (tabId === tabStore.activeTabId) return;
-    tabStore.setActiveTab(tabId);
+    const panelStore = usePanelStore.getState();
+    const targetPanelId = panelStore.tabPanels[tabId]?.activePanelId;
+    if (tabId !== tabStore.activeTabId) {
+      tabStore.setActiveTab(tabId);
+    }
+    if (targetPanelId) {
+      focusPanelControl(targetPanelId);
+    }
   }, []);
 
   const handleTabClose = useCallback(function handleTabClose(tabId: string) {

--- a/src/hooks/use-session-click-handlers.ts
+++ b/src/hooks/use-session-click-handlers.ts
@@ -3,11 +3,11 @@ import type React from 'react';
 import { useSessionStore } from '@/stores/session-store';
 import { useNotificationStore } from '@/stores/notification-store';
 import { useSelectionStore } from '@/stores/selection-store';
-import { usePanelStore } from '@/stores/panel-store';
 import { useTabStore } from '@/stores/tab-store';
 import { wsClient } from '@/lib/ws/client';
 import { useSessionNavigation } from '@/hooks/use-session-navigation';
 import { getSessionSelectionId } from '@/lib/constants/special-sessions';
+import { activateSessionPanel } from '@/lib/session/focus-session-panel';
 import type { UnifiedSession } from '@/types/chat';
 
 interface PopoutElectronApi {
@@ -108,18 +108,9 @@ export function useSessionClickHandlers(options?: {
 
       // 2. Cross-tab location search (BR-SIDEBAR-004: replaces isInAnotherPanel)
       const location = useTabStore.getState().findSessionLocation(session.id);
-      const currentActiveTabId = useTabStore.getState().activeTabId;
 
       if (location) {
-        if (location.tabId !== currentActiveTabId) {
-          // CASE B1 — Session found in ANOTHER tab (BR-SIDEBAR-005)
-          // Order matters: setActiveTab BEFORE setActivePanelId (BR-EDGE-003)
-          useTabStore.getState().setActiveTab(location.tabId);
-          usePanelStore.getState().setActivePanelId(location.panelId);
-        } else {
-          // CASE B2 — Session found in ACTIVE TAB (BR-SIDEBAR-006)
-          usePanelStore.getState().setActivePanelId(location.panelId);
-        }
+        activateSessionPanel(session.id, { location });
         return;
       }
 
@@ -141,7 +132,7 @@ export function useSessionClickHandlers(options?: {
       const location = tabStore.findSessionLocation(session.id);
       if (location) {
         // 이미 열려있으면 해당 탭으로 이동 + 고정
-        tabStore.setActiveTab(location.tabId);
+        activateSessionPanel(session.id, { location });
         tabStore.pinTab(location.tabId);
       } else {
         // 새 고정 탭으로 열기

--- a/src/lib/session/focus-session-panel.ts
+++ b/src/lib/session/focus-session-panel.ts
@@ -1,0 +1,67 @@
+import { usePanelStore } from '@/stores/panel-store';
+import { useTabStore } from '@/stores/tab-store';
+
+export interface SessionPanelLocation {
+  tabId: string;
+  panelId: string;
+}
+
+function queryPanelElement(panelId: string): HTMLElement | null {
+  if (typeof document === 'undefined') return null;
+  return document.querySelector<HTMLElement>(
+    `[data-panel-wrapper="true"][data-panel-id="${panelId}"]`,
+  );
+}
+
+function focusPanelControlNow(panelId: string): void {
+  const panelEl = queryPanelElement(panelId);
+  if (!panelEl || panelEl.dataset.active !== 'true') return;
+
+  const prompt = panelEl.querySelector<HTMLElement>('[data-interactive-prompt]');
+  if (prompt) {
+    prompt.focus();
+    return;
+  }
+
+  const textarea = panelEl.querySelector<HTMLTextAreaElement>('textarea:not([disabled])');
+  if (textarea) {
+    textarea.focus();
+    return;
+  }
+
+  const createBtn = panelEl.querySelector<HTMLElement>('[data-testid="empty-panel-create-session"]');
+  createBtn?.focus();
+}
+
+export function focusPanelControl(panelId: string): void {
+  if (typeof requestAnimationFrame === 'undefined') {
+    focusPanelControlNow(panelId);
+    return;
+  }
+
+  requestAnimationFrame(() => {
+    focusPanelControlNow(panelId);
+    requestAnimationFrame(() => focusPanelControlNow(panelId));
+  });
+}
+
+export function activateSessionPanel(
+  sessionId: string,
+  options: { location?: SessionPanelLocation | null; focus?: boolean } = {},
+): boolean {
+  const tabStore = useTabStore.getState();
+  const location = options.location ?? tabStore.findSessionLocation(sessionId);
+  if (!location) return false;
+
+  if (location.tabId !== tabStore.activeTabId) {
+    tabStore.setActiveTab(location.tabId);
+  }
+
+  usePanelStore.getState().setActivePanelId(location.panelId);
+
+  if (options.focus !== false) {
+    focusPanelControl(location.panelId);
+  }
+
+  return true;
+}

--- a/tests/session-activation-focus-contract.test.mjs
+++ b/tests/session-activation-focus-contract.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const read = (rel) => fs.readFileSync(new URL(rel, import.meta.url), 'utf8');
+
+const focusHelper = read('../src/lib/session/focus-session-panel.ts');
+const panelWrapper = read('../src/components/panel/panel-wrapper.tsx');
+const tabBar = read('../src/components/tab/tab-bar.tsx');
+const clickHandlers = read('../src/hooks/use-session-click-handlers.ts');
+const chatLayout = read('../src/components/chat/chat-layout.tsx');
+const runningProcessPanel = read('../src/components/layout/running-process-panel.tsx');
+const notificationCenter = read('../src/components/notifications/notification-center.tsx');
+const toastContainer = read('../src/components/notifications/toast-container.tsx');
+
+test('session activation helper selects tab, panel, and composer focus together', () => {
+  assert.match(focusHelper, /export function activateSessionPanel/);
+  assert.ok(
+    focusHelper.indexOf('tabStore.setActiveTab(location.tabId)') <
+      focusHelper.indexOf('setActivePanelId(location.panelId)'),
+  );
+  assert.ok(
+    focusHelper.indexOf('setActivePanelId(location.panelId)') <
+      focusHelper.indexOf('focusPanelControl(location.panelId)'),
+  );
+});
+
+test('panel focus only treats a panel as active in the visible active tab', () => {
+  assert.match(panelWrapper, /s\.activeTabId === tabId && s\.tabPanels\[tabId\]\?\.activePanelId === panelId/);
+});
+
+test('tab clicks refocus the active panel even when the tab is already active', () => {
+  assert.match(tabBar, /focusPanelControl\(targetPanelId\)/);
+  assert.doesNotMatch(tabBar, /if \(tabId === tabStore\.activeTabId\) return/);
+});
+
+test('session-open surfaces activate the located panel instead of only activeSessionId', () => {
+  for (const source of [
+    clickHandlers,
+    chatLayout,
+    runningProcessPanel,
+    notificationCenter,
+    toastContainer,
+  ]) {
+    assert.match(source, /activateSessionPanel\(/);
+  }
+  assert.doesNotMatch(chatLayout, /if \(location !== null\) return/);
+});


### PR DESCRIPTION
## Summary

This PR fixes cases where opening an already-open session did not reliably make that session the active session/panel or return focus to its composer.

The affected paths included clicking a session from the sidebar/board, double-clicking an already-open session, switching back to an existing tab, using running-session navigation, notification/toast navigation, and popout-forwarded session open requests.

## Root Cause

Session activation was split across several independent state updates and UI entry points:

- Some flows updated `activeSessionId` without also selecting the tab and panel that already contained the session.
- Some flows selected a tab but did not select the specific panel inside a multi-panel tab.
- `ChatLayout` had a bridge effect from `activeSessionId` to panel state, but if the session was already open elsewhere it returned early instead of navigating to that existing tab/panel.
- `PanelWrapper` considered a panel active based only on that tab's `activePanelId`, even when the tab itself was hidden in the LRU-mounted tab host. That allowed hidden tabs to participate in active-panel focus behavior.
- Tab clicks no-op'ed when the tab was already active, so clicking the active tab could not restore focus to the composer.

Together these made `activeSessionId`, `panelStore.activePanelId`, and DOM focus diverge depending on which entry point opened the session.

## What Changed

- Added `activateSessionPanel()` and `focusPanelControl()` in `src/lib/session/focus-session-panel.ts`.
  - `activateSessionPanel()` finds or accepts the session location, switches the tab first, selects the target panel, then focuses that panel's interactive prompt, textarea, or empty-panel create button.
  - `focusPanelControl()` double-schedules focus with `requestAnimationFrame` so it works after tab/panel visibility has updated.
- Updated session-open surfaces to use the shared activation path when a session is already open:
  - sidebar/board session click and double-click
  - `ChatLayout` active-session bridge
  - popout-open-session forwarding
  - running process panel navigation
  - notification center navigation
  - toast navigation
- Tightened `PanelWrapper` active state so a panel is only active when both its tab is the active tab and its panel id is the active panel id.
- Updated tab activation so clicking an already-active tab still refocuses the current panel composer.
- Added a contract test that checks these activation/focus paths stay wired together.

## Review Notes

The intended behavior after this change is:

1. If the target session is already open anywhere, opening it should switch to that tab, select the exact panel containing it, and focus the composer for that panel.
2. This should be true for both single-panel tabs and multi-panel tabs.
3. Hidden but LRU-mounted tabs should not steal focus just because their internal `activePanelId` matches a panel.
4. Clicking the active tab should act as a focus restore for the active panel.

The most important files to review are:

- `src/lib/session/focus-session-panel.ts`
- `src/components/chat/chat-layout.tsx`
- `src/components/panel/panel-wrapper.tsx`
- `src/hooks/use-session-click-handlers.ts`
- `src/components/tab/tab-bar.tsx`

## Validation

- `node --test tests/session-activation-focus-contract.test.mjs`
- `git diff --check origin/dev`
- `eslint` on the touched files and new contract test, run via a temporary symlink to the existing main checkout `node_modules` because this worktree did not have its own dependency install.
