### PR TITLE
fix(git-panel): cap changed-file list so huge untracked trees don't overload the panel

### DIFF
--- a/src/components/git/git-panel-sections.tsx
+++ b/src/components/git/git-panel-sections.tsx
@@ -659,7 +659,9 @@ export function GitPanelContentSection({
                 Changed files
               </span>
               <span className="font-mono text-[11px] text-(--text-muted) tabular-nums">
-                {changedFileCount}
+                {data.changedFilesTruncated
+                  ? (data.changedFilesTotal ?? `${changedFileCount}+`)
+                  : changedFileCount}
               </span>
             </div>
             <ScrollArea className="flex-1">
@@ -779,6 +781,15 @@ export function GitPanelContentSection({
                 })}
               </div>
             </ScrollArea>
+            {data.changedFilesTruncated ? (
+              <div className="px-2 pb-1 text-[10px] leading-snug text-(--text-muted)">
+                {data.changedFilesTotal != null
+                  ? `Showing ${changedFileCount} of ${data.changedFilesTotal} changed files. `
+                  : `Showing the first ${changedFileCount} changed files; the repository has many more. `}
+                Add large or generated folders (e.g. .venv, node_modules) to
+                .gitignore to see the rest.
+              </div>
+            ) : null}
           </div>
         )
       )}

--- a/src/components/git/use-git-panel-controller.ts
+++ b/src/components/git/use-git-panel-controller.ts
@@ -38,6 +38,11 @@ interface GitPanelSessionCacheEntry {
 
 const PANEL_CACHE_LIMIT = 20;
 const GIT_PANEL_POLL_INTERVAL_MS = 5000;
+// Upper bound and slow-scan multiplier for adaptive polling: after a slow scan
+// (e.g. a huge repo) we wait roughly `elapsed * BACKOFF` before the next tick so
+// we never re-poll on top of an unfinished scan, capped at MAX.
+const GIT_PANEL_POLL_MAX_INTERVAL_MS = 60_000;
+const GIT_PANEL_POLL_SLOW_BACKOFF = 3;
 const gitPanelSessionCache = new Map<string, GitPanelSessionCacheEntry>();
 
 async function writeClipboardText(value: string | null | undefined) {
@@ -193,6 +198,8 @@ export function useGitPanelController(sessionId: string | null) {
         applyGitPanelData(sessionId, {
           ...current,
           changedFiles: changedFilesPayload.changedFiles,
+          changedFilesTotal: changedFilesPayload.changedFilesTotal,
+          changedFilesTruncated: changedFilesPayload.changedFilesTruncated,
         });
       }
     } catch (nextError) {
@@ -265,13 +272,45 @@ export function useGitPanelController(sessionId: string | null) {
     if (!sessionId || isTransientSessionId(sessionId)) return;
     if (typeof document === "undefined" || typeof window === "undefined") return;
 
-    const timer = window.setInterval(() => {
-      if (document.visibilityState === "visible") {
-        void loadChangedFiles();
-      }
-    }, GIT_PANEL_POLL_INTERVAL_MS);
+    let cancelled = false;
+    let timer: number | undefined;
+    let inFlight = false;
 
-    return () => window.clearInterval(timer);
+    const schedule = (delayMs: number) => {
+      if (cancelled) return;
+      timer = window.setTimeout(runTick, delayMs);
+    };
+
+    const runTick = async () => {
+      if (cancelled) return;
+      if (document.visibilityState !== "visible" || inFlight) {
+        schedule(GIT_PANEL_POLL_INTERVAL_MS);
+        return;
+      }
+      inFlight = true;
+      const startedAt = performance.now();
+      try {
+        await loadChangedFiles();
+      } finally {
+        inFlight = false;
+        const elapsed = performance.now() - startedAt;
+        const nextDelay = Math.min(
+          GIT_PANEL_POLL_MAX_INTERVAL_MS,
+          Math.max(
+            GIT_PANEL_POLL_INTERVAL_MS,
+            Math.round(elapsed * GIT_PANEL_POLL_SLOW_BACKOFF),
+          ),
+        );
+        schedule(nextDelay);
+      }
+    };
+
+    schedule(GIT_PANEL_POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
   }, [loadChangedFiles, sessionId]);
 
   const panelData = useMemo<GitPanelData | null>(() => {

--- a/src/lib/git/git-panel.ts
+++ b/src/lib/git/git-panel.ts
@@ -29,6 +29,27 @@ import type {
 const COMMAND_MAX_BUFFER = 4 * 1024 * 1024;
 const MAX_SYNTHETIC_DIFF_BYTES = 64 * 1024;
 const COMMAND_TIMEOUT_MS = 10_000;
+// Upper bound on how many changed-file rows we serialize to the client and
+// render. When something like an unignored `.venv` produces tens of thousands
+// of untracked files, sending and rendering them all freezes the git panel;
+// we cap the list and surface the true total via `changedFilesTruncated`.
+const MAX_CHANGED_FILES = 1000;
+// `git status -z` emits one NUL per path (renames/copies emit two). Once we've
+// streamed past this many NULs we already have more than enough entries to know
+// the list overflows `MAX_CHANGED_FILES`, so we kill git before it walks the
+// rest of a huge untracked tree (e.g. an unignored `.venv`).
+const STATUS_STREAM_NUL_LIMIT = (MAX_CHANGED_FILES + 1) * 2;
+
+interface ChangedFilesResult {
+  files: GitChangedFile[];
+  /**
+   * Total changed-file count. Omitted when the status stream was cut short
+   * early (`truncated` via `stoppedEarly`), in which case the true total is
+   * unknown — only that it exceeds what we display.
+   */
+  total?: number;
+  truncated: boolean;
+}
 
 export class GitPanelError extends Error {
   readonly code:
@@ -132,6 +153,131 @@ async function runOptionalCommand(
     if (error instanceof GitPanelError && error.status === 504) throw error;
     return null;
   }
+}
+
+interface StreamedStatus {
+  stdout: string;
+  stoppedEarly: boolean;
+}
+
+// Stream `git status -z`, counting NUL delimiters as they arrive. Once we pass
+// `nulLimit` we kill the git process group instead of letting it enumerate a
+// massive untracked tree and buffer megabytes we'd only throw away. Returns
+// whatever was collected plus whether we stopped it early.
+async function runStatusStreaming(
+  workDir: string,
+  agentEnvironment: AgentEnvironment,
+  nulLimit: number,
+): Promise<StreamedStatus> {
+  return new Promise((resolve, reject) => {
+    const options: SpawnOptions = {
+      cwd: workDir,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    };
+    const child = spawnCli(
+      "git",
+      ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+      options,
+      agentEnvironment,
+    );
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let nulCount = 0;
+    let stoppedEarly = false;
+    let settled = false;
+
+    const killGroup = () => {
+      try {
+        // detached spawn makes the command a group leader on POSIX; kill the
+        // whole group so wedged grandchildren die with it.
+        if (child.pid) process.kill(-child.pid, "SIGKILL");
+        else child.kill("SIGKILL");
+      } catch {
+        child.kill("SIGKILL");
+      }
+    };
+
+    const finish = (result: StreamedStatus) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(killTimer);
+      resolve(result);
+    };
+
+    const killTimer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      killGroup();
+      reject(
+        new GitPanelError(
+          "command_timeout",
+          `git status did not respond within ${COMMAND_TIMEOUT_MS / 1000}s and was terminated`,
+          504,
+        ),
+      );
+    }, COMMAND_TIMEOUT_MS);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+      if (stoppedEarly) return;
+      for (let i = 0; i < chunk.length; i++) {
+        if (chunk[i] === 0) nulCount++;
+      }
+      if (nulCount > nulLimit) {
+        stoppedEarly = true;
+        killGroup();
+        // Grandchildren holding the stdout pipe can delay "close"; resolve with
+        // what we have shortly after killing rather than waiting out the timeout.
+        setTimeout(() => {
+          finish({
+            stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+            stoppedEarly: true,
+          });
+        }, 500);
+      }
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      if (stderrChunks.length < 64) stderrChunks.push(chunk);
+    });
+
+    child.on("close", (code) => {
+      if (stoppedEarly) {
+        finish({
+          stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+          stoppedEarly: true,
+        });
+        return;
+      }
+      if (settled) return;
+      settled = true;
+      clearTimeout(killTimer);
+      const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+      if (code === 0) {
+        resolve({ stdout, stoppedEarly: false });
+        return;
+      }
+      const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+      reject(
+        new GitPanelError("command_failed", stderr || "Failed to run git status", 500),
+      );
+    });
+
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(killTimer);
+      reject(
+        new GitPanelError(
+          "command_failed",
+          error.message || "Failed to run git status",
+          500,
+        ),
+      );
+    });
+  });
 }
 
 interface GitSessionContext {
@@ -407,21 +553,22 @@ function getFetchRemoteName(upstream: string | null): string {
 async function getChangedFiles(
   workDir: string,
   agentEnvironment: AgentEnvironment,
-): Promise<GitChangedFile[]> {
-  const [statusRaw, fileDiffStats] = await Promise.all([
-    runOptionalCommand(
-      "git",
-      ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
-      workDir,
-      agentEnvironment,
-    ),
+): Promise<ChangedFilesResult> {
+  const [status, fileDiffStats] = await Promise.all([
+    runStatusStreaming(workDir, agentEnvironment, STATUS_STREAM_NUL_LIMIT),
     computeWorktreeFileDiffStats(workDir, agentEnvironment),
   ]);
   const statsByPath = fileDiffStats ?? new Map();
-  return parseGitStatus(statusRaw ?? "").map((file) => {
+  const parsed = parseGitStatus(status.stdout);
+  const truncated = status.stoppedEarly || parsed.length > MAX_CHANGED_FILES;
+  const limited = truncated ? parsed.slice(0, MAX_CHANGED_FILES) : parsed;
+  const files = limited.map((file) => {
     const diffStats = statsByPath.get(file.path);
     return diffStats ? { ...file, diffStats } : file;
   });
+  // When we killed git early the parsed count is only a lower bound, so leave
+  // `total` unset — the client shows "first N, many more" instead of a wrong number.
+  return { files, total: status.stoppedEarly ? undefined : parsed.length, truncated };
 }
 
 function ensurePathInsideRepo(repoRoot: string, relativePath: string): string {
@@ -588,7 +735,9 @@ export async function getGitPanelData(
       .split("\n")
       .map((b) => b.trim())
       .filter((b) => b && !b.includes("HEAD")),
-    changedFiles,
+    changedFiles: changedFiles.files,
+    changedFilesTotal: changedFiles.total,
+    changedFilesTruncated: changedFiles.truncated,
     recentCommits: parseRecentCommits(recentCommitsRaw ?? ""),
     github,
     diffStats: sessionContext.worktreeBranch
@@ -611,9 +760,12 @@ export async function getGitChangedFilesData(
   const agentEnvironment = await resolveCommandEnvironment(workDir, userId);
   await resolveRepoRoot(workDir, agentEnvironment);
 
+  const changedFiles = await getChangedFiles(workDir, agentEnvironment);
   return {
     sessionId,
-    changedFiles: await getChangedFiles(workDir, agentEnvironment),
+    changedFiles: changedFiles.files,
+    changedFilesTotal: changedFiles.total,
+    changedFilesTruncated: changedFiles.truncated,
   };
 }
 
@@ -645,7 +797,7 @@ export async function getGitDiffData(
   const agentEnvironment = await resolveCommandEnvironment(workDir, userId);
   const repoRoot = await resolveRepoRoot(workDir, agentEnvironment);
   const changedFiles = await getChangedFiles(workDir, agentEnvironment);
-  const fileEntry = changedFiles.find((file) => file.path === relativePath);
+  const fileEntry = changedFiles.files.find((file) => file.path === relativePath);
 
   if (!fileEntry) {
     throw new GitPanelError(

--- a/src/lib/git/worktree-diff-stats.ts
+++ b/src/lib/git/worktree-diff-stats.ts
@@ -13,6 +13,38 @@ import type {
 
 const UNTRACKED_MAX_BYTES = 512 * 1024;
 
+// Beyond this many untracked files (e.g. an accidentally-unignored `.venv` or
+// `node_modules`), skip the per-file line-count I/O entirely. Reading every file
+// to count newlines would otherwise open thousands of descriptors at once and
+// stall the event loop (or hit EMFILE). We still report the count of new files.
+const UNTRACKED_LINECOUNT_MAX_FILES = 1000;
+// Cap concurrent file reads so even a large-but-under-limit untracked set can't
+// exhaust file descriptors.
+const NEWLINE_COUNT_CONCURRENCY = 16;
+
+// Map over items with a bounded number of in-flight async calls.
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const worker = async () => {
+    for (;;) {
+      const index = next++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index]);
+    }
+  };
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
 async function runGit(
   workDir: string,
   args: string[],
@@ -185,18 +217,24 @@ export async function computeWorktreeDiffStats(
     let changedFiles = numstat.changedFiles;
     const deletedFiles = nameStatus.deletedFiles;
 
-    const untrackedCounts = await Promise.all(
-      untracked.paths.map((relPath) =>
-        countFileNewlinesCapped(pathModule.join(resolved, relPath)),
-      ),
-    );
-
     let newFiles = 0;
-    for (const count of untrackedCounts) {
-      newFiles += 1;
-      changedFiles += 1;
-      if (count !== null) {
-        added += count;
+    if (untracked.paths.length > UNTRACKED_LINECOUNT_MAX_FILES) {
+      // Too many untracked files to read individually — count them without
+      // folding their line totals into `added`.
+      newFiles = untracked.paths.length;
+      changedFiles += untracked.paths.length;
+    } else {
+      const untrackedCounts = await mapWithConcurrency(
+        untracked.paths,
+        NEWLINE_COUNT_CONCURRENCY,
+        (relPath) => countFileNewlinesCapped(pathModule.join(resolved, relPath)),
+      );
+      for (const count of untrackedCounts) {
+        newFiles += 1;
+        changedFiles += 1;
+        if (count !== null) {
+          added += count;
+        }
       }
     }
 
@@ -231,15 +269,24 @@ export async function computeWorktreeFileDiffStats(
     if (!numstat || !untracked) return null;
 
     const files = new Map(numstat.files);
-    const untrackedCounts = await Promise.all(
-      untracked.paths.map(async (relPath) => ({
-        relPath,
-        count: await countFileNewlinesCapped(pathModule.join(resolved, relPath)),
-      })),
-    );
-
-    for (const { relPath, count } of untrackedCounts) {
-      files.set(relPath, { added: count ?? 0, removed: 0 });
+    if (untracked.paths.length > UNTRACKED_LINECOUNT_MAX_FILES) {
+      // Too many untracked files to read individually — record them with an
+      // unknown (zero) added count rather than opening every file.
+      for (const relPath of untracked.paths) {
+        files.set(relPath, { added: 0, removed: 0 });
+      }
+    } else {
+      const untrackedCounts = await mapWithConcurrency(
+        untracked.paths,
+        NEWLINE_COUNT_CONCURRENCY,
+        async (relPath) => ({
+          relPath,
+          count: await countFileNewlinesCapped(pathModule.join(resolved, relPath)),
+        }),
+      );
+      for (const { relPath, count } of untrackedCounts) {
+        files.set(relPath, { added: count ?? 0, removed: 0 });
+      }
     }
 
     return files;

--- a/src/types/git.ts
+++ b/src/types/git.ts
@@ -84,6 +84,10 @@ export interface GitPanelData {
   defaultBranch: string | null;
   branches: string[];
   changedFiles: GitChangedFile[];
+  /** Total number of changed files before capping to `changedFiles`. */
+  changedFilesTotal?: number;
+  /** True when `changedFiles` was capped and omits some entries. */
+  changedFilesTruncated?: boolean;
   recentCommits: GitCommitSummary[];
   github: GitHubPanelState;
   diffStats?: WorktreeDiffStats | null;
@@ -105,4 +109,8 @@ export interface GitDiffData {
 export interface GitChangedFilesData {
   sessionId: string;
   changedFiles: GitChangedFile[];
+  /** Total number of changed files before capping to `changedFiles`. */
+  changedFilesTotal?: number;
+  /** True when `changedFiles` was capped and omits some entries. */
+  changedFilesTruncated?: boolean;
 }


### PR DESCRIPTION
## Problem

When a folder like `.venv` or `node_modules` is left untracked, `git status --untracked-files=all` can surface tens of thousands of files. The git panel then:

1. Read **every untracked file** to count added lines with **unbounded concurrent I/O** (`Promise.all` over all paths) — thousands of open descriptors at once (EMFILE / event-loop stall).
2. Buffered the entire `git status` output (capped at 4 MB, silently corrupting the parse past that).
3. Serialized the whole list to the client and rendered **every row without virtualization**.

The result froze the panel and nearly took the app down.

## Fix

Defend against the blow-up as far upstream as possible:

- **Stream `git status -z`** and kill git (process-group SIGKILL) as soon as the change set overflows the cap, instead of letting it walk a massive untracked tree and buffering megabytes we'd throw away.
- **Bound untracked line-counting**: skip it entirely above a file-count threshold, and cap concurrency at 16 otherwise.
- **Truncate** the changed-file list to `MAX_CHANGED_FILES` and report the true `total` + a `truncated` flag. `total` is omitted when the stream was cut short (the parsed count is only a lower bound), so the client shows "first N, many more" instead of a wrong number.
- **Banner** when the list is capped, hinting to add large/generated folders to `.gitignore`.
- **Adaptive polling**: guard against overlapping runs and back off after slow scans instead of a fixed 5s interval.

## Verification

Ran the dev server against synthetic repos and drove the real git panel:

| Case | untracked | HTTP | warm resp | DOM rows | header badge | banner |
|---|---|---|---|---|---|---|
| Huge | 20,000 | 200 | 0.27s | 1000 | `1000+` | "Showing the first 1000 changed files; the repository has many more…" |
| Mid | 1,500 | 200 | 0.24s | 1000 | `1500` | "Showing 1000 of 1500 changed files…" |
| Normal | 9 | 200 | 0.21s | 9 | 9 | (none) |

- No EMFILE / git errors in server logs on the 20k case; panel rendered instantly with exactly 1000 DOM rows.
- Both banner branches (unknown vs. exact total) confirmed in the browser.
- `npx tsc --noEmit` clean; `eslint` no errors on touched files.

**Not verified:** the adaptive-poll backoff — local SSD scans are too fast (0.27s) to trigger the slow-scan path, so it's covered by static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)