### PR TITLE
Add live workspace file sync

### DIFF
--- a/_bmad-output/planning-artifacts/architecture/architecture-tessera-2026-07-07/.memlog.md
+++ b/_bmad-output/planning-artifacts/architecture/architecture-tessera-2026-07-07/.memlog.md
@@ -1,0 +1,22 @@
+---
+scope: Tessera workspace file tab external filesystem change sync
+purpose: build-substrate
+altitude: feature
+updated: 2026-07-07T16:15
+---
+
+- (assumption) Fast path used because user asked to architecture the already-discussed file tab sync requirement with BMad; spine should be reviewed for product/audience nuance before downstream story generation.
+- (constraint) Requirement: when a Files tab or Files panel is open and visible, file additions/deletions from Finder, terminal, or an external editor should appear in the UI within one to two seconds without manual refresh.
+- (constraint) Brownfield fact: src/app/api/sessions/[id]/files/route.ts currently walks the workspace on each request, ignores heavy folders, and returns up to 20000 relative file paths.
+- (constraint) Brownfield fact: WorkspaceFilePanel and WorkspaceExplorerTab currently fetch file lists only on session mount or sourceSessionId change; WorkspaceFileTab refreshes file content on focus and selected WebSocket events.
+- (decision) Use a visible-subscriber filesystem watcher paradigm: UI visibility creates a subscription; a server-side watcher/index owns filesystem observation; clients receive invalidation/version events and reconcile UI state.
+- (decision) Watchers are keyed by canonical workDir, not by panel or tab, and are reference counted by user/session/subscriber so duplicate panels do not create duplicate watchers.
+- (decision) The server owns the file list index as a sorted Set of workspace-relative file paths; the API returns the indexed snapshot when present and falls back to a full walk when no visible subscription/index exists.
+- (decision) File tree changes send workspace_files_changed invalidation messages over the existing WebSocket layer after debounce; clients do not poll while watcher is healthy.
+- (decision) File list events and single file content refresh are separate: add/unlink/addDir/unlinkDir affect the tree index; change affects open WorkspaceFileTab content only when that path is open.
+- (decision) Polling is only a degraded-mode fallback for visible subscribers when watcher setup fails, watcher overflows, or the platform path is unsupported; interval should be two seconds while visible and stopped when hidden.
+- (decision) Ignore rules must be shared between initial walk, watcher, and fallback reconcile so node_modules, .git, .next, dist, build, and similar folders cannot diverge.
+- (question) Open: choose dependency after implementation spike: add chokidar for cross-platform watcher semantics or start with Node fs.watch plus recursive/platform fallbacks.
+- (decision) File-list snapshot contract must preserve the current files API response shape: chats, tasks, workDir, reason, truncated, MAX_FILES behavior, and relative path strings; the live index only changes how files are sourced.
+- (decision) File snapshots should be deterministic: sort relative paths before returning indexed or walked results so UI churn is caused by filesystem changes, not traversal order.
+- (event) draft architecture spine produced; lint passed with zero findings; sequential rubric and adversarial reviews recorded because subagent spawn was not authorized by user request.

--- a/_bmad-output/planning-artifacts/architecture/architecture-tessera-2026-07-07/ARCHITECTURE-SPINE.md
+++ b/_bmad-output/planning-artifacts/architecture/architecture-tessera-2026-07-07/ARCHITECTURE-SPINE.md
@@ -1,0 +1,248 @@
+---
+name: 'Tessera Workspace Files Live Sync'
+type: architecture-spine
+purpose: build-substrate
+altitude: feature
+paradigm: 'Visible-subscriber watcher with server-owned file index'
+scope: 'Files tab, workspace file explorer, workspace file content refresh, and workspace file-list API'
+status: draft
+created: '2026-07-07'
+updated: '2026-07-07'
+binds:
+  - WorkspaceFilePanel
+  - WorkspaceExplorerTab
+  - WorkspaceFileTab
+  - /api/sessions/[id]/files
+  - WebSocket transport
+sources:
+  - src/components/workspace/workspace-file-panel.tsx
+  - src/components/workspace/workspace-explorer-tab.tsx
+  - src/components/workspace/workspace-file-tab.tsx
+  - src/app/api/sessions/[id]/files/route.ts
+  - src/lib/ws/server.ts
+  - src/lib/ws/client.ts
+  - src/lib/ws/message-types.ts
+companions:
+  - .memlog.md
+---
+
+# Architecture Spine - Tessera Workspace Files Live Sync
+
+## Design Paradigm
+
+Files live sync uses a visible-subscriber watcher pattern.
+
+The UI does not poll by default. A visible Files surface subscribes to a workspace root; the server owns filesystem observation and a normalized file index; WebSocket messages tell clients when that index changed. Clients then reconcile their local tree state from the indexed snapshot.
+
+```mermaid
+flowchart LR
+  UI[Visible Files surface] -->|subscribe sessionId| WS[WebSocket route]
+  WS --> Manager[WorkspaceFileWatchManager]
+  Manager --> Resolver[Session workspace root resolver]
+  Resolver --> Index[WorkspaceFileIndex keyed by canonical workDir]
+  Index --> Watcher[Filesystem watcher]
+  Watcher -->|add unlink addDir unlinkDir| Index
+  Index -->|debounced version event| WSOut[workspace_files_changed]
+  WSOut --> UI
+  UI -->|silent reconcile| API[/api/sessions/:id/files]
+  API --> Index
+```
+
+Dependency direction:
+
+```mermaid
+flowchart TD
+  Components[workspace components] --> WsClient[ws client]
+  Components --> FilesApi[files API]
+  WsRouting[ws server routing] --> WatchManager[watch manager]
+  FilesApi --> WatchManager
+  WatchManager --> WorkspaceRoot[session workspace root]
+  WatchManager --> HostPath[host path utilities]
+  WatchManager --> FsWatcher[filesystem watcher adapter]
+```
+
+## Invariants & Rules
+
+### AD-1 - Visibility owns subscription lifetime
+
+- **Binds:** WorkspaceFilePanel, WorkspaceExplorerTab, tab/panel visibility handling
+- **Prevents:** Hidden tabs or inactive panels consuming filesystem watchers and stale visible panels never subscribing.
+- **Rule:** A Files surface must subscribe only while it is actually visible to the user and `document.visibilityState === "visible"`. It must unsubscribe on session change, panel/tab close, hidden tab state, or document hidden.
+
+### AD-2 - Canonical workDir owns watcher identity
+
+- **Binds:** WorkspaceFileWatchManager, session workspace root resolver
+- **Prevents:** Duplicate watchers for the same workspace and inconsistent state between panels viewing the same workDir.
+- **Rule:** Watchers and indexes are keyed by canonical host filesystem root, not by panel id, tab id, or session id. Subscriptions are reference-counted by `{userId, clientId, sessionId, subscriberId}`.
+
+### AD-3 - Server owns the file index
+
+- **Binds:** /api/sessions/[id]/files, WorkspaceFileWatchManager
+- **Prevents:** Every refresh recursively scanning the full repo and clients deriving incompatible file lists.
+- **Rule:** When a visible subscription exists, the server maintains an in-memory `Set<string>` of workspace-relative file paths for that canonical root. `/api/sessions/:id/files` returns that indexed snapshot. Full recursive walk is used for index bootstrap, no-index fallback, and explicit reconcile.
+
+### AD-4 - Watcher events invalidate; snapshots reconcile
+
+- **Binds:** WebSocket transport, WorkspaceFilePanel, WorkspaceExplorerTab
+- **Prevents:** Large file lists being pushed over WebSocket and clients applying partial filesystem deltas incorrectly.
+- **Rule:** Watcher changes emit only `workspace_files_changed` with `{sessionIds, workDir, version}` after debounce. Clients treat the event as invalidation and silently refetch the file-list snapshot before updating UI.
+
+### AD-5 - File tree and file content refresh are separate channels
+
+- **Binds:** WorkspaceFilePanel, WorkspaceExplorerTab, WorkspaceFileTab
+- **Prevents:** Content-only file writes rebuilding the whole tree and file creation/deletion leaving open file tabs stale.
+- **Rule:** Tree subscriptions react to path membership events: `add`, `unlink`, `addDir`, `unlinkDir`, and rename equivalents. Open file content tabs react to `change` for their exact path and to `unlink` by showing a file-not-found state.
+
+### AD-6 - Ignore rules are a shared module
+
+- **Binds:** initial walk, watcher adapter, fallback reconcile, files API
+- **Prevents:** Initial lists, live updates, and fallback refreshes disagreeing about `.git`, `node_modules`, `.next`, `dist`, `build`, and hidden files.
+- **Rule:** Ignore names and hidden-file policy live in one shared server module. No caller may duplicate its own ignore set.
+
+### AD-7 - Polling is degraded mode only
+
+- **Binds:** WorkspaceFilePanel, WorkspaceExplorerTab, WorkspaceFileWatchManager
+- **Prevents:** 1-2 second full-tree polling becoming the primary architecture and overloading large workspaces.
+- **Rule:** Visible-only polling is allowed only when watcher setup fails, a watcher overflow is detected, or a platform path is unsupported. Fallback interval is 2 seconds while visible; it stops immediately when hidden.
+
+### AD-8 - Backpressure beats freshness under load
+
+- **Binds:** WebSocket event scheduling, client reconcile fetches
+- **Prevents:** Event storms from dependency installs, branch switches, or generated directories flooding UI and server.
+- **Rule:** Watcher events are coalesced per canonical workDir with a 250-500ms debounce and monotonically increasing version. A client with an in-flight reconcile does not start another request; it records the latest version and reconciles once more after the current request completes.
+
+### AD-9 - Security stays session-scoped
+
+- **Binds:** WebSocket subscribe route, files API, session access checks
+- **Prevents:** A client subscribing to a workspace outside the sessions it can access.
+- **Rule:** Clients subscribe by `sessionId` only. The server resolves the workDir and reuses the existing session access checks before adding a subscriber. Clients never send absolute paths to create watchers.
+
+### AD-10 - Snapshot compatibility is preserved
+
+- **Binds:** /api/sessions/[id]/files, WorkspaceFilePanel, WorkspaceExplorerTab
+- **Prevents:** Live sync breaking existing file picker/reference-session behavior or causing UI churn from nondeterministic traversal order.
+- **Rule:** The file-list API response keeps the current envelope: `files`, `chats`, `tasks`, `truncated`, `reason`, and `workDir`. Indexed and walked snapshots both return deterministic sorted relative paths and enforce the same `MAX_FILES`/`truncated` behavior.
+
+## Consistency Conventions
+
+| Concern | Convention |
+| --- | --- |
+| Server module names | `workspace-file-watch-manager.ts`, `workspace-file-index.ts`, `workspace-file-ignore.ts`, `workspace-file-events.ts` under `src/lib/workspace-files/` |
+| Client hook names | `useWorkspaceFilesLiveSync` for Files tree surfaces; `useWorkspaceFileContentRefresh` only if content refresh is split from `WorkspaceFileTab` |
+| WebSocket client messages | `subscribe_workspace_files`, `unsubscribe_workspace_files` |
+| WebSocket server messages | `workspace_files_changed`, `workspace_file_watch_status` |
+| Subscriber id | Stable client-generated id per visible Files surface: `{panelId}:{sessionId}` or special tab equivalent |
+| File paths | Always workspace-relative POSIX-style paths in UI/API payloads; absolute paths remain server-side except existing `workDir` response field |
+| Errors | Watcher failure is non-fatal: send `workspace_file_watch_status` and enter visible polling fallback |
+| Logging | Log watcher start/stop, fallback activation, overflow/reconcile, and slow bootstrap with canonical workDir and subscriber count |
+| Snapshot ordering | Sort relative paths before returning file snapshots from either index or walk |
+
+## Stack
+
+| Name | Version |
+| --- | --- |
+| Node.js | >=20.0.0 |
+| Next.js | 16.2.3 |
+| React | 19.2.5 |
+| TypeScript | 5.9.3 |
+| ws | 8.16.0 |
+| Electron | 33.0.0 |
+
+## Structural Seed
+
+```text
+src/lib/workspace-files/
+  workspace-file-ignore.ts        # shared ignore policy for walk, watcher, fallback
+  workspace-file-index.ts         # canonical-root file Set, version, bootstrap/reconcile
+  workspace-file-watch-manager.ts # ref-counted subscriptions and watcher lifecycle
+  workspace-file-events.ts        # WS payload builders and type helpers
+```
+
+```text
+src/components/workspace/
+  workspace-file-panel.tsx        # visible subscription + snapshot reconcile
+  workspace-explorer-tab.tsx      # same subscription contract as side panel
+  workspace-file-tab.tsx          # path-specific content refresh on change/unlink
+```
+
+Bootstrap/reconcile flow:
+
+```mermaid
+sequenceDiagram
+  participant UI as Visible Files UI
+  participant WS as WebSocket route
+  participant M as WatchManager
+  participant I as FileIndex
+  participant API as /api/sessions/:id/files
+
+  UI->>WS: subscribe_workspace_files(sessionId, subscriberId)
+  WS->>M: subscribe(userId, sessionId, subscriberId)
+  M->>I: ensureIndex(canonicalWorkDir)
+  I->>I: initial walk with shared ignore policy
+  M-->>WS: workspace_file_watch_status(active)
+  WS-->>UI: status
+  UI->>API: GET files
+  API-->>UI: indexed snapshot
+```
+
+Change flow:
+
+```mermaid
+sequenceDiagram
+  participant FS as Finder/terminal/editor
+  participant W as Watcher
+  participant I as FileIndex
+  participant WS as WebSocket
+  participant UI as Visible Files UI
+  participant API as /api/sessions/:id/files
+
+  FS->>W: add/unlink/rename
+  W->>I: apply event
+  I->>I: debounce and bump version
+  I->>WS: workspace_files_changed(version)
+  WS->>UI: workspace_files_changed(version)
+  UI->>API: silent GET files
+  API-->>UI: indexed snapshot
+```
+
+Fallback flow:
+
+```mermaid
+flowchart LR
+  WatchError[watcher setup error or overflow] --> Status[workspace_file_watch_status fallback]
+  Status --> Client[visible Files client]
+  Client -->|2s while visible| API[/api/sessions/:id/files]
+  API --> Walk[full walk with shared ignore policy]
+  Walk --> Client
+```
+
+## Capability -> Architecture Map
+
+| Capability / Area | Lives in | Governed by |
+| --- | --- | --- |
+| External add/delete appears within 1-2 seconds | `workspace-file-watch-manager.ts`, `workspace-file-index.ts`, Files UI hook | AD-1, AD-2, AD-3, AD-4, AD-8 |
+| No manual refresh required | WebSocket invalidation + silent reconcile | AD-4, AD-8 |
+| No full-tree polling as primary behavior | Watcher/index path | AD-3, AD-7 |
+| Multiple panels/tabs viewing same workspace stay consistent | Canonical workDir watcher/index | AD-2, AD-4 |
+| Hidden tabs do not waste resources | Visibility-scoped subscriptions | AD-1 |
+| Open file content updates independently | `WorkspaceFileTab` content channel | AD-5 |
+| Large ignored folders stay ignored everywhere | shared ignore module | AD-6 |
+| Unauthorized workspace watch cannot be requested | server-side sessionId resolution | AD-9 |
+| Existing file references remain compatible | files API envelope | AD-10 |
+
+## Deferred
+
+| Decision | Why it can wait | Revisit when |
+| --- | --- | --- |
+| `chokidar` vs Node `fs.watch` | The spine binds watcher semantics, not the adapter choice. Current dependencies do not include `chokidar`; implementation should spike platform behavior before adding a dependency. | First implementation story starts or platform-specific watcher gaps appear. |
+| Persistent on-disk file index | Requirement only needs open-tab freshness. In-memory index with bootstrap/reconcile is enough. | App needs file search across closed workspaces or startup pre-indexing. |
+| Incremental client-side tree patching | Snapshot reconcile is simpler and avoids partial-delta bugs. | File lists become large enough that snapshot transfer/render is the bottleneck. |
+| Watch closed but recently used tabs | User requirement is open/visible Files tab only. | Product requires background freshness for hidden tabs. |
+
+## Open Questions
+
+| Question | Current assumption |
+| --- | --- |
+| Should the first implementation use `chokidar`? | Start with an adapter interface and choose after a small macOS/Windows/Linux spike. |
+| Should `WorkspaceExplorerTab` hidden by tab LRU count as open? | No. Only visible tab panel should subscribe. |
+| Should content `change` events update Monaco without focus? | Yes for visible open file tabs, but this is separate from the file tree. |

--- a/_bmad-output/planning-artifacts/architecture/architecture-tessera-2026-07-07/reviews/review-adversarial-divergence.md
+++ b/_bmad-output/planning-artifacts/architecture/architecture-tessera-2026-07-07/reviews/review-adversarial-divergence.md
@@ -1,0 +1,21 @@
+# Adversarial Divergence Review
+
+Verdict: pass after API compatibility fix.
+
+Attack scenario 1: one story updates `WorkspaceFilePanel` to poll every two seconds while another story adds a server watcher for `WorkspaceExplorerTab`.
+
+- Covered by AD-1, AD-3, AD-4, and AD-7. Polling is degraded mode only; both surfaces share the same subscription and snapshot contract.
+
+Attack scenario 2: two stories implement different ignore lists, causing files to appear after initial load but disappear after live events.
+
+- Covered by AD-6. Ignore policy is a shared server module used by walk, watcher, and fallback reconcile.
+
+Attack scenario 3: one story pushes full file lists over WebSocket while another expects `/files` to own the response envelope.
+
+- Covered by AD-4 and AD-10. WebSocket sends invalidation/version only; `/files` keeps the existing envelope.
+
+Attack scenario 4: hidden LRU-mounted tabs keep watchers alive forever.
+
+- Covered by AD-1. Subscription lifetime is actual visibility, not React mount state.
+
+No critical or high findings remain.

--- a/_bmad-output/planning-artifacts/architecture/architecture-tessera-2026-07-07/reviews/review-rubric-walker.md
+++ b/_bmad-output/planning-artifacts/architecture/architecture-tessera-2026-07-07/reviews/review-rubric-walker.md
@@ -1,0 +1,17 @@
+# Rubric Walker Review
+
+Verdict: pass with one intentional open question.
+
+The spine fixes the main divergence points for implementation stories: subscription lifetime, watcher identity, server-owned index, invalidation-vs-snapshot, tree/content split, shared ignore rules, degraded polling, backpressure, security, and API compatibility.
+
+No critical or high findings remain.
+
+Medium follow-up:
+
+- The watcher adapter dependency is intentionally deferred. Implementation should run a small platform spike before choosing between `chokidar` and Node `fs.watch`.
+
+Evidence:
+
+- Mechanical BMAD lint passed with zero findings.
+- Existing project versions were reality-checked against `package.json`.
+- New dependency choice was not bound in the spine.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@xterm/xterm": "^5.5.0",
         "agentation": "^3.0.2",
         "bcryptjs": "^3.0.3",
+        "chokidar": "^4.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -48,6 +49,7 @@
       },
       "devDependencies": {
         "@electron/osx-sign": "^1.3.1",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.1.18",
         "@types/bcryptjs": "^2.4.6",
         "@types/jsonwebtoken": "^9.0.6",
@@ -2779,14 +2781,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -16230,6 +16231,80 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@xterm/xterm": "^5.5.0",
     "agentation": "^3.0.2",
     "bcryptjs": "^3.0.3",
+    "chokidar": "^4.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
@@ -115,6 +116,7 @@
   },
   "devDependencies": {
     "@electron/osx-sign": "^1.3.1",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.6",

--- a/src/app/api/sessions/[id]/files/route.ts
+++ b/src/app/api/sessions/[id]/files/route.ts
@@ -1,72 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import * as dbSessions from '@/lib/db/sessions';
 import { getDb } from '@/lib/db/database';
-import { getFilesystemPathModule } from '@/lib/filesystem/host-path';
 import { resolveSessionWorkspaceFilesystemRoot } from '@/lib/session/session-workspace-root';
-
-const MAX_FILES = 20000;
-
-const IGNORED_DIR_NAMES = new Set([
-  'node_modules',
-  '.next',
-  '.git',
-  'dist',
-  'build',
-  '.turbo',
-  'coverage',
-  '.cache',
-  '.vercel',
-  '.idea',
-  '.vscode',
-  'out',
-]);
-
-type WalkResult = { files: string[]; truncated: boolean };
-type PathModule = typeof path.win32 | typeof path.posix;
+import { workspaceFileWatchManager } from '@/lib/workspace-files/workspace-file-watch-manager';
+import { walkWorkspaceFiles } from '@/lib/workspace-files/workspace-file-scan';
 
 interface SessionRef {
   sessionId: string;
   title: string;
-}
-
-async function walk(root: string): Promise<WalkResult> {
-  const out: string[] = [];
-  let truncated = false;
-  const pathModule: PathModule = getFilesystemPathModule(root);
-
-  async function recurse(absDir: string, relDir: string): Promise<void> {
-    if (truncated) return;
-    let entries: import('fs').Dirent[];
-    try {
-      entries = await fs.readdir(absDir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const ent of entries) {
-      if (truncated) return;
-      if (ent.name.startsWith('.') && ent.name !== '.env.example') {
-        continue;
-      }
-      if (ent.isDirectory()) {
-        if (IGNORED_DIR_NAMES.has(ent.name)) continue;
-        const childRel = relDir ? `${relDir}/${ent.name}` : ent.name;
-        await recurse(pathModule.join(absDir, ent.name), childRel);
-      } else if (ent.isFile()) {
-        const childRel = relDir ? `${relDir}/${ent.name}` : ent.name;
-        out.push(childRel);
-        if (out.length >= MAX_FILES) {
-          truncated = true;
-          return;
-        }
-      }
-    }
-  }
-
-  await recurse(root, '');
-  return { files: out, truncated };
 }
 
 function listReferenceSessions(projectId: string, currentSessionId: string): {
@@ -147,7 +90,8 @@ export async function GET(
   }
 
   try {
-    const result = await walk(root);
+    const result = await workspaceFileWatchManager.getIndexedSnapshotForRoot(root)
+      ?? await walkWorkspaceFiles(root);
     return NextResponse.json({
       files: result.files,
       chats: refs.chats,

--- a/src/components/workspace/workspace-explorer-tab.tsx
+++ b/src/components/workspace/workspace-explorer-tab.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import { AlertCircle, FileText, FolderTree, LoaderCircle, Search } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { fetchWithTimeout, isTimeoutError } from "@/lib/api/fetch-with-timeout";
+import {
+  useDocumentVisibility,
+  useStableWorkspaceFilesSubscriberId,
+  useWorkspaceFilesLiveSync,
+} from "@/hooks/use-workspace-files-live-sync";
 import { openWorkspaceFileTab } from "@/lib/workspace-tabs/open-workspace-tab";
 import type { WorkspaceExplorerSessionRef } from "@/lib/workspace-tabs/special-session";
+import { TabIdContext } from "@/stores/panel-store";
+import { useTabStore } from "@/stores/tab-store";
 import { cn } from "@/lib/utils";
 
 interface WorkspaceFilesResponse {
@@ -21,6 +28,11 @@ function basename(filePath: string): string {
 function dirname(filePath: string): string {
   const slash = filePath.lastIndexOf("/");
   return slash >= 0 ? filePath.slice(0, slash) : ".";
+}
+
+function sameStringArray(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
 }
 
 function EmptyState({
@@ -51,38 +63,75 @@ export function WorkspaceExplorerTab({
 }: {
   explorerRef: WorkspaceExplorerSessionRef;
 }) {
+  const tabId = useContext(TabIdContext);
+  const isTabActive = useTabStore((state) => state.activeTabId === tabId);
+  const isDocumentVisible = useDocumentVisibility();
+  const subscriberId = useStableWorkspaceFilesSubscriberId("workspace-explorer-tab");
   const [files, setFiles] = useState<string[]>([]);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [truncated, setTruncated] = useState(false);
+  const requestSeqRef = useRef(0);
+  const activeLoadsRef = useRef(0);
 
-  useEffect(() => {
-    const abortController = new AbortController();
+  const loadFiles = useCallback(async (options?: {
+    signal?: AbortSignal;
+    silent?: boolean;
+  }) => {
+    const requestSeq = requestSeqRef.current + 1;
+    requestSeqRef.current = requestSeq;
 
-    const loadFiles = async () => {
-      try {
-        const response = await fetchWithTimeout(
-          `/api/sessions/${encodeURIComponent(explorerRef.sourceSessionId)}/files`,
-          { signal: abortController.signal, retries: 1 },
-        );
-        const payload = (await response.json().catch(() => null)) as WorkspaceFilesResponse | null;
-        if (!response.ok) throw new Error("Failed to load files.");
-        setFiles(Array.isArray(payload?.files) ? payload.files : []);
-        setTruncated(Boolean(payload?.truncated));
-      } catch (error) {
-        if (abortController.signal.aborted) return;
+    if (!options?.silent) {
+      setLoading(true);
+      setError(null);
+    }
+
+    activeLoadsRef.current += 1;
+    try {
+      const response = await fetchWithTimeout(
+        `/api/sessions/${encodeURIComponent(explorerRef.sourceSessionId)}/files`,
+        { signal: options?.signal, retries: 1 },
+      );
+      const payload = (await response.json().catch(() => null)) as WorkspaceFilesResponse | null;
+      if (!response.ok) throw new Error("Failed to load files.");
+
+      if (requestSeqRef.current !== requestSeq) return;
+      const nextFiles = Array.isArray(payload?.files) ? payload.files : [];
+      setFiles((current) => sameStringArray(current, nextFiles) ? current : nextFiles);
+      setTruncated(Boolean(payload?.truncated));
+      setError(null);
+    } catch (error) {
+      if (options?.signal?.aborted || requestSeqRef.current !== requestSeq) return;
+      if (!options?.silent) {
         setError(isTimeoutError(error)
           ? "The file list did not load in time."
           : error instanceof Error ? error.message : "Failed to load files.");
-      } finally {
-        if (!abortController.signal.aborted) setLoading(false);
       }
-    };
-
-    void loadFiles();
-    return () => abortController.abort();
+    } finally {
+      activeLoadsRef.current -= 1;
+      if (!options?.signal?.aborted && requestSeqRef.current === requestSeq) {
+        setLoading(false);
+      }
+    }
   }, [explorerRef.sourceSessionId]);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    void loadFiles({ signal: abortController.signal });
+    return () => abortController.abort();
+  }, [loadFiles]);
+
+  const refreshFiles = useCallback(() => {
+    void loadFiles({ silent: true });
+  }, [loadFiles]);
+
+  useWorkspaceFilesLiveSync({
+    enabled: isTabActive && isDocumentVisible,
+    onRefresh: refreshFiles,
+    sessionId: explorerRef.sourceSessionId,
+    subscriberId,
+  });
 
   const visibleFiles = useMemo(() => {
     const trimmed = query.trim().toLowerCase();

--- a/src/components/workspace/workspace-explorer-tab.tsx
+++ b/src/components/workspace/workspace-explorer-tab.tsx
@@ -1,24 +1,19 @@
 "use client";
 
 import { AlertCircle, FileText, FolderTree, LoaderCircle, Search } from "lucide-react";
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { fetchWithTimeout, isTimeoutError } from "@/lib/api/fetch-with-timeout";
 import {
   useDocumentVisibility,
   useStableWorkspaceFilesSubscriberId,
   useWorkspaceFilesLiveSync,
 } from "@/hooks/use-workspace-files-live-sync";
+import { useWorkspaceFileList } from "@/hooks/use-workspace-file-list";
 import { openWorkspaceFileTab } from "@/lib/workspace-tabs/open-workspace-tab";
 import type { WorkspaceExplorerSessionRef } from "@/lib/workspace-tabs/special-session";
 import { TabIdContext } from "@/stores/panel-store";
 import { useTabStore } from "@/stores/tab-store";
 import { cn } from "@/lib/utils";
-
-interface WorkspaceFilesResponse {
-  files?: string[];
-  truncated?: boolean;
-}
 
 function basename(filePath: string): string {
   const parts = filePath.split("/");
@@ -28,11 +23,6 @@ function basename(filePath: string): string {
 function dirname(filePath: string): string {
   const slash = filePath.lastIndexOf("/");
   return slash >= 0 ? filePath.slice(0, slash) : ".";
-}
-
-function sameStringArray(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((value, index) => value === b[index]);
 }
 
 function EmptyState({
@@ -67,64 +57,14 @@ export function WorkspaceExplorerTab({
   const isTabActive = useTabStore((state) => state.activeTabId === tabId);
   const isDocumentVisible = useDocumentVisibility();
   const subscriberId = useStableWorkspaceFilesSubscriberId("workspace-explorer-tab");
-  const [files, setFiles] = useState<string[]>([]);
   const [query, setQuery] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [truncated, setTruncated] = useState(false);
-  const requestSeqRef = useRef(0);
-  const activeLoadsRef = useRef(0);
-
-  const loadFiles = useCallback(async (options?: {
-    signal?: AbortSignal;
-    silent?: boolean;
-  }) => {
-    const requestSeq = requestSeqRef.current + 1;
-    requestSeqRef.current = requestSeq;
-
-    if (!options?.silent) {
-      setLoading(true);
-      setError(null);
-    }
-
-    activeLoadsRef.current += 1;
-    try {
-      const response = await fetchWithTimeout(
-        `/api/sessions/${encodeURIComponent(explorerRef.sourceSessionId)}/files`,
-        { signal: options?.signal, retries: 1 },
-      );
-      const payload = (await response.json().catch(() => null)) as WorkspaceFilesResponse | null;
-      if (!response.ok) throw new Error("Failed to load files.");
-
-      if (requestSeqRef.current !== requestSeq) return;
-      const nextFiles = Array.isArray(payload?.files) ? payload.files : [];
-      setFiles((current) => sameStringArray(current, nextFiles) ? current : nextFiles);
-      setTruncated(Boolean(payload?.truncated));
-      setError(null);
-    } catch (error) {
-      if (options?.signal?.aborted || requestSeqRef.current !== requestSeq) return;
-      if (!options?.silent) {
-        setError(isTimeoutError(error)
-          ? "The file list did not load in time."
-          : error instanceof Error ? error.message : "Failed to load files.");
-      }
-    } finally {
-      activeLoadsRef.current -= 1;
-      if (!options?.signal?.aborted && requestSeqRef.current === requestSeq) {
-        setLoading(false);
-      }
-    }
-  }, [explorerRef.sourceSessionId]);
-
-  useEffect(() => {
-    const abortController = new AbortController();
-    void loadFiles({ signal: abortController.signal });
-    return () => abortController.abort();
-  }, [loadFiles]);
-
-  const refreshFiles = useCallback(() => {
-    void loadFiles({ silent: true });
-  }, [loadFiles]);
+  const {
+    error,
+    files,
+    loading,
+    refreshFiles,
+    truncated,
+  } = useWorkspaceFileList(explorerRef.sourceSessionId);
 
   useWorkspaceFilesLiveSync({
     enabled: isTabActive && isDocumentVisible,

--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -11,9 +11,14 @@ import {
   LoaderCircle,
   Search,
 } from "lucide-react";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tooltip } from "@/components/ui/tooltip";
+import {
+  useDocumentVisibility,
+  useStableWorkspaceFilesSubscriberId,
+  useWorkspaceFilesLiveSync,
+} from "@/hooks/use-workspace-files-live-sync";
 import {
   openWorkspaceFileTab,
   previewWorkspaceFileTab,
@@ -130,6 +135,11 @@ function buildFileTree(filePaths: string[]): WorkspaceTreeNode[] {
   return finalizeDirectory(root).children;
 }
 
+function sameStringArray(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
 function EmptyState({
   title,
   body,
@@ -158,6 +168,8 @@ function EmptyState({
 }
 
 export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) {
+  const isDocumentVisible = useDocumentVisibility();
+  const subscriberId = useStableWorkspaceFilesSubscriberId("workspace-file-panel");
   const [files, setFiles] = useState<string[]>([]);
   const [query, setQuery] = useState("");
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -169,46 +181,85 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
     error: null,
     truncated: false,
   }));
+  const requestSeqRef = useRef(0);
+  const activeLoadsRef = useRef(0);
 
-  useEffect(() => {
+  const loadFiles = useCallback(async (options?: {
+    signal?: AbortSignal;
+    silent?: boolean;
+  }) => {
     if (!sessionId) {
+      setFiles([]);
       setWorkDir(null);
+      setState({ loading: false, error: null, truncated: false });
       return;
     }
 
-    const abortController = new AbortController();
-    setWorkDir(null);
+    const requestSeq = requestSeqRef.current + 1;
+    requestSeqRef.current = requestSeq;
 
-    const loadFiles = async () => {
-      try {
-        const response = await fetchWithTimeout(
-          `/api/sessions/${encodeURIComponent(sessionId)}/files`,
-          { signal: abortController.signal, retries: 1 },
-        );
-        const payload = (await response.json().catch(() => null)) as WorkspaceFilesResponse | null;
-        if (!response.ok) throw new Error("Failed to load files.");
-        setFiles(Array.isArray(payload?.files) ? payload.files : []);
-        setWorkDir(payload?.workDir ?? null);
-        setState({
+    if (!options?.silent) {
+      setWorkDir(null);
+      setState({ loading: true, error: null, truncated: false });
+    }
+
+    activeLoadsRef.current += 1;
+    try {
+      const response = await fetchWithTimeout(
+        `/api/sessions/${encodeURIComponent(sessionId)}/files`,
+        { signal: options?.signal, retries: 1 },
+      );
+      const payload = (await response.json().catch(() => null)) as WorkspaceFilesResponse | null;
+      if (!response.ok) throw new Error("Failed to load files.");
+
+      if (requestSeqRef.current !== requestSeq) return;
+      const nextFiles = Array.isArray(payload?.files) ? payload.files : [];
+      setFiles((current) => sameStringArray(current, nextFiles) ? current : nextFiles);
+      setWorkDir(payload?.workDir ?? null);
+      setState({
+        loading: false,
+        error: null,
+        truncated: Boolean(payload?.truncated),
+      });
+    } catch (error) {
+      if (options?.signal?.aborted || requestSeqRef.current !== requestSeq) return;
+      const message = isTimeoutError(error)
+        ? "The file list did not load in time."
+        : error instanceof Error ? error.message : "Failed to load files.";
+      if (options?.silent) {
+        setState((current) => current.loading ? current : {
           loading: false,
-          error: null,
-          truncated: Boolean(payload?.truncated),
+          error: current.error,
+          truncated: current.truncated,
         });
-      } catch (error) {
-        if (abortController.signal.aborted) return;
+      } else {
         setState({
           loading: false,
-          error: isTimeoutError(error)
-            ? "The file list did not load in time."
-            : error instanceof Error ? error.message : "Failed to load files.",
+          error: message,
           truncated: false,
         });
       }
-    };
-
-    void loadFiles();
-    return () => abortController.abort();
+    } finally {
+      activeLoadsRef.current -= 1;
+    }
   }, [sessionId]);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    void loadFiles({ signal: abortController.signal });
+    return () => abortController.abort();
+  }, [loadFiles]);
+
+  const refreshFiles = useCallback(() => {
+    void loadFiles({ silent: true });
+  }, [loadFiles]);
+
+  useWorkspaceFilesLiveSync({
+    enabled: Boolean(sessionId) && isDocumentVisible,
+    onRefresh: refreshFiles,
+    sessionId,
+    subscriberId,
+  });
 
   const visibleFiles = useMemo(() => {
     const trimmed = query.trim().toLowerCase();

--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -11,7 +11,7 @@ import {
   LoaderCircle,
   Search,
 } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tooltip } from "@/components/ui/tooltip";
 import {
@@ -19,30 +19,18 @@ import {
   useStableWorkspaceFilesSubscriberId,
   useWorkspaceFilesLiveSync,
 } from "@/hooks/use-workspace-files-live-sync";
+import { useWorkspaceFileList } from "@/hooks/use-workspace-file-list";
 import {
   openWorkspaceFileTab,
   previewWorkspaceFileTab,
 } from "@/lib/workspace-tabs/open-workspace-tab";
 import { setWorkspaceFileDragData } from "@/lib/dnd/panel-session-drag";
-import { fetchWithTimeout, isTimeoutError } from "@/lib/api/fetch-with-timeout";
 import {
   copyText,
   toAbsoluteWorkspacePath,
 } from "@/lib/workspace-tabs/file-path-actions";
 import { WorkspaceFileContextMenu } from "@/components/workspace/workspace-file-context-menu";
 import { cn } from "@/lib/utils";
-
-interface WorkspaceFilesResponse {
-  files?: string[];
-  truncated?: boolean;
-  workDir?: string | null;
-}
-
-interface WorkspaceFilePanelState {
-  loading: boolean;
-  error: string | null;
-  truncated: boolean;
-}
 
 interface WorkspaceFileNode {
   type: "file";
@@ -135,11 +123,6 @@ function buildFileTree(filePaths: string[]): WorkspaceTreeNode[] {
   return finalizeDirectory(root).children;
 }
 
-function sameStringArray(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((value, index) => value === b[index]);
-}
-
 function EmptyState({
   title,
   body,
@@ -170,89 +153,18 @@ function EmptyState({
 export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) {
   const isDocumentVisible = useDocumentVisibility();
   const subscriberId = useStableWorkspaceFilesSubscriberId("workspace-file-panel");
-  const [files, setFiles] = useState<string[]>([]);
   const [query, setQuery] = useState("");
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
-  const [workDir, setWorkDir] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<PathContextMenuState | null>(null);
-  const [state, setState] = useState<WorkspaceFilePanelState>(() => ({
-    loading: Boolean(sessionId),
-    error: null,
-    truncated: false,
-  }));
-  const requestSeqRef = useRef(0);
-  const activeLoadsRef = useRef(0);
-
-  const loadFiles = useCallback(async (options?: {
-    signal?: AbortSignal;
-    silent?: boolean;
-  }) => {
-    if (!sessionId) {
-      setFiles([]);
-      setWorkDir(null);
-      setState({ loading: false, error: null, truncated: false });
-      return;
-    }
-
-    const requestSeq = requestSeqRef.current + 1;
-    requestSeqRef.current = requestSeq;
-
-    if (!options?.silent) {
-      setWorkDir(null);
-      setState({ loading: true, error: null, truncated: false });
-    }
-
-    activeLoadsRef.current += 1;
-    try {
-      const response = await fetchWithTimeout(
-        `/api/sessions/${encodeURIComponent(sessionId)}/files`,
-        { signal: options?.signal, retries: 1 },
-      );
-      const payload = (await response.json().catch(() => null)) as WorkspaceFilesResponse | null;
-      if (!response.ok) throw new Error("Failed to load files.");
-
-      if (requestSeqRef.current !== requestSeq) return;
-      const nextFiles = Array.isArray(payload?.files) ? payload.files : [];
-      setFiles((current) => sameStringArray(current, nextFiles) ? current : nextFiles);
-      setWorkDir(payload?.workDir ?? null);
-      setState({
-        loading: false,
-        error: null,
-        truncated: Boolean(payload?.truncated),
-      });
-    } catch (error) {
-      if (options?.signal?.aborted || requestSeqRef.current !== requestSeq) return;
-      const message = isTimeoutError(error)
-        ? "The file list did not load in time."
-        : error instanceof Error ? error.message : "Failed to load files.";
-      if (options?.silent) {
-        setState((current) => current.loading ? current : {
-          loading: false,
-          error: current.error,
-          truncated: current.truncated,
-        });
-      } else {
-        setState({
-          loading: false,
-          error: message,
-          truncated: false,
-        });
-      }
-    } finally {
-      activeLoadsRef.current -= 1;
-    }
-  }, [sessionId]);
-
-  useEffect(() => {
-    const abortController = new AbortController();
-    void loadFiles({ signal: abortController.signal });
-    return () => abortController.abort();
-  }, [loadFiles]);
-
-  const refreshFiles = useCallback(() => {
-    void loadFiles({ silent: true });
-  }, [loadFiles]);
+  const {
+    error,
+    files,
+    loading,
+    refreshFiles,
+    truncated,
+    workDir,
+  } = useWorkspaceFileList(sessionId);
 
   useWorkspaceFilesLiveSync({
     enabled: Boolean(sessionId) && isDocumentVisible,
@@ -422,7 +334,7 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
               </p>
               <p className="truncate text-[11px] text-(--text-muted)">
                 {files.length.toLocaleString()} files
-                {state.truncated ? " · truncated" : ""}
+                {truncated ? " · truncated" : ""}
               </p>
             </div>
           </div>
@@ -438,12 +350,12 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
         </label>
       </div>
 
-      {state.loading ? (
+      {loading ? (
         <div className="flex h-full items-center justify-center">
           <LoaderCircle className="h-5 w-5 animate-spin text-(--text-muted)" />
         </div>
-      ) : state.error ? (
-        <EmptyState title="Files unavailable" body={state.error} icon="error" />
+      ) : error ? (
+        <EmptyState title="Files unavailable" body={error} icon="error" />
       ) : fileTree.length === 0 ? (
         <EmptyState
           title={query.trim() ? "No matches" : "No files"}

--- a/src/components/workspace/workspace-file-tab.tsx
+++ b/src/components/workspace/workspace-file-tab.tsx
@@ -1,14 +1,23 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { WorkspaceCodeView } from "@/components/workspace/workspace-code-view";
 import { extractGitPanelErrorMessage } from "@/components/git/git-panel-shared";
+import {
+  useDocumentVisibility,
+  useStableWorkspaceFilesSubscriberId,
+  useWorkspaceFilesLiveSync,
+} from "@/hooks/use-workspace-files-live-sync";
 import { fetchWithTimeout, isTimeoutError } from "@/lib/api/fetch-with-timeout";
 import { wsClient } from "@/lib/ws/client";
-import { usePanelStore, selectActiveTab, EMPTY_PANELS } from "@/stores/panel-store";
+import { usePanelStore, selectActiveTab, EMPTY_PANELS, TabIdContext } from "@/stores/panel-store";
+import { useTabStore } from "@/stores/tab-store";
 import type { GitDiffData } from "@/types/git";
 import type { WorkspaceFileData } from "@/types/workspace-file";
-import type { WorkspaceFileSessionRef } from "@/lib/workspace-tabs/special-session";
+import {
+  buildWorkspaceFileSessionId,
+  type WorkspaceFileSessionRef,
+} from "@/lib/workspace-tabs/special-session";
 import type { ServerTransportMessage } from "@/lib/ws/message-types";
 
 interface WorkspaceFileTabState {
@@ -28,9 +37,37 @@ function getFileUrl(ref: WorkspaceFileSessionRef): string {
   return `/api/sessions/${sessionId}/file?path=${path}`;
 }
 
+function getDirectoryName(filePath: string): string {
+  const slashIndex = filePath.lastIndexOf("/");
+  return slashIndex === -1 ? "" : filePath.slice(0, slashIndex);
+}
+
+function getExtension(filePath: string): string {
+  const basename = filePath.split("/").pop() ?? filePath;
+  const dotIndex = basename.lastIndexOf(".");
+  return dotIndex <= 0 ? "" : basename.slice(dotIndex);
+}
+
+function findRenameTarget(
+  msg: ServerTransportMessage,
+  filePath: string,
+): string | null {
+  if (msg.type !== "workspace_files_changed") return null;
+  if (msg.hasMoreChangedPaths || !msg.deletedPaths.includes(filePath)) return null;
+
+  const currentDirectory = getDirectoryName(filePath);
+  const sameDirectoryAdded = msg.addedPaths.filter((path) => getDirectoryName(path) === currentDirectory);
+  if (sameDirectoryAdded.length === 1) return sameDirectoryAdded[0];
+
+  const currentExtension = getExtension(filePath);
+  const sameExtensionAdded = sameDirectoryAdded.filter((path) => getExtension(path) === currentExtension);
+  return sameExtensionAdded.length === 1 ? sameExtensionAdded[0] : null;
+}
+
 function shouldRefreshForSession(
   msg: ServerTransportMessage,
   sessionId: string,
+  filePath: string,
 ): boolean {
   switch (msg.type) {
     case "git_panel_state":
@@ -42,6 +79,9 @@ function shouldRefreshForSession(
       return msg.sessionId === sessionId && msg.event === "completed";
     case "worktree_diff_stats":
       return msg.sessionIds.includes(sessionId);
+    case "workspace_files_changed":
+      return msg.sessionIds.includes(sessionId)
+        && (msg.hasMoreChangedPaths || msg.changedPaths.includes(filePath));
     case "replay_events":
       return msg.sessionId === sessionId
         && msg.events.some((event) =>
@@ -62,6 +102,10 @@ export function WorkspaceFileTab({
   panelId: string;
 }) {
   const { kind, path, sourceSessionId } = fileRef;
+  const tabId = useContext(TabIdContext);
+  const isTabActive = useTabStore((state) => state.activeTabId === tabId);
+  const isDocumentVisible = useDocumentVisibility();
+  const subscriberId = useStableWorkspaceFilesSubscriberId("workspace-file-tab");
   const panelCount = usePanelStore(
     (state) => Object.keys(selectActiveTab(state)?.panels ?? EMPTY_PANELS).length,
   );
@@ -136,6 +180,18 @@ export function WorkspaceFileTab({
     }
   }, [kind, path, sourceSessionId]);
 
+  const refreshFile = useCallback(() => {
+    void loadFile({ silent: true });
+  }, [loadFile]);
+
+  useWorkspaceFilesLiveSync({
+    enabled: isTabActive && isDocumentVisible,
+    onRefresh: refreshFile,
+    refreshOnTreeChange: false,
+    sessionId: sourceSessionId,
+    subscriberId,
+  });
+
   useEffect(() => {
     const abortController = new AbortController();
     void loadFile({ signal: abortController.signal });
@@ -175,7 +231,25 @@ export function WorkspaceFileTab({
     };
 
     const unsubscribe = wsClient.subscribeServerMessages((msg) => {
-      if (shouldRefreshForSession(msg, sourceSessionId)) {
+      const renameTarget = findRenameTarget(msg, path);
+      if (renameTarget && msg.type === "workspace_files_changed" && msg.sessionIds.includes(sourceSessionId)) {
+        assignSession(
+          panelId,
+          buildWorkspaceFileSessionId(sourceSessionId, kind, renameTarget),
+        );
+        return;
+      }
+
+      if (
+        msg.type === "workspace_files_changed"
+        && msg.sessionIds.includes(sourceSessionId)
+        && msg.deletedPaths.includes(path)
+      ) {
+        void loadFile({ signal: abortController.signal });
+        return;
+      }
+
+      if (shouldRefreshForSession(msg, sourceSessionId, path)) {
         scheduleRefresh();
       }
     });
@@ -187,7 +261,7 @@ export function WorkspaceFileTab({
         window.clearTimeout(refreshTimer);
       }
     };
-  }, [loadFile, sourceSessionId]);
+  }, [assignSession, kind, loadFile, panelId, path, sourceSessionId]);
 
   return (
     <WorkspaceCodeView

--- a/src/components/workspace/workspace-file-tab.tsx
+++ b/src/components/workspace/workspace-file-tab.tsx
@@ -20,6 +20,11 @@ import {
 } from "@/lib/workspace-tabs/special-session";
 import type { ServerTransportMessage } from "@/lib/ws/message-types";
 
+type WorkspaceFilesChangedMessage = Extract<
+  ServerTransportMessage,
+  { type: "workspace_files_changed" }
+>;
+
 interface WorkspaceFileTabState {
   loading: boolean;
   error: string | null;
@@ -42,32 +47,27 @@ function getDirectoryName(filePath: string): string {
   return slashIndex === -1 ? "" : filePath.slice(0, slashIndex);
 }
 
-function getExtension(filePath: string): string {
-  const basename = filePath.split("/").pop() ?? filePath;
-  const dotIndex = basename.lastIndexOf(".");
-  return dotIndex <= 0 ? "" : basename.slice(dotIndex);
-}
-
 function findRenameTarget(
-  msg: ServerTransportMessage,
+  msg: WorkspaceFilesChangedMessage,
   filePath: string,
 ): string | null {
-  if (msg.type !== "workspace_files_changed") return null;
-  if (msg.hasMoreChangedPaths || !msg.deletedPaths.includes(filePath)) return null;
+  if (
+    msg.hasMoreChangedPaths
+    || msg.deletedPaths.length !== 1
+    || msg.addedPaths.length !== 1
+    || msg.deletedPaths[0] !== filePath
+  ) {
+    return null;
+  }
 
   const currentDirectory = getDirectoryName(filePath);
-  const sameDirectoryAdded = msg.addedPaths.filter((path) => getDirectoryName(path) === currentDirectory);
-  if (sameDirectoryAdded.length === 1) return sameDirectoryAdded[0];
-
-  const currentExtension = getExtension(filePath);
-  const sameExtensionAdded = sameDirectoryAdded.filter((path) => getExtension(path) === currentExtension);
-  return sameExtensionAdded.length === 1 ? sameExtensionAdded[0] : null;
+  const addedPath = msg.addedPaths[0];
+  return getDirectoryName(addedPath) === currentDirectory ? addedPath : null;
 }
 
 function shouldRefreshForSession(
   msg: ServerTransportMessage,
   sessionId: string,
-  filePath: string,
 ): boolean {
   switch (msg.type) {
     case "git_panel_state":
@@ -79,9 +79,6 @@ function shouldRefreshForSession(
       return msg.sessionId === sessionId && msg.event === "completed";
     case "worktree_diff_stats":
       return msg.sessionIds.includes(sessionId);
-    case "workspace_files_changed":
-      return msg.sessionIds.includes(sessionId)
-        && (msg.hasMoreChangedPaths || msg.changedPaths.includes(filePath));
     case "replay_events":
       return msg.sessionId === sessionId
         && msg.events.some((event) =>
@@ -184,8 +181,31 @@ export function WorkspaceFileTab({
     void loadFile({ silent: true });
   }, [loadFile]);
 
+  const handleWorkspaceFilesChanged = useCallback((msg: WorkspaceFilesChangedMessage) => {
+    if (!msg.sessionIds.includes(sourceSessionId)) return;
+
+    const renameTarget = findRenameTarget(msg, path);
+    if (renameTarget) {
+      assignSession(
+        panelId,
+        buildWorkspaceFileSessionId(sourceSessionId, kind, renameTarget),
+      );
+      return;
+    }
+
+    if (msg.deletedPaths.includes(path)) {
+      void loadFile();
+      return;
+    }
+
+    if (msg.hasMoreChangedPaths || msg.changedPaths.includes(path)) {
+      refreshFile();
+    }
+  }, [assignSession, kind, loadFile, panelId, path, refreshFile, sourceSessionId]);
+
   useWorkspaceFilesLiveSync({
     enabled: isTabActive && isDocumentVisible,
+    onFilesChanged: handleWorkspaceFilesChanged,
     onRefresh: refreshFile,
     refreshOnTreeChange: false,
     sessionId: sourceSessionId,
@@ -231,25 +251,7 @@ export function WorkspaceFileTab({
     };
 
     const unsubscribe = wsClient.subscribeServerMessages((msg) => {
-      const renameTarget = findRenameTarget(msg, path);
-      if (renameTarget && msg.type === "workspace_files_changed" && msg.sessionIds.includes(sourceSessionId)) {
-        assignSession(
-          panelId,
-          buildWorkspaceFileSessionId(sourceSessionId, kind, renameTarget),
-        );
-        return;
-      }
-
-      if (
-        msg.type === "workspace_files_changed"
-        && msg.sessionIds.includes(sourceSessionId)
-        && msg.deletedPaths.includes(path)
-      ) {
-        void loadFile({ signal: abortController.signal });
-        return;
-      }
-
-      if (shouldRefreshForSession(msg, sourceSessionId, path)) {
+      if (shouldRefreshForSession(msg, sourceSessionId)) {
         scheduleRefresh();
       }
     });
@@ -261,7 +263,7 @@ export function WorkspaceFileTab({
         window.clearTimeout(refreshTimer);
       }
     };
-  }, [assignSession, kind, loadFile, panelId, path, sourceSessionId]);
+  }, [loadFile, sourceSessionId]);
 
   return (
     <WorkspaceCodeView

--- a/src/hooks/use-workspace-file-list.ts
+++ b/src/hooks/use-workspace-file-list.ts
@@ -1,0 +1,120 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchWithTimeout, isTimeoutError } from "@/lib/api/fetch-with-timeout";
+
+interface WorkspaceFilesResponse {
+  files?: string[];
+  truncated?: boolean;
+  workDir?: string | null;
+}
+
+interface WorkspaceFileListState {
+  error: string | null;
+  files: string[];
+  loading: boolean;
+  truncated: boolean;
+  workDir: string | null;
+}
+
+function sameStringArray(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
+export function useWorkspaceFileList(sessionId: string | null): WorkspaceFileListState & {
+  loadFiles: (options?: { signal?: AbortSignal; silent?: boolean }) => void;
+  refreshFiles: () => void;
+} {
+  const [state, setState] = useState<WorkspaceFileListState>(() => ({
+    error: null,
+    files: [],
+    loading: Boolean(sessionId),
+    truncated: false,
+    workDir: null,
+  }));
+  const requestSeqRef = useRef(0);
+
+  const loadFiles = useCallback((options?: {
+    signal?: AbortSignal;
+    silent?: boolean;
+  }) => {
+    void (async () => {
+      if (!sessionId) {
+        setState({
+          error: null,
+          files: [],
+          loading: false,
+          truncated: false,
+          workDir: null,
+        });
+        return;
+      }
+
+      const requestSeq = requestSeqRef.current + 1;
+      requestSeqRef.current = requestSeq;
+
+      if (!options?.silent) {
+        setState((current) => ({
+          ...current,
+          error: null,
+          loading: true,
+          truncated: false,
+          workDir: null,
+        }));
+      }
+
+      try {
+        const response = await fetchWithTimeout(
+          `/api/sessions/${encodeURIComponent(sessionId)}/files`,
+          { signal: options?.signal, retries: 1 },
+        );
+        const payload = (await response.json().catch(() => null)) as WorkspaceFilesResponse | null;
+        if (!response.ok) throw new Error("Failed to load files.");
+
+        if (requestSeqRef.current !== requestSeq) return;
+        const nextFiles = Array.isArray(payload?.files) ? payload.files : [];
+        setState((current) => ({
+          error: null,
+          files: sameStringArray(current.files, nextFiles) ? current.files : nextFiles,
+          loading: false,
+          truncated: Boolean(payload?.truncated),
+          workDir: payload?.workDir ?? null,
+        }));
+      } catch (error) {
+        if (options?.signal?.aborted || requestSeqRef.current !== requestSeq) return;
+        const message = isTimeoutError(error)
+          ? "The file list did not load in time."
+          : error instanceof Error ? error.message : "Failed to load files.";
+        setState((current) => options?.silent
+          ? {
+              ...current,
+              loading: false,
+            }
+          : {
+              error: message,
+              files: [],
+              loading: false,
+              truncated: false,
+              workDir: null,
+            });
+      }
+    })();
+  }, [sessionId]);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    loadFiles({ signal: abortController.signal });
+    return () => abortController.abort();
+  }, [loadFiles]);
+
+  const refreshFiles = useCallback(() => {
+    loadFiles({ silent: true });
+  }, [loadFiles]);
+
+  return {
+    ...state,
+    loadFiles,
+    refreshFiles,
+  };
+}

--- a/src/hooks/use-workspace-files-live-sync.ts
+++ b/src/hooks/use-workspace-files-live-sync.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useChatStore } from "@/stores/chat-store";
+import { wsClient } from "@/lib/ws/client";
+import type { ServerTransportMessage } from "@/lib/ws/message-types";
+
+const FALLBACK_POLL_INTERVAL_MS = 2_000;
+
+function createSubscriberId(prefix: string): string {
+  const random =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  return `${prefix}:${random}`;
+}
+
+function isDocumentVisible(): boolean {
+  return typeof document === "undefined" || document.visibilityState === "visible";
+}
+
+export function useDocumentVisibility(): boolean {
+  const [visible, setVisible] = useState(isDocumentVisible);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const update = () => setVisible(document.visibilityState === "visible");
+    document.addEventListener("visibilitychange", update);
+    window.addEventListener("focus", update);
+    window.addEventListener("blur", update);
+    return () => {
+      document.removeEventListener("visibilitychange", update);
+      window.removeEventListener("focus", update);
+      window.removeEventListener("blur", update);
+    };
+  }, []);
+
+  return visible;
+}
+
+export function useStableWorkspaceFilesSubscriberId(prefix: string): string {
+  const [subscriberId] = useState(() => createSubscriberId(prefix));
+  return subscriberId;
+}
+
+export function useWorkspaceFilesLiveSync({
+  enabled,
+  onRefresh,
+  refreshOnTreeChange = true,
+  sessionId,
+  subscriberId,
+}: {
+  enabled: boolean;
+  onRefresh: () => void;
+  refreshOnTreeChange?: boolean;
+  sessionId: string | null;
+  subscriberId: string;
+}): void {
+  const connectionStatus = useChatStore((state) => state.connectionStatus);
+  const [fallbackPolling, setFallbackPolling] = useState(false);
+  const onRefreshRef = useRef(onRefresh);
+
+  useEffect(() => {
+    onRefreshRef.current = onRefresh;
+  }, [onRefresh]);
+
+  useEffect(() => {
+    if (!enabled || !sessionId || connectionStatus !== "connected") {
+      return;
+    }
+
+    const sent = wsClient.subscribeWorkspaceFiles(sessionId, subscriberId);
+    if (!sent) {
+      queueMicrotask(() => setFallbackPolling(true));
+      onRefreshRef.current();
+      return;
+    }
+    onRefreshRef.current();
+
+    return () => {
+      setFallbackPolling(false);
+      wsClient.unsubscribeWorkspaceFiles(sessionId, subscriberId);
+    };
+  }, [connectionStatus, enabled, sessionId, subscriberId]);
+
+  useEffect(() => {
+    if (!enabled || !sessionId) return;
+
+    const unsubscribe = wsClient.subscribeServerMessages((msg: ServerTransportMessage) => {
+      if (
+        msg.type === "workspace_file_watch_status"
+        && msg.sessionId === sessionId
+        && msg.subscriberId === subscriberId
+      ) {
+        setFallbackPolling(msg.status === "fallback");
+        return;
+      }
+
+      if (
+        msg.type === "workspace_files_changed"
+        && msg.sessionIds.includes(sessionId)
+      ) {
+        if (refreshOnTreeChange && msg.treeChanged) {
+          onRefreshRef.current();
+        }
+      }
+    });
+
+    return unsubscribe;
+  }, [enabled, refreshOnTreeChange, sessionId, subscriberId]);
+
+  useEffect(() => {
+    if (!enabled || !sessionId || !fallbackPolling) return;
+    const timer = window.setInterval(() => {
+      onRefreshRef.current();
+    }, FALLBACK_POLL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [enabled, fallbackPolling, sessionId]);
+}

--- a/src/hooks/use-workspace-files-live-sync.ts
+++ b/src/hooks/use-workspace-files-live-sync.ts
@@ -7,6 +7,11 @@ import type { ServerTransportMessage } from "@/lib/ws/message-types";
 
 const FALLBACK_POLL_INTERVAL_MS = 2_000;
 
+type WorkspaceFilesChangedMessage = Extract<
+  ServerTransportMessage,
+  { type: "workspace_files_changed" }
+>;
+
 function createSubscriberId(prefix: string): string {
   const random =
     typeof crypto !== "undefined" && "randomUUID" in crypto
@@ -45,12 +50,14 @@ export function useStableWorkspaceFilesSubscriberId(prefix: string): string {
 
 export function useWorkspaceFilesLiveSync({
   enabled,
+  onFilesChanged,
   onRefresh,
   refreshOnTreeChange = true,
   sessionId,
   subscriberId,
 }: {
   enabled: boolean;
+  onFilesChanged?: (msg: WorkspaceFilesChangedMessage) => void;
   onRefresh: () => void;
   refreshOnTreeChange?: boolean;
   sessionId: string | null;
@@ -58,7 +65,12 @@ export function useWorkspaceFilesLiveSync({
 }): void {
   const connectionStatus = useChatStore((state) => state.connectionStatus);
   const [fallbackPolling, setFallbackPolling] = useState(false);
+  const onFilesChangedRef = useRef(onFilesChanged);
   const onRefreshRef = useRef(onRefresh);
+
+  useEffect(() => {
+    onFilesChangedRef.current = onFilesChanged;
+  }, [onFilesChanged]);
 
   useEffect(() => {
     onRefreshRef.current = onRefresh;
@@ -100,6 +112,7 @@ export function useWorkspaceFilesLiveSync({
         msg.type === "workspace_files_changed"
         && msg.sessionIds.includes(sessionId)
       ) {
+        onFilesChangedRef.current?.(msg);
         if (refreshOnTreeChange && msg.treeChanged) {
           onRefreshRef.current();
         }

--- a/src/lib/workspace-files/workspace-file-scan.ts
+++ b/src/lib/workspace-files/workspace-file-scan.ts
@@ -1,0 +1,97 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { getFilesystemPathModule } from "@/lib/filesystem/host-path";
+
+export const MAX_WORKSPACE_FILES = 20000;
+
+export const IGNORED_WORKSPACE_DIR_NAMES = new Set([
+  "node_modules",
+  ".next",
+  ".git",
+  "dist",
+  "build",
+  ".turbo",
+  "coverage",
+  ".cache",
+  ".vercel",
+  ".idea",
+  ".vscode",
+  "out",
+]);
+
+export type WorkspaceFileWalkResult = {
+  files: string[];
+  truncated: boolean;
+};
+
+type PathModule = typeof path.win32 | typeof path.posix;
+
+export function normalizeWorkspaceRelativePath(filePath: string): string {
+  return filePath
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter((part) => part && part !== ".")
+    .join("/");
+}
+
+export function isIgnoredWorkspacePath(filePath: string, stats?: { isDirectory(): boolean }): boolean {
+  const normalized = normalizeWorkspaceRelativePath(filePath);
+  if (!normalized) return false;
+
+  const parts = normalized.split("/");
+  const basename = parts[parts.length - 1] ?? "";
+  if (basename.startsWith(".") && basename !== ".env.example") {
+    return true;
+  }
+
+  const directoryParts = stats?.isDirectory() ? parts : parts.slice(0, -1);
+  if (directoryParts.some((part) => part.startsWith("."))) {
+    return true;
+  }
+  return directoryParts.some((part) => IGNORED_WORKSPACE_DIR_NAMES.has(part));
+}
+
+export async function walkWorkspaceFiles(root: string): Promise<WorkspaceFileWalkResult> {
+  const out: string[] = [];
+  let truncated = false;
+  const pathModule: PathModule = getFilesystemPathModule(root);
+
+  async function recurse(absDir: string, relDir: string): Promise<void> {
+    if (truncated) return;
+    let entries: import("fs").Dirent[];
+    try {
+      entries = await fs.readdir(absDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const ent of entries) {
+      if (truncated) return;
+      const childRel = relDir ? `${relDir}/${ent.name}` : ent.name;
+      if (isIgnoredWorkspacePath(childRel, ent)) continue;
+
+      if (ent.isDirectory()) {
+        await recurse(pathModule.join(absDir, ent.name), childRel);
+      } else if (ent.isFile()) {
+        out.push(childRel);
+        if (out.length >= MAX_WORKSPACE_FILES) {
+          truncated = true;
+          return;
+        }
+      }
+    }
+  }
+
+  await recurse(root, "");
+  out.sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }));
+  return { files: out, truncated };
+}
+
+export function applyMaxFiles(fileSet: Set<string>): WorkspaceFileWalkResult {
+  const files = Array.from(fileSet)
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }));
+  return {
+    files: files.slice(0, MAX_WORKSPACE_FILES),
+    truncated: files.length > MAX_WORKSPACE_FILES,
+  };
+}

--- a/src/lib/workspace-files/workspace-file-watch-manager.ts
+++ b/src/lib/workspace-files/workspace-file-watch-manager.ts
@@ -1,0 +1,500 @@
+import * as fs from "fs/promises";
+import chokidar, { type FSWatcher } from "chokidar";
+import { getFilesystemPathModule } from "@/lib/filesystem/host-path";
+import logger from "@/lib/logger";
+import { resolveSessionWorkspaceFilesystemRoot } from "@/lib/session/session-workspace-root";
+import type { ServerTransportMessage } from "@/lib/ws/message-types";
+import {
+  applyMaxFiles,
+  isIgnoredWorkspacePath,
+  normalizeWorkspaceRelativePath,
+  type WorkspaceFileWalkResult,
+  walkWorkspaceFiles,
+} from "./workspace-file-scan";
+
+type WsSendToUser = (userId: string, message: ServerTransportMessage) => void;
+
+type WatchStatus = "starting" | "active" | "fallback";
+type WatchEventName = "add" | "addDir" | "change" | "unlink" | "unlinkDir";
+
+interface WorkspaceFileSubscriber {
+  connectionId: string;
+  sendToUser: WsSendToUser;
+  sessionId: string;
+  subscriberId: string;
+  userId: string;
+}
+
+interface PendingWatchEvent {
+  eventName: WatchEventName;
+  relativePath: string;
+}
+
+interface WatchEventStats {
+  isDirectory(): boolean;
+  isFile(): boolean;
+}
+
+interface WorkspaceWatchEntry {
+  debounceTimer: NodeJS.Timeout | null;
+  files: Set<string>;
+  pendingAddedPaths: Set<string>;
+  pendingChangedPaths: Set<string>;
+  pendingDeletedPaths: Set<string>;
+  pendingEventsBeforeReady: PendingWatchEvent[];
+  pendingHasMoreChangedPaths: boolean;
+  pendingTreeChanged: boolean;
+  ready: boolean;
+  readyPromise: Promise<void>;
+  root: string;
+  status: WatchStatus;
+  subscribers: Map<string, WorkspaceFileSubscriber>;
+  truncated: boolean;
+  version: number;
+  watcher: FSWatcher | null;
+}
+
+const CHANGE_DEBOUNCE_MS = 300;
+const MAX_CHANGED_PATHS_PER_EVENT = 200;
+
+function subscriberKey(connectionId: string, sessionId: string, subscriberId: string): string {
+  return `${connectionId}:${sessionId}:${subscriberId}`;
+}
+
+async function resolveCanonicalWorkspaceRoot(root: string): Promise<string> {
+  try {
+    return await fs.realpath(root);
+  } catch {
+    return root;
+  }
+}
+
+function uniqueSessionIds(subscribers: Iterable<WorkspaceFileSubscriber>): string[] {
+  return Array.from(new Set(Array.from(subscribers, (subscriber) => subscriber.sessionId)));
+}
+
+function toWorkspaceRelativePath(root: string, filePath: string): string {
+  const pathModule = getFilesystemPathModule(root);
+  const relativePath = pathModule.isAbsolute(filePath)
+    ? pathModule.relative(root, filePath)
+    : filePath;
+  return normalizeWorkspaceRelativePath(relativePath);
+}
+
+class WorkspaceFileWatchManager {
+  private readonly canceledSubscriberKeys = new Set<string>();
+  private readonly closedConnectionIds = new Set<string>();
+  private readonly closedConnectionCleanupTimers = new Map<string, NodeJS.Timeout>();
+  private readonly entriesByRoot = new Map<string, WorkspaceWatchEntry>();
+  private readonly rootBySessionId = new Map<string, string>();
+
+  async subscribe(options: {
+    connectionId: string;
+    sendToUser: WsSendToUser;
+    sessionId: string;
+    subscriberId: string;
+    userId: string;
+  }): Promise<void> {
+    const key = subscriberKey(options.connectionId, options.sessionId, options.subscriberId);
+    if (this.closedConnectionIds.has(options.connectionId)) {
+      return;
+    }
+
+    const root = await this.resolveRootForSession(options.sessionId);
+    if (this.closedConnectionIds.has(options.connectionId) || this.canceledSubscriberKeys.delete(key)) {
+      return;
+    }
+    if (!root) {
+      options.sendToUser(options.userId, {
+        type: "workspace_file_watch_status",
+        sessionId: options.sessionId,
+        subscriberId: options.subscriberId,
+        status: "fallback",
+        reason: "missing_work_dir",
+      });
+      return;
+    }
+
+    const entry = this.getOrCreateEntry(root);
+    entry.subscribers.set(key, options);
+
+    options.sendToUser(options.userId, {
+      type: "workspace_file_watch_status",
+      sessionId: options.sessionId,
+      subscriberId: options.subscriberId,
+      workDir: entry.root,
+      status: entry.status === "active" ? "active" : "starting",
+      version: entry.version,
+    });
+
+    void entry.readyPromise.then(() => {
+      const current = entry.subscribers.get(
+        key,
+      );
+      if (!current) return;
+      current.sendToUser(current.userId, {
+        type: "workspace_file_watch_status",
+        sessionId: current.sessionId,
+        subscriberId: current.subscriberId,
+        workDir: entry.root,
+        status: entry.status === "active" ? "active" : "fallback",
+        version: entry.version,
+      });
+    }).catch((error) => {
+      logger.warn({ error, root: entry.root }, "Workspace file watch bootstrap failed");
+    });
+  }
+
+  unsubscribe(options: {
+    connectionId: string;
+    sessionId: string;
+    subscriberId: string;
+  }): void {
+    const key = subscriberKey(options.connectionId, options.sessionId, options.subscriberId);
+    const root = this.rootBySessionId.get(options.sessionId);
+    if (!root) {
+      this.canceledSubscriberKeys.add(key);
+      return;
+    }
+
+    const entry = this.entriesByRoot.get(root);
+    if (!entry) {
+      this.canceledSubscriberKeys.add(key);
+      return;
+    }
+
+    const removed = entry.subscribers.delete(key);
+    if (!removed) {
+      this.canceledSubscriberKeys.add(key);
+    }
+    this.closeEntryIfUnused(entry);
+  }
+
+  unsubscribeConnection(connectionId: string): void {
+    this.rememberClosedConnection(connectionId);
+    for (const key of Array.from(this.canceledSubscriberKeys)) {
+      if (key.startsWith(`${connectionId}:`)) {
+        this.canceledSubscriberKeys.delete(key);
+      }
+    }
+    for (const entry of Array.from(this.entriesByRoot.values())) {
+      for (const [key, subscriber] of Array.from(entry.subscribers.entries())) {
+        if (subscriber.connectionId === connectionId) {
+          entry.subscribers.delete(key);
+        }
+      }
+      this.closeEntryIfUnused(entry);
+    }
+  }
+
+  private rememberClosedConnection(connectionId: string): void {
+    this.closedConnectionIds.add(connectionId);
+    const existingTimer = this.closedConnectionCleanupTimers.get(connectionId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+    const timer = setTimeout(() => {
+      this.closedConnectionIds.delete(connectionId);
+      this.closedConnectionCleanupTimers.delete(connectionId);
+    }, 60_000);
+    timer.unref?.();
+    this.closedConnectionCleanupTimers.set(connectionId, timer);
+  }
+
+  async getIndexedSnapshotForRoot(root: string): Promise<WorkspaceFileWalkResult | null> {
+    const canonicalRoot = await resolveCanonicalWorkspaceRoot(root);
+    const entry = this.entriesByRoot.get(canonicalRoot);
+    if (!entry || entry.status !== "active" || entry.truncated) return null;
+
+    await entry.readyPromise;
+    if (entry.status !== "active" || entry.truncated) return null;
+    return applyMaxFiles(entry.files);
+  }
+
+  private async resolveRootForSession(sessionId: string): Promise<string | null> {
+    const root = await resolveSessionWorkspaceFilesystemRoot(sessionId);
+    if (!root) return null;
+    const canonicalRoot = await resolveCanonicalWorkspaceRoot(root);
+    this.rootBySessionId.set(sessionId, canonicalRoot);
+    return canonicalRoot;
+  }
+
+  private getOrCreateEntry(root: string): WorkspaceWatchEntry {
+    const existing = this.entriesByRoot.get(root);
+    if (existing) return existing;
+
+    const entry: WorkspaceWatchEntry = {
+      debounceTimer: null,
+      files: new Set(),
+      pendingAddedPaths: new Set(),
+      pendingChangedPaths: new Set(),
+      pendingDeletedPaths: new Set(),
+      pendingEventsBeforeReady: [],
+      pendingHasMoreChangedPaths: false,
+      pendingTreeChanged: false,
+      ready: false,
+      readyPromise: Promise.resolve(),
+      root,
+      status: "starting",
+      subscribers: new Map(),
+      truncated: false,
+      version: 0,
+      watcher: null,
+    };
+    this.entriesByRoot.set(root, entry);
+    this.startWatcher(entry);
+    entry.readyPromise = this.bootstrapEntry(entry);
+    return entry;
+  }
+
+  private async bootstrapEntry(entry: WorkspaceWatchEntry): Promise<void> {
+    try {
+      const snapshot = await walkWorkspaceFiles(entry.root);
+      entry.files = new Set(snapshot.files);
+      entry.truncated = snapshot.truncated;
+      entry.ready = true;
+
+      const pending = entry.pendingEventsBeforeReady.splice(0);
+      for (const event of pending) {
+        this.applyWatchEvent(entry, event.eventName, event.relativePath);
+      }
+
+      if (entry.status !== "fallback") {
+        entry.status = "active";
+      }
+      logger.info({
+        root: entry.root,
+        files: entry.files.size,
+        truncated: entry.truncated,
+      }, "Workspace file watch index ready");
+    } catch (error) {
+      entry.status = "fallback";
+      logger.warn({ error, root: entry.root }, "Failed to bootstrap workspace file index");
+    }
+  }
+
+  private startWatcher(entry: WorkspaceWatchEntry): void {
+    try {
+      const watcher = chokidar.watch(entry.root, {
+        atomic: true,
+        awaitWriteFinish: false,
+        cwd: entry.root,
+        followSymlinks: false,
+        ignoreInitial: true,
+        ignored: (filePath, stats) => (
+          isIgnoredWorkspacePath(toWorkspaceRelativePath(entry.root, String(filePath)), stats)
+        ),
+        persistent: true,
+      });
+
+      watcher.on("all", (eventName, filePath, stats?: WatchEventStats) => {
+        if (!this.isWatchEventName(eventName)) return;
+        if (!this.isWatchEventShape(eventName, stats)) return;
+        const relativePath = toWorkspaceRelativePath(entry.root, String(filePath));
+        if (!relativePath || isIgnoredWorkspacePath(relativePath)) return;
+        if (!entry.ready) {
+          entry.pendingEventsBeforeReady.push({ eventName, relativePath });
+          return;
+        }
+        this.applyWatchEvent(entry, eventName, relativePath);
+      });
+
+      watcher.on("error", (error) => {
+        entry.status = "fallback";
+        logger.warn({ error, root: entry.root }, "Workspace file watcher failed; falling back to visible polling");
+        this.emitWatchStatus(entry, "fallback", "watch_error");
+      });
+
+      entry.watcher = watcher;
+    } catch (error) {
+      entry.status = "fallback";
+      logger.warn({ error, root: entry.root }, "Failed to start workspace file watcher");
+      this.emitWatchStatus(entry, "fallback", "watch_start_failed");
+    }
+  }
+
+  private isWatchEventName(eventName: string): eventName is WatchEventName {
+    return eventName === "add"
+      || eventName === "addDir"
+      || eventName === "change"
+      || eventName === "unlink"
+      || eventName === "unlinkDir";
+  }
+
+  private isWatchEventShape(eventName: WatchEventName, stats?: WatchEventStats): boolean {
+    if (!stats) return true;
+    if (eventName === "add" || eventName === "change") return stats.isFile();
+    if (eventName === "addDir") return stats.isDirectory();
+    return true;
+  }
+
+  private applyWatchEvent(
+    entry: WorkspaceWatchEntry,
+    eventName: WatchEventName,
+    relativePath: string,
+  ): void {
+    switch (eventName) {
+      case "add":
+        entry.files.add(relativePath);
+        this.scheduleChange(entry, relativePath, {
+          added: true,
+          treeChanged: true,
+        });
+        return;
+      case "unlink":
+        entry.files.delete(relativePath);
+        this.scheduleChange(entry, relativePath, {
+          deleted: true,
+          treeChanged: true,
+        });
+        return;
+      case "unlinkDir": {
+        const prefix = `${relativePath}/`;
+        const deletedPaths: string[] = [];
+        for (const filePath of Array.from(entry.files)) {
+          if (filePath.startsWith(prefix)) {
+            entry.files.delete(filePath);
+            deletedPaths.push(filePath);
+          }
+        }
+        this.scheduleChange(entry, relativePath, {
+          deleted: true,
+          deletedPaths,
+          treeChanged: true,
+        });
+        return;
+      }
+      case "addDir":
+        this.scheduleChange(entry, relativePath, { treeChanged: true });
+        return;
+      case "change":
+        this.scheduleChange(entry, relativePath, { treeChanged: false });
+        return;
+    }
+  }
+
+  private scheduleChange(
+    entry: WorkspaceWatchEntry,
+    relativePath: string,
+    options: {
+      added?: boolean;
+      deleted?: boolean;
+      deletedPaths?: string[];
+      treeChanged: boolean;
+    },
+  ): void {
+    if (options.treeChanged) {
+      entry.pendingTreeChanged = true;
+    }
+    this.addPendingPath(entry, entry.pendingChangedPaths, relativePath);
+    if (options.added) this.addPendingPath(entry, entry.pendingAddedPaths, relativePath);
+    if (options.deleted) this.addPendingPath(entry, entry.pendingDeletedPaths, relativePath);
+    for (const deletedPath of options.deletedPaths ?? []) {
+      this.addPendingPath(entry, entry.pendingDeletedPaths, deletedPath);
+    }
+
+    if (entry.debounceTimer) {
+      clearTimeout(entry.debounceTimer);
+    }
+    entry.debounceTimer = setTimeout(() => this.flushChanges(entry), CHANGE_DEBOUNCE_MS);
+  }
+
+  private addPendingPath(
+    entry: WorkspaceWatchEntry,
+    target: Set<string>,
+    relativePath: string,
+  ): void {
+    if (target.size < MAX_CHANGED_PATHS_PER_EVENT) {
+      target.add(relativePath);
+    } else {
+      entry.pendingHasMoreChangedPaths = true;
+    }
+  }
+
+  private flushChanges(entry: WorkspaceWatchEntry): void {
+    entry.debounceTimer = null;
+    if (entry.subscribers.size === 0) return;
+
+    entry.version += 1;
+    const changedPaths = Array.from(entry.pendingChangedPaths)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }));
+    const addedPaths = Array.from(entry.pendingAddedPaths)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }));
+    const deletedPaths = Array.from(entry.pendingDeletedPaths)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }));
+    const treeChanged = entry.pendingTreeChanged;
+    const hasMoreChangedPaths = entry.pendingHasMoreChangedPaths;
+
+    entry.pendingAddedPaths.clear();
+    entry.pendingChangedPaths.clear();
+    entry.pendingDeletedPaths.clear();
+    entry.pendingTreeChanged = false;
+    entry.pendingHasMoreChangedPaths = false;
+
+    const subscribersByUser = new Map<string, WorkspaceFileSubscriber[]>();
+    for (const subscriber of entry.subscribers.values()) {
+      const subscribers = subscribersByUser.get(subscriber.userId) ?? [];
+      subscribers.push(subscriber);
+      subscribersByUser.set(subscriber.userId, subscribers);
+    }
+
+    for (const [userId, subscribers] of subscribersByUser.entries()) {
+      const sendToUser = subscribers[0]?.sendToUser;
+      if (!sendToUser) continue;
+      sendToUser(userId, {
+        type: "workspace_files_changed",
+        workDir: entry.root,
+        sessionIds: uniqueSessionIds(subscribers),
+        version: entry.version,
+        treeChanged,
+        changedPaths,
+        addedPaths,
+        deletedPaths,
+        hasMoreChangedPaths,
+      });
+    }
+  }
+
+  private emitWatchStatus(
+    entry: WorkspaceWatchEntry,
+    status: Extract<WatchStatus, "active" | "fallback">,
+    reason?: string,
+  ): void {
+    for (const subscriber of entry.subscribers.values()) {
+      subscriber.sendToUser(subscriber.userId, {
+        type: "workspace_file_watch_status",
+        sessionId: subscriber.sessionId,
+        subscriberId: subscriber.subscriberId,
+        workDir: entry.root,
+        status,
+        version: entry.version,
+        ...(reason ? { reason } : {}),
+      });
+    }
+  }
+
+  private closeEntryIfUnused(entry: WorkspaceWatchEntry): void {
+    if (entry.subscribers.size > 0) return;
+
+    this.entriesByRoot.delete(entry.root);
+    for (const [sessionId, root] of Array.from(this.rootBySessionId.entries())) {
+      if (root === entry.root) {
+        this.rootBySessionId.delete(sessionId);
+      }
+    }
+    if (entry.debounceTimer) {
+      clearTimeout(entry.debounceTimer);
+      entry.debounceTimer = null;
+    }
+    const watcher = entry.watcher;
+    entry.watcher = null;
+    if (watcher) {
+      void watcher.close().catch((error) => {
+        logger.warn({ error, root: entry.root }, "Failed to close workspace file watcher");
+      });
+    }
+    logger.info({ root: entry.root }, "Workspace file watcher closed");
+  }
+}
+
+export const workspaceFileWatchManager = new WorkspaceFileWatchManager();

--- a/src/lib/ws/client.ts
+++ b/src/lib/ws/client.ts
@@ -396,6 +396,14 @@ export class WebSocketClient {
     this.sendRequest('terminal_close', { terminalId });
   }
 
+  subscribeWorkspaceFiles(sessionId: string, subscriberId: string): boolean {
+    return this.sendRequest('subscribe_workspace_files', { sessionId, subscriberId });
+  }
+
+  unsubscribeWorkspaceFiles(sessionId: string, subscriberId: string): boolean {
+    return this.sendRequest('unsubscribe_workspace_files', { sessionId, subscriberId });
+  }
+
   private sendRequest<T extends ClientMessage['type']>(
     type: T,
     payload: Omit<Extract<ClientMessage, { type: T }>, 'type' | 'requestId'>,

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -90,7 +90,9 @@ export type ClientMessage =
   | { type: 'terminal_create'; requestId: string; terminalId: string; cwd?: string | null; sessionId?: string | null; shellKind?: TerminalShellKind; cols?: number; rows?: number }
   | { type: 'terminal_input'; requestId: string; terminalId: string; data: string }
   | { type: 'terminal_resize'; requestId: string; terminalId: string; cols: number; rows: number }
-  | { type: 'terminal_close'; requestId: string; terminalId: string };
+  | { type: 'terminal_close'; requestId: string; terminalId: string }
+  | { type: 'subscribe_workspace_files'; requestId: string; sessionId: string; subscriberId: string }
+  | { type: 'unsubscribe_workspace_files'; requestId: string; sessionId: string; subscriberId: string };
 
 export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'dontAsk' | 'bypassPermissions';
 
@@ -390,6 +392,26 @@ export type AppServerMessage =
       type: 'git_panel_state';
       sessionId: string;
       data: import('@/types/git').GitPanelData;
+    }
+  | {
+      type: 'workspace_files_changed';
+      workDir: string;
+      sessionIds: string[];
+      version: number;
+      treeChanged: boolean;
+      changedPaths: string[];
+      addedPaths: string[];
+      deletedPaths: string[];
+      hasMoreChangedPaths: boolean;
+    }
+  | {
+      type: 'workspace_file_watch_status';
+      sessionId: string;
+      subscriberId: string;
+      status: 'starting' | 'active' | 'fallback';
+      version?: number;
+      workDir?: string;
+      reason?: string;
     }
   | {
       type: 'session_mutated';

--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -6,6 +6,7 @@ import * as dbSessions from '../db/sessions';
 import logger from '../logger';
 import { refreshSessionDiffStateSoon } from '../git/session-diff-refresh';
 import { bindTerminalSender } from '../terminal/shared-terminal-manager';
+import { workspaceFileWatchManager } from '../workspace-files/workspace-file-watch-manager';
 import type { ClientMessage, ServerTransportMessage } from './message-types';
 import type { ProviderMeta } from '../cli/providers/types';
 import {
@@ -28,6 +29,7 @@ import {
 type WsSendToUser = (userId: string, message: ServerTransportMessage) => void;
 
 interface RouteClientTransportMessageOptions {
+  connectionId: string;
   message: ClientMessage;
   sendToUser: WsSendToUser;
   userId: string;
@@ -98,6 +100,7 @@ export function verifyClientSessionAccess(
 }
 
 export async function routeClientTransportMessage({
+  connectionId,
   message,
   sendToUser,
   userId,
@@ -383,6 +386,24 @@ export async function routeClientTransportMessage({
 
     case 'terminal_close':
       bindTerminalSender(sendToUser).close(message.terminalId, userId);
+      return;
+
+    case 'subscribe_workspace_files':
+      await workspaceFileWatchManager.subscribe({
+        connectionId,
+        sendToUser,
+        sessionId: message.sessionId,
+        subscriberId: message.subscriberId,
+        userId,
+      });
+      return;
+
+    case 'unsubscribe_workspace_files':
+      workspaceFileWatchManager.unsubscribe({
+        connectionId,
+        sessionId: message.sessionId,
+        subscriberId: message.subscriberId,
+      });
       return;
 
     default:

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -1,5 +1,6 @@
 import { WebSocketServer as WSServer, WebSocket } from 'ws';
 import { IncomingMessage } from 'http';
+import { randomUUID } from 'crypto';
 import { ServerTransportMessage } from './message-types';
 import { processManager } from '../cli/process-manager';
 import { protocolAdapter } from '../cli/protocol-adapter';
@@ -15,6 +16,7 @@ import { sessionHistory } from '../session-history';
 import { installDiffStatsBroadcast } from '../git/worktree-diff-stats-broadcast';
 import { installGitPanelBroadcast } from '../git/git-panel-broadcast';
 import { terminalManager } from '../terminal/shared-terminal-manager';
+import { workspaceFileWatchManager } from '../workspace-files/workspace-file-watch-manager';
 import { getGeneratingTitleSessionIds } from './title-generation-state';
 import {
   logReceivedClientTransportMessage,
@@ -24,6 +26,7 @@ import {
 } from './server-message-routing';
 
 interface AuthenticatedWebSocket extends WebSocket {
+  connectionId?: string;
   userId?: string;
   username?: string;
   isAlive?: boolean; // For ping/pong tracking
@@ -170,6 +173,7 @@ export class WebSocketServer {
     }
 
     ws.userId = userId;
+    ws.connectionId = randomUUID();
 
     // Add to connection set for this user
     if (!this.connections.has(userId)) {
@@ -194,6 +198,9 @@ export class WebSocketServer {
     });
 
     ws.on('close', () => {
+      if (ws.connectionId) {
+        workspaceFileWatchManager.unsubscribeConnection(ws.connectionId);
+      }
       const wsSet = this.connections.get(userId);
       if (wsSet) {
         wsSet.delete(ws);
@@ -302,6 +309,7 @@ export class WebSocketServer {
       }
 
       await routeClientTransportMessage({
+        connectionId: ws.connectionId!,
         userId,
         message,
         sendToUser: this.sendToUser.bind(this),

--- a/tests/workspace-file-live-sync.e2e.mjs
+++ b/tests/workspace-file-live-sync.e2e.mjs
@@ -1,0 +1,101 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { chromium } from "@playwright/test";
+
+const appUrl = process.env.TESSERA_E2E_APP_URL ?? "http://127.0.0.1:3100/chat";
+const workspaceRoot = process.env.TESSERA_E2E_WORKSPACE_ROOT ?? "/Users/rs/source/tessera";
+const timeoutMs = Number(process.env.TESSERA_E2E_SYNC_TIMEOUT_MS ?? "2500");
+
+const stamp = Date.now();
+const prefix = `zz-tessera-live-sync-e2e-${stamp}`;
+const originalName = `${prefix}.txt`;
+const renamedName = `${prefix}-renamed.txt`;
+const originalPath = path.join(workspaceRoot, originalName);
+const renamedPath = path.join(workspaceRoot, renamedName);
+
+function testIdSelector(testId) {
+  return `[data-testid=${JSON.stringify(testId)}]`;
+}
+
+async function cleanup() {
+  await fs.rm(originalPath, { force: true }).catch(() => {});
+  await fs.rm(renamedPath, { force: true }).catch(() => {});
+}
+
+async function waitForRow(page, fileName, present) {
+  const started = Date.now();
+  const selector = testIdSelector(`workspace-file-row-${fileName}`);
+  await page.waitForFunction(
+    ({ selector, present }) => Boolean(document.querySelector(selector)) === present,
+    { selector, present },
+    { timeout: timeoutMs },
+  );
+  return Date.now() - started;
+}
+
+async function openFilesPanel(page) {
+  await page.goto(appUrl, { waitUntil: "domcontentloaded", timeout: 60_000 });
+  await page.waitForSelector('[data-testid="chat-layout"]', { timeout: 30_000 });
+
+  if ((await page.getByPlaceholder("Search files").count()) === 0) {
+    await page.getByTestId("tab-bar-git-toggle").click({ timeout: 10_000 });
+    await page.waitForTimeout(300);
+    await page.getByRole("tab", { name: "Files" }).click({ timeout: 10_000 });
+  }
+
+  await page.getByPlaceholder("Search files").waitFor({ timeout: 30_000 });
+}
+
+async function main() {
+  await cleanup();
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 960 } });
+  const workspaceEvents = [];
+
+  page.on("console", (msg) => {
+    const text = msg.text();
+    if (text.includes("workspace_file")) {
+      workspaceEvents.push(text);
+    }
+  });
+
+  try {
+    await openFilesPanel(page);
+    await page.getByPlaceholder("Search files").fill(prefix);
+    await waitForRow(page, originalName, false);
+    await waitForRow(page, renamedName, false);
+
+    const results = [];
+
+    await fs.writeFile(originalPath, `live sync e2e ${new Date().toISOString()}\n`, "utf8");
+    results.push({ op: "add", ms: await waitForRow(page, originalName, true) });
+
+    await fs.rename(originalPath, renamedPath);
+    const renameNewVisibleMs = await waitForRow(page, renamedName, true);
+    const renameOldGoneMs = await waitForRow(page, originalName, false);
+    results.push({ op: "rename", newVisibleMs: renameNewVisibleMs, oldGoneMs: renameOldGoneMs });
+
+    await fs.rm(renamedPath, { force: true });
+    results.push({ op: "delete", ms: await waitForRow(page, renamedName, false) });
+
+    console.log(JSON.stringify({
+      appUrl,
+      workspaceRoot,
+      timeoutMs,
+      results,
+      workspaceEventCount: workspaceEvents.length,
+    }, null, 2));
+  } catch (error) {
+    await page.screenshot({ path: "/tmp/tessera-live-sync-e2e-failure.png", fullPage: true }).catch(() => {});
+    throw error;
+  } finally {
+    await browser.close().catch(() => {});
+    await cleanup();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/workspace-file-scan.test.ts
+++ b/tests/workspace-file-scan.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  applyMaxFiles,
+  isIgnoredWorkspacePath,
+  MAX_WORKSPACE_FILES,
+  normalizeWorkspaceRelativePath,
+  walkWorkspaceFiles,
+} from "../src/lib/workspace-files/workspace-file-scan";
+
+async function withTempWorkspace<T>(fn: (root: string) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(path.join(tmpdir(), "tessera-workspace-files-"));
+  try {
+    return await fn(root);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+test("workspace file scan ignores heavy and hidden paths consistently", async () => {
+  await withTempWorkspace(async (root) => {
+    await mkdir(path.join(root, "src"), { recursive: true });
+    await mkdir(path.join(root, "node_modules/pkg"), { recursive: true });
+    await mkdir(path.join(root, ".git"), { recursive: true });
+    await mkdir(path.join(root, ".config"), { recursive: true });
+    await mkdir(path.join(root, "dist"), { recursive: true });
+
+    await writeFile(path.join(root, "src/b.ts"), "");
+    await writeFile(path.join(root, "src/a.ts"), "");
+    await writeFile(path.join(root, ".env.example"), "");
+    await writeFile(path.join(root, ".env"), "");
+    await writeFile(path.join(root, "node_modules/pkg/index.js"), "");
+    await writeFile(path.join(root, ".git/config"), "");
+    await writeFile(path.join(root, ".config/settings.json"), "");
+    await writeFile(path.join(root, "dist/bundle.js"), "");
+
+    const result = await walkWorkspaceFiles(root);
+
+    assert.equal(result.truncated, false);
+    assert.deepEqual(result.files, [
+      ".env.example",
+      "src/a.ts",
+      "src/b.ts",
+    ]);
+  });
+});
+
+test("workspace path helpers normalize and classify ignored paths", () => {
+  assert.equal(normalizeWorkspaceRelativePath("."), "");
+  assert.equal(normalizeWorkspaceRelativePath("src\\nested//file.ts"), "src/nested/file.ts");
+  assert.equal(isIgnoredWorkspacePath(".", { isDirectory: () => true }), false);
+  assert.equal(isIgnoredWorkspacePath(".env.example"), false);
+  assert.equal(isIgnoredWorkspacePath(".env"), true);
+  assert.equal(isIgnoredWorkspacePath("src/.generated/file.ts"), true);
+  assert.equal(isIgnoredWorkspacePath("node_modules/pkg/index.js"), true);
+  assert.equal(isIgnoredWorkspacePath("src/file.ts"), false);
+});
+
+test("workspace file index caps sorted snapshots", () => {
+  const files = new Set<string>();
+  for (let index = MAX_WORKSPACE_FILES + 1; index >= 0; index -= 1) {
+    files.add(`file-${String(index).padStart(5, "0")}.ts`);
+  }
+
+  const result = applyMaxFiles(files);
+
+  assert.equal(result.truncated, true);
+  assert.equal(result.files.length, MAX_WORKSPACE_FILES);
+  assert.equal(result.files[0], "file-00000.ts");
+  assert.equal(result.files.at(-1), `file-${String(MAX_WORKSPACE_FILES - 1).padStart(5, "0")}.ts`);
+});


### PR DESCRIPTION
## Summary

- Add a workspace file watcher backed by chokidar and expose file change notifications over the existing WebSocket channel.
- Update the right-side Files panel, workspace explorer, and open workspace file tabs when files are added, renamed, changed, or deleted outside Tessera.
- Share workspace file-list loading through a dedicated hook and add a Playwright E2E script that performs real local add/rename/delete operations against the Files panel.
- Include BMAD architecture notes for the live file-sync design.

## Root Cause

The right-side Files panel was rendered outside the main workspace tab context, but the live-sync code initially treated main-tab activity as the gate for subscribing to file changes. That meant the backend could detect filesystem changes while the visible Files panel was not listening for updates.

## Validation

- `npx tsc --noEmit --pretty false`
- `npx eslint src/hooks/use-workspace-file-list.ts src/hooks/use-workspace-files-live-sync.ts src/components/workspace/workspace-file-panel.tsx src/components/workspace/workspace-explorer-tab.tsx src/components/workspace/workspace-file-tab.tsx tests/workspace-file-live-sync.e2e.mjs`
- `node tests/workspace-file-live-sync.e2e.mjs`
- `npm run server:compile`
- `npx tsx --test tests/workspace-file-scan.test.ts`
