### PR TITLE
Show Claude task progress in chat

### DIFF
--- a/src/components/chat/tool-call-block-utils.tsx
+++ b/src/components/chat/tool-call-block-utils.tsx
@@ -7,6 +7,7 @@ import {
   FileEdit,
   FileText,
   Globe,
+  ListTodo,
   MessageCircleQuestion,
   Search,
   Terminal,
@@ -83,6 +84,8 @@ export function getToolIcon(toolName: string, toolKind?: ToolCallKind): ReactNod
       return <Bot className="h-3.5 w-3.5" />;
     case 'question_prompt':
       return <MessageCircleQuestion className="h-3.5 w-3.5" />;
+    case 'todo_update':
+      return <ListTodo className="h-3.5 w-3.5" />;
     default:
       return <Code2 className="h-3.5 w-3.5" />;
   }
@@ -122,6 +125,23 @@ export function getToolSummary(
     }
 
     return `${toolParams.todos.length} tasks`;
+  }
+
+  if (effectiveKind === 'todo_update') {
+    const normalizedName = toolName.toLowerCase();
+    if (normalizedName === 'taskcreate') {
+      return toolParams.subject || toolParams.content || 'Create task';
+    }
+    if (normalizedName === 'taskupdate') {
+      const taskId = toolParams.taskId || toolParams.task_id || toolParams.id;
+      const detail = toolParams.subject || toolParams.activeForm || toolParams.status;
+      return detail || (taskId ? `Task ${taskId}` : 'Update task');
+    }
+    if (normalizedName === 'tasklist') return 'List tasks';
+    if (normalizedName === 'taskget') {
+      const taskId = toolParams.taskId || toolParams.task_id || toolParams.id;
+      return taskId ? `Task ${taskId}` : 'Get task';
+    }
   }
 
   if (effectiveKind === 'subagent_task' && toolParams.subagent_type) {

--- a/src/lib/cli/protocol-message-types.ts
+++ b/src/lib/cli/protocol-message-types.ts
@@ -71,6 +71,9 @@ export type CliMessage = {
   response?: CliControlResponsePayload;
   event?: CliStreamEventPayload;
   parent_tool_use_id?: string | null;
+  /** Structured tool result envelope (Claude has emitted both spellings). */
+  tool_use_result?: unknown;
+  toolUseResult?: unknown;
 };
 
 /**

--- a/src/lib/cli/providers/claude-code/protocol-parser.ts
+++ b/src/lib/cli/providers/claude-code/protocol-parser.ts
@@ -21,7 +21,14 @@ import { buildModelUsageEntries, pickPrimaryModelName } from '../../protocol-ada
 import { parseContentBlocks, extractToolResultOutput, extractOutputString } from '../../message-parser';
 import { hookHandler } from '../../hook-handler';
 import { truncateToolResult } from '../../truncate-tool-result';
-import { extractTodoSnapshot, mapClaudeToolNameToToolKind, synthesizeClaudeToolResult } from './synthesize-claude-tool-result';
+import {
+  applyClaudeTaskToolResult,
+  extractTodoSnapshot,
+  isClaudeTaskToolResultFailure,
+  mapClaudeToolNameToToolKind,
+  synthesizeClaudeToolResult,
+  type ClaudeTaskTodo,
+} from './synthesize-claude-tool-result';
 import logger from '../../../logger';
 import type { ToolCallKind } from '@/types/tool-call-kind';
 import type { ToolDisplayMetadata } from '@/types/tool-display';
@@ -102,6 +109,9 @@ export class ClaudeCodeProtocolParser {
 
   /** Per-session TodoWrite snapshot for synthesizing rich todo diffs without CLI JSONL. */
   private lastTodoSnapshots = new Map<string, Array<{ content: string; status: 'pending' | 'in_progress' | 'completed'; activeForm?: string }>>();
+
+  /** Per-session Claude Task* state, keyed by the ids returned by the CLI. */
+  private taskTodoSnapshots = new Map<string, Map<string, ClaudeTaskTodo>>();
 
   /**
    * Per-session set of background-task ids known to be dynamic workflows.
@@ -188,6 +198,7 @@ export class ClaudeCodeProtocolParser {
     this.lastAssistantMessage.delete(sessionId);
     this.lastAssistantModel.delete(sessionId);
     this.lastTodoSnapshots.delete(sessionId);
+    this.taskTodoSnapshots.delete(sessionId);
     this.workflowTaskIds.delete(sessionId);
 
     return [
@@ -773,6 +784,7 @@ export class ClaudeCodeProtocolParser {
     const isError = msg.message?.is_error || false;
     const rawContent = msg.message?.content;
     const output = extractOutputString(rawContent);
+    const rawToolUseResult = extractClaudeToolUseResult(msg);
 
     const sessionPending = this.pendingToolCalls.get(sessionId);
     const pendingTool = sessionPending?.get(toolUseId);
@@ -819,16 +831,33 @@ export class ClaudeCodeProtocolParser {
       ? buildImageToolResult(sessionId, toolUseId)
       : undefined;
 
-    const effectiveToolUseResult = imageToolUseResult ?? synthesizeClaudeToolResult(pendingTool.toolKind, pendingTool.toolParams, {
-      output,
-      error: isError ? output : undefined,
+    const appliedTaskResult = applyClaudeTaskToolResult({
       isError,
+      output,
+      previousTasks: this.taskTodoSnapshots.get(sessionId),
       previousTodos: this.lastTodoSnapshots.get(sessionId),
+      rawToolUseResult,
+      toolName: pendingTool.toolName,
+      toolParams: pendingTool.toolParams,
     });
+    const isTaskTodoTool = isClaudeTaskTodoTool(pendingTool.toolName);
+    const effectiveIsError = isError
+      || (isTaskTodoTool && isClaudeTaskToolResultFailure(rawToolUseResult, output));
+    const effectiveToolUseResult = imageToolUseResult
+      ?? appliedTaskResult?.todoUpdate
+      ?? (isTaskTodoTool ? undefined : synthesizeClaudeToolResult(pendingTool.toolKind, pendingTool.toolParams, {
+          output,
+          error: isError ? output : undefined,
+          isError,
+          previousTodos: this.lastTodoSnapshots.get(sessionId),
+        }));
 
-    const nextTodos = extractTodoSnapshot(pendingTool.toolKind, pendingTool.toolParams);
-    if (nextTodos) {
-      this.lastTodoSnapshots.set(sessionId, nextTodos);
+    if (appliedTaskResult) {
+      this.taskTodoSnapshots.set(sessionId, appliedTaskResult.nextTasks);
+      this.lastTodoSnapshots.set(sessionId, appliedTaskResult.todoUpdate.next);
+    } else if (!effectiveIsError) {
+      const nextTodos = extractTodoSnapshot(pendingTool.toolKind, pendingTool.toolParams);
+      if (nextTodos) this.lastTodoSnapshots.set(sessionId, nextTodos);
     }
 
     return [{
@@ -839,9 +868,9 @@ export class ClaudeCodeProtocolParser {
         ...(pendingTool.toolKind !== undefined ? { toolKind: pendingTool.toolKind } : {}),
         toolParams: pendingTool.toolParams,
         ...(pendingTool.toolDisplay !== undefined ? { toolDisplay: pendingTool.toolDisplay } : {}),
-        status: isError ? 'error' : 'completed',
-        output: isError ? undefined : output,
-        error: isError ? output : undefined,
+        status: effectiveIsError ? 'error' : 'completed',
+        output: effectiveIsError ? undefined : output,
+        error: effectiveIsError ? output : undefined,
         ...(effectiveToolUseResult !== undefined ? { toolUseResult: effectiveToolUseResult } : {}),
         toolUseId,
         timestamp: new Date().toISOString(),
@@ -864,7 +893,8 @@ export class ClaudeCodeProtocolParser {
     const content = msg.message?.content;
     if (!Array.isArray(content)) return [];
 
-    const rawToolUseResult = (msg as any).toolUseResult;
+    const rawToolUseResult = extractClaudeToolUseResult(msg);
+    const toolResultCount = content.filter((block) => extractToolResultOutput(block) !== undefined).length;
     const results: ParsedMessage[] = [];
 
     for (const block of content) {
@@ -886,29 +916,48 @@ export class ClaudeCodeProtocolParser {
       const isImageRead = !toolResult.isError
         && pendingTool.toolKind === 'file_read'
         && isImagePath(pendingTool.toolParams?.file_path);
+      const resultRawToolUseResult = toolResultCount === 1 ? rawToolUseResult : undefined;
 
-      const toolUseResult = rawToolUseResult
-        ? normalizeToolResult(
-            pendingTool.toolKind,
-            truncateToolResult(rawToolUseResult, {
-              sessionId,
-              toolName: pendingTool.toolName,
-            }),
-          )
-        : isImageRead
-          ? buildImageToolResult(sessionId, toolResult.toolUseId)
-          : synthesizeClaudeToolResult(pendingTool.toolKind, pendingTool.toolParams, {
-              output: toolResult.output,
-              error: toolResult.isError ? toolResult.output : undefined,
-              isError: toolResult.isError,
-              previousTodos: this.lastTodoSnapshots.get(sessionId),
-            });
+      const appliedTaskResult = applyClaudeTaskToolResult({
+        isError: toolResult.isError,
+        output: toolResult.output,
+        previousTasks: this.taskTodoSnapshots.get(sessionId),
+        previousTodos: this.lastTodoSnapshots.get(sessionId),
+        rawToolUseResult: resultRawToolUseResult,
+        toolName: pendingTool.toolName,
+        toolParams: pendingTool.toolParams,
+      });
+      const isTaskTodoTool = isClaudeTaskTodoTool(pendingTool.toolName);
+      const effectiveIsError = toolResult.isError
+        || (isTaskTodoTool && isClaudeTaskToolResultFailure(resultRawToolUseResult, toolResult.output));
+      const toolUseResult = appliedTaskResult?.todoUpdate
+        ?? (isTaskTodoTool
+          ? undefined
+          : resultRawToolUseResult
+            ? normalizeToolResult(
+                pendingTool.toolKind,
+                truncateToolResult(resultRawToolUseResult, {
+                  sessionId,
+                  toolName: pendingTool.toolName,
+                }),
+              )
+            : isImageRead
+              ? buildImageToolResult(sessionId, toolResult.toolUseId)
+              : synthesizeClaudeToolResult(pendingTool.toolKind, pendingTool.toolParams, {
+                  output: toolResult.output,
+                  error: toolResult.isError ? toolResult.output : undefined,
+                  isError: toolResult.isError,
+                  previousTodos: this.lastTodoSnapshots.get(sessionId),
+                }));
 
       sessionPending!.delete(toolResult.toolUseId);
 
-      const nextTodos = extractTodoSnapshot(pendingTool.toolKind, pendingTool.toolParams);
-      if (nextTodos) {
-        this.lastTodoSnapshots.set(sessionId, nextTodos);
+      if (appliedTaskResult) {
+        this.taskTodoSnapshots.set(sessionId, appliedTaskResult.nextTasks);
+        this.lastTodoSnapshots.set(sessionId, appliedTaskResult.todoUpdate.next);
+      } else if (!effectiveIsError) {
+        const nextTodos = extractTodoSnapshot(pendingTool.toolKind, pendingTool.toolParams);
+        if (nextTodos) this.lastTodoSnapshots.set(sessionId, nextTodos);
       }
 
       logger.debug('Tool result from user message', {
@@ -916,7 +965,7 @@ export class ClaudeCodeProtocolParser {
         toolName: pendingTool.toolName,
         toolUseId: toolResult.toolUseId,
         isError: toolResult.isError,
-        hasToolUseResult: !!rawToolUseResult,
+        hasToolUseResult: !!resultRawToolUseResult,
         outputLength: toolResult.output?.length || 0,
       });
 
@@ -928,10 +977,10 @@ export class ClaudeCodeProtocolParser {
           ...(pendingTool.toolKind !== undefined ? { toolKind: pendingTool.toolKind } : {}),
           toolParams: pendingTool.toolParams,
           ...(pendingTool.toolDisplay !== undefined ? { toolDisplay: pendingTool.toolDisplay } : {}),
-          status: toolResult.isError ? 'error' : 'completed',
-          output: toolResult.isError ? undefined : toolResult.output,
-          error: toolResult.isError ? toolResult.output : undefined,
-          toolUseResult,
+          status: effectiveIsError ? 'error' : 'completed',
+          output: effectiveIsError ? undefined : toolResult.output,
+          error: effectiveIsError ? toolResult.output : undefined,
+          ...(toolUseResult !== undefined ? { toolUseResult } : {}),
           toolUseId: toolResult.toolUseId,
           timestamp: new Date().toISOString(),
         },
@@ -1562,6 +1611,18 @@ function buildStreamToolUseBlock(block: NonNullable<SessionStreamState['activeTo
     name: block.name,
     input,
   };
+}
+
+function isClaudeTaskTodoTool(toolName: string): boolean {
+  return ['taskcreate', 'taskupdate', 'tasklist', 'taskget'].includes(toolName.toLowerCase());
+}
+
+function extractClaudeToolUseResult(msg: CliMessage): unknown {
+  const raw = msg as any;
+  return raw.tool_use_result
+    ?? raw.toolUseResult
+    ?? raw.message?.tool_use_result
+    ?? raw.message?.toolUseResult;
 }
 
 function buildClaudeSystemWarning(

--- a/src/lib/cli/providers/claude-code/synthesize-claude-tool-result.ts
+++ b/src/lib/cli/providers/claude-code/synthesize-claude-tool-result.ts
@@ -23,6 +23,25 @@ interface SynthesizeClaudeToolResultOptions {
   previousTodos?: TodoItem[];
 }
 
+export interface ClaudeTaskTodo extends TodoItem {
+  id: string;
+}
+
+export interface ApplyClaudeTaskToolResultOptions {
+  isError?: boolean;
+  output?: string;
+  previousTasks?: ReadonlyMap<string, ClaudeTaskTodo>;
+  previousTodos?: TodoItem[];
+  rawToolUseResult?: unknown;
+  toolName: string;
+  toolParams: Record<string, any>;
+}
+
+export interface AppliedClaudeTaskToolResult {
+  nextTasks: Map<string, ClaudeTaskTodo>;
+  todoUpdate: TodoUpdateToolResult;
+}
+
 function toStringValue(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
@@ -53,6 +72,194 @@ function normalizeTodos(rawTodos: unknown): TodoItem[] {
       status: todo.status === 'completed' || todo.status === 'in_progress' ? todo.status : 'pending',
       ...(typeof todo.activeForm === 'string' ? { activeForm: todo.activeForm } : {}),
     }));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseStructuredCandidates(rawToolUseResult: unknown, output: string): unknown[] {
+  const candidates: unknown[] = [];
+  for (const value of [rawToolUseResult, output]) {
+    if (isRecord(value)) {
+      candidates.push(value);
+      continue;
+    }
+    if (typeof value !== 'string' || !value.trim()) continue;
+    try {
+      candidates.push(JSON.parse(value));
+    } catch {
+      // Claude may also emit a human-readable output alongside structured data.
+    }
+  }
+  return candidates;
+}
+
+function unwrapTaskResult(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+  for (const key of ['tool_use_result', 'toolUseResult', 'result']) {
+    if (isRecord(value[key])) return value[key] as Record<string, unknown>;
+  }
+  return value;
+}
+
+function taskIdFrom(value: unknown): string {
+  if (!isRecord(value)) return '';
+  const id = value.id ?? value.taskId ?? value.task_id;
+  return typeof id === 'string' || typeof id === 'number' ? String(id).trim() : '';
+}
+
+function normalizeTask(value: unknown): ClaudeTaskTodo | undefined {
+  if (!isRecord(value)) return undefined;
+  const id = taskIdFrom(value);
+  const content = toStringValue(value.subject ?? value.content).trim();
+  if (!id || !content) return undefined;
+
+  return {
+    id,
+    content,
+    status: value.status === 'completed' || value.status === 'in_progress'
+      ? value.status
+      : 'pending',
+    ...(typeof value.activeForm === 'string' ? { activeForm: value.activeForm } : {}),
+  };
+}
+
+function taskTodos(tasks: ReadonlyMap<string, ClaudeTaskTodo>): TodoItem[] {
+  return [...tasks.values()].map(({ content, status, activeForm }) => ({
+    content,
+    status,
+    ...(activeForm ? { activeForm } : {}),
+  }));
+}
+
+function hasFailedTaskResult(result: Record<string, unknown> | undefined): boolean {
+  return result?.success === false || result?.isError === true || result?.is_error === true;
+}
+
+function isUsableTaskResult(toolName: string, result: Record<string, unknown>): boolean {
+  if (toolName === 'taskcreate') return !!(taskIdFrom(result.task) || taskIdFrom(result));
+  if (toolName === 'tasklist') return Array.isArray(result.tasks);
+  if (toolName === 'taskget') return Object.hasOwn(result, 'task');
+  return result.success === true
+    || !!taskIdFrom(result.task)
+    || !!taskIdFrom(result)
+    || Array.isArray(result.updatedFields)
+    || isRecord(result.statusChange);
+}
+
+function selectTaskResult(
+  toolName: string,
+  rawToolUseResult: unknown,
+  output: string,
+): Record<string, unknown> | undefined {
+  const candidates = parseStructuredCandidates(rawToolUseResult, output)
+    .map(unwrapTaskResult)
+    .filter((candidate): candidate is Record<string, unknown> => candidate !== undefined);
+  return candidates.find(hasFailedTaskResult)
+    ?? candidates.find((candidate) => isUsableTaskResult(toolName, candidate));
+}
+
+export function isClaudeTaskToolResultFailure(rawToolUseResult: unknown, output: string): boolean {
+  return parseStructuredCandidates(rawToolUseResult, output)
+    .map(unwrapTaskResult)
+    .some(hasFailedTaskResult);
+}
+
+/**
+ * Apply one completed Claude Task* tool call to its session-scoped task map.
+ * Returns undefined for errors, malformed results, and unknown update ids so
+ * callers can preserve the previous snapshot without emitting a misleading UI.
+ */
+export function applyClaudeTaskToolResult(
+  options: ApplyClaudeTaskToolResultOptions,
+): AppliedClaudeTaskToolResult | undefined {
+  const normalizedName = options.toolName.toLowerCase();
+  if (!['taskcreate', 'taskupdate', 'tasklist', 'taskget'].includes(normalizedName)) {
+    return undefined;
+  }
+  if (options.isError) return undefined;
+
+  const result = selectTaskResult(
+    normalizedName,
+    options.rawToolUseResult,
+    options.output ?? '',
+  );
+  if (hasFailedTaskResult(result)) return undefined;
+
+  const previousTasks = options.previousTasks ?? new Map<string, ClaudeTaskTodo>();
+  const nextTasks = new Map(previousTasks);
+
+  if (normalizedName === 'taskcreate') {
+    const task = normalizeTask(result?.task) ?? normalizeTask(result);
+    const id = task?.id || taskIdFrom(result);
+    const content = task?.content || toStringValue(options.toolParams.subject ?? options.toolParams.content).trim();
+    if (!id || !content) return undefined;
+    const activeForm = task?.activeForm
+      ?? (typeof options.toolParams.activeForm === 'string' ? options.toolParams.activeForm : undefined);
+    nextTasks.set(id, {
+      id,
+      content,
+      status: task?.status ?? 'pending',
+      ...(activeForm ? { activeForm } : {}),
+    });
+  } else if (normalizedName === 'taskupdate') {
+    const id = taskIdFrom(options.toolParams) || taskIdFrom(result?.task) || taskIdFrom(result);
+    if (!id || !nextTasks.has(id)) return undefined;
+
+    const statusChange = isRecord(result?.statusChange) ? result.statusChange : undefined;
+    const expectedPreviousStatus = statusChange?.from;
+    if (typeof expectedPreviousStatus === 'string'
+      && nextTasks.get(id)?.status !== expectedPreviousStatus) return undefined;
+
+    if (options.toolParams.status === 'deleted') {
+      nextTasks.delete(id);
+    } else {
+      const current = nextTasks.get(id)!;
+      const returnedTask = normalizeTask(result?.task);
+      const status = options.toolParams.status === 'completed' || options.toolParams.status === 'in_progress'
+        ? options.toolParams.status
+        : options.toolParams.status === 'pending'
+          ? 'pending'
+          : returnedTask?.status ?? current.status;
+      const content = toStringValue(options.toolParams.subject ?? options.toolParams.content).trim()
+        || returnedTask?.content
+        || current.content;
+      const activeForm = typeof options.toolParams.activeForm === 'string'
+        ? options.toolParams.activeForm
+        : returnedTask?.activeForm ?? current.activeForm;
+      nextTasks.set(id, {
+        id,
+        content,
+        status,
+        ...(activeForm ? { activeForm } : {}),
+      });
+    }
+  } else if (normalizedName === 'tasklist') {
+    if (!result || !Array.isArray(result.tasks)) return undefined;
+    const normalizedTasks = result.tasks.map(normalizeTask);
+    if (normalizedTasks.some((task) => task === undefined)) return undefined;
+    const taskIds = normalizedTasks.map((task) => task!.id);
+    if (new Set(taskIds).size !== taskIds.length) return undefined;
+    nextTasks.clear();
+    for (const task of normalizedTasks) {
+      if (task) nextTasks.set(task.id, task);
+    }
+  } else {
+    if (!result || result.task == null) return undefined;
+    const task = normalizeTask(result.task);
+    if (!task) return undefined;
+    nextTasks.set(task.id, task);
+  }
+
+  return {
+    nextTasks,
+    todoUpdate: {
+      kind: 'todo_update',
+      previous: options.previousTodos ?? taskTodos(previousTasks),
+      next: taskTodos(nextTasks),
+    },
+  };
 }
 
 function normalizeAskUserQuestions(rawQuestions: unknown): AskUserQuestionItem[] {
@@ -256,6 +463,10 @@ export function mapClaudeToolNameToToolKind(toolName: string): ToolCallKind | un
     case 'webfetch':
       return 'web_fetch';
     case 'todowrite':
+    case 'taskcreate':
+    case 'taskupdate':
+    case 'tasklist':
+    case 'taskget':
       return 'todo_update';
     default:
       return undefined;

--- a/src/types/tool-call-kind.ts
+++ b/src/types/tool-call-kind.ts
@@ -47,6 +47,10 @@ export function inferToolCallKindFromToolName(toolName: string): ToolCallKind | 
     case 'webfetch':
       return 'web_fetch';
     case 'todowrite':
+    case 'taskcreate':
+    case 'taskupdate':
+    case 'tasklist':
+    case 'taskget':
       return 'todo_update';
     default:
       return undefined;

--- a/tests/claude-code-task-todo.test.ts
+++ b/tests/claude-code-task-todo.test.ts
@@ -1,0 +1,259 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { ClaudeCodeProtocolParser } from '../src/lib/cli/providers/claude-code/protocol-parser';
+import type { TodoUpdateToolResult } from '../src/types/tool-result';
+
+function startTool(
+  parser: ClaudeCodeProtocolParser,
+  sessionId: string,
+  toolUseId: string,
+  name: string,
+  input: Record<string, unknown>,
+) {
+  return parser.parseStdout(sessionId, JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id: toolUseId, name, input }] },
+  }));
+}
+
+function finishTool(
+  parser: ClaudeCodeProtocolParser,
+  sessionId: string,
+  toolUseId: string,
+  result: unknown,
+  options: { camelCase?: boolean; isError?: boolean; output?: string } = {},
+) {
+  return parser.parseStdout(sessionId, JSON.stringify({
+    type: 'tool_result',
+    tool_use_id: toolUseId,
+    message: { is_error: !!options.isError, content: options.output ?? JSON.stringify(result) },
+    [options.camelCase ? 'toolUseResult' : 'tool_use_result']: result,
+  }));
+}
+
+function finishUserTool(
+  parser: ClaudeCodeProtocolParser,
+  sessionId: string,
+  toolUseId: string,
+  result: unknown,
+  options: { camelCase?: boolean; isError?: boolean; output?: string } = {},
+) {
+  return parser.parseStdout(sessionId, JSON.stringify({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{
+        type: 'tool_result',
+        tool_use_id: toolUseId,
+        is_error: !!options.isError,
+        content: options.output ?? JSON.stringify(result),
+      }],
+    },
+    [options.camelCase ? 'toolUseResult' : 'tool_use_result']: result,
+  }));
+}
+
+function completedTodo(messages: ReturnType<ClaudeCodeProtocolParser['parseStdout']>) {
+  const toolCall = messages
+    .map((message) => message.serverMessage)
+    .find((message): message is any => !!message && message.type === 'tool_call' && message.status !== 'running');
+  return toolCall?.toolUseResult as TodoUpdateToolResult | undefined;
+}
+
+test('TaskCreate, TaskUpdate, and delete emit canonical todo snapshots only after success', () => {
+  const parser = new ClaudeCodeProtocolParser();
+  const session = 'task-transitions';
+
+  const running = startTool(parser, session, 'create-1', 'TaskCreate', {
+    subject: 'Investigate parser',
+    activeForm: 'Investigating parser',
+  });
+  const runningCall = running.map((entry) => entry.serverMessage).find((message: any) => message?.type === 'tool_call') as any;
+  assert.equal(runningCall.toolKind, 'todo_update');
+  assert.equal(runningCall.toolUseResult, undefined, 'TaskCreate must not update the list optimistically');
+
+  let todo = completedTodo(finishUserTool(parser, session, 'create-1', {
+    task: { id: '1', subject: 'Investigate parser', status: 'pending' },
+  }));
+  assert.deepEqual(todo, {
+    kind: 'todo_update',
+    previous: [],
+    next: [{ content: 'Investigate parser', status: 'pending', activeForm: 'Investigating parser' }],
+  });
+
+  startTool(parser, session, 'update-1', 'TaskUpdate', {
+    taskId: '1',
+    status: 'in_progress',
+    activeForm: 'Inspecting stream events',
+  });
+  todo = completedTodo(finishTool(parser, session, 'update-1', { success: true, taskId: '1' }));
+  assert.equal(todo?.next[0].status, 'in_progress');
+  assert.equal(todo?.next[0].activeForm, 'Inspecting stream events');
+
+  startTool(parser, session, 'rename-1', 'TaskUpdate', { task_id: '1', subject: 'Fix parser' });
+  todo = completedTodo(finishTool(parser, session, 'rename-1', { success: true }));
+  assert.equal(todo?.next[0].content, 'Fix parser');
+
+  startTool(parser, session, 'delete-1', 'TaskUpdate', { id: '1', status: 'deleted' });
+  todo = completedTodo(finishTool(parser, session, 'delete-1', { success: true }));
+  assert.deepEqual(todo?.next, []);
+});
+
+test('TaskList replaces the session snapshot authoritatively, including an empty list', () => {
+  const parser = new ClaudeCodeProtocolParser();
+  const session = 'task-list';
+
+  startTool(parser, session, 'list-1', 'TaskList', {});
+  let todo = completedTodo(finishTool(parser, session, 'list-1', {
+    tasks: [
+      { id: 'a', subject: 'First', status: 'completed' },
+      { id: 'b', subject: 'Second', status: 'in_progress', activeForm: 'Doing second' },
+    ],
+  }));
+  assert.deepEqual(todo?.next, [
+    { content: 'First', status: 'completed' },
+    { content: 'Second', status: 'in_progress', activeForm: 'Doing second' },
+  ]);
+
+  startTool(parser, session, 'list-2', 'TaskList', {});
+  todo = completedTodo(finishTool(parser, session, 'list-2', { tasks: [] }));
+  assert.equal(todo?.previous.length, 2);
+  assert.deepEqual(todo?.next, []);
+});
+
+test('TaskGet upserts a task while null and malformed results preserve the list', () => {
+  const parser = new ClaudeCodeProtocolParser();
+  const session = 'task-get';
+
+  startTool(parser, session, 'get-1', 'TaskGet', { taskId: '7' });
+  const todo = completedTodo(finishTool(parser, session, 'get-1', {
+    task: { id: '7', subject: 'Recovered task', status: 'completed' },
+  }, { camelCase: true, output: 'Task retrieved' }));
+  assert.equal(todo?.next[0].content, 'Recovered task');
+
+  startTool(parser, session, 'get-null', 'TaskGet', { taskId: 'missing' });
+  assert.equal(completedTodo(finishTool(parser, session, 'get-null', { task: null })), undefined);
+
+  startTool(parser, session, 'list-bad', 'TaskList', {});
+  assert.equal(completedTodo(finishTool(parser, session, 'list-bad', { tasks: 'bad' })), undefined);
+
+  startTool(parser, session, 'list-partial', 'TaskList', {});
+  assert.equal(completedTodo(finishTool(parser, session, 'list-partial', {
+    tasks: [{ id: '8', subject: 'Valid' }, { id: 'missing-subject' }],
+  })), undefined);
+
+  startTool(parser, session, 'list-duplicate', 'TaskList', {});
+  assert.equal(completedTodo(finishTool(parser, session, 'list-duplicate', {
+    tasks: [{ id: '8', subject: 'First' }, { id: '8', subject: 'Duplicate' }],
+  })), undefined);
+
+  startTool(parser, session, 'list-blank', 'TaskList', {});
+  assert.equal(completedTodo(finishTool(parser, session, 'list-blank', {
+    tasks: [{ id: ' ', subject: 'Blank id' }],
+  })), undefined);
+});
+
+test('failed calls and updates for unknown ids never mutate or fabricate tasks', () => {
+  const parser = new ClaudeCodeProtocolParser();
+  const session = 'task-errors';
+
+  startTool(parser, session, 'create-failed', 'TaskCreate', { subject: 'Must not appear' });
+  assert.equal(completedTodo(finishTool(parser, session, 'create-failed', {
+    task: { id: '1', subject: 'Must not appear' },
+  }, { isError: true })), undefined);
+
+  startTool(parser, session, 'create-unsuccessful', 'TaskCreate', { subject: 'Also hidden' });
+  const failed = finishTool(parser, session, 'create-unsuccessful', {
+    success: false,
+    task: { id: '2', subject: 'Also hidden' },
+  }, { output: 'Task creation failed' });
+  assert.equal(completedTodo(failed), undefined);
+  assert.equal(failed.find((entry) => entry.serverMessage?.type === 'tool_call')?.serverMessage?.status, 'error');
+
+  startTool(parser, session, 'unknown-update', 'TaskUpdate', { taskId: '404', status: 'completed' });
+  assert.equal(completedTodo(finishTool(parser, session, 'unknown-update', { success: true })), undefined);
+});
+
+test('batched results use their own block output and stale status transitions cannot regress', () => {
+  const parser = new ClaudeCodeProtocolParser();
+  const session = 'task-batched';
+
+  startTool(parser, session, 'create-a', 'TaskCreate', { subject: 'Alpha' });
+  startTool(parser, session, 'create-b', 'TaskCreate', { subject: 'Beta' });
+  const batched = parser.parseStdout(session, JSON.stringify({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'create-a', content: JSON.stringify({ task: { id: 'a', subject: 'Alpha' } }) },
+        { type: 'tool_result', tool_use_id: 'create-b', content: JSON.stringify({ task: { id: 'b', subject: 'Beta' } }) },
+      ],
+    },
+    tool_use_result: { task: { id: 'wrong', subject: 'Wrong shared result' } },
+  }));
+  const snapshots = batched
+    .map((entry) => entry.serverMessage?.type === 'tool_call' ? entry.serverMessage.toolUseResult as TodoUpdateToolResult : undefined)
+    .filter((value): value is TodoUpdateToolResult => value !== undefined);
+  assert.deepEqual(snapshots.at(-1)?.next.map((todo) => todo.content), ['Alpha', 'Beta']);
+
+  startTool(parser, session, 'done-a', 'TaskUpdate', { taskId: 'a', status: 'completed' });
+  startTool(parser, session, 'active-a', 'TaskUpdate', { taskId: 'a', status: 'in_progress' });
+  let todo = completedTodo(finishTool(parser, session, 'done-a', {
+    success: true,
+    statusChange: { from: 'pending', to: 'completed' },
+  }));
+  assert.equal(todo?.next[0].status, 'completed');
+  todo = completedTodo(finishTool(parser, session, 'active-a', {
+    success: true,
+    statusChange: { from: 'pending', to: 'in_progress' },
+  }));
+  assert.equal(todo, undefined);
+});
+
+test('valid JSON output is used when the structured result object is malformed', () => {
+  const parser = new ClaudeCodeProtocolParser();
+  const session = 'task-result-fallback';
+  startTool(parser, session, 'create-1', 'TaskCreate', { subject: 'Recovered' });
+  const messages = parser.parseStdout(session, JSON.stringify({
+    type: 'tool_result',
+    tool_use_id: 'create-1',
+    message: { is_error: false, content: JSON.stringify({ task: { id: '1', subject: 'Recovered' } }) },
+    tool_use_result: {},
+  }));
+  assert.equal(completedTodo(messages)?.next[0].content, 'Recovered');
+});
+
+test('task maps are isolated by session and cleared on process exit', () => {
+  const parser = new ClaudeCodeProtocolParser();
+
+  for (const [session, subject] of [['session-a', 'Alpha'], ['session-b', 'Beta']]) {
+    startTool(parser, session, `${session}-create`, 'TaskCreate', { subject });
+    finishTool(parser, session, `${session}-create`, { task: { id: '1', subject } });
+  }
+
+  startTool(parser, 'session-a', 'a-update', 'TaskUpdate', { taskId: '1', status: 'completed' });
+  const alpha = completedTodo(finishTool(parser, 'session-a', 'a-update', { success: true }));
+  assert.deepEqual(alpha?.next, [{ content: 'Alpha', status: 'completed' }]);
+
+  startTool(parser, 'session-b', 'b-update', 'TaskUpdate', { taskId: '1', status: 'in_progress' });
+  const beta = completedTodo(finishTool(parser, 'session-b', 'b-update', { success: true }));
+  assert.deepEqual(beta?.next, [{ content: 'Beta', status: 'in_progress' }]);
+
+  parser.handleProcessExit('session-a', 0);
+  startTool(parser, 'session-a', 'after-exit', 'TaskUpdate', { taskId: '1', status: 'completed' });
+  assert.equal(completedTodo(finishTool(parser, 'session-a', 'after-exit', { success: true })), undefined);
+});
+
+test('legacy TodoWrite remains compatible', () => {
+  const parser = new ClaudeCodeProtocolParser();
+  const session = 'legacy-todo';
+  const todos = [
+    { content: 'Old protocol', status: 'in_progress', activeForm: 'Testing old protocol' },
+    { content: 'Ship', status: 'pending' },
+  ];
+
+  startTool(parser, session, 'todo-1', 'TodoWrite', { todos });
+  const todo = completedTodo(finishTool(parser, session, 'todo-1', 'Todos updated'));
+  assert.deepEqual(todo?.next, todos);
+});

--- a/tests/claude-task-todo.e2e.mjs
+++ b/tests/claude-task-todo.e2e.mjs
@@ -1,0 +1,106 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from '@playwright/test';
+
+const appUrl = process.env.TESSERA_E2E_APP_URL ?? 'http://127.0.0.1:3191/chat';
+const workspaceRoot = process.env.TESSERA_E2E_WORKSPACE_ROOT ?? process.cwd();
+const screenshotPath = process.env.TESSERA_E2E_SCREENSHOT
+  ?? '/tmp/tessera-claude-task-todo-success.png';
+const fixturePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures/mock-claude-task-cli.mjs',
+);
+
+function apiUrl(pathname) {
+  return new URL(pathname, appUrl).toString();
+}
+
+async function expectOk(response, label) {
+  if (!response.ok()) throw new Error(`${label} failed: ${response.status()} ${await response.text()}`);
+  return response.json();
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  let createdSessionId;
+  let originalClaudeOverride;
+
+  try {
+    await page.goto(appUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+    await page.getByTestId('chat-layout').waitFor({ timeout: 30_000 });
+
+    const current = await expectOk(await page.request.get(apiUrl('/api/settings')), 'read settings');
+    originalClaudeOverride = current.settings.cliCommandOverrides?.['claude-code'];
+    await expectOk(await page.request.put(apiUrl('/api/settings'), {
+      data: {
+        ...current.settings,
+        cliCommandOverrides: {
+          ...(current.settings.cliCommandOverrides ?? {}),
+          'claude-code': { native: fixturePath },
+        },
+      },
+    }), 'configure mock Claude');
+
+    const created = await expectOk(await page.request.post(apiUrl('/api/sessions'), {
+      data: {
+        workDir: workspaceRoot,
+        title: 'Claude Task todo E2E',
+        hasCustomTitle: true,
+        providerId: 'claude-code',
+      },
+    }), 'create session');
+    createdSessionId = created.sessionId;
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    const sidebarRow = page.getByTestId(`collection-chat-${created.sessionId}`).first();
+    await sidebarRow.waitFor({ timeout: 30_000 });
+    await sidebarRow.click();
+
+    const input = page.locator(`textarea[data-session-input=${JSON.stringify(created.sessionId)}]`);
+    await input.waitFor({ timeout: 30_000 });
+    await input.fill('Create and complete a visible task checklist');
+    await input.press('Enter');
+
+    const activePanel = page.locator('[role="tabpanel"]:visible');
+    await activePanel.getByText('Task checklist verified.').waitFor({ timeout: 30_000 });
+    await activePanel.getByTestId('tool-call-summary-bar').last().click();
+    const lastUpdate = activePanel.getByTestId('tool-call-row-TaskUpdate').last();
+    await lastUpdate.click();
+    const detail = page.getByTestId('tool-detail-panel');
+    await detail.getByText('3 done').waitFor({ timeout: 10_000 });
+    await detail.getByText('3 total').waitFor({ timeout: 10_000 });
+    for (const subject of [
+      'Inspect Claude task events',
+      'Translate tasks into todos',
+      'Verify the checklist UI',
+    ]) {
+      await detail.getByText(subject).waitFor({ timeout: 10_000 });
+    }
+
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    process.stdout.write(JSON.stringify({ screenshotPath, sessionId: created.sessionId }, null, 2) + '\n');
+  } catch (error) {
+    await page.screenshot({ path: '/tmp/tessera-claude-task-todo-failure.png', fullPage: true }).catch(() => {});
+    throw error;
+  } finally {
+    if (createdSessionId) {
+      await page.request.delete(apiUrl(`/api/sessions/${encodeURIComponent(createdSessionId)}`)).catch(() => {});
+    }
+    const latest = await page.request.get(apiUrl('/api/settings')).then(expectOk).catch(() => undefined);
+    if (latest?.settings) {
+      const cliCommandOverrides = { ...(latest.settings.cliCommandOverrides ?? {}) };
+      if (originalClaudeOverride === undefined) delete cliCommandOverrides['claude-code'];
+      else cliCommandOverrides['claude-code'] = originalClaudeOverride;
+      await page.request.put(apiUrl('/api/settings'), {
+        data: { ...latest.settings, cliCommandOverrides },
+      }).catch(() => {});
+    }
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/fixtures/mock-claude-task-cli.mjs
+++ b/tests/fixtures/mock-claude-task-cli.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import readline from 'node:readline';
+
+const args = process.argv.slice(2);
+if (args.includes('--version')) {
+  process.stdout.write('2.1.207 (Claude Code)\n');
+  process.exit(0);
+}
+if (args[0] === 'auth' && args[1] === 'status') {
+  process.stdout.write(JSON.stringify({ loggedIn: true }) + '\n');
+  process.exit(0);
+}
+
+const sessionId = valueAfter('--session-id') || valueAfter('--resume') || 'mock-claude-task-session';
+let turnStarted = false;
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function emit(message) {
+  process.stdout.write(JSON.stringify({ session_id: sessionId, ...message }) + '\n');
+}
+
+function assistantTool(id, name, input) {
+  emit({
+    type: 'assistant',
+    message: { role: 'assistant', content: [{ type: 'tool_use', id, name, input }] },
+  });
+}
+
+function toolResult(id, result, spelling = 'tool_use_result') {
+  emit({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{
+        type: 'tool_result',
+        tool_use_id: id,
+        is_error: false,
+        content: `Completed ${id}`,
+      }],
+    },
+    [spelling]: result,
+  });
+}
+
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function runTaskTurn() {
+  const tasks = [
+    ['1', 'Inspect Claude task events'],
+    ['2', 'Translate tasks into todos'],
+    ['3', 'Verify the checklist UI'],
+  ];
+
+  for (const [id, subject] of tasks) {
+    assistantTool(`create-${id}`, 'TaskCreate', { subject, activeForm: `${subject}…` });
+    await delay(100);
+    toolResult(`create-${id}`, { task: { id, subject, status: 'pending' } }, id === '2' ? 'toolUseResult' : 'tool_use_result');
+    await delay(100);
+  }
+
+  assistantTool('list-snapshot', 'TaskList', {});
+  await delay(100);
+  toolResult('list-snapshot', {
+    tasks: tasks.map(([id, subject]) => ({ id, subject, status: 'pending' })),
+  });
+
+  assistantTool('update-1-active', 'TaskUpdate', { taskId: '1', status: 'in_progress', activeForm: 'Inspecting Claude task events' });
+  await delay(120);
+  toolResult('update-1-active', { success: true, taskId: '1' });
+
+  for (const [id] of tasks) {
+    assistantTool(`update-${id}-done`, 'TaskUpdate', { taskId: id, status: 'completed' });
+    await delay(120);
+    toolResult(`update-${id}-done`, { success: true, taskId: id });
+  }
+
+  emit({
+    type: 'assistant',
+    message: { role: 'assistant', content: [{ type: 'text', text: 'Task checklist verified.' }] },
+  });
+  emit({ type: 'result', subtype: 'success', result: 'Task checklist verified.', is_error: false });
+}
+
+emit({ type: 'system', subtype: 'init', message: { model: 'mock-claude-task', tools: ['TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet'] } });
+
+const input = readline.createInterface({ input: process.stdin });
+input.on('line', (line) => {
+  let message;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  if (message.type === 'control_request') {
+    emit({
+      type: 'control_response',
+      request_id: message.request_id,
+      response: { subtype: 'success', request_id: message.request_id, response: { commands: [] } },
+    });
+    return;
+  }
+
+  if (message.type === 'user' && !turnStarted) {
+    turnStarted = true;
+    void runTaskTurn();
+  }
+});


### PR DESCRIPTION
## Summary

- Normalize Claude TaskCreate, TaskUpdate, TaskList, and TaskGet events into todo snapshots.
- Keep active tasks visible above the composer while any item is pending or running.
- Update task statuses live and hide the task panel once all work is complete.
- Restore task state from session history and WebSocket reconnects, and clear stale state when a session stops.
- Preserve legacy TodoWrite and OpenCode compatibility without changing existing tool detail rows.

## Verification

- 18 targeted Node tests passed.
- TypeScript type-check passed.
- ESLint passed for changed files.
- Production build passed.
- Browser E2E passed for pending → running → completed transitions and automatic panel dismissal.