### PR TITLE
Fix notification project switching

### DIFF
--- a/src/components/notifications/notification-center.tsx
+++ b/src/components/notifications/notification-center.tsx
@@ -6,11 +6,11 @@ import { CheckCircle, AlertTriangle, Inbox } from 'lucide-react';
 import { useNotificationStore } from '@/stores/notification-store';
 import { useSessionStore } from '@/stores/session-store';
 import { useTabStore } from '@/stores/tab-store';
-import { useBoardStore } from '@/stores/board-store';
 import { wsClient } from '@/lib/ws/client';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 import { activateSessionPanel } from '@/lib/session/focus-session-panel';
+import { useSessionNavigation } from '@/hooks/use-session-navigation';
 
 interface NotificationCenterProps {
   isOpen: boolean;
@@ -54,6 +54,7 @@ function NotificationCenterContent({
   const markAsRead = useNotificationStore((state) => state.markAsRead);
   const getSession = useSessionStore((state) => state.getSession);
   const setActiveSession = useSessionStore((state) => state.setActiveSession);
+  const { viewSession } = useSessionNavigation();
 
   useEffect(() => {
     const timer = window.setInterval(() => setNow(Date.now()), 60_000);
@@ -81,15 +82,7 @@ function NotificationCenterContent({
     useSessionStore.getState().clearUnreadCount(sessionId);
     wsClient.sendMarkAsRead(sessionId);
 
-    // Switch to the session's project if different from current
     const session = getSession(sessionId);
-    if (session) {
-      const currentProjectDir = useBoardStore.getState().selectedProjectDir;
-      if (session.projectDir && session.projectDir !== currentProjectDir) {
-        useBoardStore.getState().setSelectedProjectDir(session.projectDir);
-        useTabStore.getState().switchProject(session.projectDir);
-      }
-    }
 
     // Tab-aware session focus: use findSessionLocation (same as sidebar click handler)
     const tabStore = useTabStore.getState();
@@ -99,8 +92,13 @@ function NotificationCenterContent({
       // Session already open — switch to correct tab and focus panel
       activateSessionPanel(sessionId, { location });
     } else {
-      // Session not in any tab/panel — let bridge effect assign it
-      setActiveSession(sessionId);
+      // Session not in any tab/panel — open it without changing the project filter.
+      if (session) {
+        tabStore.openPreview(sessionId);
+        void viewSession(session);
+      } else {
+        setActiveSession(sessionId);
+      }
     }
 
     onClose();

--- a/src/components/notifications/toast-container.tsx
+++ b/src/components/notifications/toast-container.tsx
@@ -8,7 +8,6 @@ import { toast } from '@/stores/notification-store';
 import { useI18n } from '@/lib/i18n';
 import { useTabStore } from '@/stores/tab-store';
 import { useSessionStore } from '@/stores/session-store';
-import { useBoardStore } from '@/stores/board-store';
 import { ToastNotification } from './toast-notification';
 import { NotificationSound } from './notification-sound';
 import { useSessionNavigation } from '@/hooks/use-session-navigation';
@@ -113,13 +112,6 @@ export function ToastContainer() {
 
     clearUnreadCount(sessionId);
     wsClient.sendMarkAsRead(sessionId);
-
-    // Switch to the session's project if different from current
-    const currentProjectDir = useBoardStore.getState().selectedProjectDir;
-    if (session.projectDir && session.projectDir !== currentProjectDir) {
-      useBoardStore.getState().setSelectedProjectDir(session.projectDir);
-      useTabStore.getState().switchProject(session.projectDir);
-    }
 
     // Tab-aware session focus: use findSessionLocation (same as sidebar click handler)
     const tabStore = useTabStore.getState();


### PR DESCRIPTION
## Summary
- Stop notification-center and toast notification clicks from switching the selected project.
- Keep All Projects selected while focusing an already-open session or opening the notified session in preview.

## Root cause
Notification click handlers explicitly called `setSelectedProjectDir` and `switchProject` before opening the target session. That forced the project strip out of All Projects mode.

## Testing
- `npx eslint src/components/notifications/notification-center.tsx src/components/notifications/toast-container.tsx`
- `npx tsc --noEmit --pretty false`
- `git diff --check`