### PR TITLE
Improve font scaling and list status indicators

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,8 +23,9 @@ const themeScript = `
     var theme = settings.theme || 'auto';
     var isDark = theme === 'dark' || (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);
     if (isDark) document.documentElement.classList.add('dark');
-    var scales = [0.8125, 0.875, 0.9375, 1];
+    var scales = [0.8125, 0.875, 1, 1.25];
     var raw = typeof settings.fontSize === 'number' ? settings.fontSize : 0.875;
+    if (raw === 0.9375) raw = 1;
     var scale = 0.875;
     if (raw < 2) {
       var best = scales[0];

--- a/src/components/chat/work-item-primitives.tsx
+++ b/src/components/chat/work-item-primitives.tsx
@@ -58,7 +58,7 @@ export function ItemStatusIndicator({
         className={cn(
           getPlacementClassName(placement, false, isEnlargedSidebarCorner),
           ringClass,
-          isEnlargedSidebarCorner ? 'h-[10px] w-[10px]' : 'h-[7px] w-[7px]',
+          isEnlargedSidebarCorner ? 'h-[0.75rem] w-[0.75rem]' : 'h-[7px] w-[7px]',
           'rounded-full bg-[#facc15] attention-dot-blink',
         )}
       />
@@ -71,7 +71,7 @@ export function ItemStatusIndicator({
         className={cn(
           getPlacementClassName(placement, false, isEnlargedSidebarCorner),
           ringClass,
-          isEnlargedSidebarCorner ? 'h-[9px] w-[9px]' : 'h-[6px] w-[6px]',
+          isEnlargedSidebarCorner ? 'h-[0.6875rem] w-[0.6875rem]' : 'h-[6px] w-[6px]',
           'rounded-full bg-[#facc15]',
         )}
       />
@@ -84,7 +84,7 @@ export function ItemStatusIndicator({
         className={cn(
           getPlacementClassName(placement, true, isEnlargedSidebarCorner),
           ringClass,
-          isEnlargedSidebarCorner ? 'h-[10px] w-[10px]' : 'h-[7px] w-[7px]',
+          isEnlargedSidebarCorner ? 'h-[0.75rem] w-[0.75rem]' : 'h-[7px] w-[7px]',
           'animate-spin rounded-full border border-(--success) border-t-transparent',
         )}
       />
@@ -96,7 +96,7 @@ export function ItemStatusIndicator({
       className={cn(
         getPlacementClassName(placement, false, isEnlargedSidebarCorner),
         ringClass,
-        isEnlargedSidebarCorner ? 'h-[8px] w-[8px]' : 'h-[5px] w-[5px]',
+        isEnlargedSidebarCorner ? 'h-[0.625rem] w-[0.625rem]' : 'h-[5px] w-[5px]',
         'rounded-full bg-(--success)',
       )}
     />

--- a/src/components/chat/work-item-primitives.tsx
+++ b/src/components/chat/work-item-primitives.tsx
@@ -43,6 +43,8 @@ export function ItemStatusIndicator({
     return null;
   }
 
+  const isEnlargedSidebarCorner = surface === 'sidebar' && placement === 'corner';
+
   const ringClass =
     placement === 'inline'
       ? ''
@@ -54,9 +56,10 @@ export function ItemStatusIndicator({
     return (
       <span
         className={cn(
-          getPlacementClassName(placement, false),
+          getPlacementClassName(placement, false, isEnlargedSidebarCorner),
           ringClass,
-          'h-[7px] w-[7px] rounded-full bg-[#facc15] attention-dot-blink',
+          isEnlargedSidebarCorner ? 'h-[10px] w-[10px]' : 'h-[7px] w-[7px]',
+          'rounded-full bg-[#facc15] attention-dot-blink',
         )}
       />
     );
@@ -66,9 +69,10 @@ export function ItemStatusIndicator({
     return (
       <span
         className={cn(
-          getPlacementClassName(placement, false),
+          getPlacementClassName(placement, false, isEnlargedSidebarCorner),
           ringClass,
-          'h-[6px] w-[6px] rounded-full bg-[#facc15]',
+          isEnlargedSidebarCorner ? 'h-[9px] w-[9px]' : 'h-[6px] w-[6px]',
+          'rounded-full bg-[#facc15]',
         )}
       />
     );
@@ -78,9 +82,10 @@ export function ItemStatusIndicator({
     return (
       <span
         className={cn(
-          getPlacementClassName(placement, true),
+          getPlacementClassName(placement, true, isEnlargedSidebarCorner),
           ringClass,
-          'h-[7px] w-[7px] animate-spin rounded-full border border-(--success) border-t-transparent',
+          isEnlargedSidebarCorner ? 'h-[10px] w-[10px]' : 'h-[7px] w-[7px]',
+          'animate-spin rounded-full border border-(--success) border-t-transparent',
         )}
       />
     );
@@ -89,9 +94,10 @@ export function ItemStatusIndicator({
   return (
     <span
       className={cn(
-        getPlacementClassName(placement, false),
+        getPlacementClassName(placement, false, isEnlargedSidebarCorner),
         ringClass,
-        'h-[5px] w-[5px] rounded-full bg-(--success)',
+        isEnlargedSidebarCorner ? 'h-[8px] w-[8px]' : 'h-[5px] w-[5px]',
+        'rounded-full bg-(--success)',
       )}
     />
   );
@@ -300,11 +306,14 @@ export function OverflowMenuButton({
 function getPlacementClassName(
   placement: ItemStatusPlacement,
   isProcessing: boolean,
+  isEnlargedSidebarCorner: boolean,
 ): string {
   switch (placement) {
     case 'corner':
       // Industry-standard: top-left of the icon (like Gmail/Jira unread dots).
-      return 'absolute -top-0.5 -left-0.5';
+      return isEnlargedSidebarCorner
+        ? 'absolute -top-1 -left-1'
+        : 'absolute -top-0.5 -left-0.5';
     case 'leading':
       return cn(
         'absolute top-1/2 z-[1] -translate-y-1/2',

--- a/src/lib/settings/provider-defaults.ts
+++ b/src/lib/settings/provider-defaults.ts
@@ -23,7 +23,7 @@ import {
   DEFAULT_PROFILE_DISPLAY_NAME,
 } from './profile-defaults';
 
-export const FONT_SCALE_OPTIONS = [0.8125, 0.875, 0.9375, 1] as const;
+export const FONT_SCALE_OPTIONS = [0.8125, 0.875, 1, 1.25] as const;
 export const DEFAULT_FONT_SCALE = 0.875;
 type ClaudeAccessMode = Extract<
   ProviderSessionAccessMode,
@@ -49,6 +49,11 @@ export function normalizeFontScale(raw: unknown): number {
   }
   if (raw >= 2) {
     return DEFAULT_FONT_SCALE;
+  }
+  // Preserve the semantic "large" choice for users upgrading from the old
+  // preset list, where 0.9375 sat exactly between the new medium and large.
+  if (raw === 0.9375) {
+    return 1;
   }
   let best: number = FONT_SCALE_OPTIONS[0];
   let bestDelta = Math.abs(raw - best);

--- a/tests/font-scale-and-status-indicator-contract.test.mjs
+++ b/tests/font-scale-and-status-indicator-contract.test.mjs
@@ -52,20 +52,43 @@ function renderStatusIndicator({
 }
 
 test('sidebar corner status indicators render enlarged sizes and offset', () => {
-  assert.match(renderStatusIndicator({ isAwaitingUser: true }), /h-\[10px\].*w-\[10px\]/);
-  assert.match(renderStatusIndicator({ hasUnread: true }), /h-\[9px\].*w-\[9px\]/);
-  assert.match(renderStatusIndicator({ isProcessing: true }), /h-\[10px\].*w-\[10px\]/);
-  assert.match(renderStatusIndicator({ isRunning: true }), /h-\[8px\].*w-\[8px\]/);
+  const awaiting = renderStatusIndicator({ isAwaitingUser: true });
+  const unread = renderStatusIndicator({ hasUnread: true });
+  const processing = renderStatusIndicator({ isProcessing: true });
+  const running = renderStatusIndicator({ isRunning: true });
+
+  assert.match(awaiting, /h-\[0\.75rem\].*w-\[0\.75rem\]/);
+  assert.match(unread, /h-\[0\.6875rem\].*w-\[0\.6875rem\]/);
+  assert.match(processing, /h-\[0\.75rem\].*w-\[0\.75rem\]/);
+  assert.match(running, /h-\[0\.625rem\].*w-\[0\.625rem\]/);
   assert.match(renderStatusIndicator({ isRunning: true }), /-top-1 -left-1/);
+
+  for (const rootFontSize of [16, 20]) {
+    const expectedSpinnerSize = rootFontSize === 16 ? 12 : 15;
+    assert.equal(0.75 * rootFontSize, expectedSpinnerSize);
+  }
 });
 
 test('board and non-corner status indicators keep their original sizing', () => {
-  const boardSpinner = renderStatusIndicator({ isProcessing: true, surface: 'board' });
-  const leadingSpinner = renderStatusIndicator({ isProcessing: true, placement: 'leading' });
+  const statusCases = [
+    [{ isAwaitingUser: true }, 7],
+    [{ hasUnread: true }, 6],
+    [{ isProcessing: true }, 7],
+    [{ isRunning: true }, 5],
+  ];
 
-  assert.match(boardSpinner, /h-\[7px\].*w-\[7px\]/);
-  assert.match(boardSpinner, /-top-0\.5 -left-0\.5/);
-  assert.doesNotMatch(boardSpinner, /h-\[10px\]/);
-  assert.match(leadingSpinner, /h-\[7px\].*w-\[7px\]/);
-  assert.doesNotMatch(leadingSpinner, /h-\[10px\]/);
+  for (const [status, expectedSize] of statusCases) {
+    const boardCorner = renderStatusIndicator({ ...status, surface: 'board' });
+    assert.match(boardCorner, new RegExp(`h-\\[${expectedSize}px\\].*w-\\[${expectedSize}px\\]`));
+    assert.match(boardCorner, /-top-0\.5 -left-0\.5/);
+    assert.doesNotMatch(boardCorner, /h-\[[0-9.]+rem\]/);
+
+    for (const placement of ['leading', 'inline']) {
+      for (const surface of ['sidebar', 'board']) {
+        const nonCorner = renderStatusIndicator({ ...status, placement, surface });
+        assert.match(nonCorner, new RegExp(`h-\\[${expectedSize}px\\].*w-\\[${expectedSize}px\\]`));
+        assert.doesNotMatch(nonCorner, /h-\[[0-9.]+rem\]/);
+      }
+    }
+  }
 });

--- a/tests/font-scale-and-status-indicator-contract.test.mjs
+++ b/tests/font-scale-and-status-indicator-contract.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ItemStatusIndicator } from '../src/components/chat/work-item-primitives.tsx';
+import {
+  FONT_SCALE_OPTIONS,
+  normalizeFontScale,
+} from '../src/lib/settings/provider-defaults.ts';
+
+const settingsDefaultsSource = fs.readFileSync(
+  new URL('../src/lib/settings/provider-defaults.ts', import.meta.url),
+  'utf8',
+);
+const layoutSource = fs.readFileSync(
+  new URL('../src/app/layout.tsx', import.meta.url),
+  'utf8',
+);
+test('font scale presets keep the default and provide a substantially larger maximum', () => {
+  const expectedScales = /\[0\.8125, 0\.875, 1, 1\.25\]/;
+
+  assert.deepEqual(FONT_SCALE_OPTIONS, [0.8125, 0.875, 1, 1.25]);
+  assert.match(settingsDefaultsSource, expectedScales);
+  assert.match(layoutSource, expectedScales);
+  assert.match(settingsDefaultsSource, /DEFAULT_FONT_SCALE = 0\.875/);
+});
+
+test('legacy large font scale upgrades without shrinking', () => {
+  assert.equal(normalizeFontScale(0.9375), 1);
+  assert.equal(normalizeFontScale(0.875), 0.875);
+  assert.equal(normalizeFontScale(1.25), 1.25);
+  assert.match(layoutSource, /if \(raw === 0\.9375\) raw = 1/);
+});
+
+function renderStatusIndicator({
+  hasUnread = false,
+  isAwaitingUser = false,
+  isProcessing = false,
+  isRunning = false,
+  placement = 'corner',
+  surface = 'sidebar',
+} = {}) {
+  return renderToStaticMarkup(createElement(ItemStatusIndicator, {
+    hasUnread,
+    isAwaitingUser,
+    isProcessing,
+    isRunning,
+    placement,
+    surface,
+  }));
+}
+
+test('sidebar corner status indicators render enlarged sizes and offset', () => {
+  assert.match(renderStatusIndicator({ isAwaitingUser: true }), /h-\[10px\].*w-\[10px\]/);
+  assert.match(renderStatusIndicator({ hasUnread: true }), /h-\[9px\].*w-\[9px\]/);
+  assert.match(renderStatusIndicator({ isProcessing: true }), /h-\[10px\].*w-\[10px\]/);
+  assert.match(renderStatusIndicator({ isRunning: true }), /h-\[8px\].*w-\[8px\]/);
+  assert.match(renderStatusIndicator({ isRunning: true }), /-top-1 -left-1/);
+});
+
+test('board and non-corner status indicators keep their original sizing', () => {
+  const boardSpinner = renderStatusIndicator({ isProcessing: true, surface: 'board' });
+  const leadingSpinner = renderStatusIndicator({ isProcessing: true, placement: 'leading' });
+
+  assert.match(boardSpinner, /h-\[7px\].*w-\[7px\]/);
+  assert.match(boardSpinner, /-top-0\.5 -left-0\.5/);
+  assert.doesNotMatch(boardSpinner, /h-\[10px\]/);
+  assert.match(leadingSpinner, /h-\[7px\].*w-\[7px\]/);
+  assert.doesNotMatch(leadingSpinner, /h-\[10px\]/);
+});


### PR DESCRIPTION
## Summary

- Expand the font-size presets to `0.8125 / 0.875 / 1 / 1.25` while preserving the existing default.
- Scale list-view corner status indicators with the selected font size.
- Keep kanban and non-corner indicator sizes unchanged.
- Preserve the legacy `0.9375` large setting by migrating it to `1`.
- Add runtime contract coverage for font normalization and every indicator state, surface, and placement.

## Why

The previous maximum font scale was only `1`, so increasing the setting produced a limited visual change. List icons were rem-based, but their corner indicators used fixed pixel sizes, making the spinner and notification dots look disproportionately small at Large and Extra Large.

## User impact

Extra Large now renders the root font at 20px. The list-view processing spinner scales to 12px at Large and 15px at Extra Large, while board indicators retain their previous dimensions.

## Validation

- `node --import tsx --test tests/font-scale-and-status-indicator-contract.test.mjs tests/provider-icons-contract.test.mjs`
- `npx eslint src/lib/settings/provider-defaults.ts src/app/layout.tsx src/components/chat/work-item-primitives.tsx tests/font-scale-and-status-indicator-contract.test.mjs`
- `npm run build`
- Browser E2E verification at Large and Extra Large, including computed indicator dimensions and overflow behavior
