### PR TITLE
Fix Electron UI state persistence across restarts

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -44,6 +44,60 @@ const WINDOWS_TITLEBAR_DIMMED_THEME = {
 } satisfies Record<TitlebarTheme, { color: string; symbolColor: string }>;
 const TESSERA_HOMEPAGE = 'https://github.com/horang-labs/tessera';
 const MAX_SHELL_PATH_LENGTH = 32768;
+const ELECTRON_DEFAULT_PORT = 32123;
+const ELECTRON_PORT_SCAN_LIMIT = 100;
+const UI_STORAGE_PATH = getTesseraDataPath('ui-state.json');
+
+function readUiStorage(): Record<string, string> {
+  try {
+    const raw = fs.readFileSync(UI_STORAGE_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+
+    const state: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof key === 'string' && typeof value === 'string') {
+        state[key] = value;
+      }
+    }
+    return state;
+  } catch {
+    return {};
+  }
+}
+
+function writeUiStorage(state: Record<string, string>): void {
+  try {
+    fs.mkdirSync(path.dirname(UI_STORAGE_PATH), { recursive: true });
+    const tmpPath = `${UI_STORAGE_PATH}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(state), 'utf8');
+    fs.renameSync(tmpPath, UI_STORAGE_PATH);
+  } catch (error) {
+    log('warn', `Failed to write UI storage: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function getUiStorageItem(key: unknown): string | null {
+  if (typeof key !== 'string' || key.length === 0) return null;
+  return readUiStorage()[key] ?? null;
+}
+
+function setUiStorageItem(payload: unknown): void {
+  if (!payload || typeof payload !== 'object') return;
+  const { key, value } = payload as { key?: unknown; value?: unknown };
+  if (typeof key !== 'string' || key.length === 0 || typeof value !== 'string') return;
+  const state = readUiStorage();
+  state[key] = value;
+  writeUiStorage(state);
+}
+
+function removeUiStorageItem(key: unknown): void {
+  if (typeof key !== 'string' || key.length === 0) return;
+  const state = readUiStorage();
+  if (!(key in state)) return;
+  delete state[key];
+  writeUiStorage(state);
+}
 
 function isWindowsStylePath(filesystemPath: string): boolean {
   return (
@@ -497,16 +551,30 @@ function forceKillProcessTree(proc: ChildProcess): void {
 }
 
 // ── Port allocation ────────────────────────────────────────────────────────
-async function findFreePort(): Promise<number> {
+async function isPortAvailable(port: number): Promise<boolean> {
   return new Promise((resolve, reject) => {
     const srv = net.createServer();
-    srv.listen(0, '127.0.0.1', () => {
-      const addr = srv.address() as net.AddressInfo;
-      const port = addr.port;
-      srv.close(() => resolve(port));
+    srv.once('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'EADDRINUSE' || error.code === 'EACCES') {
+        resolve(false);
+        return;
+      }
+      reject(error);
     });
-    srv.on('error', reject);
+    srv.listen(port, '127.0.0.1', () => {
+      srv.close(() => resolve(true));
+    });
   });
+}
+
+async function findStablePort(): Promise<number> {
+  for (let offset = 0; offset < ELECTRON_PORT_SCAN_LIMIT; offset += 1) {
+    const candidate = ELECTRON_DEFAULT_PORT + offset;
+    if (await isPortAvailable(candidate)) return candidate;
+  }
+  throw new Error(
+    `No available port found from ${ELECTRON_DEFAULT_PORT} to ${ELECTRON_DEFAULT_PORT + ELECTRON_PORT_SCAN_LIMIT - 1}`
+  );
 }
 
 // ── Server lifecycle ───────────────────────────────────────────────────────
@@ -517,8 +585,8 @@ async function startServer(): Promise<number> {
     return serverPort;
   }
 
-  const port = await findFreePort();
-  log('debug', `Free port found: ${port}`);
+  const port = await findStablePort();
+  log('debug', `Electron server port selected: ${port}`);
 
   return new Promise((resolve, reject) => {
     const isPackaged = app.isPackaged;
@@ -822,6 +890,17 @@ function broadcastPopoutState(): void {
 
 // ── IPC ────────────────────────────────────────────────────────────────────
 ipcMain.handle('get-server-port', () => serverPort);
+ipcMain.on('ui-storage-get-item', (event, key: unknown) => {
+  event.returnValue = getUiStorageItem(key);
+});
+ipcMain.on('ui-storage-set-item', (event, payload: unknown) => {
+  setUiStorageItem(payload);
+  event.returnValue = true;
+});
+ipcMain.on('ui-storage-remove-item', (event, key: unknown) => {
+  removeUiStorageItem(key);
+  event.returnValue = true;
+});
 ipcMain.handle('shell-open-path', async (_event, rawPath: unknown) => {
   const targetPath = resolveShellPath(rawPath);
   if (!targetPath) return { ok: false, error: 'invalid_path' };

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,6 +4,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
   isElectron: true,
   getServerPort: () => ipcRenderer.invoke('get-server-port'),
+  uiStorageGetItem: (key: string) => ipcRenderer.sendSync('ui-storage-get-item', key) as string | null,
+  uiStorageSetItem: (key: string, value: string) =>
+    ipcRenderer.sendSync('ui-storage-set-item', { key, value }),
+  uiStorageRemoveItem: (key: string) =>
+    ipcRenderer.sendSync('ui-storage-remove-item', key),
   onWindowCloseRequest: (callback: (payload: { requestId: string }) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: { requestId?: string }) => {
       if (typeof payload?.requestId === 'string') {

--- a/src/lib/persistence/ui-storage.ts
+++ b/src/lib/persistence/ui-storage.ts
@@ -15,7 +15,11 @@ export function readUiStorageItem(key: string): string | null {
 
   const electronApi = getElectronUiStorageApi();
   if (electronApi?.isElectron && electronApi.uiStorageGetItem) {
-    return electronApi.uiStorageGetItem(key);
+    try {
+      return electronApi.uiStorageGetItem(key);
+    } catch {
+      // Fall back to browser storage below.
+    }
   }
 
   try {
@@ -30,8 +34,12 @@ export function writeUiStorageItem(key: string, value: string): void {
 
   const electronApi = getElectronUiStorageApi();
   if (electronApi?.isElectron && electronApi.uiStorageSetItem) {
-    electronApi.uiStorageSetItem(key, value);
-    return;
+    try {
+      electronApi.uiStorageSetItem(key, value);
+      return;
+    } catch {
+      // Fall back to browser storage below.
+    }
   }
 
   try {
@@ -46,8 +54,12 @@ export function removeUiStorageItem(key: string): void {
 
   const electronApi = getElectronUiStorageApi();
   if (electronApi?.isElectron && electronApi.uiStorageRemoveItem) {
-    electronApi.uiStorageRemoveItem(key);
-    return;
+    try {
+      electronApi.uiStorageRemoveItem(key);
+      return;
+    } catch {
+      // Fall back to browser storage below.
+    }
   }
 
   try {

--- a/src/lib/persistence/ui-storage.ts
+++ b/src/lib/persistence/ui-storage.ts
@@ -1,0 +1,58 @@
+interface ElectronUiStorageApi {
+  isElectron?: boolean;
+  uiStorageGetItem?: (key: string) => string | null;
+  uiStorageSetItem?: (key: string, value: string) => void;
+  uiStorageRemoveItem?: (key: string) => void;
+}
+
+function getElectronUiStorageApi(): ElectronUiStorageApi | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return (window as Window & { electronAPI?: ElectronUiStorageApi }).electronAPI;
+}
+
+export function readUiStorageItem(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+
+  const electronApi = getElectronUiStorageApi();
+  if (electronApi?.isElectron && electronApi.uiStorageGetItem) {
+    return electronApi.uiStorageGetItem(key);
+  }
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function writeUiStorageItem(key: string, value: string): void {
+  if (typeof window === 'undefined') return;
+
+  const electronApi = getElectronUiStorageApi();
+  if (electronApi?.isElectron && electronApi.uiStorageSetItem) {
+    electronApi.uiStorageSetItem(key, value);
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // ignore
+  }
+}
+
+export function removeUiStorageItem(key: string): void {
+  if (typeof window === 'undefined') return;
+
+  const electronApi = getElectronUiStorageApi();
+  if (electronApi?.isElectron && electronApi.uiStorageRemoveItem) {
+    electronApi.uiStorageRemoveItem(key);
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // ignore
+  }
+}

--- a/src/stores/board-store.ts
+++ b/src/stores/board-store.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
 import { captureTelemetryEvent } from '@/lib/telemetry/client';
+import {
+  readUiStorageItem,
+  removeUiStorageItem,
+  writeUiStorageItem,
+} from '@/lib/persistence/ui-storage';
 
 export type ViewMode = 'list' | 'board';
 
@@ -98,7 +103,7 @@ function isViewMode(value: unknown): value is ViewMode {
 function loadViewMode(): ViewMode {
   if (typeof window === 'undefined') return 'list';
   try {
-    const saved = localStorage.getItem(VIEW_MODE_KEY);
+    const saved = readUiStorageItem(VIEW_MODE_KEY);
     if (isViewMode(saved)) return saved;
     return 'list';
   } catch {
@@ -109,7 +114,7 @@ function loadViewMode(): ViewMode {
 function loadProjectViewModes(): Record<string, ViewMode> {
   if (typeof window === 'undefined') return {};
   try {
-    const parsed = JSON.parse(localStorage.getItem(PROJECT_VIEW_MODES_KEY) ?? '{}') as Record<string, unknown>;
+    const parsed = JSON.parse(readUiStorageItem(PROJECT_VIEW_MODES_KEY) ?? '{}') as Record<string, unknown>;
     if (!parsed || typeof parsed !== 'object') return {};
 
     const modes: Record<string, ViewMode> = {};
@@ -127,7 +132,7 @@ function loadProjectViewModes(): Record<string, ViewMode> {
 function saveProjectViewModes(modes: Record<string, ViewMode>): void {
   if (typeof window === 'undefined') return;
   try {
-    localStorage.setItem(PROJECT_VIEW_MODES_KEY, JSON.stringify(modes));
+    writeUiStorageItem(PROJECT_VIEW_MODES_KEY, JSON.stringify(modes));
   } catch {
     // ignore
   }
@@ -136,7 +141,7 @@ function saveProjectViewModes(modes: Record<string, ViewMode>): void {
 function loadCollapsedCollections(): Record<string, boolean> {
   if (typeof window === 'undefined') return {};
   try {
-    const parsed = JSON.parse(localStorage.getItem(COLLAPSED_COLLECTIONS_KEY) ?? '{}') as Record<string, unknown>;
+    const parsed = JSON.parse(readUiStorageItem(COLLAPSED_COLLECTIONS_KEY) ?? '{}') as Record<string, unknown>;
     if (!parsed || typeof parsed !== 'object') return {};
 
     const collapsed: Record<string, boolean> = {};
@@ -154,7 +159,7 @@ function loadCollapsedCollections(): Record<string, boolean> {
 function saveCollapsedCollections(collapsed: Record<string, boolean>): void {
   if (typeof window === 'undefined') return;
   try {
-    localStorage.setItem(COLLAPSED_COLLECTIONS_KEY, JSON.stringify(collapsed));
+    writeUiStorageItem(COLLAPSED_COLLECTIONS_KEY, JSON.stringify(collapsed));
   } catch {
     // ignore
   }
@@ -163,7 +168,7 @@ function saveCollapsedCollections(collapsed: Record<string, boolean>): void {
 function loadBooleanRecord(key: string): Record<string, boolean> {
   if (typeof window === 'undefined') return {};
   try {
-    const parsed = JSON.parse(localStorage.getItem(key) ?? '{}') as Record<string, unknown>;
+    const parsed = JSON.parse(readUiStorageItem(key) ?? '{}') as Record<string, unknown>;
     if (!parsed || typeof parsed !== 'object') return {};
 
     const record: Record<string, boolean> = {};
@@ -181,7 +186,7 @@ function loadBooleanRecord(key: string): Record<string, boolean> {
 function saveBooleanRecord(key: string, record: Record<string, boolean>): void {
   if (typeof window === 'undefined') return;
   try {
-    localStorage.setItem(key, JSON.stringify(record));
+    writeUiStorageItem(key, JSON.stringify(record));
   } catch {
     // ignore
   }
@@ -190,7 +195,7 @@ function saveBooleanRecord(key: string, record: Record<string, boolean>): void {
 function loadNullableString(key: string): string | null {
   if (typeof window === 'undefined') return null;
   try {
-    const value = localStorage.getItem(key);
+    const value = readUiStorageItem(key);
     return value && value.length > 0 ? value : null;
   } catch {
     return null;
@@ -201,9 +206,9 @@ function saveNullableString(key: string, value: string | null): void {
   if (typeof window === 'undefined') return;
   try {
     if (value && value.length > 0) {
-      localStorage.setItem(key, value);
+      writeUiStorageItem(key, value);
     } else {
-      localStorage.removeItem(key);
+      removeUiStorageItem(key);
     }
   } catch {
     // ignore
@@ -213,7 +218,7 @@ function saveNullableString(key: string, value: string | null): void {
 function loadBooleanFlag(key: string): boolean {
   if (typeof window === 'undefined') return false;
   try {
-    return localStorage.getItem(key) === 'true';
+    return readUiStorageItem(key) === 'true';
   } catch {
     return false;
   }
@@ -222,7 +227,7 @@ function loadBooleanFlag(key: string): boolean {
 function saveBooleanFlag(key: string, value: boolean): void {
   if (typeof window === 'undefined') return;
   try {
-    localStorage.setItem(key, value ? 'true' : 'false');
+    writeUiStorageItem(key, value ? 'true' : 'false');
   } catch {
     // ignore
   }
@@ -254,7 +259,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
             }
           : state.projectViewModes;
 
-      try { localStorage.setItem(VIEW_MODE_KEY, mode); } catch { /* ignore */ }
+      try { writeUiStorageItem(VIEW_MODE_KEY, mode); } catch { /* ignore */ }
       if (nextProjectViewModes !== state.projectViewModes) {
         saveProjectViewModes(nextProjectViewModes);
       }
@@ -375,7 +380,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
     });
     const { projectViewModes, viewMode } = get();
     saveNullableString(SELECTED_PROJECT_DIR_KEY, dir);
-    try { localStorage.setItem(VIEW_MODE_KEY, viewMode); } catch { /* ignore */ }
+    try { writeUiStorageItem(VIEW_MODE_KEY, viewMode); } catch { /* ignore */ }
     saveProjectViewModes(projectViewModes);
   },
 

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -18,6 +18,7 @@ import { usePanelStore } from '@/stores/panel-store';
 import { useSessionStore } from '@/stores/session-store';
 import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
 import { getSpecialSessionSourceSessionId, isSpecialSession } from '@/lib/constants/special-sessions';
+import { readUiStorageItem, writeUiStorageItem } from '@/lib/persistence/ui-storage';
 import {
   parseMemoryFileSessionId,
   parseWorkspaceFileSessionId,
@@ -818,7 +819,7 @@ export const useTabStore = create<TabStore>()((set, get) => ({
 
     // Step 3: 직렬화 및 저장
     try {
-      localStorage.setItem(TAB_STORE_KEY, JSON.stringify(data));
+      writeUiStorageItem(TAB_STORE_KEY, JSON.stringify(data));
     } catch (e) {
       console.warn('[tab-store] persistToLocalStorage() failed:', e);
     }
@@ -909,11 +910,11 @@ export const useTabStore = create<TabStore>()((set, get) => ({
     };
 
     try {
-      const raw = localStorage.getItem(TAB_STORE_KEY);
+      const raw = readUiStorageItem(TAB_STORE_KEY);
 
       if (raw === null) {
         // TAB_STORE_KEY가 없는 경우: 레거시 마이그레이션 또는 fresh init
-        const legacyRaw = localStorage.getItem(PANEL_LAYOUT_STORAGE_KEY);
+        const legacyRaw = readUiStorageItem(PANEL_LAYOUT_STORAGE_KEY);
         if (legacyRaw !== null) {
           runLegacyMigration(legacyRaw, initializeEmpty, set);
         } else {
@@ -1261,7 +1262,7 @@ function runLegacyMigration(
     };
 
     try {
-      localStorage.setItem(TAB_STORE_KEY, JSON.stringify(migratedStore));
+      writeUiStorageItem(TAB_STORE_KEY, JSON.stringify(migratedStore));
     } catch (e) {
       console.warn('[tab-store] Migration write to localStorage failed:', e);
     }

--- a/tests/electron-ui-state-persistence-contract.test.mjs
+++ b/tests/electron-ui-state-persistence-contract.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const electronMainSource = fs.readFileSync(
+  new URL('../electron/main.ts', import.meta.url),
+  'utf8',
+);
+const electronPreloadSource = fs.readFileSync(
+  new URL('../electron/preload.ts', import.meta.url),
+  'utf8',
+);
+const uiStorageSource = fs.readFileSync(
+  new URL('../src/lib/persistence/ui-storage.ts', import.meta.url),
+  'utf8',
+);
+const boardStoreSource = fs.readFileSync(
+  new URL('../src/stores/board-store.ts', import.meta.url),
+  'utf8',
+);
+const tabStoreSource = fs.readFileSync(
+  new URL('../src/stores/tab-store.ts', import.meta.url),
+  'utf8',
+);
+
+test('packaged Electron prefers a stable local server port', () => {
+  assert.match(electronMainSource, /const ELECTRON_DEFAULT_PORT = 32123;/);
+  assert.match(electronMainSource, /const ELECTRON_PORT_SCAN_LIMIT = 100;/);
+  assert.match(electronMainSource, /async function findStablePort\(\): Promise<number>/);
+  assert.match(electronMainSource, /const candidate = ELECTRON_DEFAULT_PORT \+ offset;/);
+  assert.match(electronMainSource, /const port = await findStablePort\(\);/);
+  assert.doesNotMatch(electronMainSource, /srv\.listen\(0, '127\.0\.0\.1'/);
+});
+
+test('Electron UI storage is persisted by main process outside the page origin', () => {
+  assert.match(electronMainSource, /const UI_STORAGE_PATH = getTesseraDataPath\('ui-state\.json'\);/);
+  assert.match(electronMainSource, /function readUiStorage\(\): Record<string, string>/);
+  assert.match(electronMainSource, /function writeUiStorage\(state: Record<string, string>\): void/);
+  assert.match(electronMainSource, /ipcMain\.on\('ui-storage-get-item'/);
+  assert.match(electronMainSource, /ipcMain\.on\('ui-storage-set-item'/);
+  assert.match(electronMainSource, /ipcMain\.on\('ui-storage-remove-item'/);
+  assert.match(electronMainSource, /event\.returnValue = getUiStorageItem\(key\);/);
+});
+
+test('preload exposes synchronous UI storage methods for store bootstrap', () => {
+  assert.match(electronPreloadSource, /uiStorageGetItem: \(key: string\) => ipcRenderer\.sendSync\('ui-storage-get-item', key\)/);
+  assert.match(electronPreloadSource, /uiStorageSetItem: \(key: string, value: string\) =>/);
+  assert.match(electronPreloadSource, /ipcRenderer\.sendSync\('ui-storage-set-item', \{ key, value \}\)/);
+  assert.match(electronPreloadSource, /uiStorageRemoveItem: \(key: string\) =>/);
+  assert.match(electronPreloadSource, /ipcRenderer\.sendSync\('ui-storage-remove-item', key\)/);
+});
+
+test('renderer persistence uses Electron storage before localStorage fallback', () => {
+  assert.match(uiStorageSource, /electronApi\?\.isElectron && electronApi\.uiStorageGetItem/);
+  assert.match(uiStorageSource, /electronApi\?\.isElectron && electronApi\.uiStorageSetItem/);
+  assert.match(uiStorageSource, /electronApi\?\.isElectron && electronApi\.uiStorageRemoveItem/);
+  assert.match(uiStorageSource, /window\.localStorage\.getItem\(key\)/);
+  assert.match(uiStorageSource, /window\.localStorage\.setItem\(key, value\)/);
+  assert.match(uiStorageSource, /window\.localStorage\.removeItem\(key\)/);
+});
+
+test('board and tab stores avoid direct origin-scoped localStorage access', () => {
+  assert.match(boardStoreSource, /from '@\/lib\/persistence\/ui-storage';/);
+  assert.match(tabStoreSource, /from '@\/lib\/persistence\/ui-storage';/);
+  assert.doesNotMatch(boardStoreSource, /\blocalStorage\./);
+  assert.doesNotMatch(tabStoreSource, /\blocalStorage\./);
+  assert.match(tabStoreSource, /readUiStorageItem\(TAB_STORE_KEY\)/);
+  assert.match(tabStoreSource, /writeUiStorageItem\(TAB_STORE_KEY, JSON\.stringify\(data\)\)/);
+});


### PR DESCRIPTION
## Summary
- Prefer a stable Electron local server port before scanning nearby fallback ports.
- Persist restartable UI state through Electron main-process storage at the Tessera data dir instead of origin-scoped renderer localStorage.
- Route board and tab store persistence through the new UI storage wrapper while preserving browser localStorage fallback, including fallback if the Electron bridge fails.

## Validation
- git diff --check
- node --test tests/electron-ui-state-persistence-contract.test.mjs tests/board-state-persistence-contract.test.mjs tests/tab-panel-persistence-contract.test.mjs
- npx eslint electron/main.ts electron/preload.ts src/lib/persistence/ui-storage.ts src/stores/board-store.ts src/stores/tab-store.ts src/components/chat/chat-layout.tsx tests/electron-ui-state-persistence-contract.test.mjs tests/board-state-persistence-contract.test.mjs tests/tab-panel-persistence-contract.test.mjs
- npm run electron:compile