### PR TITLE
Improve worktree icon: GitBranch, sidebar alignment, kanban stacking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ next-env.d.ts
 
 # IDE / Tools
 .claude/
+.playwright-cli/
 _bmad-output/
 aidlc-docs/
 prd-doc/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# Tessera — agent notes
+
+Guidance for Claude/agents working in this repo. Human contributor setup lives in
+`CONTRIBUTING.md` and `README.md`.
+
+## Running the dev server
+
+Standard: `npm install && npm run dev` — runs through `server.ts` on port `3100`
+(never `next dev` directly).
+
+**Gotcha — an agent shell often inherits the installed app's production env.**
+When Claude Code runs inside (or as a child of) the installed Tessera desktop
+app, a plain `npm run dev` fails. Check first: `env | grep -i tessera`.
+
+Inherited vars that break it:
+
+- `TESSERA_APP_ROOT` → points at `…/Tessera.app/…/app.asar`, so Next looks for
+  `pages/`/`app/` there and dies with *"Couldn't find any pages or app directory"*.
+- `TESSERA_PRODUCTION_DB=1`, `TESSERA_ELECTRON_SERVER=1` → force the **production**
+  DB `~/.tessera/tessera.db`, the same file the running app uses. Sharing it can
+  corrupt real user data.
+
+Start it safely by stripping those. The dev server then uses the correct project
+root and the isolated per-branch dev DB (`~/.tessera/tessera-dev.db`, auto-selected
+on any non-`main` branch — see `src/lib/db/location.ts`):
+
+```bash
+env -u TESSERA_APP_ROOT -u TESSERA_PRODUCTION_DB -u TESSERA_ELECTRON_SERVER -u __CFBundleIdentifier \
+  TESSERA_ELECTRON_AUTH_BYPASS=1 PORT=3100 \
+  npm run dev
+```
+
+- `TESSERA_ELECTRON_AUTH_BYPASS=1` skips login so the UI is reachable in a browser.
+- The dev DB is separate from production, so the installed app keeps running untouched.
+- Next's first compile is lazy; wait for port `3100` to listen, then load a page.
+
+## Screenshotting the dev UI
+
+`playwright-cli` drives the browser — general usage and multi-session handling are
+in the global `~/.claude/CLAUDE.md`. Against the running dev server, confirm the
+sidebar rows rendered (Next compiles lazily) before capturing:
+
+```bash
+playwright-cli open http://localhost:3100
+playwright-cli --raw eval "document.querySelectorAll('[data-testid^=\"collection-task-\"]').length"
+playwright-cli screenshot --filename=/tmp/shot.png --hires
+playwright-cli close
+```
+
+## Checks (before committing code changes)
+
+```bash
+npm run lint
+npx tsc --noEmit
+```

--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useState, useCallback, useRef } from 'react';
 import type React from 'react';
-import { FolderGit2, MessageSquare, Plus, Tag, TriangleAlert } from 'lucide-react';
+import { GitBranch, MessageSquare, Plus, Tag, TriangleAlert } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 import { getTitleGeneratingStyle } from '@/lib/title-generating-style';
@@ -849,9 +849,10 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
         title={stripeLabel ?? undefined}
       >
         {/* Main row: icon + content */}
-        <div className="flex items-start gap-2.5">
-          {/* Provider mark leads; worktree/status icon follows when present */}
-          <span className="mt-[3px] flex shrink-0 items-center gap-1">
+        <div className="flex items-stretch gap-2.5">
+          {/* Provider mark on top (aligned to the title); worktree branch icon
+              pushed to the bottom so it lines up with the meta row (tag / diff). */}
+          <span className="mt-[3px] flex flex-col shrink-0 items-center justify-between pb-0.5">
             {showProviderIcons ? (
               <span className="relative flex h-3.5 w-3.5 shrink-0 items-center justify-center">
                 <ProviderLogoMark
@@ -897,7 +898,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                 }
                 className="relative flex h-3.5 w-3.5 shrink-0 items-center justify-center"
               >
-                <FolderGit2
+                <GitBranch
                   className={cn(
                     'w-3.5 h-3.5',
                     task.worktreeDeletedAt || task.worktreeMissing

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -10,12 +10,14 @@ import {
   ExternalLink,
   FolderGit2,
   FolderInput,
+  GitBranch,
   MessageSquare,
   Pencil,
   Plus,
   Sparkles,
   Trash2,
   TriangleAlert,
+  type LucideIcon,
 } from 'lucide-react';
 import { useArchiveConfirm } from '@/hooks/use-archive-confirm';
 import { useInlineRename } from '@/hooks/use-inline-rename';
@@ -822,6 +824,69 @@ export function TaskItemRow({
     );
   }, [isRenaming, onSessionDoubleClick, task.sessions]);
 
+  // Worktree mark (git branch icon + PR-mismatch / missing badges). Rendered on
+  // the leading side when provider icons are off (it's the task's primary mark),
+  // or trailing when provider icons are on — keeping the leading slot a single
+  // icon so task titles align with chat titles. `showStatus` attaches the
+  // status dot; only the leading placement carries it (trailing gets it on the
+  // provider mark instead).
+  const renderWorktreeMark = (showStatus: boolean, className?: string, Icon: LucideIcon = FolderGit2) => {
+    if (!task.worktreeBranch) return null;
+    return (
+      <span
+        title={task.worktreeMissing ? t('task.worktree.missing', { branch: task.worktreeBranch }) : task.worktreeBranch}
+        className={cn('relative flex shrink-0 items-center', className)}
+      >
+        <Icon
+          className={cn(
+            'h-3.5 w-3.5',
+            task.worktreeMissing
+              ? 'text-(--status-error-text) opacity-70'
+              : getWorktreeIconClass(task.workflowStatus),
+          )}
+        />
+        {showStatus && (
+          <ItemStatusIndicator
+            isProcessing={hasProcessingSession}
+            isAwaitingUser={hasAwaitingUserSession}
+            hasUnread={hasUnreadSession}
+            isRunning={hasRunningSession}
+            placement="corner"
+            surface="sidebar"
+          />
+        )}
+        {(() => {
+          // Skip mismatch badge when PR sync is unsupported — we have no
+          // reliable prStatus to compare against the column.
+          const mismatch = task.prUnsupported
+            ? null
+            : detectPrMismatch(task.workflowStatus, task.prStatus);
+          if (!mismatch) return null;
+          const reason = prMismatchTooltip(mismatch, task.prStatus?.number, t);
+          return (
+            <span
+              title={reason}
+              aria-label={reason}
+              className="absolute -bottom-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-(--sidebar-bg) cursor-help"
+              data-testid="task-pr-mismatch-badge"
+            >
+              <TriangleAlert
+                className="h-full w-full text-(--status-warning-text)"
+                strokeWidth={2.5}
+              />
+            </span>
+          );
+        })()}
+        {task.worktreeMissing && (
+          <span
+            aria-hidden
+            className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-(--status-error-text) ring-1 ring-(--sidebar-bg)"
+          />
+        )}
+      </span>
+    );
+  };
+
   return (
     <div className="task-item-container" data-item-id={task.id}>
       {dropIndicatorBefore && (
@@ -862,7 +927,7 @@ export function TaskItemRow({
         data-session-id={task.sessions[0]?.id}
         data-testid={`collection-task-${task.id}`}
       >
-        <span className="flex shrink-0 items-center gap-1">
+        <span className="flex shrink-0 items-center">
           {showProviderIcons ? (
             <span className="relative flex shrink-0 items-center">
               <ProviderLogoMark
@@ -870,42 +935,6 @@ export function TaskItemRow({
                 className={COLLECTION_PROVIDER_MARK_CLASS}
                 iconClassName={COLLECTION_PROVIDER_ICON_CLASS}
                 data-testid={`collection-task-agent-icon-${task.id}`}
-              />
-              {!task.worktreeBranch && (
-                <ItemStatusIndicator
-                  isProcessing={hasProcessingSession}
-                  isAwaitingUser={hasAwaitingUserSession}
-                  hasUnread={hasUnreadSession}
-                  isRunning={hasRunningSession}
-                  placement="corner"
-                  surface="sidebar"
-                />
-              )}
-            </span>
-          ) : !task.worktreeBranch && hasTaskStatus ? (
-            <span className="relative flex w-3.5 shrink-0 items-center justify-center">
-              <ItemStatusIndicator
-                isProcessing={hasProcessingSession}
-                isAwaitingUser={hasAwaitingUserSession}
-                hasUnread={hasUnreadSession}
-                isRunning={hasRunningSession}
-                placement="inline"
-                surface="sidebar"
-              />
-            </span>
-          ) : null}
-          {task.worktreeBranch ? (
-            <span
-              title={task.worktreeMissing ? t('task.worktree.missing', { branch: task.worktreeBranch }) : task.worktreeBranch}
-              className="relative flex shrink-0 items-center"
-            >
-              <FolderGit2
-                className={cn(
-                  'h-3.5 w-3.5',
-                  task.worktreeMissing
-                    ? 'text-(--status-error-text) opacity-70'
-                    : getWorktreeIconClass(task.workflowStatus),
-                )}
               />
               <ItemStatusIndicator
                 isProcessing={hasProcessingSession}
@@ -915,34 +944,19 @@ export function TaskItemRow({
                 placement="corner"
                 surface="sidebar"
               />
-              {(() => {
-                // Skip mismatch badge when PR sync is unsupported — we have no
-                // reliable prStatus to compare against the column.
-                const mismatch = task.prUnsupported
-                  ? null
-                  : detectPrMismatch(task.workflowStatus, task.prStatus);
-                if (!mismatch) return null;
-                const reason = prMismatchTooltip(mismatch, task.prStatus?.number, t);
-                return (
-                  <span
-                    title={reason}
-                    aria-label={reason}
-                    className="absolute -bottom-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-(--sidebar-bg) cursor-help"
-                    data-testid="task-pr-mismatch-badge"
-                  >
-                    <TriangleAlert
-                      className="h-full w-full text-(--status-warning-text)"
-                      strokeWidth={2.5}
-                    />
-                  </span>
-                );
-              })()}
-              {task.worktreeMissing && (
-                <span
-                  aria-hidden
-                  className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-(--status-error-text) ring-1 ring-(--sidebar-bg)"
-                />
-              )}
+            </span>
+          ) : task.worktreeBranch ? (
+            renderWorktreeMark(true)
+          ) : hasTaskStatus ? (
+            <span className="relative flex w-3.5 shrink-0 items-center justify-center">
+              <ItemStatusIndicator
+                isProcessing={hasProcessingSession}
+                isAwaitingUser={hasAwaitingUserSession}
+                hasUnread={hasUnreadSession}
+                isRunning={hasRunningSession}
+                placement="inline"
+                surface="sidebar"
+              />
             </span>
           ) : null}
         </span>
@@ -974,14 +988,20 @@ export function TaskItemRow({
           )}
         </div>
 
+        {/* Diff stats + worktree mark grouped tight on the trailing edge: a
+            single gap to the title, minimal internal spacing, so the title keeps
+            as much width as possible. Worktree stays pinned last so it never
+            shifts when the diff appears or changes digit count. */}
         {!isRenaming && (
-          <DiffStatsBadge
-            stats={task.diffStats}
+          <span
             className={cn(
-              'mr-1 transition-opacity duration-150',
+              'flex shrink-0 items-center gap-1.5 transition-opacity duration-150',
               isHovered ? 'opacity-0' : 'opacity-100',
             )}
-          />
+          >
+            <DiffStatsBadge stats={task.diffStats} />
+            {showProviderIcons && renderWorktreeMark(false, undefined, GitBranch)}
+          </span>
         )}
 
         <div


### PR DESCRIPTION
## What

Reworks how the worktree mark appears and fixes task/chat title alignment in both the sidebar and the kanban board.

### Sidebar (`collection-group-sections.tsx`)
- Task rows now keep a **single provider icon** in the leading slot, so task titles line up with chat titles. (Before: with provider icons on, tasks showed provider **+** worktree, pushing titles ~18px to the right.)
- The worktree mark moved to the **trailing edge** and renders as a **`GitBranch`** icon, pinned to the right so it doesn't shift when diff stats appear or change digit count.
- `FolderGit2` stays on the leading slot when provider icons are **off** (there it reads as the task's primary mark).

### Kanban (`kanban-card.tsx`)
- Worktree renders as a **`GitBranch`** icon **stacked under** the provider mark.
- Aligned with the meta row (tag / diff) via `items-stretch` + `justify-between`, so it stays aligned whether the title is 1 or 2 lines.

### Docs / tooling
- Add `CLAUDE.md`: starting the dev server from an agent shell (production-env inheritance gotcha) + `playwright-cli` usage.
- git-ignore `.playwright-cli/`.

## Testing
- `npx tsc --noEmit` and `eslint` pass.
- Verified visually against a running dev server — sidebar list + kanban board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)