### PR TITLE
fix(telemetry): source install id from server bootstrap + track first-run skip reason

### DIFF
--- a/src/app/api/telemetry/first-run/route.ts
+++ b/src/app/api/telemetry/first-run/route.ts
@@ -1,16 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerHostInfo } from '@/lib/system/server-host';
-import { markTelemetryFirstRun } from '@/lib/telemetry/server-state';
+import { markTelemetryFirstRun, type FirstRunSkipReason } from '@/lib/telemetry/server-state';
 import logger from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json().catch(() => ({})) as { status?: unknown };
+    const body = await request.json().catch(() => ({})) as {
+      status?: unknown;
+      skipReason?: unknown;
+    };
     const requestedStatus = body.status === 'captured' ? 'captured' : 'skipped';
-    const status = getServerHostInfo().telemetryDisabledByEnv ? 'skipped' : requestedStatus;
-    const state = await markTelemetryFirstRun(status);
+    const hostInfo = getServerHostInfo();
+    const status = hostInfo.telemetryDisabledByEnv ? 'skipped' : requestedStatus;
+    const skipReason = hostInfo.telemetryDisabledByEnv
+      ? 'telemetry_disabled_by_env'
+      : normalizeFirstRunSkipReason(body.skipReason);
+    const state = await markTelemetryFirstRun(status, { skipReason });
     return NextResponse.json({ success: true, state });
   } catch (error) {
     logger.error({ error }, 'POST /api/telemetry/first-run error');
@@ -19,4 +26,16 @@ export async function POST(request: NextRequest) {
       { status: 500 },
     );
   }
+}
+
+function normalizeFirstRunSkipReason(value: unknown): FirstRunSkipReason | null {
+  if (
+    value === 'client_disabled'
+    || value === 'existing_install_data'
+    || value === 'telemetry_disabled_by_env'
+    || value === 'unknown'
+  ) {
+    return value;
+  }
+  return null;
 }

--- a/src/components/telemetry/telemetry-provider.tsx
+++ b/src/components/telemetry/telemetry-provider.tsx
@@ -8,7 +8,6 @@ import {
   captureTelemetryFirstRun,
   configureTelemetry,
   createTelemetrySessionId,
-  getTelemetryInstallId,
   type TelemetryRuntimeContext,
 } from '@/lib/telemetry/client';
 import type { TelemetryBootstrapInfo } from '@/lib/telemetry/server-state';
@@ -23,30 +22,28 @@ export function TelemetryProvider() {
   const telemetrySettingEnabled = useSettingsStore(
     (state) => state.settings.telemetry.enabled,
   );
-  const settingsServerHostInfo = useSettingsStore((state) => state.serverHostInfo);
   const activeProviderId = useSessionStore((state) => {
     if (!state.activeSessionId) return null;
     return state.getSession(state.activeSessionId)?.provider ?? null;
   });
 
-  const [fallbackInstallId] = useState(getTelemetryInstallId);
   const [appSessionId] = useState(createTelemetrySessionId);
   const [bootstrap, setBootstrap] = useState<TelemetryBootstrapResponse | null>(null);
   const appStartedCapturedRef = useRef(false);
   const firstRunCaptureStartedRef = useRef(false);
   const previousProviderRef = useRef<string | null>(null);
   const activeProviderIdRef = useRef<string | null>(null);
-  const contextServerHostInfo = settingsServerHostInfo ?? bootstrap?.serverHostInfo ?? null;
-  const installId = bootstrap?.installId ?? fallbackInstallId;
+  const contextServerHostInfo = bootstrap?.serverHostInfo ?? null;
+  const installId = bootstrap?.installId ?? null;
 
   const telemetryAllowed = Boolean(
-    settingsServerHostInfo
+    bootstrap
       && telemetrySettingEnabled
-      && !settingsServerHostInfo.telemetryDisabledByEnv,
+      && !bootstrap.serverHostInfo.telemetryDisabledByEnv,
   );
 
   const telemetryContext = useMemo<TelemetryRuntimeContext | null>(() => {
-    if (!contextServerHostInfo) return null;
+    if (!contextServerHostInfo || !installId) return null;
 
     return {
       installId,
@@ -105,6 +102,7 @@ export function TelemetryProvider() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             status: result === 'captured' ? 'captured' : 'skipped',
+            ...(result === 'disabled' ? { skipReason: 'client_disabled' } : {}),
           }),
         });
       } catch {

--- a/src/lib/telemetry/client.ts
+++ b/src/lib/telemetry/client.ts
@@ -35,7 +35,6 @@ export interface TelemetryRuntimeContext {
   channel: string;
 }
 
-const INSTALL_ID_KEY = 'tessera:telemetry:install-id';
 const MAX_STRING_LENGTH = 100;
 const MAX_ARRAY_LENGTH = 20;
 
@@ -165,21 +164,6 @@ type PostHogClient = typeof import('posthog-js')['default'];
 
 export function createTelemetrySessionId(): string {
   return randomId();
-}
-
-export function getTelemetryInstallId(): string {
-  if (!isBrowser()) return randomId();
-
-  try {
-    const existing = window.localStorage.getItem(INSTALL_ID_KEY);
-    if (existing) return existing;
-
-    const installId = randomId();
-    window.localStorage.setItem(INSTALL_ID_KEY, installId);
-    return installId;
-  } catch {
-    return randomId();
-  }
 }
 
 export function configureTelemetry(

--- a/src/lib/telemetry/server-state.ts
+++ b/src/lib/telemetry/server-state.ts
@@ -10,6 +10,7 @@ export interface TelemetryInstallState {
   installId: string;
   firstRunCapturedAt: string | null;
   firstRunSkippedAt: string | null;
+  firstRunSkipReason: FirstRunSkipReason | null;
 }
 
 export interface TelemetryBootstrapInfo extends TelemetryInstallState {
@@ -18,6 +19,11 @@ export interface TelemetryBootstrapInfo extends TelemetryInstallState {
 }
 
 type FirstRunDisposition = 'captured' | 'skipped';
+export type FirstRunSkipReason =
+  | 'client_disabled'
+  | 'existing_install_data'
+  | 'telemetry_disabled_by_env'
+  | 'unknown';
 
 const TELEMETRY_STATE_FILE = 'telemetry.json';
 const EXISTING_INSTALL_MARKERS = [
@@ -48,6 +54,9 @@ export async function getTelemetryBootstrapInfo(
     state = createTelemetryInstallState();
     if (serverHostInfo.telemetryDisabledByEnv || startupHadExistingInstallData === true) {
       state.firstRunSkippedAt = now;
+      state.firstRunSkipReason = serverHostInfo.telemetryDisabledByEnv
+        ? 'telemetry_disabled_by_env'
+        : 'existing_install_data';
     }
     await writeTelemetryInstallState(state);
   } else if (
@@ -55,7 +64,11 @@ export async function getTelemetryBootstrapInfo(
     && !state.firstRunSkippedAt
     && serverHostInfo.telemetryDisabledByEnv
   ) {
-    state = { ...state, firstRunSkippedAt: now };
+    state = {
+      ...state,
+      firstRunSkippedAt: now,
+      firstRunSkipReason: 'telemetry_disabled_by_env',
+    };
     await writeTelemetryInstallState(state);
   }
 
@@ -70,6 +83,7 @@ export async function getTelemetryBootstrapInfo(
 
 export async function markTelemetryFirstRun(
   disposition: FirstRunDisposition,
+  options: { skipReason?: FirstRunSkipReason | null } = {},
 ): Promise<TelemetryInstallState> {
   const current = await readTelemetryInstallState();
   const state = current ?? createTelemetryInstallState();
@@ -83,7 +97,10 @@ export async function markTelemetryFirstRun(
     ...state,
     ...(disposition === 'captured'
       ? { firstRunCapturedAt: now }
-      : { firstRunSkippedAt: now }),
+      : {
+        firstRunSkippedAt: now,
+        firstRunSkipReason: options.skipReason ?? 'unknown',
+      }),
   };
   await writeTelemetryInstallState(updated);
   return updated;
@@ -104,6 +121,7 @@ function createTelemetryInstallState(): TelemetryInstallState {
     installId: randomUUID(),
     firstRunCapturedAt: null,
     firstRunSkippedAt: null,
+    firstRunSkipReason: null,
   };
 }
 
@@ -122,7 +140,20 @@ function normalizeTelemetryInstallState(raw: unknown): TelemetryInstallState | n
     firstRunSkippedAt: typeof value.firstRunSkippedAt === 'string'
       ? value.firstRunSkippedAt
       : null,
+    firstRunSkipReason: normalizeFirstRunSkipReason(value.firstRunSkipReason),
   };
+}
+
+function normalizeFirstRunSkipReason(value: unknown): FirstRunSkipReason | null {
+  if (
+    value === 'client_disabled'
+    || value === 'existing_install_data'
+    || value === 'telemetry_disabled_by_env'
+    || value === 'unknown'
+  ) {
+    return value;
+  }
+  return null;
 }
 
 async function writeTelemetryInstallState(state: TelemetryInstallState): Promise<void> {

--- a/src/lib/telemetry/server.ts
+++ b/src/lib/telemetry/server.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { getServerHostInfo } from '@/lib/system/server-host';
 import { getTelemetryBootstrapInfo } from './server-state';
+import type { TelemetryBootstrapInfo } from './server-state';
 import logger from '@/lib/logger';
 
 export type ServerTelemetryEventName =
@@ -73,6 +74,11 @@ export async function captureServerTelemetryEvent(
           platform: hostInfo.platform,
           arch: hostInfo.arch,
           channel: hostInfo.channel,
+          first_run_eligible: bootstrap.firstRunEligible,
+          first_run_status: getFirstRunStatus(bootstrap),
+          ...(bootstrap.firstRunSkipReason
+            ? { first_run_skip_reason: bootstrap.firstRunSkipReason }
+            : {}),
           $geoip_disable: true,
           $process_person_profile: false,
           ...sanitizeTelemetryProperties(properties),
@@ -89,6 +95,13 @@ export async function captureServerTelemetryEvent(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function getFirstRunStatus(bootstrap: TelemetryBootstrapInfo): string {
+  if (bootstrap.firstRunCapturedAt) return 'captured';
+  if (bootstrap.firstRunSkippedAt) return 'skipped';
+  if (bootstrap.firstRunEligible) return 'eligible';
+  return 'unknown';
 }
 
 function getPostHogCaptureHost(): string {

--- a/tests/telemetry-first-run-state.test.ts
+++ b/tests/telemetry-first-run-state.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  getTelemetryBootstrapInfo,
+  markTelemetryFirstRun,
+  readTelemetryInstallState,
+} from '../src/lib/telemetry/server-state';
+import type { ServerHostInfo } from '../src/lib/system/types';
+
+// Each test gets an isolated data dir so telemetry.json state never leaks
+// between cases. getTesseraDataDir() reads process.env.TESSERA_DATA_DIR on
+// every call, so pointing it at a fresh temp dir fully isolates the fixture.
+function useTempDataDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-telemetry-'));
+  process.env.TESSERA_DATA_DIR = dir;
+  return dir;
+}
+
+function hostInfo(overrides: Partial<ServerHostInfo> = {}): ServerHostInfo {
+  return {
+    appVersion: '1.2.3',
+    platform: 'darwin',
+    arch: 'arm64',
+    channel: 'stable',
+    telemetryDisabledByEnv: false,
+    ...overrides,
+  } as ServerHostInfo;
+}
+
+test('skip disposition persists the reason it was skipped', async () => {
+  useTempDataDir();
+
+  const state = await markTelemetryFirstRun('skipped', { skipReason: 'client_disabled' });
+
+  assert.equal(state.firstRunSkippedAt !== null, true);
+  assert.equal(state.firstRunCapturedAt, null);
+  assert.equal(state.firstRunSkipReason, 'client_disabled');
+
+  const persisted = await readTelemetryInstallState();
+  assert.equal(persisted?.firstRunSkipReason, 'client_disabled');
+});
+
+test('skip without an explicit reason falls back to "unknown"', async () => {
+  useTempDataDir();
+
+  const state = await markTelemetryFirstRun('skipped');
+
+  assert.equal(state.firstRunSkipReason, 'unknown');
+});
+
+test('capture disposition records no skip reason', async () => {
+  useTempDataDir();
+
+  const state = await markTelemetryFirstRun('captured');
+
+  assert.equal(state.firstRunCapturedAt !== null, true);
+  assert.equal(state.firstRunSkippedAt, null);
+  assert.equal(state.firstRunSkipReason, null);
+});
+
+test('first-run disposition is write-once: a later call cannot overwrite it', async () => {
+  useTempDataDir();
+
+  const first = await markTelemetryFirstRun('skipped', { skipReason: 'existing_install_data' });
+  const second = await markTelemetryFirstRun('captured');
+
+  // The second call must be a no-op and return the already-committed state.
+  assert.equal(second.firstRunCapturedAt, null);
+  assert.equal(second.firstRunSkippedAt, first.firstRunSkippedAt);
+  assert.equal(second.firstRunSkipReason, 'existing_install_data');
+});
+
+test('bootstrap on a fresh install is eligible for first-run capture', async () => {
+  useTempDataDir();
+
+  const bootstrap = await getTelemetryBootstrapInfo(hostInfo());
+
+  assert.equal(bootstrap.firstRunEligible, true);
+  assert.equal(bootstrap.firstRunSkippedAt, null);
+  assert.equal(bootstrap.firstRunSkipReason, null);
+  assert.equal(typeof bootstrap.installId, 'string');
+});
+
+test('bootstrap with telemetry disabled by env skips with the env reason', async () => {
+  useTempDataDir();
+
+  const bootstrap = await getTelemetryBootstrapInfo(hostInfo({ telemetryDisabledByEnv: true }));
+
+  assert.equal(bootstrap.firstRunEligible, false);
+  assert.equal(bootstrap.firstRunSkippedAt !== null, true);
+  assert.equal(bootstrap.firstRunSkipReason, 'telemetry_disabled_by_env');
+});
+
+test('normalize drops legacy state without a skip reason and keeps other fields', async () => {
+  const dir = useTempDataDir();
+  // Simulate a telemetry.json written before firstRunSkipReason existed.
+  const legacy = {
+    installId: 'legacy-install-id',
+    firstRunCapturedAt: null,
+    firstRunSkippedAt: '2024-01-01T00:00:00.000Z',
+  };
+  await fsp.writeFile(path.join(dir, 'telemetry.json'), JSON.stringify(legacy), 'utf8');
+
+  const state = await readTelemetryInstallState();
+
+  assert.equal(state?.installId, 'legacy-install-id');
+  assert.equal(state?.firstRunSkippedAt, '2024-01-01T00:00:00.000Z');
+  assert.equal(state?.firstRunSkipReason, null);
+});
+
+test('normalize rejects an unrecognized skip reason', async () => {
+  const dir = useTempDataDir();
+  const tampered = {
+    installId: 'install-id',
+    firstRunCapturedAt: null,
+    firstRunSkippedAt: '2024-01-01T00:00:00.000Z',
+    firstRunSkipReason: 'not_a_real_reason',
+  };
+  await fsp.writeFile(path.join(dir, 'telemetry.json'), JSON.stringify(tampered), 'utf8');
+
+  const state = await readTelemetryInstallState();
+
+  assert.equal(state?.firstRunSkipReason, null);
+});

--- a/tests/telemetry-install-id-contract.test.mjs
+++ b/tests/telemetry-install-id-contract.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const telemetryProviderSource = fs.readFileSync(
+  new URL('../src/components/telemetry/telemetry-provider.tsx', import.meta.url),
+  'utf8',
+);
+const telemetryClientSource = fs.readFileSync(
+  new URL('../src/lib/telemetry/client.ts', import.meta.url),
+  'utf8',
+);
+const telemetryServerSource = fs.readFileSync(
+  new URL('../src/lib/telemetry/server.ts', import.meta.url),
+  'utf8',
+);
+const telemetryServerStateSource = fs.readFileSync(
+  new URL('../src/lib/telemetry/server-state.ts', import.meta.url),
+  'utf8',
+);
+const firstRunRouteSource = fs.readFileSync(
+  new URL('../src/app/api/telemetry/first-run/route.ts', import.meta.url),
+  'utf8',
+);
+
+test('browser telemetry waits for the server bootstrap install id', () => {
+  // Runtime behaviour is covered in telemetry-first-run-state.test.ts. These
+  // assertions guard the wiring that can only be checked at the source level:
+  // the browser must never mint or persist its own install id.
+  assert.doesNotMatch(telemetryProviderSource, /getTelemetryInstallId/);
+  assert.doesNotMatch(telemetryProviderSource, /fallbackInstallId/);
+  assert.doesNotMatch(telemetryClientSource, /getTelemetryInstallId/);
+  assert.doesNotMatch(telemetryClientSource, /tessera:telemetry:install-id/);
+  // Install id and host info are sourced only from the bootstrap response.
+  assert.match(telemetryProviderSource, /installId = bootstrap\?\.installId \?\? null/);
+  assert.match(telemetryProviderSource, /contextServerHostInfo = bootstrap\?\.serverHostInfo \?\? null/);
+  // No runtime context (and therefore no capture) until an install id exists.
+  assert.match(telemetryProviderSource, /!installId\)\s*return null/);
+  // The allow-gate no longer depends on the settings-store host info.
+  assert.doesNotMatch(telemetryProviderSource, /settingsServerHostInfo/);
+});
+
+test('first-run skip state is persisted with a reason and exposed on server telemetry', () => {
+  assert.match(telemetryServerStateSource, /firstRunSkipReason: FirstRunSkipReason \| null/);
+  assert.match(telemetryServerStateSource, /existing_install_data/);
+  assert.match(telemetryServerStateSource, /telemetry_disabled_by_env/);
+  assert.match(telemetryServerStateSource, /client_disabled/);
+  assert.match(firstRunRouteSource, /skipReason/);
+  assert.match(firstRunRouteSource, /normalizeFirstRunSkipReason/);
+  assert.match(telemetryServerSource, /first_run_eligible: bootstrap\.firstRunEligible/);
+  assert.match(telemetryServerSource, /first_run_status: getFirstRunStatus\(bootstrap\)/);
+  assert.match(telemetryServerSource, /first_run_skip_reason: bootstrap\.firstRunSkipReason/);
+});


### PR DESCRIPTION
## What

Make the server bootstrap the single source of truth for the telemetry install id, and track *why* a first run was skipped.

## Why

The browser used to mint and persist its own install id in `localStorage`, which could diverge from the server's `telemetry.json` id. This drops the client-side id entirely and reads `installId`/`serverHostInfo` only from the `/api/telemetry/bootstrap` response, so there is a single source of truth and no capture happens until the id is available.

## Changes

- **client:** remove `getTelemetryInstallId` (the localStorage-backed id).
- **provider:** read `installId`/host info only from the bootstrap response; when absent it is `null` and no runtime context is built. Drop the redundant `settingsServerHostInfo` dependency from the allow-gate (now gated on bootstrap consistently).
- **server-state:** persist and normalize the first-run skip reason (`client_disabled` / `existing_install_data` / `telemetry_disabled_by_env` / `unknown`), with backward compatibility for legacy `telemetry.json` files.
- **server:** expose `first_run_eligible` / `first_run_status` / `first_run_skip_reason` on server telemetry events.

## Tests

- `tests/telemetry-first-run-state.test.ts` (new, 8 cases): behavioural coverage of the actual state transitions — write-once disposition, skip-reason persistence, telemetry-disabled-by-env handling, legacy-file compat, rejection of tampered reasons.
- `tests/telemetry-install-id-contract.test.mjs`: refreshed source-level wiring contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)