### PR TITLE
Show live Claude task progress in chat

### DIFF
--- a/src/app/api/sessions/[id]/messages/route.ts
+++ b/src/app/api/sessions/[id]/messages/route.ts
@@ -10,6 +10,7 @@ function buildEmptyHistoryResponse(sessionId: string): NextResponse {
     sessionId,
     messages: [],
     activeInteractivePrompt: null,
+    todoSnapshot: [],
     pagination: { hasMore: false, nextBeforeBytes: 0 },
   });
 }
@@ -87,6 +88,7 @@ export async function GET(
       ...(beforeBytes === undefined && result.usage ? { usage: result.usage } : {}),
       ...(beforeBytes === undefined && result.contextUsage ? { contextUsage: result.contextUsage } : {}),
       ...(beforeBytes === undefined ? { activeInteractivePrompt: result.activeInteractivePrompt } : {}),
+      ...(beforeBytes === undefined ? { todoSnapshot: result.todoSnapshot } : {}),
     });
   } catch (err) {
     logger.error({

--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -11,6 +11,7 @@ import { Header } from "./header";
 import { MessageList } from "./message-list";
 import { MessageInput } from "./message-input";
 import { WorkflowStatusBar } from "./workflow/workflow-status-bar";
+import { TodoStatusBar } from "./todo/todo-status-bar";
 import { InteractivePromptOverlay } from "./interactive-prompt-overlay";
 import { MessageSquare, AlertCircle, X as XIcon } from "lucide-react";
 import { ChatAreaSkeleton } from "./chat-area-skeleton";
@@ -170,7 +171,10 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
 
       {!isReadOnly && <InteractivePromptOverlay sessionId={sessionId} />}
 
-      <WorkflowStatusBar sessionId={sessionId} isSinglePanel={isSinglePanel} />
+      <div className="max-h-[45vh] overflow-y-auto">
+        <WorkflowStatusBar sessionId={sessionId} isSinglePanel={isSinglePanel} />
+        <TodoStatusBar sessionId={sessionId} isSinglePanel={isSinglePanel} />
+      </div>
 
       <MessageInput
         sessionId={sessionId}

--- a/src/components/chat/todo/todo-status-bar.tsx
+++ b/src/components/chat/todo/todo-status-bar.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { CheckCircle2, Circle, ListTodo, LoaderCircle } from 'lucide-react';
+import { useChatStore } from '@/stores/chat-store';
+import type { TodoItem } from '@/types/cli-jsonl-schemas';
+import { cn } from '@/lib/utils';
+import { SINGLE_PANEL_CONTENT_SHELL } from '../single-panel-shell';
+
+interface TodoStatusBarProps {
+  sessionId: string;
+  isSinglePanel?: boolean;
+}
+
+function TodoStatusIcon({ status }: { status: TodoItem['status'] }) {
+  if (status === 'completed') {
+    return <CheckCircle2 className="size-3.5 shrink-0 text-(--status-success-text)" />;
+  }
+  if (status === 'in_progress') {
+    return <LoaderCircle className="size-3.5 shrink-0 animate-spin text-(--accent)" />;
+  }
+  return <Circle className="size-3.5 shrink-0 text-(--text-muted)" />;
+}
+
+function statusLabel(status: TodoItem['status']): string {
+  return status === 'in_progress' ? 'running' : status;
+}
+
+function statusClass(status: TodoItem['status']): string {
+  if (status === 'completed') {
+    return 'bg-(--status-success-bg) text-(--status-success-text)';
+  }
+  if (status === 'in_progress') {
+    return 'bg-(--status-info-bg) text-(--status-info-text)';
+  }
+  return 'bg-(--text-muted)/15 text-(--text-muted)';
+}
+
+/**
+ * Latest live todo projection, docked above the composer independently from
+ * message pagination. Completed items remain visible while any task is active;
+ * the whole card disappears as soon as the snapshot becomes terminal or empty.
+ */
+export function TodoStatusBar({ sessionId, isSinglePanel }: TodoStatusBarProps) {
+  const todos = useChatStore((state) => state.todoSnapshots.get(sessionId));
+  const hasActiveTodo = todos?.some(
+    (todo) => todo.status === 'pending' || todo.status === 'in_progress',
+  );
+
+  if (!todos || todos.length === 0 || !hasActiveTodo) return null;
+
+  const completedCount = todos.filter((todo) => todo.status === 'completed').length;
+  const runningCount = todos.filter((todo) => todo.status === 'in_progress').length;
+
+  return (
+    <div className="pt-1.5" data-testid="todo-status-bar">
+      <div className={cn('w-full', isSinglePanel ? SINGLE_PANEL_CONTENT_SHELL : 'px-4')}>
+        <section
+          aria-label="Task progress"
+          className="overflow-hidden rounded-lg border border-(--tool-border) bg-(--tool-bg) shadow-sm"
+        >
+          <header className="flex items-center gap-2 border-b border-(--tool-border) px-3 py-2">
+            <ListTodo className="size-4 shrink-0 text-(--accent)" />
+            <span className="text-xs font-medium text-(--text-primary)">Tasks</span>
+            <div className="ml-auto flex items-center gap-1.5 text-[10px]">
+              {runningCount > 0 && (
+                <span className="rounded bg-(--status-info-bg) px-1.5 py-0.5 text-(--status-info-text)">
+                  {runningCount} running
+                </span>
+              )}
+              <span className="text-(--text-muted)">
+                {completedCount}/{todos.length} completed
+              </span>
+            </div>
+          </header>
+
+          <div className="max-h-[30vh] space-y-0.5 overflow-y-auto p-1.5">
+            {todos.map((todo, index) => (
+              <div
+                key={`${todo.content}-${index}`}
+                className="flex min-w-0 items-center gap-2 rounded px-1.5 py-1"
+                data-status={todo.status}
+                data-testid="todo-status-item"
+              >
+                <TodoStatusIcon status={todo.status} />
+                <div className="min-w-0 flex-1">
+                  <div
+                    title={todo.content}
+                    className={cn(
+                      'truncate text-[11px]',
+                      todo.status === 'completed'
+                        ? 'text-(--text-muted) line-through'
+                        : 'text-(--text-secondary)',
+                    )}
+                  >
+                    {todo.content}
+                  </div>
+                  {todo.status === 'in_progress' && todo.activeForm && todo.activeForm !== todo.content && (
+                    <div
+                      className="truncate text-[10px] text-(--accent)"
+                      title={todo.activeForm}
+                    >
+                      {todo.activeForm}
+                    </div>
+                  )}
+                </div>
+                <span
+                  className={cn(
+                    'shrink-0 rounded px-1.5 py-0.5 text-[9px]',
+                    statusClass(todo.status),
+                  )}
+                >
+                  {statusLabel(todo.status)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/chat/apply-session-replay-events.ts
+++ b/src/lib/chat/apply-session-replay-events.ts
@@ -68,6 +68,9 @@ function deriveReplayStateFromStores(sessionId: string): SessionReplayState {
   const interactivePromptMap = chatStore.activeInteractivePrompt instanceof Map
     ? chatStore.activeInteractivePrompt
     : new Map<string, SessionReplayState['activeInteractivePrompt']>();
+  const todoSnapshotMap = chatStore.todoSnapshots instanceof Map
+    ? chatStore.todoSnapshots
+    : new Map<string, SessionReplayState['todoSnapshot']>();
 
   const baseMessages = messageMap.get(sessionId) || [];
   const pendingAssistantText = assistantTextBufferMap.get(sessionId) || '';
@@ -88,6 +91,7 @@ function deriveReplayStateFromStores(sessionId: string): SessionReplayState {
     usage: derivePersistedUsage(sessionId),
     contextUsage: derivePersistedContextUsage(sessionId),
     activeInteractivePrompt: interactivePromptMap.get(sessionId) || null,
+    todoSnapshot: todoSnapshotMap.get(sessionId) || [],
   };
 }
 
@@ -246,6 +250,9 @@ function projectReplayStateTransition(
     }
 
     case 'tool_call': {
+      if (nextState.todoSnapshot !== prevState.todoSnapshot) {
+        chatStore.setTodoSnapshot(sessionId, nextState.todoSnapshot);
+      }
       if (nextState.messages.length > prevState.messages.length) {
         appendLastMessageIfPresent(sessionId, nextState);
         return;

--- a/src/lib/chat/restore-session-replay.ts
+++ b/src/lib/chat/restore-session-replay.ts
@@ -1,6 +1,7 @@
 import { useChatStore } from '@/stores/chat-store';
 import { useUsageStore } from '@/stores/usage-store';
 import type { ActiveInteractivePrompt, EnhancedMessage } from '@/types/chat';
+import type { TodoItem } from '@/types/cli-jsonl-schemas';
 
 import type { ModelUsageEntry } from '@/lib/ws/message-types';
 
@@ -29,12 +30,14 @@ export interface SessionReplayPayload {
   usage?: ReplayUsage | null;
   contextUsage?: ReplayContextUsage | null;
   activeInteractivePrompt?: ActiveInteractivePrompt | null;
+  todoSnapshot?: TodoItem[];
 }
 
 export function restoreSessionReplay(sessionId: string, replay: SessionReplayPayload): void {
   const chatStore = useChatStore.getState();
   chatStore.loadHistory(sessionId, replay.messages);
   chatStore.setActiveInteractivePrompt(sessionId, replay.activeInteractivePrompt ?? null);
+  chatStore.setTodoSnapshot(sessionId, replay.todoSnapshot ?? []);
 
   const usageStore = useUsageStore.getState();
   usageStore.clearUsage(sessionId);

--- a/src/lib/cli/protocol-adapter-conversation.ts
+++ b/src/lib/cli/protocol-adapter-conversation.ts
@@ -187,7 +187,7 @@ export function handleProtocolToolResultMessage({
     outputLength: output.length,
   }, 'Tool result received');
 
-  finalizeProtocolPendingToolCall(lastTodoSnapshots, sessionId, toolUseId, pendingTool);
+  finalizeProtocolPendingToolCall(lastTodoSnapshots, sessionId, toolUseId, pendingTool, isError);
 }
 
 export function handleProtocolUserMessage({
@@ -243,6 +243,7 @@ export function handleProtocolUserMessage({
       sessionId,
       toolResult.toolUseId,
       pendingTool,
+      toolResult.isError,
     );
   }
 }

--- a/src/lib/cli/protocol-adapter-session-state.ts
+++ b/src/lib/cli/protocol-adapter-session-state.ts
@@ -87,8 +87,11 @@ export function finalizeProtocolPendingToolCall(
   sessionId: string,
   toolUseId: string,
   pendingTool: PendingToolCall,
+  isError = false,
 ): void {
-  const nextTodos = extractTodoSnapshot(pendingTool.toolKind, pendingTool.toolParams);
+  const nextTodos = isError
+    ? undefined
+    : extractTodoSnapshot(pendingTool.toolKind, pendingTool.toolParams);
   if (nextTodos) {
     lastTodoSnapshots.set(sessionId, nextTodos);
   }

--- a/src/lib/cli/providers/claude-code/synthesize-claude-tool-result.ts
+++ b/src/lib/cli/providers/claude-code/synthesize-claude-tool-result.ts
@@ -359,8 +359,12 @@ function synthesizeTodoWriteResult(
   toolParams: Record<string, any>,
   previousTodos?: TodoItem[],
 ): TodoUpdateToolResult | undefined {
+  if (!Array.isArray(toolParams.todos)) return undefined;
   const newTodos = normalizeTodos(toolParams.todos);
-  if (newTodos.length === 0) return undefined;
+  if (toolParams.todos.length > 0 && (
+    newTodos.length !== toolParams.todos.length ||
+    newTodos.some((todo) => !todo.content.trim())
+  )) return undefined;
   return {
     kind: 'todo_update',
     previous: previousTodos ?? [],
@@ -514,6 +518,11 @@ export function extractTodoSnapshot(
     return undefined;
   }
 
+  if (!Array.isArray(toolParams.todos)) return undefined;
   const todos = normalizeTodos(toolParams.todos);
-  return todos.length > 0 ? todos : undefined;
+  if (toolParams.todos.length > 0 && (
+    todos.length !== toolParams.todos.length ||
+    todos.some((todo) => !todo.content.trim())
+  )) return undefined;
+  return todos;
 }

--- a/src/lib/cli/providers/opencode/protocol-parser.ts
+++ b/src/lib/cli/providers/opencode/protocol-parser.ts
@@ -1089,8 +1089,10 @@ function synthesizeOpenCodeTodoResult(
   rawOutput: Record<string, any> | undefined,
   previousTodos: TodoItem[],
 ): CanonicalToolResultValue | undefined {
-  const nextTodos = extractOpenCodeTodos(toolParams, rawOutput);
-  if (nextTodos.length === 0) return undefined;
+  const rawTodos = extractRawOpenCodeTodos(toolParams, rawOutput);
+  if (!Array.isArray(rawTodos)) return undefined;
+  const nextTodos = normalizeOpenCodeTodos(rawTodos);
+  if (rawTodos.length > 0 && nextTodos.length === 0) return undefined;
   return {
     kind: 'todo_update',
     previous: previousTodos,
@@ -1147,13 +1149,16 @@ function extractOpenCodeTodos(
   toolParams: Record<string, any>,
   rawOutput?: Record<string, any>,
 ): TodoItem[] {
-  const rawTodos = Array.isArray(rawOutput?.metadata?.todos)
-      ? rawOutput.metadata.todos
-      : Array.isArray(toolParams.todos)
-        ? toolParams.todos
-        : parseTodosFromOutput(toStringValue(rawOutput?.output));
+  return normalizeOpenCodeTodos(extractRawOpenCodeTodos(toolParams, rawOutput));
+}
 
-  return normalizeOpenCodeTodos(rawTodos);
+function extractRawOpenCodeTodos(
+  toolParams: Record<string, any>,
+  rawOutput?: Record<string, any>,
+): unknown {
+  if (Array.isArray(rawOutput?.metadata?.todos)) return rawOutput.metadata.todos;
+  if (Array.isArray(toolParams.todos)) return toolParams.todos;
+  return parseTodosFromOutput(toStringValue(rawOutput?.output));
 }
 
 function hasOpenCodeTodoPayload(
@@ -1190,11 +1195,11 @@ function normalizeTodoStatus(status: unknown): TodoItem['status'] {
 }
 
 function parseTodosFromOutput(output: string): unknown {
-  if (!output.trim()) return [];
+  if (!output.trim()) return undefined;
   try {
     return JSON.parse(output);
   } catch {
-    return [];
+    return undefined;
   }
 }
 

--- a/src/lib/session-history.ts
+++ b/src/lib/session-history.ts
@@ -44,6 +44,7 @@ interface SessionHistoryPage {
   usage: PersistedUsage | null;
   contextUsage: PersistedContextUsage | null;
   activeInteractivePrompt: SessionReplayState['activeInteractivePrompt'];
+  todoSnapshot: SessionReplayState['todoSnapshot'];
   hasMore: boolean;
   nextBeforeBytes: number;
 }

--- a/src/lib/session-replay-reducer.ts
+++ b/src/lib/session-replay-reducer.ts
@@ -11,6 +11,7 @@ import type {
 import type {
   WorkflowAgentEntry,
   WorkflowPhaseEntry,
+  TodoItem,
 } from '@/types/cli-jsonl-schemas';
 import { isRenderableEnhancedMessage } from '@/lib/chat/renderability';
 import type {
@@ -25,6 +26,8 @@ export interface SessionReplayState {
   usage: PersistedUsage | null;
   contextUsage: PersistedContextUsage | null;
   activeInteractivePrompt: ActiveInteractivePrompt | null;
+  /** Latest successful canonical todo snapshot, independent of message pagination. */
+  todoSnapshot: TodoItem[];
 }
 
 function makeTextMessage(
@@ -42,7 +45,37 @@ export function createEmptySessionReplayState(): SessionReplayState {
     usage: null,
     contextUsage: null,
     activeInteractivePrompt: null,
+    todoSnapshot: [],
   };
+}
+
+function canonicalTodoSnapshot(value: unknown): TodoItem[] | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const result = value as Record<string, unknown>;
+  if (result.kind !== 'todo_update' || !Array.isArray(result.next)) return null;
+
+  const snapshot: TodoItem[] = [];
+  for (const raw of result.next) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const todo = raw as Record<string, unknown>;
+    if (
+      typeof todo.content !== 'string' ||
+      !todo.content.trim() ||
+      (todo.status !== 'pending' && todo.status !== 'in_progress' && todo.status !== 'completed') ||
+      (todo.activeForm !== undefined && typeof todo.activeForm !== 'string')
+    ) {
+      return null;
+    }
+    const activeForm = typeof todo.activeForm === 'string' ? todo.activeForm.trim() : '';
+    snapshot.push({
+      content: todo.content.trim(),
+      status: todo.status,
+      ...(activeForm
+        ? { activeForm }
+        : {}),
+    });
+  }
+  return snapshot;
 }
 
 function makeCompletedThinkingMessageId(state: SessionReplayState, thinkingId?: string): string {
@@ -335,6 +368,7 @@ export function applySessionReplayEvent(
     usage: currentState.usage,
     contextUsage: currentState.contextUsage,
     activeInteractivePrompt: currentState.activeInteractivePrompt,
+    todoSnapshot: currentState.todoSnapshot,
   };
 
   switch (event.type) {
@@ -458,9 +492,14 @@ export function applySessionReplayEvent(
       return state;
     }
 
-    case 'tool_call':
+    case 'tool_call': {
+      if (event.status === 'completed') {
+        const snapshot = canonicalTodoSnapshot(event.toolUseResult);
+        if (snapshot) state.todoSnapshot = snapshot;
+      }
       upsertToolCallMessage(state, sessionId, event, options);
       return state;
+    }
 
     case 'workflow_event':
       upsertWorkflowMessage(state, sessionId, event);

--- a/src/lib/session/session-orchestrator-lifecycle.ts
+++ b/src/lib/session/session-orchestrator-lifecycle.ts
@@ -24,6 +24,7 @@ interface ResumeReplayState {
   usage: SessionResumeResult['usage'];
   contextUsage: SessionResumeResult['contextUsage'];
   activeInteractivePrompt: SessionResumeResult['activeInteractivePrompt'];
+  todoSnapshot: SessionResumeResult['todoSnapshot'];
 }
 
 interface CreateSessionWithLifecycleOptions {
@@ -165,6 +166,7 @@ export async function resumeSessionWithLifecycle({
         usage: replayState.usage,
         contextUsage: replayState.contextUsage,
         activeInteractivePrompt: replayState.activeInteractivePrompt,
+        todoSnapshot: replayState.todoSnapshot,
       };
     }
     useResume = !!threadId;
@@ -184,6 +186,7 @@ export async function resumeSessionWithLifecycle({
         usage: replayState.usage,
         contextUsage: replayState.contextUsage,
         activeInteractivePrompt: replayState.activeInteractivePrompt,
+        todoSnapshot: replayState.todoSnapshot,
       };
     }
     useResume = !!opencodeSessionId;
@@ -348,6 +351,7 @@ export async function resumeSessionWithLifecycle({
     usage: replayState.usage,
     contextUsage: replayState.contextUsage,
     activeInteractivePrompt: replayState.activeInteractivePrompt,
+    todoSnapshot: replayState.todoSnapshot,
   };
 }
 
@@ -362,5 +366,6 @@ async function loadReadOnlyReplayState(sessionId: string): Promise<ResumeReplayS
     usage: null,
     contextUsage: null,
     activeInteractivePrompt: null,
+    todoSnapshot: [],
   };
 }

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -70,6 +70,7 @@ export interface SessionResumeResult {
   usage?: PersistedUsage | null;
   contextUsage?: PersistedContextUsage | null;
   activeInteractivePrompt?: ActiveInteractivePrompt | null;
+  todoSnapshot?: import('@/types/cli-jsonl-schemas').TodoItem[];
 }
 
 /**

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -73,6 +73,7 @@ export function handleIncomingServerMessage({
       // longer emit its terminal task_notification — settle it instead of
       // leaving the card spinning forever.
       chatStore.settleRunningWorkflows(msg.sessionId, 'failed');
+      chatStore.setTodoSnapshot(msg.sessionId, []);
       sessionStore.setSessionWorkflowRunning(msg.sessionId, false);
       useCommandStore.getState().clearSession(msg.sessionId);
       return { wasReconnect };
@@ -145,6 +146,7 @@ export function handleIncomingServerMessage({
       // where that event is missed/reordered, so the live view never shows a
       // card spinning past the session's death.
       chatStore.settleRunningWorkflows(msg.sessionId, 'failed');
+      chatStore.setTodoSnapshot(msg.sessionId, []);
       sessionStore.setSessionWorkflowRunning(msg.sessionId, false);
       sessionStore.updateSessionStatus(msg.sessionId, 'error');
       chatStore.addMessage(msg.sessionId, {
@@ -162,6 +164,7 @@ export function handleIncomingServerMessage({
         usage: msg.usage,
         contextUsage: msg.contextUsage,
         activeInteractivePrompt: msg.activeInteractivePrompt,
+        todoSnapshot: msg.todoSnapshot,
       });
       return { wasReconnect };
 
@@ -436,6 +439,9 @@ function handleSessionListMessage(
       if (hasActivePrompt) {
         stopTurnInFlight(session.id);
       }
+    }
+    if ('todoSnapshot' in session) {
+      chatStore.setTodoSnapshot(session.id, session.todoSnapshot ?? []);
     }
     if (session.isGenerating && !hasActivePrompt) {
       generatingSessionIds.push(session.id);

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -305,6 +305,7 @@ export type AppServerMessage =
         contextWindowSize?: number;
       } | null;
       activeInteractivePrompt?: import('@/types/chat').ActiveInteractivePrompt | null;
+      todoSnapshot?: import('@/types/cli-jsonl-schemas').TodoItem[];
     }
   | {
       type: 'session_list';
@@ -314,6 +315,7 @@ export type AppServerMessage =
         isGenerating: boolean;
         createdAt: string;
         activeInteractivePrompt?: import('@/types/chat').ActiveInteractivePrompt | null;
+        todoSnapshot?: import('@/types/cli-jsonl-schemas').TodoItem[];
       }>;
       titleGeneratingSessionIds?: string[];
     }

--- a/src/lib/ws/server-session-actions.ts
+++ b/src/lib/ws/server-session-actions.ts
@@ -739,6 +739,7 @@ async function ensureSessionProcess({
       usage: result.usage,
       contextUsage: result.contextUsage,
       activeInteractivePrompt: result.activeInteractivePrompt,
+      todoSnapshot: result.todoSnapshot,
     });
     sendToUser(userId, {
       type: 'error',
@@ -824,6 +825,7 @@ export async function resumeSessionFromWebSocket({
         usage: result.usage,
         contextUsage: result.contextUsage,
         activeInteractivePrompt: result.activeInteractivePrompt,
+        todoSnapshot: result.todoSnapshot,
       });
       logger.info({ userId, sessionId, messageCount: result.messages.length }, 'Session resumed (read_only)');
       return;
@@ -841,6 +843,7 @@ export async function resumeSessionFromWebSocket({
         usage: replayState.usage,
         contextUsage: replayState.contextUsage,
         activeInteractivePrompt: replayState.activeInteractivePrompt,
+        todoSnapshot: replayState.todoSnapshot,
       });
       logger.info({ userId, sessionId, messageCount: replayState.messages.length }, 'Session resumed');
       return;
@@ -1571,6 +1574,7 @@ function sendSessionHistoryToUser({
   sessionId,
   usage,
   userId,
+  todoSnapshot,
 }: {
   activeInteractivePrompt?: SessionHistoryMessage['activeInteractivePrompt'];
   contextUsage?: SessionHistoryMessage['contextUsage'];
@@ -1579,6 +1583,7 @@ function sendSessionHistoryToUser({
   sessionId: string;
   usage?: SessionHistoryMessage['usage'];
   userId: string;
+  todoSnapshot?: SessionHistoryMessage['todoSnapshot'];
 }): void {
   sendToUser(userId, {
     type: 'session_history',
@@ -1587,5 +1592,6 @@ function sendSessionHistoryToUser({
     usage,
     contextUsage,
     activeInteractivePrompt,
+    todoSnapshot,
   });
 }

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -236,6 +236,7 @@ export class WebSocketServer {
         isGenerating: p.isGenerating,
         createdAt: p.createdAt.toISOString(),
         activeInteractivePrompt: replayState?.activeInteractivePrompt ?? null,
+        todoSnapshot: replayState?.todoSnapshot ?? [],
       };
     }));
     this.sendToConnection(ws, userId, {

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -4,6 +4,7 @@ import type { EnhancedMessage, ConnectionStatus, ActiveInteractivePrompt } from 
 import type { AgentContextEvent } from '@/types/agent-context';
 import type { ToolCallKind } from '@/types/tool-call-kind';
 import type { ToolDisplayMetadata } from '@/types/tool-display';
+import type { TodoItem } from '@/types/cli-jsonl-schemas';
 
 const STREAM_FLUSH_BASE_MS = 60;
 const STREAM_FLUSH_MEDIUM_MS = 110;
@@ -100,6 +101,10 @@ export interface ChatState {
   // touch the underlying run.
   dismissedWorkflowTaskIds: Set<string>;
 
+  // Latest successful canonical todo snapshot for each session. The docked todo
+  // bar reads this projection instead of depending on the paginated message list.
+  todoSnapshots: Map<string, TodoItem[]>;
+
   // Assistant text blocks currently waiting for text flush, keyed by session.
   // This drives only the inline streaming dots. It is intentionally separate
   // from turnInFlightBySession, which can stay true during thinking/tools.
@@ -178,6 +183,7 @@ export interface ChatState {
   setScrollPosition: (sessionId: string, position: number | ScrollPositionSnapshot) => void;
   getScrollPosition: (sessionId: string) => ScrollPositionSnapshot | undefined;
   setActiveInteractivePrompt: (sessionId: string, prompt: ActiveInteractivePrompt | null) => void;
+  setTodoSnapshot: (sessionId: string, snapshot: TodoItem[]) => void;
   recordPromptHistoryItem: (sessionId: string, item: AgentPromptHistoryItem) => void;
   resolvePromptHistoryItem: (sessionId: string, promptId: string) => void;
   setTurnInFlight: (sessionId: string, inFlight: boolean) => void;
@@ -314,8 +320,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
   translateQueue: new Map(),
   scrollPositions: new Map(),
   dismissedWorkflowTaskIds: new Set(),
+  todoSnapshots: new Map(),
 
   isHistoryLoaded: (sessionId) => get().historyLoaded.has(sessionId),
+
+  setTodoSnapshot: (sessionId, snapshot) =>
+    set((state) => {
+      const updated = new Map(state.todoSnapshots);
+      if (snapshot.length === 0) {
+        updated.delete(sessionId);
+      } else {
+        updated.set(sessionId, snapshot.map((todo) => ({ ...todo })));
+      }
+      return { todoSnapshots: updated };
+    }),
 
   setDraftInput: (sessionId, text) =>
     set((state) => {
@@ -687,11 +705,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
       updatedPagination.delete(sessionId);
       const updatedPromptHistory = new Map(state.promptHistory);
       updatedPromptHistory.delete(sessionId);
+      const updatedTodoSnapshots = new Map(state.todoSnapshots);
+      updatedTodoSnapshots.delete(sessionId);
       return {
         messages: updatedMessages,
         historyLoaded: updatedHistoryLoaded,
         readOnlyPagination: updatedPagination,
         promptHistory: updatedPromptHistory,
+        todoSnapshots: updatedTodoSnapshots,
       };
     }),
 
@@ -733,6 +754,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const clearedTranslateQueue = new Map(state.translateQueue);
       clearedTranslateQueue.delete(sessionId);
 
+      const clearedTodoSnapshots = new Map(state.todoSnapshots);
+      clearedTodoSnapshots.delete(sessionId);
+
       return {
         messages: updatedMessages,
         historyLoaded: clearedHistoryLoaded,
@@ -754,6 +778,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         promptHistory: clearedPromptHistory,
         draftInputs: clearedDrafts,
         scrollPositions: clearedScrollPositions,
+        todoSnapshots: clearedTodoSnapshots,
       };
     }),
 

--- a/tests/claude-code-task-todo.test.ts
+++ b/tests/claude-code-task-todo.test.ts
@@ -254,6 +254,14 @@ test('legacy TodoWrite remains compatible', () => {
   ];
 
   startTool(parser, session, 'todo-1', 'TodoWrite', { todos });
-  const todo = completedTodo(finishTool(parser, session, 'todo-1', 'Todos updated'));
+  let todo = completedTodo(finishTool(parser, session, 'todo-1', 'Todos updated'));
   assert.deepEqual(todo?.next, todos);
+
+  startTool(parser, session, 'todo-clear', 'TodoWrite', { todos: [] });
+  todo = completedTodo(finishTool(parser, session, 'todo-clear', 'Todos cleared'));
+  assert.deepEqual(todo, {
+    kind: 'todo_update',
+    previous: todos,
+    next: [],
+  });
 });

--- a/tests/claude-task-todo.e2e.mjs
+++ b/tests/claude-task-todo.e2e.mjs
@@ -6,6 +6,8 @@ const appUrl = process.env.TESSERA_E2E_APP_URL ?? 'http://127.0.0.1:3191/chat';
 const workspaceRoot = process.env.TESSERA_E2E_WORKSPACE_ROOT ?? process.cwd();
 const screenshotPath = process.env.TESSERA_E2E_SCREENSHOT
   ?? '/tmp/tessera-claude-task-todo-success.png';
+const completedScreenshotPath = process.env.TESSERA_E2E_COMPLETED_SCREENSHOT
+  ?? '/tmp/tessera-claude-task-todo-completed.png';
 const fixturePath = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   'fixtures/mock-claude-task-cli.mjs',
@@ -25,6 +27,7 @@ async function main() {
   const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
   let createdSessionId;
   let originalClaudeOverride;
+  let settingsConfigured = false;
 
   try {
     await page.goto(appUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
@@ -41,6 +44,7 @@ async function main() {
         },
       },
     }), 'configure mock Claude');
+    settingsConfigured = true;
 
     const created = await expectOk(await page.request.post(apiUrl('/api/sessions'), {
       data: {
@@ -57,13 +61,45 @@ async function main() {
     await sidebarRow.waitFor({ timeout: 30_000 });
     await sidebarRow.click();
 
-    const input = page.locator(`textarea[data-session-input=${JSON.stringify(created.sessionId)}]`);
+    const input = page.locator(`textarea[data-session-input=${JSON.stringify(created.sessionId)}]:visible`);
     await input.waitFor({ timeout: 30_000 });
     await input.fill('Create and complete a visible task checklist');
     await input.press('Enter');
 
-    const activePanel = page.locator('[role="tabpanel"]:visible');
+    let activePanel = page.locator('[role="tabpanel"]:visible');
+    let todoBar = activePanel.getByTestId('todo-status-bar');
+    await todoBar.waitFor({ timeout: 30_000 });
+    await page.waitForFunction(() => (
+      document.querySelectorAll('[data-testid="todo-status-bar"] [data-status="pending"]').length === 3
+    ), undefined, { timeout: 10_000 });
+    for (const subject of [
+      'Inspect Claude task events',
+      'Translate tasks into todos',
+      'Verify the checklist UI',
+    ]) {
+      await todoBar.getByText(subject).waitFor({ timeout: 10_000 });
+    }
+
+    await todoBar.getByText('Inspecting Claude task events').waitFor({ timeout: 10_000 });
+    await todoBar.locator('[data-status="in_progress"]').waitFor({ timeout: 10_000 });
+
+    // A full reload exercises the history projection while tool outputs remain lazy.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.getByTestId('chat-layout').waitFor({ timeout: 30_000 });
+    await page.getByTestId(`collection-chat-${created.sessionId}`).first().click();
+    activePanel = page.locator('[role="tabpanel"]:visible');
+    todoBar = activePanel.getByTestId('todo-status-bar');
+    await todoBar.getByText('Inspecting Claude task events').waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+
+    // A partial completion stays visible because other tasks are still active.
+    await todoBar.locator('[data-status="completed"]').first().waitFor({ timeout: 20_000 });
+    await todoBar.waitFor({ state: 'visible' });
+
     await activePanel.getByText('Task checklist verified.').waitFor({ timeout: 30_000 });
+    await todoBar.waitFor({ state: 'hidden', timeout: 10_000 });
+
+    // Existing tool rows and the structured detail panel continue to work.
     await activePanel.getByTestId('tool-call-summary-bar').last().click();
     const lastUpdate = activePanel.getByTestId('tool-call-row-TaskUpdate').last();
     await lastUpdate.click();
@@ -78,23 +114,30 @@ async function main() {
       await detail.getByText(subject).waitFor({ timeout: 10_000 });
     }
 
-    await page.screenshot({ path: screenshotPath, fullPage: true });
-    process.stdout.write(JSON.stringify({ screenshotPath, sessionId: created.sessionId }, null, 2) + '\n');
+    await page.screenshot({ path: completedScreenshotPath, fullPage: true });
+    process.stdout.write(JSON.stringify({
+      screenshotPath,
+      completedScreenshotPath,
+      sessionId: created.sessionId,
+    }, null, 2) + '\n');
   } catch (error) {
     await page.screenshot({ path: '/tmp/tessera-claude-task-todo-failure.png', fullPage: true }).catch(() => {});
     throw error;
   } finally {
     if (createdSessionId) {
-      await page.request.delete(apiUrl(`/api/sessions/${encodeURIComponent(createdSessionId)}`)).catch(() => {});
+      await expectOk(
+        await page.request.delete(apiUrl(`/api/sessions/${encodeURIComponent(createdSessionId)}`)),
+        'delete E2E session',
+      );
     }
-    const latest = await page.request.get(apiUrl('/api/settings')).then(expectOk).catch(() => undefined);
-    if (latest?.settings) {
+    if (settingsConfigured) {
+      const latest = await expectOk(await page.request.get(apiUrl('/api/settings')), 'read cleanup settings');
       const cliCommandOverrides = { ...(latest.settings.cliCommandOverrides ?? {}) };
       if (originalClaudeOverride === undefined) delete cliCommandOverrides['claude-code'];
       else cliCommandOverrides['claude-code'] = originalClaudeOverride;
-      await page.request.put(apiUrl('/api/settings'), {
+      await expectOk(await page.request.put(apiUrl('/api/settings'), {
         data: { ...latest.settings, cliCommandOverrides },
-      }).catch(() => {});
+      }), 'restore settings');
     }
     await browser.close();
   }

--- a/tests/fixtures/mock-claude-task-cli.mjs
+++ b/tests/fixtures/mock-claude-task-cli.mjs
@@ -68,14 +68,18 @@ async function runTaskTurn() {
   toolResult('list-snapshot', {
     tasks: tasks.map(([id, subject]) => ({ id, subject, status: 'pending' })),
   });
+  await delay(1_000);
 
   assistantTool('update-1-active', 'TaskUpdate', { taskId: '1', status: 'in_progress', activeForm: 'Inspecting Claude task events' });
   await delay(120);
   toolResult('update-1-active', { success: true, taskId: '1' });
+  // Leave enough time for the E2E browser to reload and prove the active
+  // projection is restored from canonical history, not the visible message page.
+  await delay(8_000);
 
   for (const [id] of tasks) {
     assistantTool(`update-${id}-done`, 'TaskUpdate', { taskId: id, status: 'completed' });
-    await delay(120);
+    await delay(500);
     toolResult(`update-${id}-done`, { success: true, taskId: id });
   }
 

--- a/tests/session-replay-todo-projection.test.ts
+++ b/tests/session-replay-todo-projection.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import test, { beforeEach } from 'node:test';
+
+import { applySessionReplayEventsToStores } from '../src/lib/chat/apply-session-replay-events';
+import { restoreSessionReplay } from '../src/lib/chat/restore-session-replay';
+import {
+  applySessionReplayEvent,
+  createEmptySessionReplayState,
+} from '../src/lib/session-replay-reducer';
+import type { SessionReplayEvent } from '../src/lib/session-replay-types';
+import { useChatStore } from '../src/stores/chat-store';
+import type { TodoItem } from '../src/types/cli-jsonl-schemas';
+
+const SID = 'todo-session';
+const OTHER_SID = 'todo-session-other';
+const TS = '2026-07-13T00:00:00.000Z';
+
+function todoEvent(
+  id: string,
+  status: 'running' | 'completed' | 'error',
+  next: TodoItem[],
+): SessionReplayEvent {
+  return {
+    v: 1,
+    type: 'tool_call',
+    timestamp: TS,
+    toolName: 'TaskUpdate',
+    toolKind: 'todo_update',
+    toolParams: {},
+    status,
+    toolUseId: id,
+    toolUseResult: { kind: 'todo_update', previous: [], next },
+  };
+}
+
+beforeEach(() => {
+  useChatStore.setState({
+    messages: new Map(),
+    todoSnapshots: new Map(),
+    historyLoaded: new Set(),
+    activeInteractivePrompt: new Map(),
+  });
+});
+
+test('replay projection updates only from completed canonical todo results', () => {
+  const initial = createEmptySessionReplayState();
+  const active: TodoItem[] = [
+    { content: 'Inspect events', status: 'in_progress', activeForm: 'Inspecting events' },
+    { content: 'Ship UI', status: 'pending' },
+  ];
+
+  const running = applySessionReplayEvent(SID, initial, {
+    ...todoEvent('t1', 'running', active),
+    toolUseResult: undefined,
+  });
+  assert.deepEqual(running.todoSnapshot, [], 'running calls must not update optimistically');
+
+  const completed = applySessionReplayEvent(SID, running, todoEvent('t1', 'completed', active), {
+    lazyToolOutput: true,
+  });
+  assert.deepEqual(completed.todoSnapshot, active);
+  const toolMessage = completed.messages.find((message) => message.type === 'tool_call');
+  assert.equal(toolMessage?.type === 'tool_call' ? toolMessage.toolUseResult : undefined, undefined);
+
+  const failed = applySessionReplayEvent(SID, completed, todoEvent('t2', 'error', [
+    { content: 'Wrong', status: 'completed' },
+  ]));
+  assert.deepEqual(failed.todoSnapshot, active, 'failed results preserve the previous snapshot');
+
+  const malformed = applySessionReplayEvent(SID, failed, {
+    ...todoEvent('t3', 'completed', []),
+    toolUseResult: { kind: 'todo_update', next: [{ content: '', status: 'pending' }] } as any,
+  });
+  assert.deepEqual(malformed.todoSnapshot, active, 'malformed results preserve the previous snapshot');
+});
+
+test('live events update, isolate, and clear per-session store projections', () => {
+  const active: TodoItem[] = [{ content: 'Alpha', status: 'pending' }];
+  const other: TodoItem[] = [{ content: 'Beta', status: 'in_progress' }];
+
+  applySessionReplayEventsToStores(SID, [todoEvent('a', 'completed', active)]);
+  applySessionReplayEventsToStores(OTHER_SID, [todoEvent('b', 'completed', other)]);
+
+  assert.deepEqual(useChatStore.getState().todoSnapshots.get(SID), active);
+  assert.deepEqual(useChatStore.getState().todoSnapshots.get(OTHER_SID), other);
+
+  applySessionReplayEventsToStores(SID, [todoEvent('a-clear', 'completed', [])]);
+  assert.equal(useChatStore.getState().todoSnapshots.has(SID), false);
+  assert.deepEqual(useChatStore.getState().todoSnapshots.get(OTHER_SID), other);
+
+  useChatStore.getState().resetForReload(OTHER_SID);
+  assert.equal(useChatStore.getState().todoSnapshots.has(OTHER_SID), false);
+
+  useChatStore.getState().setTodoSnapshot(OTHER_SID, other);
+  useChatStore.getState().clearSession(OTHER_SID);
+  assert.equal(useChatStore.getState().todoSnapshots.has(OTHER_SID), false);
+});
+
+test('history restore replaces stale todo state without fetching lazy tool output', () => {
+  useChatStore.getState().setTodoSnapshot(SID, [{ content: 'Stale', status: 'pending' }]);
+
+  const restored: TodoItem[] = [
+    { content: 'Done', status: 'completed' },
+    { content: 'Continue', status: 'in_progress', activeForm: 'Continuing' },
+  ];
+  restoreSessionReplay(SID, { messages: [], todoSnapshot: restored });
+  assert.deepEqual(useChatStore.getState().todoSnapshots.get(SID), restored);
+
+  restoreSessionReplay(SID, { messages: [] });
+  assert.equal(useChatStore.getState().todoSnapshots.has(SID), false);
+});


### PR DESCRIPTION
## Summary

- Parse Claude TaskCreate, TaskUpdate, TaskList, and TaskGet events into canonical todo snapshots.
- Keep active tasks visible above the composer while any item is pending or running.
- Update task statuses live and hide the task panel once all work is complete.
- Restore task state from session history and WebSocket reconnects, and clear stale state when a session stops.
- Preserve legacy TodoWrite and OpenCode compatibility without changing existing tool detail rows.

## Verification

- 18 targeted Node tests passed.
- TypeScript type-check passed.
- ESLint passed for changed files.
- Production build passed.
- Browser E2E passed for pending → running → completed transitions and automatic panel dismissal.