### PR TITLE
Fix kanban collection menu behavior

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -67,11 +67,17 @@ function formatRelativeTime(
 }
 
 /** Collection name label with Tag icon (matching list view) */
-function CollectionLabel({ collectionId, isActive }: { collectionId?: string; isActive?: boolean }) {
+function CollectionLabel({ collectionId, isActive }: { collectionId?: string | null; isActive?: boolean }) {
+  const { t } = useI18n();
+  const collectionsByProject = useCollectionStore((state) => state.collectionsByProject);
   const config = collectionId
-    ? useCollectionStore.getState().getCollectionConfig(collectionId)
+    ? Object.values(collectionsByProject)
+        .flat()
+        .find((collection) => collection.id === collectionId)
     : null;
-  if (!config) return null;
+  const label = collectionId ? config?.label : t('task.creation.noCollection');
+
+  if (!label) return null;
 
   return (
     <span className={cn(
@@ -79,7 +85,7 @@ function CollectionLabel({ collectionId, isActive }: { collectionId?: string; is
       isActive ? 'text-(--text-primary) opacity-55' : 'text-(--text-muted)',
     )}>
       <Tag className="w-2.5 h-2.5" />
-      {config.label}
+      {label}
     </span>
   );
 }

--- a/src/components/chat/collection-move-submenu.tsx
+++ b/src/components/chat/collection-move-submenu.tsx
@@ -6,6 +6,8 @@ import type { Collection } from '@/types/collection';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 
+const SUBMENU_CLOSE_DELAY_MS = 180;
+
 interface CollectionMoveSubmenuProps {
   collections: Collection[];
   currentCollectionId: string | null;
@@ -30,9 +32,29 @@ export function CollectionMoveSubmenu({
   const [openToLeft, setOpenToLeft] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const submenuRef = useRef<HTMLDivElement>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const openSubmenu = useCallback(() => setIsOpen(true), []);
-  const closeSubmenu = useCallback(() => setIsOpen(false), []);
+  const clearCloseTimeout = useCallback(() => {
+    if (closeTimeoutRef.current !== null) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+  }, []);
+
+  const openSubmenu = useCallback(() => {
+    clearCloseTimeout();
+    setIsOpen(true);
+  }, [clearCloseTimeout]);
+
+  const closeSubmenu = useCallback(() => {
+    clearCloseTimeout();
+    closeTimeoutRef.current = setTimeout(() => {
+      closeTimeoutRef.current = null;
+      setIsOpen(false);
+    }, SUBMENU_CLOSE_DELAY_MS);
+  }, [clearCloseTimeout]);
+
+  useEffect(() => clearCloseTimeout, [clearCloseTimeout]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -65,6 +87,7 @@ export function CollectionMoveSubmenu({
         onClick={(event) => {
           event.preventDefault();
           event.stopPropagation();
+          clearCloseTimeout();
           setIsOpen((prev) => !prev);
         }}
         data-testid={`${testIdPrefix}-move-to`}
@@ -80,9 +103,12 @@ export function CollectionMoveSubmenu({
           role="menu"
           className={cn(
             'absolute top-0 z-10 min-w-[180px] rounded-lg border border-(--divider) bg-(--sidebar-bg) p-1.5',
+            'before:absolute before:top-0 before:h-full before:w-2 before:content-[""]',
             'shadow-[0_8px_32px_rgba(0,0,0,0.24),0_2px_8px_rgba(0,0,0,0.16)]',
-            openToLeft ? 'right-full mr-1' : 'left-full ml-1',
+            openToLeft ? 'right-full mr-1 before:-right-2' : 'left-full ml-1 before:-left-2',
           )}
+          onMouseEnter={openSubmenu}
+          onMouseLeave={closeSubmenu}
           data-testid={`${testIdPrefix}-move-to-menu`}
         >
           {collections.map((collection) => (

--- a/tests/kanban-collection-menu-contract.test.mjs
+++ b/tests/kanban-collection-menu-contract.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const kanbanCardSource = fs.readFileSync(
+  new URL('../src/components/board/kanban-card.tsx', import.meta.url),
+  'utf8',
+);
+const collectionMoveSubmenuSource = fs.readFileSync(
+  new URL('../src/components/chat/collection-move-submenu.tsx', import.meta.url),
+  'utf8',
+);
+
+test('kanban cards render the Other collection label for uncategorized cards', () => {
+  assert.match(
+    kanbanCardSource,
+    /function CollectionLabel\(\{ collectionId, isActive \}: \{ collectionId\?: string \| null;/,
+  );
+  assert.match(
+    kanbanCardSource,
+    /const label = collectionId \? config\?\.label : t\('task\.creation\.noCollection'\);/,
+  );
+  assert.match(kanbanCardSource, /<CollectionLabel collectionId=\{session\.collectionId\}/);
+  assert.match(kanbanCardSource, /<CollectionLabel collectionId=\{task\.collectionId\}/);
+});
+
+test('collection move submenu tolerates cursor travel from trigger to submenu', () => {
+  assert.match(collectionMoveSubmenuSource, /const SUBMENU_CLOSE_DELAY_MS = 180;/);
+  assert.match(collectionMoveSubmenuSource, /const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> \| null>\(null\);/);
+  assert.match(
+    collectionMoveSubmenuSource,
+    /closeTimeoutRef\.current = setTimeout\(\(\) => \{[\s\S]*setIsOpen\(false\);[\s\S]*SUBMENU_CLOSE_DELAY_MS/,
+  );
+  assert.match(
+    collectionMoveSubmenuSource,
+    /before:absolute before:top-0 before:h-full before:w-2 before:content-\[""\]/,
+  );
+  assert.match(
+    collectionMoveSubmenuSource,
+    /onMouseEnter=\{openSubmenu\}[\s\S]*onMouseLeave=\{closeSubmenu\}[\s\S]*data-testid=\{`\$\{testIdPrefix\}-move-to-menu`\}/,
+  );
+});


### PR DESCRIPTION
## Summary

- Show the `Other` collection label on kanban cards when a task or chat has no collection.
- Keep the `Move to` collection submenu open while the cursor travels from the parent menu item into the submenu.
- Add a source contract test covering the uncategorized label and submenu hover behavior.

## Root Cause

Uncategorized kanban cards returned `null` from `CollectionLabel`, so the tag row disappeared for `Other`. The collection submenu also closed immediately on `mouseleave`, so crossing the small gap between the trigger and the submenu dismissed it before the user could select a collection.

## Validation

- `node --test tests/kanban-collection-menu-contract.test.mjs`
- `npx tsc --noEmit --pretty false`
- `npx eslint src/components/board/kanban-card.tsx src/components/chat/collection-move-submenu.tsx tests/kanban-collection-menu-contract.test.mjs`