### PR TITLE
fix(chat): add collapse/expand toggle to task progress bar

### DIFF
--- a/src/components/chat/todo/todo-status-bar.tsx
+++ b/src/components/chat/todo/todo-status-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { CheckCircle2, Circle, ListTodo, LoaderCircle } from 'lucide-react';
+import { useState } from 'react';
+import { CheckCircle2, ChevronDown, ChevronRight, Circle, ListTodo, LoaderCircle } from 'lucide-react';
 import { useChatStore } from '@/stores/chat-store';
 import type { TodoItem } from '@/types/cli-jsonl-schemas';
 import { cn } from '@/lib/utils';
@@ -9,6 +10,25 @@ import { SINGLE_PANEL_CONTENT_SHELL } from '../single-panel-shell';
 interface TodoStatusBarProps {
   sessionId: string;
   isSinglePanel?: boolean;
+}
+
+const COLLAPSED_STORAGE_KEY = 'tessera.todo-status-bar.collapsed';
+
+function readStoredCollapsed(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(COLLAPSED_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeStoredCollapsed(collapsed: boolean): void {
+  try {
+    window.localStorage.setItem(COLLAPSED_STORAGE_KEY, collapsed ? '1' : '0');
+  } catch {
+    // localStorage unavailable (private mode etc.) — collapse still works for the session.
+  }
 }
 
 function TodoStatusIcon({ status }: { status: TodoItem['status'] }) {
@@ -39,9 +59,15 @@ function statusClass(status: TodoItem['status']): string {
  * Latest live todo projection, docked above the composer independently from
  * message pagination. Completed items remain visible while any task is active;
  * the whole card disappears as soon as the snapshot becomes terminal or empty.
+ * The header toggles the item list; the collapsed preference persists across
+ * sessions via localStorage (#151).
  */
 export function TodoStatusBar({ sessionId, isSinglePanel }: TodoStatusBarProps) {
   const todos = useChatStore((state) => state.todoSnapshots.get(sessionId));
+  // Safe to read during the initial render: the bar only mounts client-side
+  // once the store receives a todo snapshot, so SSR never renders it.
+  const [collapsed, setCollapsed] = useState(readStoredCollapsed);
+
   const hasActiveTodo = todos?.some(
     (todo) => todo.status === 'pending' || todo.status === 'in_progress',
   );
@@ -50,18 +76,56 @@ export function TodoStatusBar({ sessionId, isSinglePanel }: TodoStatusBarProps) 
 
   const completedCount = todos.filter((todo) => todo.status === 'completed').length;
   const runningCount = todos.filter((todo) => todo.status === 'in_progress').length;
+  const activeTodo = todos.find((todo) => todo.status === 'in_progress')
+    ?? todos.find((todo) => todo.status === 'pending');
+  const collapsedSummary = activeTodo
+    ? (activeTodo.status === 'in_progress' && activeTodo.activeForm) || activeTodo.content
+    : null;
+
+  const toggleCollapsed = () => {
+    setCollapsed((previous) => {
+      const next = !previous;
+      writeStoredCollapsed(next);
+      return next;
+    });
+  };
 
   return (
-    <div className="pt-1.5" data-testid="todo-status-bar">
+    <div className="pt-1.5" data-testid="todo-status-bar" data-collapsed={collapsed}>
       <div className={cn('w-full', isSinglePanel ? SINGLE_PANEL_CONTENT_SHELL : 'px-4')}>
         <section
           aria-label="Task progress"
           className="overflow-hidden rounded-lg border border-(--tool-border) bg-(--tool-bg) shadow-sm"
         >
-          <header className="flex items-center gap-2 border-b border-(--tool-border) px-3 py-2">
+          <header
+            role="button"
+            tabIndex={0}
+            aria-expanded={!collapsed}
+            data-testid="todo-status-toggle"
+            onClick={toggleCollapsed}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                toggleCollapsed();
+              }
+            }}
+            className={cn(
+              'flex cursor-pointer select-none items-center gap-2 px-3 py-2 transition-colors hover:bg-(--text-muted)/10',
+              !collapsed && 'border-b border-(--tool-border)',
+            )}
+          >
             <ListTodo className="size-4 shrink-0 text-(--accent)" />
-            <span className="text-xs font-medium text-(--text-primary)">Tasks</span>
-            <div className="ml-auto flex items-center gap-1.5 text-[10px]">
+            <span className="shrink-0 text-xs font-medium text-(--text-primary)">Tasks</span>
+            {collapsed && collapsedSummary && (
+              <span
+                title={collapsedSummary}
+                data-testid="todo-status-collapsed-summary"
+                className="min-w-0 truncate text-[11px] text-(--text-secondary)"
+              >
+                {collapsedSummary}
+              </span>
+            )}
+            <div className="ml-auto flex shrink-0 items-center gap-1.5 text-[10px]">
               {runningCount > 0 && (
                 <span className="rounded bg-(--status-info-bg) px-1.5 py-0.5 text-(--status-info-text)">
                   {runningCount} running
@@ -70,50 +134,55 @@ export function TodoStatusBar({ sessionId, isSinglePanel }: TodoStatusBarProps) 
               <span className="text-(--text-muted)">
                 {completedCount}/{todos.length} completed
               </span>
+              {collapsed
+                ? <ChevronRight className="size-3.5 shrink-0 text-(--text-muted)" />
+                : <ChevronDown className="size-3.5 shrink-0 text-(--text-muted)" />}
             </div>
           </header>
 
-          <div className="max-h-[30vh] space-y-0.5 overflow-y-auto p-1.5">
-            {todos.map((todo, index) => (
-              <div
-                key={`${todo.content}-${index}`}
-                className="flex min-w-0 items-center gap-2 rounded px-1.5 py-1"
-                data-status={todo.status}
-                data-testid="todo-status-item"
-              >
-                <TodoStatusIcon status={todo.status} />
-                <div className="min-w-0 flex-1">
-                  <div
-                    title={todo.content}
+          {!collapsed && (
+            <div className="max-h-[30vh] space-y-0.5 overflow-y-auto p-1.5">
+              {todos.map((todo, index) => (
+                <div
+                  key={`${todo.content}-${index}`}
+                  className="flex min-w-0 items-center gap-2 rounded px-1.5 py-1"
+                  data-status={todo.status}
+                  data-testid="todo-status-item"
+                >
+                  <TodoStatusIcon status={todo.status} />
+                  <div className="min-w-0 flex-1">
+                    <div
+                      title={todo.content}
+                      className={cn(
+                        'truncate text-[11px]',
+                        todo.status === 'completed'
+                          ? 'text-(--text-muted) line-through'
+                          : 'text-(--text-secondary)',
+                      )}
+                    >
+                      {todo.content}
+                    </div>
+                    {todo.status === 'in_progress' && todo.activeForm && todo.activeForm !== todo.content && (
+                      <div
+                        className="truncate text-[10px] text-(--accent)"
+                        title={todo.activeForm}
+                      >
+                        {todo.activeForm}
+                      </div>
+                    )}
+                  </div>
+                  <span
                     className={cn(
-                      'truncate text-[11px]',
-                      todo.status === 'completed'
-                        ? 'text-(--text-muted) line-through'
-                        : 'text-(--text-secondary)',
+                      'shrink-0 rounded px-1.5 py-0.5 text-[9px]',
+                      statusClass(todo.status),
                     )}
                   >
-                    {todo.content}
-                  </div>
-                  {todo.status === 'in_progress' && todo.activeForm && todo.activeForm !== todo.content && (
-                    <div
-                      className="truncate text-[10px] text-(--accent)"
-                      title={todo.activeForm}
-                    >
-                      {todo.activeForm}
-                    </div>
-                  )}
+                    {statusLabel(todo.status)}
+                  </span>
                 </div>
-                <span
-                  className={cn(
-                    'shrink-0 rounded px-1.5 py-0.5 text-[9px]',
-                    statusClass(todo.status),
-                  )}
-                >
-                  {statusLabel(todo.status)}
-                </span>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
         </section>
       </div>
     </div>

--- a/tests/claude-task-todo.e2e.mjs
+++ b/tests/claude-task-todo.e2e.mjs
@@ -8,6 +8,8 @@ const screenshotPath = process.env.TESSERA_E2E_SCREENSHOT
   ?? '/tmp/tessera-claude-task-todo-success.png';
 const completedScreenshotPath = process.env.TESSERA_E2E_COMPLETED_SCREENSHOT
   ?? '/tmp/tessera-claude-task-todo-completed.png';
+const collapsedScreenshotPath = process.env.TESSERA_E2E_COLLAPSED_SCREENSHOT
+  ?? '/tmp/tessera-claude-task-todo-collapsed.png';
 const fixturePath = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   'fixtures/mock-claude-task-cli.mjs',
@@ -27,6 +29,7 @@ async function main() {
   const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
   let createdSessionId;
   let originalClaudeOverride;
+  let originalAgentEnvironment;
   let settingsConfigured = false;
 
   try {
@@ -35,12 +38,15 @@ async function main() {
 
     const current = await expectOk(await page.request.get(apiUrl('/api/settings')), 'read settings');
     originalClaudeOverride = current.settings.cliCommandOverrides?.['claude-code'];
+    originalAgentEnvironment = current.settings.agentEnvironment;
+    // Register the mock for both environments so it applies regardless of the
+    // agentEnvironment stored in the (possibly shared) dev settings.
     await expectOk(await page.request.put(apiUrl('/api/settings'), {
       data: {
         ...current.settings,
         cliCommandOverrides: {
           ...(current.settings.cliCommandOverrides ?? {}),
-          'claude-code': { native: fixturePath },
+          'claude-code': { native: fixturePath, wsl: fixturePath },
         },
       },
     }), 'configure mock Claude');
@@ -83,12 +89,28 @@ async function main() {
     await todoBar.getByText('Inspecting Claude task events').waitFor({ timeout: 10_000 });
     await todoBar.locator('[data-status="in_progress"]').waitFor({ timeout: 10_000 });
 
-    // A full reload exercises the history projection while tool outputs remain lazy.
+    // Collapsing hides the item list but keeps the header summary visible (#151).
+    await todoBar.getByTestId('todo-status-toggle').click();
+    await activePanel.locator('[data-testid="todo-status-bar"][data-collapsed="true"]')
+      .waitFor({ timeout: 5_000 });
+    await todoBar.getByTestId('todo-status-item').first().waitFor({ state: 'hidden', timeout: 5_000 });
+    await todoBar.getByTestId('todo-status-collapsed-summary').waitFor({ timeout: 5_000 });
+    await page.screenshot({ path: collapsedScreenshotPath, fullPage: true });
+
+    // A full reload exercises the history projection while tool outputs remain
+    // lazy, and the collapsed preference must survive it via localStorage.
     await page.reload({ waitUntil: 'domcontentloaded' });
     await page.getByTestId('chat-layout').waitFor({ timeout: 30_000 });
     await page.getByTestId(`collection-chat-${created.sessionId}`).first().click();
     activePanel = page.locator('[role="tabpanel"]:visible');
     todoBar = activePanel.getByTestId('todo-status-bar');
+    await todoBar.getByTestId('todo-status-collapsed-summary').waitFor({ timeout: 10_000 });
+    await activePanel.locator('[data-testid="todo-status-bar"][data-collapsed="true"]')
+      .waitFor({ timeout: 5_000 });
+
+    // Expanding restores the full list and the original assertions still hold.
+    await todoBar.getByTestId('todo-status-toggle').click();
+    await todoBar.getByTestId('todo-status-item').first().waitFor({ timeout: 5_000 });
     await todoBar.getByText('Inspecting Claude task events').waitFor({ timeout: 10_000 });
     await page.screenshot({ path: screenshotPath, fullPage: true });
 
@@ -117,6 +139,7 @@ async function main() {
     await page.screenshot({ path: completedScreenshotPath, fullPage: true });
     process.stdout.write(JSON.stringify({
       screenshotPath,
+      collapsedScreenshotPath,
       completedScreenshotPath,
       sessionId: created.sessionId,
     }, null, 2) + '\n');
@@ -136,7 +159,11 @@ async function main() {
       if (originalClaudeOverride === undefined) delete cliCommandOverrides['claude-code'];
       else cliCommandOverrides['claude-code'] = originalClaudeOverride;
       await expectOk(await page.request.put(apiUrl('/api/settings'), {
-        data: { ...latest.settings, cliCommandOverrides },
+        data: {
+          ...latest.settings,
+          agentEnvironment: originalAgentEnvironment ?? latest.settings.agentEnvironment,
+          cliCommandOverrides,
+        },
       }), 'restore settings');
     }
     await browser.close();

--- a/tests/fixtures/mock-claude-task-cli.mjs
+++ b/tests/fixtures/mock-claude-task-cli.mjs
@@ -73,9 +73,9 @@ async function runTaskTurn() {
   assistantTool('update-1-active', 'TaskUpdate', { taskId: '1', status: 'in_progress', activeForm: 'Inspecting Claude task events' });
   await delay(120);
   toolResult('update-1-active', { success: true, taskId: '1' });
-  // Leave enough time for the E2E browser to reload and prove the active
-  // projection is restored from canonical history, not the visible message page.
-  await delay(8_000);
+  // Leave enough time for the E2E browser to collapse the bar, reload to prove
+  // the active projection and collapsed preference both survive, then expand.
+  await delay(15_000);
 
   for (const [id] of tasks) {
     assistantTool(`update-${id}-done`, 'TaskUpdate', { taskId: id, status: 'completed' });


### PR DESCRIPTION
## Summary

- Fixes #151 — the Tasks progress box above the composer could fill ~50% of the chat window with no way to hide it.
- The **Tasks** header is now a toggle (click / Enter / Space): collapsing hides the item list, leaving a single-line header with the current in-progress item and progress counts.
- The collapsed preference persists across reloads via `localStorage` (`tessera.todo-status-bar.collapsed`); default remains expanded.
- E2E (`tests/claude-task-todo.e2e.mjs`) now covers collapse → reload persistence → re-expand. The mock CLI override is registered for both `native` and `wsl` environments so the mock applies regardless of the stored `agentEnvironment` (previously the real `claude` CLI could launch during the test).

Already shipped to the reporter as pre-release [v0.2.1-hotfix.1](https://github.com/horang-labs/tessera/releases/tag/v0.2.1-hotfix.1) (cherry-picked from `hotfix/151-todo-collapse`); this PR lands the same change in `dev` for the next regular release.

## Testing

- [x] `npm run lint` (0 errors; 4 pre-existing warnings)
- [x] `npx tsc --noEmit`
- [x] `NODE_ENV=production npm run build` (ran via `npm pack` prepack for the hotfix release build of this same diff)
- [x] Manual test: Playwright E2E against the dev server — collapse, persistence across reload, re-expand, plus the existing todo-projection assertions; unit tests (`claude-code-task-todo`, `session-replay-todo-projection`) all pass
- [ ] Not tested:

## Screenshots or Recordings

Collapsed vs expanded screenshots are attached to issue #151 discussion and the [v0.2.1-hotfix.1 release](https://github.com/horang-labs/tessera/releases/tag/v0.2.1-hotfix.1). Collapsed state renders as a single header line: `Tasks · <active item> · N running · x/y completed ›`.

## Notes

Hotfix-sized change; no architecture impact. The `v0.2.1-hotfix.1` pre-release can be deleted once the next regular release ships.
