### PR TITLE
Fix kanban task icon alignment

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -850,9 +850,9 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
       >
         {/* Main row: icon + content */}
         <div className="flex items-stretch gap-2.5">
-          {/* Provider mark on top (aligned to the title); worktree branch icon
-              pushed to the bottom so it lines up with the meta row (tag / diff). */}
-          <span className="mt-[3px] flex flex-col shrink-0 items-center justify-between pb-0.5">
+          {/* Provider mark aligns with the first title line; the branch icon sits
+              one text line below it, not at the bottom of the whole card. */}
+          <span className="mt-[3px] flex flex-col shrink-0 items-center gap-[5px]">
             {showProviderIcons ? (
               <span className="relative flex h-3.5 w-3.5 shrink-0 items-center justify-center">
                 <ProviderLogoMark
@@ -861,16 +861,14 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                   iconClassName={KANBAN_PROVIDER_ICON_CLASS}
                   data-testid={`kanban-task-agent-icon-${task.id}`}
                 />
-                {!task.worktreeBranch && (
-                  <ItemStatusIndicator
-                    isProcessing={hasProcessingSession}
-                    isAwaitingUser={hasAwaitingUserSession}
-                    hasUnread={hasUnreadSession}
-                    isRunning={hasRunningSession}
-                    placement="corner"
-                    surface="board"
-                  />
-                )}
+                <ItemStatusIndicator
+                  isProcessing={hasProcessingSession}
+                  isAwaitingUser={hasAwaitingUserSession}
+                  hasUnread={hasUnreadSession}
+                  isRunning={hasRunningSession}
+                  placement="corner"
+                  surface="board"
+                />
               </span>
             ) : !task.worktreeBranch && hasTaskStatus ? (
               <span className="relative flex h-3.5 w-3.5 shrink-0 items-center justify-center">
@@ -896,7 +894,10 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                       ? t('task.worktree.missing', { branch: task.worktreeBranch })
                     : task.worktreeBranch
                 }
-                className="relative flex h-3.5 w-3.5 shrink-0 items-center justify-center"
+                className={cn(
+                  'relative flex h-3.5 w-3.5 shrink-0 items-center justify-center',
+                  showProviderIcons && 'translate-y-[1px]',
+                )}
               >
                 <GitBranch
                   className={cn(
@@ -912,14 +913,16 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                     className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-(--status-error-text) ring-1 ring-(--board-card-bg)"
                   />
                 )}
-                <ItemStatusIndicator
-                  isProcessing={hasProcessingSession}
-                  isAwaitingUser={hasAwaitingUserSession}
-                  hasUnread={hasUnreadSession}
-                  isRunning={hasRunningSession}
-                  placement="corner"
-                  surface="board"
-                />
+                {!showProviderIcons && (
+                  <ItemStatusIndicator
+                    isProcessing={hasProcessingSession}
+                    isAwaitingUser={hasAwaitingUserSession}
+                    hasUnread={hasUnreadSession}
+                    isRunning={hasRunningSession}
+                    placement="corner"
+                    surface="board"
+                  />
+                )}
                 {prMismatch && (
                   <span
                     title={prMismatchReason ?? undefined}

--- a/tests/provider-icons-contract.test.mjs
+++ b/tests/provider-icons-contract.test.mjs
@@ -53,7 +53,11 @@ test('collection list rows switch between default type icons and provider marks'
 
   assert.match(
     collectionSource,
-    /<FolderGit2[\s\S]*<ProviderLogoMark\s+providerId=\{task\.sessions\[0\]\?\.provider\}[\s\S]*data-testid=\{`collection-task-agent-icon-\$\{task\.id\}`\}/,
+    /const renderWorktreeMark = \(showStatus: boolean[\s\S]*Icon: LucideIcon = FolderGit2/,
+  );
+  assert.match(
+    collectionSource,
+    /data-testid=\{`collection-task-agent-icon-\$\{task\.id\}`\}[\s\S]*<ItemStatusIndicator\s+isProcessing=\{hasProcessingSession\}/,
   );
 
   assert.match(
@@ -75,7 +79,30 @@ test('kanban cards switch between default type icons and provider marks', () => 
 
   assert.match(
     kanbanSource,
-    /<FolderGit2[\s\S]*<ProviderLogoMark\s+providerId=\{task\.sessions\[0\]\?\.provider\}[\s\S]*data-testid=\{`kanban-task-agent-icon-\$\{task\.id\}`\}/,
+    /data-testid=\{`kanban-task-agent-icon-\$\{task\.id\}`\}[\s\S]*<ItemStatusIndicator\s+isProcessing=\{hasProcessingSession\}/,
+  );
+
+  assert.match(
+    kanbanSource,
+    /flex flex-col shrink-0 items-center gap-\[5px\]/,
+  );
+  assert.match(
+    kanbanSource,
+    /showProviderIcons && 'translate-y-\[1px\]'/,
+  );
+  assert.doesNotMatch(
+    kanbanSource,
+    /flex flex-col shrink-0 items-center justify-between/,
+  );
+
+  assert.match(
+    kanbanSource,
+    /\{task\.worktreeBranch \? \([\s\S]*<GitBranch[\s\S]*\{!showProviderIcons && \(\s*<ItemStatusIndicator\s+isProcessing=\{hasProcessingSession\}/,
+  );
+
+  assert.match(
+    kanbanSource,
+    /\{!showProviderIcons && \(\s*<ItemStatusIndicator\s+isProcessing=\{hasProcessingSession\}[\s\S]*placement="corner"/,
   );
 
   assert.match(


### PR DESCRIPTION
## Summary
- move kanban task running/unread indicators onto the provider mark when provider icons are enabled
- keep the branch icon status indicator only for provider-icons-off mode
- align the branch icon under the provider mark by title line height instead of card bottom height

## Root cause
The kanban task icon column used bottom spacing and branch-icon status overlays that made long titles push the branch mark down to the collection row, while running/notification state could appear on the branch icon instead of the provider icon.

## Validation
- `node --test tests/provider-icons-contract.test.mjs`
- `eslint src/components/board/kanban-card.tsx tests/provider-icons-contract.test.mjs`
- `git diff --check`