### PR TITLE
Restore workspace UI state after restart

### DIFF
--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -313,6 +313,15 @@ export function ChatLayout() {
       } else {
         const stillExists = projects.some((p) => p.encodedDir === current);
         if (!stillExists) {
+          const restoredProjectDir = useTabStore.getState().currentProjectDir;
+          if (restoredProjectDir === ALL_PROJECTS_SENTINEL) {
+            useBoardStore.getState().setSelectedProjectDir(restoredProjectDir);
+            return;
+          }
+          if (restoredProjectDir && projects.some((p) => p.encodedDir === restoredProjectDir)) {
+            useBoardStore.getState().setSelectedProjectDir(restoredProjectDir);
+            return;
+          }
           const proj = projects.find((p) => p.isCurrent) ?? projects[0];
           useBoardStore.getState().setSelectedProjectDir(proj.encodedDir);
         }

--- a/src/stores/board-store.ts
+++ b/src/stores/board-store.ts
@@ -86,6 +86,10 @@ interface BoardState {
 const VIEW_MODE_KEY = 'ccw:viewMode';
 const PROJECT_VIEW_MODES_KEY = 'ccw:projectViewModes';
 const COLLAPSED_COLLECTIONS_KEY = 'ccw:collapsedCollections';
+const SELECTED_PROJECT_DIR_KEY = 'ccw:selectedProjectDir';
+const ALL_PROJECTS_EXPANDED_SECTIONS_KEY = 'ccw:allProjectsExpandedSections';
+const LIST_RUNNING_FILTER_KEY = 'ccw:listRunningFilterActive';
+const ACTIVE_COLLECTION_FILTER_KEY = 'ccw:activeCollectionFilter';
 
 function isViewMode(value: unknown): value is ViewMode {
   return value === 'list' || value === 'board';
@@ -151,6 +155,74 @@ function saveCollapsedCollections(collapsed: Record<string, boolean>): void {
   if (typeof window === 'undefined') return;
   try {
     localStorage.setItem(COLLAPSED_COLLECTIONS_KEY, JSON.stringify(collapsed));
+  } catch {
+    // ignore
+  }
+}
+
+function loadBooleanRecord(key: string): Record<string, boolean> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const parsed = JSON.parse(localStorage.getItem(key) ?? '{}') as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object') return {};
+
+    const record: Record<string, boolean> = {};
+    for (const [id, value] of Object.entries(parsed)) {
+      if (typeof id === 'string' && id.length > 0 && typeof value === 'boolean') {
+        record[id] = value;
+      }
+    }
+    return record;
+  } catch {
+    return {};
+  }
+}
+
+function saveBooleanRecord(key: string, record: Record<string, boolean>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(key, JSON.stringify(record));
+  } catch {
+    // ignore
+  }
+}
+
+function loadNullableString(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const value = localStorage.getItem(key);
+    return value && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveNullableString(key: string, value: string | null): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value && value.length > 0) {
+      localStorage.setItem(key, value);
+    } else {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function loadBooleanFlag(key: string): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return localStorage.getItem(key) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function saveBooleanFlag(key: string, value: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(key, value ? 'true' : 'false');
   } catch {
     // ignore
   }
@@ -240,32 +312,40 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       return { collapsedCollections };
     }),
 
-  allProjectsExpandedSections: {},
+  allProjectsExpandedSections: loadBooleanRecord(ALL_PROJECTS_EXPANDED_SECTIONS_KEY),
   toggleAllProjectsSection: (projectId) =>
-    set((state) => ({
-      allProjectsExpandedSections: {
+    set((state) => {
+      const allProjectsExpandedSections = {
         ...state.allProjectsExpandedSections,
         [projectId]: !state.allProjectsExpandedSections[projectId],
-      },
-    })),
+      };
+      saveBooleanRecord(ALL_PROJECTS_EXPANDED_SECTIONS_KEY, allProjectsExpandedSections);
+      return { allProjectsExpandedSections };
+    }),
   setAllProjectsSectionExpanded: (projectId, expanded) =>
-    set((state) => ({
-      allProjectsExpandedSections: {
+    set((state) => {
+      const allProjectsExpandedSections = {
         ...state.allProjectsExpandedSections,
         [projectId]: expanded,
-      },
-    })),
+      };
+      saveBooleanRecord(ALL_PROJECTS_EXPANDED_SECTIONS_KEY, allProjectsExpandedSections);
+      return { allProjectsExpandedSections };
+    }),
   setAllProjectsSectionsExpanded: (projectIds, expanded) =>
     set((state) => {
       const next = { ...state.allProjectsExpandedSections };
       for (const projectId of projectIds) {
         next[projectId] = expanded;
       }
+      saveBooleanRecord(ALL_PROJECTS_EXPANDED_SECTIONS_KEY, next);
       return { allProjectsExpandedSections: next };
     }),
 
-  isListRunningFilterActive: false,
-  setListRunningFilterActive: (active) => set({ isListRunningFilterActive: active }),
+  isListRunningFilterActive: loadBooleanFlag(LIST_RUNNING_FILTER_KEY),
+  setListRunningFilterActive: (active) => {
+    saveBooleanFlag(LIST_RUNNING_FILTER_KEY, active);
+    set({ isListRunningFilterActive: active });
+  },
 
   kanbanAddMenuColumn: null,
   setKanbanAddMenuColumn: (column) => set({ kanbanAddMenuColumn: column }),
@@ -276,7 +356,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
     set({ draggingProjectDir: dir, projectDragOverIndex: dir === null ? null : get().projectDragOverIndex }),
   setProjectDragOverIndex: (index) => set({ projectDragOverIndex: index }),
 
-  selectedProjectDir: null,
+  selectedProjectDir: loadNullableString(SELECTED_PROJECT_DIR_KEY),
   setSelectedProjectDir: (dir) => {
     set((state) => {
       const nextProjectViewModes =
@@ -294,12 +374,16 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       };
     });
     const { projectViewModes, viewMode } = get();
+    saveNullableString(SELECTED_PROJECT_DIR_KEY, dir);
     try { localStorage.setItem(VIEW_MODE_KEY, viewMode); } catch { /* ignore */ }
     saveProjectViewModes(projectViewModes);
   },
 
-  activeCollectionFilter: null,
-  setCollectionFilter: (id) => set({ activeCollectionFilter: id }),
+  activeCollectionFilter: loadNullableString(ACTIVE_COLLECTION_FILTER_KEY),
+  setCollectionFilter: (id) => {
+    saveNullableString(ACTIVE_COLLECTION_FILTER_KEY, id);
+    set({ activeCollectionFilter: id });
+  },
 
   // Collection item DnD
   draggingCollectionItem: null,

--- a/tests/board-state-persistence-contract.test.mjs
+++ b/tests/board-state-persistence-contract.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const boardStoreSource = fs.readFileSync(
+  new URL('../src/stores/board-store.ts', import.meta.url),
+  'utf8',
+);
+
+const chatLayoutSource = fs.readFileSync(
+  new URL('../src/components/chat/chat-layout.tsx', import.meta.url),
+  'utf8',
+);
+
+function sourceBetween(source, start, end) {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing start marker: ${start}`);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `missing end marker: ${end}`);
+  return source.slice(startIndex, endIndex);
+}
+
+test('board store persists restartable sidebar and project UI state', () => {
+  assert.match(boardStoreSource, /const SELECTED_PROJECT_DIR_KEY = 'ccw:selectedProjectDir';/);
+  assert.match(boardStoreSource, /const ALL_PROJECTS_EXPANDED_SECTIONS_KEY = 'ccw:allProjectsExpandedSections';/);
+  assert.match(boardStoreSource, /const LIST_RUNNING_FILTER_KEY = 'ccw:listRunningFilterActive';/);
+  assert.match(boardStoreSource, /const ACTIVE_COLLECTION_FILTER_KEY = 'ccw:activeCollectionFilter';/);
+
+  assert.match(boardStoreSource, /function loadBooleanRecord\(key: string\): Record<string, boolean>/);
+  assert.match(boardStoreSource, /function saveBooleanRecord\(key: string, record: Record<string, boolean>\): void/);
+  assert.match(boardStoreSource, /function loadNullableString\(key: string\): string \| null/);
+  assert.match(boardStoreSource, /function saveNullableString\(key: string, value: string \| null\): void/);
+  assert.match(boardStoreSource, /function loadBooleanFlag\(key: string\): boolean/);
+  assert.match(boardStoreSource, /function saveBooleanFlag\(key: string, value: boolean\): void/);
+
+  assert.match(boardStoreSource, /allProjectsExpandedSections: loadBooleanRecord\(ALL_PROJECTS_EXPANDED_SECTIONS_KEY\),/);
+  assert.match(boardStoreSource, /saveBooleanRecord\(ALL_PROJECTS_EXPANDED_SECTIONS_KEY, allProjectsExpandedSections\);/);
+  assert.match(boardStoreSource, /saveBooleanRecord\(ALL_PROJECTS_EXPANDED_SECTIONS_KEY, next\);/);
+
+  assert.match(boardStoreSource, /isListRunningFilterActive: loadBooleanFlag\(LIST_RUNNING_FILTER_KEY\),/);
+  assert.match(boardStoreSource, /saveBooleanFlag\(LIST_RUNNING_FILTER_KEY, active\);/);
+
+  assert.match(boardStoreSource, /selectedProjectDir: loadNullableString\(SELECTED_PROJECT_DIR_KEY\),/);
+  assert.match(boardStoreSource, /saveNullableString\(SELECTED_PROJECT_DIR_KEY, dir\);/);
+
+  assert.match(boardStoreSource, /activeCollectionFilter: loadNullableString\(ACTIVE_COLLECTION_FILTER_KEY\),/);
+  assert.match(boardStoreSource, /saveNullableString\(ACTIVE_COLLECTION_FILTER_KEY, id\);/);
+});
+
+test('startup keeps restored project scope before falling back to defaults', () => {
+  const nullBranch = sourceBetween(
+    chatLayoutSource,
+    'if (current === null) {',
+    '} else if (current === ALL_PROJECTS_SENTINEL) {',
+  );
+  assert.match(nullBranch, /const restoredProjectDir = useTabStore\.getState\(\)\.currentProjectDir;/);
+  assert.match(nullBranch, /if \(restoredProjectDir === ALL_PROJECTS_SENTINEL\) \{/);
+  assert.match(nullBranch, /if \(restoredProjectDir && projects\.some\(\(p\) => p\.encodedDir === restoredProjectDir\)\) \{/);
+  assert.match(nullBranch, /setSelectedProjectDir\(restoredProjectDir\);/);
+
+  const sentinelBranch = sourceBetween(
+    chatLayoutSource,
+    '} else if (current === ALL_PROJECTS_SENTINEL) {',
+    '} else {',
+  );
+  assert.match(sentinelBranch, /return; \/\/ All Projects mode is always valid/);
+
+  const staleCurrentBranch = sourceBetween(
+    chatLayoutSource,
+    'const stillExists = projects.some((p) => p.encodedDir === current);',
+    'const proj = projects.find((p) => p.isCurrent) ?? projects[0];',
+  );
+  assert.match(staleCurrentBranch, /if \(!stillExists\) \{/);
+  assert.match(staleCurrentBranch, /const restoredProjectDir = useTabStore\.getState\(\)\.currentProjectDir;/);
+  assert.match(staleCurrentBranch, /if \(restoredProjectDir === ALL_PROJECTS_SENTINEL\) \{/);
+  assert.match(staleCurrentBranch, /if \(restoredProjectDir && projects\.some\(\(p\) => p\.encodedDir === restoredProjectDir\)\) \{/);
+});


### PR DESCRIPTION
## Summary
- Persist restartable board UI state: selected project, All Projects expansion, running filter, and collection filter.
- Preserve existing tab/panel restoration by keeping startup project scope aligned with the restored tab store state.
- Add source-level contract coverage for board state persistence and startup restore branching.

## Root cause
Tabs and panel layouts were already persisted, but some board/sidebar scope state still initialized from defaults on app startup. That could make restored tabs appear missing or reopen in the wrong project/All Projects context.

## Validation
- `node --test tests/board-state-persistence-contract.test.mjs tests/tab-panel-persistence-contract.test.mjs`
- `npx eslint src/stores/board-store.ts src/components/chat/chat-layout.tsx tests/board-state-persistence-contract.test.mjs tests/tab-panel-persistence-contract.test.mjs`