### PR TITLE
feat: support Kanban across all projects

### DIFF
--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -560,12 +560,24 @@ export const KanbanBoard = memo(function KanbanBoard() {
     const draggingSession = useSessionStore.getState().getSession(draggingSessionId);
     const targetSession = useSessionStore.getState().getSession(sessionId);
     const draggingStatus = draggingSession?.workflowStatus ?? 'chat';
-    if (
-      draggingStatus !== status ||
-      !draggingSession ||
-      !targetSession ||
-      draggingSession.projectDir !== targetSession.projectDir
-    ) {
+    if (!draggingSession || !targetSession) {
+      if (useBoardStore.getState().dropIndicator) {
+        useBoardStore.getState().setDropIndicator(null);
+      }
+      return;
+    }
+
+    if (draggingSession.projectDir !== targetSession.projectDir) {
+      if (useBoardStore.getState().dropIndicator) {
+        useBoardStore.getState().setDropIndicator(null);
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      e.dataTransfer.dropEffect = 'none';
+      return;
+    }
+
+    if (draggingStatus !== status) {
       if (useBoardStore.getState().dropIndicator) {
         useBoardStore.getState().setDropIndicator(null);
       }

--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -18,12 +18,18 @@ import {
   tryForwardClickToMainWindow,
 } from '@/hooks/use-session-click-handlers';
 import { getKanbanMultiSessionDragIds, setKanbanChatDragData } from '@/lib/dnd/panel-session-drag';
+import {
+  collectKanbanScopeData,
+  getKanbanScopeProjectIds,
+  resolveKanbanScope,
+} from '@/lib/kanban/board-scope';
 import { WORKFLOW_STATUS_ORDER } from '@/types/task-entity';
 import type { WorkflowStatus, TaskEntity } from '@/types/task-entity';
 import { TASK_DND_MIME, TASK_MULTI_DND_MIME } from '@/types/task';
 import type { UnifiedSession } from '@/types/chat';
 import { mergeTasksWithLiveSessions } from '@/lib/tasks/merge-tasks-with-live-sessions';
 import { CollectionFilterBar } from './collection-filter-bar';
+import { PortfolioFilterBar } from './portfolio-filter-bar';
 import { KanbanChatColumn, KanbanWorkflowColumn } from './kanban-column';
 import { KanbanScrollControls } from './kanban-scroll-controls';
 import { TaskContextMenu } from '@/components/chat/task-context-menu';
@@ -83,20 +89,42 @@ export const KanbanBoard = memo(function KanbanBoard() {
   const kanbanAddMenuColumn = useBoardStore((s) => s.kanbanAddMenuColumn);
 
   // Collection store
-  const collections = useCollectionStore((s) =>
-    selectedProjectDir ? s.collectionsByProject[selectedProjectDir] ?? EMPTY_COLLECTIONS : EMPTY_COLLECTIONS
-  );
-  const collectionsLoadedForProject = useCollectionStore((s) =>
-    selectedProjectDir ? Boolean(s.loadedProjects[selectedProjectDir]) : false
-  );
+  const collectionsByProject = useCollectionStore((s) => s.collectionsByProject);
+  const loadedCollectionProjects = useCollectionStore((s) => s.loadedProjects);
 
   // Task store
-  const tasks = useTaskStore((s) => s.tasks);
+  const tasksByProject = useTaskStore((s) => s.tasksByProject);
   // Session store
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
   const selectionSessionId = getSessionSelectionId(activeSessionId);
   const projects = useSessionStore((s) => s.projects);
   const scrollPositionKey = getKanbanScrollPositionKey(selectedProjectDir, activeCollectionFilter);
+  const [portfolioProjectFilter, setPortfolioProjectFilter] = useState<string | null>(null);
+  const scope = useMemo(
+    () => resolveKanbanScope(selectedProjectDir, projects),
+    [projects, selectedProjectDir],
+  );
+  const scopeProjectIdsKey = JSON.stringify(getKanbanScopeProjectIds(scope));
+  const scopeProjectIds = useMemo(
+    () => JSON.parse(scopeProjectIdsKey) as string[],
+    [scopeProjectIdsKey],
+  );
+  const isAllProjects = scope?.kind === 'all-projects';
+  const scopeData = useMemo(
+    () => collectKanbanScopeData(scope, projects, tasksByProject, collectionsByProject),
+    [collectionsByProject, projects, scope, tasksByProject],
+  );
+  const focusedProjectId = isAllProjects
+    ? portfolioProjectFilter
+    : scope?.kind === 'project'
+      ? scope.projectId
+      : null;
+  const collections = focusedProjectId
+    ? collectionsByProject[focusedProjectId] ?? EMPTY_COLLECTIONS
+    : EMPTY_COLLECTIONS;
+  const collectionsLoadedForProject = focusedProjectId
+    ? Boolean(loadedCollectionProjects[focusedProjectId])
+    : false;
 
   useEffect(function keepKanbanViewportAnchoredOnResize() {
     const scrollArea = scrollAreaRef.current;
@@ -281,27 +309,52 @@ export const KanbanBoard = memo(function KanbanBoard() {
     };
   }, [scrollPositionKey]);
 
-  // Load collections on mount
+  // Load project-scoped board data without exposing the All Projects sentinel
+  // to APIs that require a real project ID.
   useEffect(() => {
-    if (!selectedProjectDir) return;
-    void useCollectionStore.getState().loadCollections(selectedProjectDir);
-  }, [selectedProjectDir]);
+    if (scopeProjectIds.length === 0) return;
+    const setCurrent = !isAllProjects;
+    void Promise.all(
+      scopeProjectIds.flatMap((projectId) => [
+        useCollectionStore.getState().loadCollections(projectId, { setCurrent }),
+        useTaskStore.getState().loadTasks(projectId, { setCurrent }),
+      ]),
+    );
+  }, [isAllProjects, scopeProjectIds]);
 
-  // Load tasks when project changes
   useEffect(() => {
-    if (selectedProjectDir) {
-      useTaskStore.getState().loadTasks(selectedProjectDir);
+    if (!isAllProjects) {
+      setPortfolioProjectFilter(null);
+      return;
     }
-  }, [selectedProjectDir]);
+    if (
+      portfolioProjectFilter &&
+      !scopeProjectIds.includes(portfolioProjectFilter)
+    ) {
+      setPortfolioProjectFilter(null);
+    }
+  }, [isAllProjects, portfolioProjectFilter, scopeProjectIds]);
+
+  useEffect(() => {
+    if (isAllProjects && activeCollectionFilter) {
+      setCollectionFilter(null);
+    }
+  }, [activeCollectionFilter, isAllProjects, setCollectionFilter]);
 
   // Session CRUD
   const { deleteSession, generateTitle, renameSession } = useSessionCrud();
 
-  // Get all sessions for the selected project
+  // Get sessions and tasks for the active board scope. The optional portfolio
+  // filter narrows the aggregate without changing the selected project scope.
   const allSessions = useMemo(() => {
-    const project = projects.find((p) => p.encodedDir === selectedProjectDir);
-    return project?.sessions ?? [];
-  }, [projects, selectedProjectDir]);
+    if (!portfolioProjectFilter || !isAllProjects) return scopeData.sessions;
+    return scopeData.sessions.filter((session) => session.projectDir === portfolioProjectFilter);
+  }, [isAllProjects, portfolioProjectFilter, scopeData.sessions]);
+
+  const tasks = useMemo(() => {
+    if (!portfolioProjectFilter || !isAllProjects) return scopeData.tasks;
+    return scopeData.tasks.filter((task) => task.projectId === portfolioProjectFilter);
+  }, [isAllProjects, portfolioProjectFilter, scopeData.tasks]);
 
   // Standalone chat sessions: no taskId, not archived. Chats without a
   // workflowStatus stay in the Chat column; positioned chats render below
@@ -368,8 +421,14 @@ export const KanbanBoard = memo(function KanbanBoard() {
   }, [activeCollectionFilter, collections, collectionsLoadedForProject, setCollectionFilter]);
 
   const selectedProject = useMemo(() => {
-    return projects.find((project) => project.encodedDir === selectedProjectDir) ?? null;
-  }, [projects, selectedProjectDir]);
+    if (!focusedProjectId) return null;
+    return projects.find((project) => project.encodedDir === focusedProjectId) ?? null;
+  }, [focusedProjectId, projects]);
+
+  const visibleProjects = useMemo(() => {
+    if (!isAllProjects || !portfolioProjectFilter) return scopeData.projects;
+    return scopeData.projects.filter((project) => project.encodedDir === portfolioProjectFilter);
+  }, [isAllProjects, portfolioProjectFilter, scopeData.projects]);
 
   const activeCollection = useMemo(() => {
     if (!activeCollectionFilter) return null;
@@ -430,21 +489,36 @@ export const KanbanBoard = memo(function KanbanBoard() {
     // Match the rendered board order exactly so Shift+Click range selection
     // uses the same primary session IDs and intra-task session ordering.
     for (const status of WORKFLOW_STATUS_ORDER) {
-      for (const task of mergedTasksByStatus[status]) {
-        const sessions = task.sessions;
-        for (const s of sessions) {
-          ids.push(s.id);
+      if (isAllProjects) {
+        for (const project of visibleProjects) {
+          for (const task of mergedTasksByStatus[status]) {
+            if (task.projectId !== project.encodedDir) continue;
+            for (const session of task.sessions) {
+              ids.push(session.id);
+            }
+          }
+          for (const session of workflowChatsByStatus[status]) {
+            if (session.projectDir === project.encodedDir) {
+              ids.push(session.id);
+            }
+          }
+        }
+      } else {
+        for (const task of mergedTasksByStatus[status]) {
+          for (const session of task.sessions) {
+            ids.push(session.id);
+          }
+        }
+        for (const session of workflowChatsByStatus[status]) {
+          ids.push(session.id);
         }
       }
-      for (const s of workflowChatsByStatus[status]) {
-        ids.push(s.id);
-      }
     }
-    for (const s of filteredChats) {
-      ids.push(s.id);
+    for (const session of filteredChats) {
+      ids.push(session.id);
     }
     return ids;
-  }, [filteredChats, mergedTasksByStatus, workflowChatsByStatus]);
+  }, [filteredChats, isAllProjects, mergedTasksByStatus, visibleProjects, workflowChatsByStatus]);
 
   // Click handlers
   const { handleSessionClick, handleSessionDoubleClick } = useSessionClickHandlers({ orderedIds });
@@ -484,8 +558,14 @@ export const KanbanBoard = memo(function KanbanBoard() {
     }
 
     const draggingSession = useSessionStore.getState().getSession(draggingSessionId);
+    const targetSession = useSessionStore.getState().getSession(sessionId);
     const draggingStatus = draggingSession?.workflowStatus ?? 'chat';
-    if (draggingStatus !== status) {
+    if (
+      draggingStatus !== status ||
+      !draggingSession ||
+      !targetSession ||
+      draggingSession.projectDir !== targetSession.projectDir
+    ) {
       if (useBoardStore.getState().dropIndicator) {
         useBoardStore.getState().setDropIndicator(null);
       }
@@ -537,7 +617,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
     const session = sessionId ? useSessionStore.getState().getSession(sessionId) : undefined;
     const multiSessionIds = getKanbanMultiSessionDragIds(e.dataTransfer);
 
-    if (selectedProjectDir && multiSessionIds.length > 1) {
+    if (multiSessionIds.length > 1) {
       const sessionStore = useSessionStore.getState();
       let movedCount = 0;
 
@@ -546,7 +626,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
         if (
           !selectedSession ||
           selectedSession.taskId ||
-          selectedSession.projectDir !== selectedProjectDir ||
+          !scopeProjectIds.includes(selectedSession.projectDir) ||
           !selectedSession.workflowStatus
         ) {
           continue;
@@ -567,11 +647,13 @@ export const KanbanBoard = memo(function KanbanBoard() {
       return;
     }
 
-    if (selectedProjectDir && sessionId && session?.workflowStatus) {
+    if (sessionId && session?.workflowStatus) {
       useSessionStore.getState().updateChatWorkflowStatus(sessionId, null);
       useBoardStore.getState().flashDrop(sessionId);
-    } else if (selectedProjectDir && sessionId) {
-      const ids = filteredChats.map((session) => session.id);
+    } else if (sessionId && session) {
+      const ids = filteredChats
+        .filter((item) => item.projectDir === session.projectDir)
+        .map((item) => item.id);
       const filtered = ids.filter((id) => id !== sessionId);
 
       if (indicator) {
@@ -584,14 +666,14 @@ export const KanbanBoard = memo(function KanbanBoard() {
         filtered.push(sessionId);
       }
 
-      useSessionStore.getState().reorderProjectSessions(selectedProjectDir, filtered);
+      useSessionStore.getState().reorderProjectSessions(session.projectDir, filtered);
       useBoardStore.getState().flashDrop(sessionId);
     }
 
     useBoardStore.getState().setDragging(null);
     useBoardStore.getState().setDragOver(null);
     useBoardStore.getState().setDropIndicator(null);
-  }, [filteredChats, selectedProjectDir]);
+  }, [filteredChats, scopeProjectIds]);
 
   // Kanban add card menu toggle
   const handleToggleAddMenu = useCallback(function handleToggleAddMenu() {
@@ -604,6 +686,12 @@ export const KanbanBoard = memo(function KanbanBoard() {
   }, []);
 
   const [quickCreateStatus, setQuickCreateStatus] = useState<WorkflowStatus | null>(null);
+
+  const handlePortfolioProjectFilter = useCallback((projectId: string | null) => {
+    setQuickCreateStatus(null);
+    useBoardStore.getState().setKanbanAddMenuColumn(null);
+    setPortfolioProjectFilter(projectId);
+  }, []);
 
   const handleCreateTaskInStatus = useCallback((status: WorkflowStatus) => {
     useBoardStore.getState().setKanbanAddMenuColumn(null);
@@ -867,12 +955,19 @@ export const KanbanBoard = memo(function KanbanBoard() {
       className="flex flex-col h-full w-full bg-(--board-bg) overflow-hidden"
       data-testid="kanban-board"
     >
-      {/* Collection filter bar */}
-      <CollectionFilterBar
-        collections={collections}
-        activeFilter={activeCollectionFilter}
-        onFilter={setCollectionFilter}
-      />
+      {isAllProjects ? (
+        <PortfolioFilterBar
+          projects={scopeData.projects}
+          activeProjectId={portfolioProjectFilter}
+          onProjectFilter={handlePortfolioProjectFilter}
+        />
+      ) : (
+        <CollectionFilterBar
+          collections={collections}
+          activeFilter={activeCollectionFilter}
+          onFilter={setCollectionFilter}
+        />
+      )}
 
       {/* Horizontal scroll container */}
       <div
@@ -893,6 +988,10 @@ export const KanbanBoard = memo(function KanbanBoard() {
               status={status}
               tasks={tasksByStatus[status]}
               chats={workflowChatsByStatus[status]}
+              collectionsByProject={scopeData.collectionsByProject}
+              projects={visibleProjects}
+              groupByProject={isAllProjects}
+              canCreate={selectedProject !== null}
               sessionsByTaskId={sessionsByTaskId}
               activeSessionId={selectionSessionId}
               onCreateTask={() => handleCreateTaskInStatus(status)}
@@ -935,6 +1034,10 @@ export const KanbanBoard = memo(function KanbanBoard() {
             chats={filteredChats}
             collection={activeCollection}
             collections={collections}
+            collectionsByProject={scopeData.collectionsByProject}
+            projects={visibleProjects}
+            groupByProject={isAllProjects}
+            canCreate={selectedProject !== null}
             projectId={selectedProject?.encodedDir ?? ''}
             projectDir={selectedProject?.decodedPath ?? ''}
             activeSessionId={selectionSessionId}
@@ -971,7 +1074,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
           anchorRect={taskMenuAnchor.rect}
           currentStatus={taskMenuAnchor.task.workflowStatus}
           isArchived={false}
-          collections={collections}
+          collections={collectionsByProject[taskMenuAnchor.task.projectId] ?? EMPTY_COLLECTIONS}
           currentCollectionId={taskMenuAnchor.task.collectionId ?? null}
           onStatusChange={handleTaskStatusChange}
           onMoveToCollection={handleTaskMoveToCollection}

--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -86,7 +86,6 @@ export const KanbanBoard = memo(function KanbanBoard() {
   const selectedProjectDir = useBoardStore((s) => s.selectedProjectDir);
   const activeCollectionFilter = useBoardStore((s) => s.activeCollectionFilter);
   const setCollectionFilter = useBoardStore((s) => s.setCollectionFilter);
-  const kanbanAddMenuColumn = useBoardStore((s) => s.kanbanAddMenuColumn);
 
   // Collection store
   const collectionsByProject = useCollectionStore((s) => s.collectionsByProject);
@@ -687,27 +686,29 @@ export const KanbanBoard = memo(function KanbanBoard() {
     useBoardStore.getState().setDropIndicator(null);
   }, [filteredChats, scopeProjectIds]);
 
-  // Kanban add card menu toggle
-  const handleToggleAddMenu = useCallback(function handleToggleAddMenu() {
-    const store = useBoardStore.getState();
-    store.setKanbanAddMenuColumn(store.kanbanAddMenuColumn === 'chat' ? null : 'chat');
+  const [quickCreateTarget, setQuickCreateTarget] = useState<{
+    column: 'chat' | WorkflowStatus;
+    projectId: string;
+  } | null>(null);
+
+  const handleToggleQuickCreate = useCallback((
+    column: 'chat' | WorkflowStatus,
+    projectId: string,
+  ) => {
+    setQuickCreateTarget((current) => (
+      current?.column === column && current.projectId === projectId
+        ? null
+        : { column, projectId }
+    ));
   }, []);
 
-  const handleCloseAddMenu = useCallback(() => {
-    useBoardStore.getState().setKanbanAddMenuColumn(null);
+  const handleCloseQuickCreate = useCallback(() => {
+    setQuickCreateTarget(null);
   }, []);
-
-  const [quickCreateStatus, setQuickCreateStatus] = useState<WorkflowStatus | null>(null);
 
   const handlePortfolioProjectFilter = useCallback((projectId: string | null) => {
-    setQuickCreateStatus(null);
-    useBoardStore.getState().setKanbanAddMenuColumn(null);
+    setQuickCreateTarget(null);
     setPortfolioProjectFilter(projectId);
-  }, []);
-
-  const handleCreateTaskInStatus = useCallback((status: WorkflowStatus) => {
-    useBoardStore.getState().setKanbanAddMenuColumn(null);
-    setQuickCreateStatus((current) => (current === status ? null : status));
   }, []);
 
   // Context menu handlers for kanban chat cards
@@ -1000,22 +1001,19 @@ export const KanbanBoard = memo(function KanbanBoard() {
               status={status}
               tasks={tasksByStatus[status]}
               chats={workflowChatsByStatus[status]}
+              collection={activeCollection}
+              collections={collections}
               collectionsByProject={scopeData.collectionsByProject}
               projects={visibleProjects}
               groupByProject={isAllProjects}
-              canCreate={selectedProject !== null}
+              createProject={selectedProject}
               sessionsByTaskId={sessionsByTaskId}
               activeSessionId={selectionSessionId}
-              onCreateTask={() => handleCreateTaskInStatus(status)}
-              isQuickCreateOpen={quickCreateStatus === status}
-              quickCreateConfig={selectedProject ? {
-                collection: activeCollection,
-                collections,
-                projectDir: selectedProject.decodedPath,
-                projectId: selectedProject.encodedDir,
-                allowCollectionSelection: activeCollection === null,
-                onClose: () => setQuickCreateStatus(null),
-              } : undefined}
+              quickCreateProjectId={
+                quickCreateTarget?.column === status ? quickCreateTarget.projectId : null
+              }
+              onToggleQuickCreate={handleToggleQuickCreate}
+              onCloseQuickCreate={handleCloseQuickCreate}
               onSessionClick={handleChatClick}
               onSessionDoubleClick={handleChatDoubleClick}
               onChatDragStart={handleChatDragStart}
@@ -1049,11 +1047,11 @@ export const KanbanBoard = memo(function KanbanBoard() {
             collectionsByProject={scopeData.collectionsByProject}
             projects={visibleProjects}
             groupByProject={isAllProjects}
-            canCreate={selectedProject !== null}
-            projectId={selectedProject?.encodedDir ?? ''}
-            projectDir={selectedProject?.decodedPath ?? ''}
+            createProject={selectedProject}
             activeSessionId={selectionSessionId}
-            isAddMenuOpen={kanbanAddMenuColumn === 'chat'}
+            quickCreateProjectId={
+              quickCreateTarget?.column === 'chat' ? quickCreateTarget.projectId : null
+            }
             onCardDragStart={handleChatDragStart}
             onCardDragEnd={handleChatDragEnd}
             onCardDragOver={handleChatSessionDragOver}
@@ -1062,8 +1060,8 @@ export const KanbanBoard = memo(function KanbanBoard() {
             onColumnDrop={handleChatColumnDrop}
             onCardClick={handleChatClick}
             onCardDoubleClick={handleChatDoubleClick}
-            onToggleAddMenu={handleToggleAddMenu}
-            onCloseAddMenu={handleCloseAddMenu}
+            onToggleQuickCreate={handleToggleQuickCreate}
+            onCloseQuickCreate={handleCloseQuickCreate}
             onCardStatusChange={handleCardStatusChange}
             onCardArchive={handleCardArchive}
             onCardUnarchive={handleCardUnarchive}

--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -24,6 +24,7 @@ import { useSelectionStore } from '@/stores/selection-store';
 import { useTaskStore } from '@/stores/task-store';
 import { TASK_MULTI_DND_MIME } from '@/types/task';
 import type { UnifiedSession } from '@/types/chat';
+import type { Collection } from '@/types/collection';
 import { CHAT_WORKFLOW_ICON_COLOR, CHAT_WORKFLOW_ICON_FILL } from '@/types/task-entity';
 import type { TaskEntity, TaskSession, WorkflowStatus } from '@/types/task-entity';
 import { TaskContextMenu } from '@/components/chat/task-context-menu';
@@ -67,13 +68,19 @@ function formatRelativeTime(
 }
 
 /** Collection name label with Tag icon (matching list view) */
-function CollectionLabel({ collectionId, isActive }: { collectionId?: string | null; isActive?: boolean }) {
+function CollectionLabel({
+  collectionId,
+  projectId,
+  isActive,
+}: {
+  collectionId?: string | null;
+  projectId: string;
+  isActive?: boolean;
+}) {
   const { t } = useI18n();
   const collectionsByProject = useCollectionStore((state) => state.collectionsByProject);
   const config = collectionId
-    ? Object.values(collectionsByProject)
-        .flat()
-        .find((collection) => collection.id === collectionId)
+    ? collectionsByProject[projectId]?.find((collection) => collection.id === collectionId)
     : null;
   const label = collectionId ? config?.label : t('task.creation.noCollection');
 
@@ -114,6 +121,7 @@ interface KanbanChatCardProps {
   onMoveToProject?: (taskId: string) => void;
   onMoveToCollection?: (taskId: string, collectionId: string | null) => void;
   onStopProcess?: (sessionId: string) => void;
+  collections?: Collection[];
 }
 
 export const KanbanChatCard = memo(function KanbanChatCard({
@@ -136,9 +144,11 @@ export const KanbanChatCard = memo(function KanbanChatCard({
   onMoveToProject,
   onMoveToCollection,
   onStopProcess,
+  collections: scopedCollections,
 }: KanbanChatCardProps) {
   const { t } = useI18n();
-  const collections = useCollectionStore((state) => state.collections);
+  const currentProjectCollections = useCollectionStore((state) => state.collections);
+  const collections = scopedCollections ?? currentProjectCollections;
   const isSelected = useSelectionStore((s) => s.selectedIds.has(session.id));
   const showProviderIcons = useSettingsStore((s) => s.settings.showProviderIcons);
   const isProcessingTurn = useChatStore(selectIsTurnInFlight(session.id));
@@ -387,7 +397,11 @@ export const KanbanChatCard = memo(function KanbanChatCard({
                 </span>
               )}
 
-              <CollectionLabel collectionId={session.collectionId} isActive={isActive && !isSelected} />
+              <CollectionLabel
+                collectionId={session.collectionId}
+                projectId={session.projectDir}
+                isActive={isActive && !isSelected}
+              />
               <DiffStatsBadge stats={session.diffStats} className="ml-auto" />
             </div>
           </div>
@@ -985,7 +999,11 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
 
             {/* Meta row: collection + status indicators */}
             <div className="flex items-center gap-2 min-w-0 mt-1">
-              <CollectionLabel collectionId={task.collectionId} isActive={isActive} />
+              <CollectionLabel
+                collectionId={task.collectionId}
+                projectId={task.projectId}
+                isActive={isActive}
+              />
               <span className="ml-auto inline-flex items-center gap-1.5">
                 <TaskPrBadge
                   workflowStatus={task.workflowStatus}

--- a/src/components/board/kanban-column.tsx
+++ b/src/components/board/kanban-column.tsx
@@ -20,12 +20,94 @@ import type { Collection } from '@/types/collection';
 import { CollectionQuickCreateSheet } from '@/components/chat/collection-quick-create-sheet';
 import { KanbanChatCard, KanbanTaskCard } from './kanban-card';
 
+type KanbanQuickCreateColumn = 'chat' | WorkflowStatus;
+
+function KanbanQuickCreateButton({
+  project,
+  column,
+  collection,
+  collections,
+  isOpen,
+  onToggle,
+  onClose,
+  testId,
+}: {
+  project: ProjectGroup | null;
+  column: KanbanQuickCreateColumn;
+  collection: Collection | null;
+  collections: Collection[];
+  isOpen: boolean;
+  onToggle: (column: KanbanQuickCreateColumn, projectId: string) => void;
+  onClose: () => void;
+  testId: string;
+}) {
+  const { t } = useI18n();
+  const addMenuRef = useRef<HTMLDivElement>(null);
+  const isChatColumn = column === 'chat';
+
+  return (
+    <div
+      ref={addMenuRef}
+      className="relative shrink-0"
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      <button
+        type="button"
+        disabled={project === null}
+        title={project === null ? t('task.board.selectProjectToCreate') : undefined}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (project) onToggle(column, project.encodedDir);
+        }}
+        className={cn(
+          'flex h-5 w-5 items-center justify-center rounded-[5px]',
+          'border-none bg-transparent transition-all',
+          'text-(--text-muted) hover:text-(--accent-light)',
+          'hover:bg-[color-mix(in_srgb,var(--accent)_15%,transparent)]',
+          'cursor-pointer disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-(--text-muted)',
+        )}
+        aria-label={isChatColumn ? t('task.newChat.label') : t('task.newChat.newTask')}
+        data-testid={testId}
+      >
+        <Plus className="h-3.5 w-3.5" />
+      </button>
+      {isOpen && project && (
+        <CollectionQuickCreateSheet
+          collection={collection}
+          collections={collections}
+          projectDir={project.decodedPath}
+          projectId={project.encodedDir}
+          initialMode={isChatColumn ? 'chat' : 'task'}
+          availableModes={isChatColumn ? ['chat'] : ['task']}
+          workflowStatus={isChatColumn ? undefined : column}
+          allowCollectionSelection={collection === null}
+          scopeId={`kanban-${column}`}
+          anchorRef={addMenuRef}
+          onClose={onClose}
+        />
+      )}
+    </div>
+  );
+}
+
 function PortfolioProjectHeader({
   project,
   count,
+  column,
+  collection,
+  collections,
+  isQuickCreateOpen,
+  onToggleQuickCreate,
+  onCloseQuickCreate,
 }: {
   project: ProjectGroup;
   count: number;
+  column: KanbanQuickCreateColumn;
+  collection: Collection | null;
+  collections: Collection[];
+  isQuickCreateOpen: boolean;
+  onToggleQuickCreate: (column: KanbanQuickCreateColumn, projectId: string) => void;
+  onCloseQuickCreate: () => void;
 }) {
   return (
     <div
@@ -41,6 +123,16 @@ function PortfolioProjectHeader({
         {project.displayName}
       </span>
       <span className="text-[0.625rem] tabular-nums text-(--text-muted)">{count}</span>
+      <KanbanQuickCreateButton
+        project={project}
+        column={column}
+        collection={collection}
+        collections={collections}
+        isOpen={isQuickCreateOpen}
+        onToggle={onToggleQuickCreate}
+        onClose={onCloseQuickCreate}
+        testId={`kanban-project-add-${column}-${project.encodedDir}`}
+      />
     </div>
   );
 }
@@ -56,11 +148,9 @@ interface KanbanChatColumnProps {
   collectionsByProject: Record<string, Collection[]>;
   projects: ProjectGroup[];
   groupByProject: boolean;
-  canCreate: boolean;
-  projectId: string;
-  projectDir: string;
+  createProject: ProjectGroup | null;
   activeSessionId: string | null;
-  isAddMenuOpen: boolean;
+  quickCreateProjectId: string | null;
   onCardDragStart: (sessionId: string, e: React.DragEvent) => void;
   onCardDragEnd: (e: React.DragEvent) => void;
   onCardDragOver: (sessionId: string, status: string, e: React.DragEvent) => void;
@@ -69,8 +159,8 @@ interface KanbanChatColumnProps {
   onColumnDrop: (status: string, e: React.DragEvent) => void;
   onCardClick: (session: UnifiedSession, event?: React.MouseEvent) => void;
   onCardDoubleClick: (session: UnifiedSession) => void;
-  onToggleAddMenu: () => void;
-  onCloseAddMenu: () => void;
+  onToggleQuickCreate: (column: KanbanQuickCreateColumn, projectId: string) => void;
+  onCloseQuickCreate: () => void;
   // Context menu actions
   onCardStatusChange?: (taskId: string, status: string) => void;
   onCardArchive?: (taskId: string) => void;
@@ -91,11 +181,9 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
   collectionsByProject,
   projects,
   groupByProject,
-  canCreate,
-  projectId,
-  projectDir,
+  createProject,
   activeSessionId,
-  isAddMenuOpen,
+  quickCreateProjectId,
   onCardDragStart,
   onCardDragEnd,
   onCardDragOver,
@@ -104,8 +192,8 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
   onColumnDrop,
   onCardClick,
   onCardDoubleClick,
-  onToggleAddMenu,
-  onCloseAddMenu,
+  onToggleQuickCreate,
+  onCloseQuickCreate,
   onCardStatusChange,
   onCardArchive,
   onCardUnarchive,
@@ -118,19 +206,16 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
   onCardStopProcess,
 }: KanbanChatColumnProps) {
   const { t } = useI18n();
-  const addMenuRef = useRef<HTMLDivElement>(null);
   const isDragOver = useBoardStore((s) => s.dragOverStatus === 'chat' && s.draggingTaskId !== null);
   const dropIndicator = useBoardStore((s) => s.dropIndicator);
   const chatGroups = useMemo(() => {
     if (!groupByProject) {
       return [{ project: null, chats }];
     }
-    return projects
-      .map((project) => ({
-        project,
-        chats: chats.filter((session) => session.projectDir === project.encodedDir),
-      }))
-      .filter((group) => group.chats.length > 0);
+    return projects.map((project) => ({
+      project,
+      chats: chats.filter((session) => session.projectDir === project.encodedDir),
+    }));
   }, [chats, groupByProject, projects]);
 
   return (
@@ -157,46 +242,18 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
         <span className="text-[0.625rem] font-semibold tabular-nums px-[7px] py-px rounded-[10px] bg-(--board-count-bg) text-(--board-count-text)">
           {chats.length}
         </span>
-        {/* Add button with dropdown */}
-        <div ref={addMenuRef} className="relative shrink-0">
-          <button
-            type="button"
-            disabled={!canCreate}
-            title={!canCreate ? t('task.board.selectProjectToCreate') : undefined}
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleAddMenu();
-            }}
-            className={cn(
-              'w-5 h-5 flex items-center justify-center rounded-[5px]',
-              'border-none bg-transparent',
-              'text-(--text-muted) hover:text-(--accent-light)',
-              'hover:bg-[color-mix(in_srgb,var(--accent)_15%,transparent)]',
-              'transition-all cursor-pointer disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-(--text-muted)',
-            )}
-            aria-label={t('task.newChat.label')}
-            data-testid="kanban-column-add-btn"
-          >
-            <Plus className="w-3.5 h-3.5" />
-          </button>
-          {isAddMenuOpen && canCreate && (
-            <div data-testid="kanban-column-add-menu">
-              <CollectionQuickCreateSheet
-                collection={collection}
-                collections={collections}
-                projectId={projectId}
-                projectDir={projectDir}
-                onClose={onCloseAddMenu}
-                allowedModes={['chat']}
-                allowCollectionSelection={collection === null}
-                scopeId="kanban-chat"
-                boundaryRef={addMenuRef}
-                anchorRef={addMenuRef}
-                className="left-0 right-auto top-8"
-              />
-            </div>
-          )}
-        </div>
+        {!groupByProject && (
+          <KanbanQuickCreateButton
+            project={createProject}
+            column="chat"
+            collection={collection}
+            collections={collections}
+            isOpen={quickCreateProjectId === createProject?.encodedDir}
+            onToggle={onToggleQuickCreate}
+            onClose={onCloseQuickCreate}
+            testId="kanban-column-add-btn"
+          />
+        )}
       </div>
 
       {/* Cards */}
@@ -216,7 +273,16 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
           {chatGroups.map((group, groupIndex) => (
             <Fragment key={group.project?.encodedDir ?? `single-${groupIndex}`}>
               {group.project && (
-                <PortfolioProjectHeader project={group.project} count={group.chats.length} />
+                <PortfolioProjectHeader
+                  project={group.project}
+                  count={group.chats.length}
+                  column="chat"
+                  collection={collection}
+                  collections={collectionsByProject[group.project.encodedDir] ?? collections}
+                  isQuickCreateOpen={quickCreateProjectId === group.project.encodedDir}
+                  onToggleQuickCreate={onToggleQuickCreate}
+                  onCloseQuickCreate={onCloseQuickCreate}
+                />
               )}
               <div className="flex flex-col gap-1.5">
                 {group.chats.map((session) => (
@@ -267,23 +333,17 @@ interface KanbanWorkflowColumnProps {
   status: WorkflowStatus;
   tasks: TaskEntity[];
   chats: UnifiedSession[];
+  collection: Collection | null;
+  collections: Collection[];
   collectionsByProject: Record<string, Collection[]>;
   projects: ProjectGroup[];
   groupByProject: boolean;
-  canCreate: boolean;
+  createProject: ProjectGroup | null;
   sessionsByTaskId: Record<string, UnifiedSession[]>;
   activeSessionId: string | null;
-  onCreateTask?: () => void;
-  isQuickCreateOpen?: boolean;
-  quickCreateSheet?: React.ReactNode;
-  quickCreateConfig?: {
-    collection: Collection | null;
-    collections: Collection[];
-    projectDir: string;
-    projectId: string;
-    allowCollectionSelection: boolean;
-    onClose: () => void;
-  };
+  quickCreateProjectId: string | null;
+  onToggleQuickCreate: (column: KanbanQuickCreateColumn, projectId: string) => void;
+  onCloseQuickCreate: () => void;
   onSessionClick: (session: UnifiedSession, event?: React.MouseEvent) => void;
   onSessionDoubleClick: (session: UnifiedSession) => void;
   onChatDragStart: (sessionId: string, e: React.DragEvent) => void;
@@ -309,16 +369,17 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
   status,
   tasks,
   chats,
+  collection,
+  collections,
   collectionsByProject,
   projects,
   groupByProject,
-  canCreate,
+  createProject,
   sessionsByTaskId,
   activeSessionId,
-  onCreateTask,
-  isQuickCreateOpen,
-  quickCreateSheet,
-  quickCreateConfig,
+  quickCreateProjectId,
+  onToggleQuickCreate,
+  onCloseQuickCreate,
   onSessionClick,
   onSessionDoubleClick,
   onChatDragStart,
@@ -340,7 +401,6 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
   onTaskRenameComplete,
 }: KanbanWorkflowColumnProps) {
   const { t } = useI18n();
-  const addMenuRef = useRef<HTMLDivElement>(null);
   const config = WORKFLOW_STATUS_CONFIG[status];
   const tasksWithLiveSessions = useMemo(
     () => mergeTasksWithLiveSessions(tasks, Object.values(sessionsByTaskId).flat()),
@@ -350,13 +410,11 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
     if (!groupByProject) {
       return [{ project: null, tasks: tasksWithLiveSessions, chats }];
     }
-    return projects
-      .map((project) => ({
-        project,
-        tasks: tasksWithLiveSessions.filter((task) => task.projectId === project.encodedDir),
-        chats: chats.filter((session) => session.projectDir === project.encodedDir),
-      }))
-      .filter((group) => group.tasks.length + group.chats.length > 0);
+    return projects.map((project) => ({
+      project,
+      tasks: tasksWithLiveSessions.filter((task) => task.projectId === project.encodedDir),
+      chats: chats.filter((session) => session.projectDir === project.encodedDir),
+    }));
   }, [chats, groupByProject, projects, tasksWithLiveSessions]);
   // DnD: highlight when a task card is dragged over this column
   const isDragOver = useBoardStore((s) => s.dragOverStatus === status && s.draggingTaskId !== null);
@@ -665,46 +723,18 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
           {tasksWithLiveSessions.length + chats.length}
         </span>
 
-        <div
-          ref={addMenuRef}
-          className="relative shrink-0"
-          onMouseDown={(event) => event.stopPropagation()}
-        >
-          <button
-            type="button"
-            disabled={!canCreate}
-            title={!canCreate ? t('task.board.selectProjectToCreate') : undefined}
-            onClick={onCreateTask}
-            className={cn(
-              'w-5 h-5 flex items-center justify-center rounded-[5px] shrink-0',
-              'border-none bg-transparent transition-all',
-              'text-(--text-muted) hover:text-(--accent-light)',
-              'hover:bg-[color-mix(in_srgb,var(--accent)_15%,transparent)]',
-              'cursor-pointer disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-(--text-muted)',
-            )}
-            aria-label={t('task.newChat.newTask')}
-            data-testid="kanban-workflow-column-add-btn"
-          >
-            <Plus className="w-3.5 h-3.5" />
-          </button>
-          {isQuickCreateOpen && canCreate && quickCreateConfig ? (
-            <CollectionQuickCreateSheet
-              collection={quickCreateConfig.collection}
-              collections={quickCreateConfig.collections}
-              projectDir={quickCreateConfig.projectDir}
-              projectId={quickCreateConfig.projectId}
-              initialMode="task"
-              availableModes={['task']}
-              workflowStatus={status}
-              allowCollectionSelection={quickCreateConfig.allowCollectionSelection}
-              scopeId={`kanban-${status}`}
-              anchorRef={addMenuRef}
-              onClose={quickCreateConfig.onClose}
-            />
-          ) : (
-            isQuickCreateOpen && canCreate && quickCreateSheet
-          )}
-        </div>
+        {!groupByProject && (
+          <KanbanQuickCreateButton
+            project={createProject}
+            column={status}
+            collection={collection}
+            collections={collections}
+            isOpen={quickCreateProjectId === createProject?.encodedDir}
+            onToggle={onToggleQuickCreate}
+            onClose={onCloseQuickCreate}
+            testId="kanban-workflow-column-add-btn"
+          />
+        )}
       </div>
 
       {/* Cards */}
@@ -723,6 +753,12 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
                 <PortfolioProjectHeader
                   project={group.project}
                   count={group.tasks.length + group.chats.length}
+                  column={status}
+                  collection={collection}
+                  collections={collectionsByProject[group.project.encodedDir] ?? collections}
+                  isQuickCreateOpen={quickCreateProjectId === group.project.encodedDir}
+                  onToggleQuickCreate={onToggleQuickCreate}
+                  onCloseQuickCreate={onCloseQuickCreate}
                 />
               )}
               <div className="flex flex-col gap-1.5">

--- a/src/components/board/kanban-column.tsx
+++ b/src/components/board/kanban-column.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { memo, useRef, useCallback, useMemo } from 'react';
+import { Fragment, memo, useRef, useCallback, useMemo } from 'react';
 import type React from 'react';
 import { Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
+import { getProjectColor } from '@/lib/constants/project-strip';
 import { getKanbanMultiSessionDragIds } from '@/lib/dnd/panel-session-drag';
 import { mergeTasksWithLiveSessions } from '@/lib/tasks/merge-tasks-with-live-sessions';
 import { useBoardStore } from '@/stores/board-store';
@@ -14,10 +15,35 @@ import { useTaskStore } from '@/stores/task-store';
 import { TASK_DND_MIME, TASK_ENTITY_DND_MIME, TASK_MULTI_DND_MIME } from '@/types/task';
 import { WORKFLOW_STATUS_CONFIG } from '@/types/task-entity';
 import type { WorkflowStatus, TaskEntity } from '@/types/task-entity';
-import type { UnifiedSession } from '@/types/chat';
+import type { ProjectGroup, UnifiedSession } from '@/types/chat';
 import type { Collection } from '@/types/collection';
 import { CollectionQuickCreateSheet } from '@/components/chat/collection-quick-create-sheet';
 import { KanbanChatCard, KanbanTaskCard } from './kanban-card';
+
+function PortfolioProjectHeader({
+  project,
+  count,
+}: {
+  project: ProjectGroup;
+  count: number;
+}) {
+  return (
+    <div
+      className="sticky top-0 z-10 -mx-0.5 flex items-center gap-1.5 bg-(--board-bg) px-1 py-1.5"
+      data-testid={`kanban-project-group-${project.encodedDir}`}
+    >
+      <span
+        className="h-2.5 w-2.5 shrink-0 rounded-full"
+        style={{ backgroundColor: getProjectColor(project.displayName) }}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 flex-1 truncate text-[0.6875rem] font-semibold text-(--text-secondary)">
+        {project.displayName}
+      </span>
+      <span className="text-[0.625rem] tabular-nums text-(--text-muted)">{count}</span>
+    </div>
+  );
+}
 
 // ============================================================
 // KanbanChatColumn
@@ -27,6 +53,10 @@ interface KanbanChatColumnProps {
   chats: UnifiedSession[];
   collection: Collection | null;
   collections: Collection[];
+  collectionsByProject: Record<string, Collection[]>;
+  projects: ProjectGroup[];
+  groupByProject: boolean;
+  canCreate: boolean;
   projectId: string;
   projectDir: string;
   activeSessionId: string | null;
@@ -58,6 +88,10 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
   chats,
   collection,
   collections,
+  collectionsByProject,
+  projects,
+  groupByProject,
+  canCreate,
   projectId,
   projectDir,
   activeSessionId,
@@ -87,6 +121,17 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
   const addMenuRef = useRef<HTMLDivElement>(null);
   const isDragOver = useBoardStore((s) => s.dragOverStatus === 'chat' && s.draggingTaskId !== null);
   const dropIndicator = useBoardStore((s) => s.dropIndicator);
+  const chatGroups = useMemo(() => {
+    if (!groupByProject) {
+      return [{ project: null, chats }];
+    }
+    return projects
+      .map((project) => ({
+        project,
+        chats: chats.filter((session) => session.projectDir === project.encodedDir),
+      }))
+      .filter((group) => group.chats.length > 0);
+  }, [chats, groupByProject, projects]);
 
   return (
     <div
@@ -115,6 +160,9 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
         {/* Add button with dropdown */}
         <div ref={addMenuRef} className="relative shrink-0">
           <button
+            type="button"
+            disabled={!canCreate}
+            title={!canCreate ? t('task.board.selectProjectToCreate') : undefined}
             onClick={(e) => {
               e.stopPropagation();
               onToggleAddMenu();
@@ -124,13 +172,14 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
               'border-none bg-transparent',
               'text-(--text-muted) hover:text-(--accent-light)',
               'hover:bg-[color-mix(in_srgb,var(--accent)_15%,transparent)]',
-              'transition-all cursor-pointer',
+              'transition-all cursor-pointer disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-(--text-muted)',
             )}
+            aria-label={t('task.newChat.label')}
             data-testid="kanban-column-add-btn"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
-          {isAddMenuOpen && (
+          {isAddMenuOpen && canCreate && (
             <div data-testid="kanban-column-add-menu">
               <CollectionQuickCreateSheet
                 collection={collection}
@@ -163,30 +212,40 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
         onDragLeave={(e) => onColumnDragLeave('chat', e)}
         onDrop={(e) => onColumnDrop('chat', e)}
       >
-        <div className="flex flex-col gap-1.5">
-          {chats.map((session) => (
-            <KanbanChatCard
-              key={session.id}
-              session={session}
-              isActive={session.id === activeSessionId}
-              dropIndicatorBefore={dropIndicator?.targetSessionId === session.id && dropIndicator.position === 'before'}
-              dropIndicatorAfter={dropIndicator?.targetSessionId === session.id && dropIndicator.position === 'after'}
-              onDragStart={(e) => onCardDragStart(session.id, e)}
-              onDragEnd={onCardDragEnd}
-              onDragOverItem={(e) => onCardDragOver(session.id, 'chat', e)}
-              onClick={(e) => onCardClick(session, e)}
-              onDoubleClick={() => onCardDoubleClick(session)}
-              onStatusChange={onCardStatusChange}
-              onArchive={onCardArchive}
-              onUnarchive={onCardUnarchive}
-              onRename={onCardRename}
-              onDelete={onCardDelete}
-              onOpenInNewTab={onCardOpenInNewTab}
-              onGenerateTitle={onCardGenerateTitle}
-              onMoveToProject={onCardMoveToProject}
-              onMoveToCollection={onCardMoveToCollection}
-              onStopProcess={onCardStopProcess}
-            />
+        <div className="flex flex-col gap-2.5">
+          {chatGroups.map((group, groupIndex) => (
+            <Fragment key={group.project?.encodedDir ?? `single-${groupIndex}`}>
+              {group.project && (
+                <PortfolioProjectHeader project={group.project} count={group.chats.length} />
+              )}
+              <div className="flex flex-col gap-1.5">
+                {group.chats.map((session) => (
+                  <KanbanChatCard
+                    key={session.id}
+                    session={session}
+                    isActive={session.id === activeSessionId}
+                    dropIndicatorBefore={dropIndicator?.targetSessionId === session.id && dropIndicator.position === 'before'}
+                    dropIndicatorAfter={dropIndicator?.targetSessionId === session.id && dropIndicator.position === 'after'}
+                    onDragStart={(e) => onCardDragStart(session.id, e)}
+                    onDragEnd={onCardDragEnd}
+                    onDragOverItem={(e) => onCardDragOver(session.id, 'chat', e)}
+                    onClick={(e) => onCardClick(session, e)}
+                    onDoubleClick={() => onCardDoubleClick(session)}
+                    onStatusChange={onCardStatusChange}
+                    onArchive={onCardArchive}
+                    onUnarchive={onCardUnarchive}
+                    onRename={onCardRename}
+                    onDelete={onCardDelete}
+                    onOpenInNewTab={onCardOpenInNewTab}
+                    onGenerateTitle={onCardGenerateTitle}
+                    onMoveToProject={onCardMoveToProject}
+                    onMoveToCollection={onCardMoveToCollection}
+                    onStopProcess={onCardStopProcess}
+                    collections={collectionsByProject[session.projectDir] ?? collections}
+                  />
+                ))}
+              </div>
+            </Fragment>
           ))}
         </div>
 
@@ -208,6 +267,10 @@ interface KanbanWorkflowColumnProps {
   status: WorkflowStatus;
   tasks: TaskEntity[];
   chats: UnifiedSession[];
+  collectionsByProject: Record<string, Collection[]>;
+  projects: ProjectGroup[];
+  groupByProject: boolean;
+  canCreate: boolean;
   sessionsByTaskId: Record<string, UnifiedSession[]>;
   activeSessionId: string | null;
   onCreateTask?: () => void;
@@ -246,6 +309,10 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
   status,
   tasks,
   chats,
+  collectionsByProject,
+  projects,
+  groupByProject,
+  canCreate,
   sessionsByTaskId,
   activeSessionId,
   onCreateTask,
@@ -279,6 +346,18 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
     () => mergeTasksWithLiveSessions(tasks, Object.values(sessionsByTaskId).flat()),
     [sessionsByTaskId, tasks],
   );
+  const projectGroups = useMemo(() => {
+    if (!groupByProject) {
+      return [{ project: null, tasks: tasksWithLiveSessions, chats }];
+    }
+    return projects
+      .map((project) => ({
+        project,
+        tasks: tasksWithLiveSessions.filter((task) => task.projectId === project.encodedDir),
+        chats: chats.filter((session) => session.projectDir === project.encodedDir),
+      }))
+      .filter((group) => group.tasks.length + group.chats.length > 0);
+  }, [chats, groupByProject, projects, tasksWithLiveSessions]);
   // DnD: highlight when a task card is dragged over this column
   const isDragOver = useBoardStore((s) => s.dragOverStatus === status && s.draggingTaskId !== null);
   const dropIndicator = useBoardStore((s) => s.dropIndicator);
@@ -294,8 +373,18 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
       return;
     }
 
-    const draggingTask = useTaskStore.getState().getTask(draggingTaskId);
-    if (!draggingTask || draggingTask.workflowStatus !== status) {
+    const taskStore = useTaskStore.getState();
+    const draggingTask = taskStore.getTask(draggingTaskId);
+    const targetTask = taskStore.getTask(taskId);
+    if (
+      !draggingTask ||
+      !targetTask ||
+      draggingTask.workflowStatus !== status ||
+      draggingTask.projectId !== targetTask.projectId
+    ) {
+      if (useBoardStore.getState().dropIndicator) {
+        useBoardStore.getState().setDropIndicator(null);
+      }
       return;
     }
 
@@ -365,8 +454,16 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
     const sessionStore = useSessionStore.getState();
     const draggedChatSession = chatSessionId ? sessionStore.getSession(chatSessionId) : undefined;
     const sourceProjectId = draggedTask?.projectId ?? draggedChatSession?.projectDir;
+    const visibleProjectIds = new Set(projects.map((project) => project.encodedDir));
 
-    if (multiSessionIds.length > 1 && sourceProjectId) {
+    const isProjectInDropScope = (projectId: string) => {
+      if (groupByProject) {
+        return visibleProjectIds.has(projectId);
+      }
+      return !sourceProjectId || projectId === sourceProjectId;
+    };
+
+    if (multiSessionIds.length > 1) {
       const selectedTaskIds: string[] = [];
       const selectedChatIds: string[] = [];
       const seenTaskIds = new Set<string>();
@@ -375,7 +472,10 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
       for (const selectedSessionId of multiSessionIds) {
         const selectedTask = taskStore.getTaskBySessionId(selectedSessionId);
         if (selectedTask) {
-          if (selectedTask.projectId !== sourceProjectId || seenTaskIds.has(selectedTask.id)) {
+          if (
+            !isProjectInDropScope(selectedTask.projectId) ||
+            seenTaskIds.has(selectedTask.id)
+          ) {
             continue;
           }
           seenTaskIds.add(selectedTask.id);
@@ -387,7 +487,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
         if (
           !selectedSession ||
           selectedSession.taskId ||
-          selectedSession.projectDir !== sourceProjectId ||
+          !isProjectInDropScope(selectedSession.projectDir) ||
           seenChatIds.has(selectedSession.id)
         ) {
           continue;
@@ -425,6 +525,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
 
       if (session && !session.taskId && session.workflowStatus === status && indicator) {
         const orderedIds = chats
+          .filter((item) => item.projectDir === session.projectDir)
           .slice()
           .sort((a, b) => a.sortOrder - b.sortOrder)
           .map((item) => item.id);
@@ -434,7 +535,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
         if (targetIdx !== -1) {
           const insertIdx = indicator.position === 'before' ? targetIdx : targetIdx + 1;
           filtered.splice(insertIdx, 0, chatSessionId);
-          sessionStore.reorderSessionsByIds(filtered);
+          sessionStore.reorderProjectSessions(session.projectDir, filtered);
           boardStore.flashDrop(chatSessionId);
         }
       } else if (session && !session.taskId && session.workflowStatus !== status) {
@@ -452,6 +553,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
 
       if (task && task.workflowStatus === status && indicator) {
         const orderedIds = tasks
+          .filter((item) => item.projectId === task.projectId)
           .slice()
           .sort((a, b) => a.sortOrder - b.sortOrder)
           .map((item) => item.id);
@@ -461,7 +563,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
         if (targetIdx !== -1) {
           const insertIdx = indicator.position === 'before' ? targetIdx : targetIdx + 1;
           filtered.splice(insertIdx, 0, taskId);
-          taskStore.reorderTasks(filtered);
+          taskStore.reorderTasks(filtered, task.projectId);
           boardStore.flashDrop(taskId);
         }
       } else if (task && task.workflowStatus !== status) {
@@ -471,7 +573,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
     }
 
     finishDrop();
-  }, [chats, status, tasks]);
+  }, [chats, groupByProject, projects, status, tasks]);
 
   // Card drag-over: Ring Gradient highlight using column status color
   const dragOverStyle = isDragOver
@@ -558,20 +660,22 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
         >
           <button
             type="button"
+            disabled={!canCreate}
+            title={!canCreate ? t('task.board.selectProjectToCreate') : undefined}
             onClick={onCreateTask}
             className={cn(
               'w-5 h-5 flex items-center justify-center rounded-[5px] shrink-0',
               'border-none bg-transparent transition-all',
               'text-(--text-muted) hover:text-(--accent-light)',
               'hover:bg-[color-mix(in_srgb,var(--accent)_15%,transparent)]',
-              'cursor-pointer',
+              'cursor-pointer disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-(--text-muted)',
             )}
             aria-label={t('task.newChat.newTask')}
             data-testid="kanban-workflow-column-add-btn"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
-          {isQuickCreateOpen && quickCreateConfig ? (
+          {isQuickCreateOpen && canCreate && quickCreateConfig ? (
             <CollectionQuickCreateSheet
               collection={quickCreateConfig.collection}
               collections={quickCreateConfig.collections}
@@ -586,7 +690,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
               onClose={quickCreateConfig.onClose}
             />
           ) : (
-            isQuickCreateOpen && quickCreateSheet
+            isQuickCreateOpen && canCreate && quickCreateSheet
           )}
         </div>
       </div>
@@ -600,55 +704,68 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
         )}
         data-testid="kanban-column-cards"
       >
-        <div className="flex flex-col gap-1.5">
-          {tasksWithLiveSessions.map((task) => (
-            <KanbanTaskCard
-              key={task.id}
-              task={task}
-              activeSessionId={activeSessionId}
-              dropIndicatorBefore={dropIndicator?.targetSessionId === task.id && dropIndicator.position === 'before'}
-              dropIndicatorAfter={dropIndicator?.targetSessionId === task.id && dropIndicator.position === 'after'}
-              onDragOverItem={(e) => handleTaskDragOver(task.id, e)}
-              onSessionClick={onSessionClick}
-              onSessionDoubleClick={onSessionDoubleClick}
-              onAddSession={onAddSession}
-              onContextMenu={onTaskContextMenu}
-              onRename={onTaskRename}
-              onSessionRename={onSessionRename}
-              onSessionDelete={onSessionDelete}
-              onSessionOpenInNewTab={onSessionOpenInNewTab}
-              onSessionGenerateTitle={onSessionGenerateTitle}
-              onSessionMoveToProject={onSessionMoveToProject}
-              onSessionStopProcess={onSessionStopProcess}
-              isRenameRequested={renamingTaskId === task.id}
-              onRenameComplete={() => onTaskRenameComplete?.(task.id)}
-            />
-          ))}
-          {chats.map((session) => (
-            <KanbanChatCard
-              key={session.id}
-              session={session}
-              isActive={session.id === activeSessionId}
-              dropIndicatorBefore={dropIndicator?.targetSessionId === session.id && dropIndicator.position === 'before'}
-              dropIndicatorAfter={dropIndicator?.targetSessionId === session.id && dropIndicator.position === 'after'}
-              onDragStart={(e) => onChatDragStart(session.id, e)}
-              onDragEnd={onChatDragEnd}
-              onDragOverItem={(e) => onChatDragOver(session.id, status, e)}
-              onClick={(e) => onSessionClick(session, e)}
-              onDoubleClick={() => onSessionDoubleClick(session)}
-              onStatusChange={onChatStatusChange}
-              onArchive={onChatArchive}
-              onUnarchive={onChatUnarchive}
-              onRename={onSessionRename}
-              onDelete={onSessionDelete}
-              onOpenInNewTab={onSessionOpenInNewTab}
-              onGenerateTitle={onSessionGenerateTitle}
-              onMoveToProject={onSessionMoveToProject}
-              onMoveToCollection={(sessionId, collectionId) =>
-                useSessionStore.getState().updateSessionCollection(sessionId, collectionId)
-              }
-              onStopProcess={onSessionStopProcess}
-            />
+        <div className="flex flex-col gap-2.5">
+          {projectGroups.map((group, groupIndex) => (
+            <Fragment key={group.project?.encodedDir ?? `single-${groupIndex}`}>
+              {group.project && (
+                <PortfolioProjectHeader
+                  project={group.project}
+                  count={group.tasks.length + group.chats.length}
+                />
+              )}
+              <div className="flex flex-col gap-1.5">
+                {group.tasks.map((task) => (
+                  <KanbanTaskCard
+                    key={task.id}
+                    task={task}
+                    activeSessionId={activeSessionId}
+                    dropIndicatorBefore={dropIndicator?.targetSessionId === task.id && dropIndicator.position === 'before'}
+                    dropIndicatorAfter={dropIndicator?.targetSessionId === task.id && dropIndicator.position === 'after'}
+                    onDragOverItem={(e) => handleTaskDragOver(task.id, e)}
+                    onSessionClick={onSessionClick}
+                    onSessionDoubleClick={onSessionDoubleClick}
+                    onAddSession={onAddSession}
+                    onContextMenu={onTaskContextMenu}
+                    onRename={onTaskRename}
+                    onSessionRename={onSessionRename}
+                    onSessionDelete={onSessionDelete}
+                    onSessionOpenInNewTab={onSessionOpenInNewTab}
+                    onSessionGenerateTitle={onSessionGenerateTitle}
+                    onSessionMoveToProject={onSessionMoveToProject}
+                    onSessionStopProcess={onSessionStopProcess}
+                    isRenameRequested={renamingTaskId === task.id}
+                    onRenameComplete={() => onTaskRenameComplete?.(task.id)}
+                  />
+                ))}
+                {group.chats.map((session) => (
+                  <KanbanChatCard
+                    key={session.id}
+                    session={session}
+                    isActive={session.id === activeSessionId}
+                    dropIndicatorBefore={dropIndicator?.targetSessionId === session.id && dropIndicator.position === 'before'}
+                    dropIndicatorAfter={dropIndicator?.targetSessionId === session.id && dropIndicator.position === 'after'}
+                    onDragStart={(e) => onChatDragStart(session.id, e)}
+                    onDragEnd={onChatDragEnd}
+                    onDragOverItem={(e) => onChatDragOver(session.id, status, e)}
+                    onClick={(e) => onSessionClick(session, e)}
+                    onDoubleClick={() => onSessionDoubleClick(session)}
+                    onStatusChange={onChatStatusChange}
+                    onArchive={onChatArchive}
+                    onUnarchive={onChatUnarchive}
+                    onRename={onSessionRename}
+                    onDelete={onSessionDelete}
+                    onOpenInNewTab={onSessionOpenInNewTab}
+                    onGenerateTitle={onSessionGenerateTitle}
+                    onMoveToProject={onSessionMoveToProject}
+                    onMoveToCollection={(sessionId, collectionId) =>
+                      useSessionStore.getState().updateSessionCollection(sessionId, collectionId)
+                    }
+                    onStopProcess={onSessionStopProcess}
+                    collections={collectionsByProject[session.projectDir]}
+                  />
+                ))}
+              </div>
+            </Fragment>
           ))}
         </div>
 

--- a/src/components/board/kanban-column.tsx
+++ b/src/components/board/kanban-column.tsx
@@ -376,12 +376,24 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
     const taskStore = useTaskStore.getState();
     const draggingTask = taskStore.getTask(draggingTaskId);
     const targetTask = taskStore.getTask(taskId);
-    if (
-      !draggingTask ||
-      !targetTask ||
-      draggingTask.workflowStatus !== status ||
-      draggingTask.projectId !== targetTask.projectId
-    ) {
+    if (!draggingTask || !targetTask) {
+      if (useBoardStore.getState().dropIndicator) {
+        useBoardStore.getState().setDropIndicator(null);
+      }
+      return;
+    }
+
+    if (draggingTask.projectId !== targetTask.projectId) {
+      if (useBoardStore.getState().dropIndicator) {
+        useBoardStore.getState().setDropIndicator(null);
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      e.dataTransfer.dropEffect = 'none';
+      return;
+    }
+
+    if (draggingTask.workflowStatus !== status) {
       if (useBoardStore.getState().dropIndicator) {
         useBoardStore.getState().setDropIndicator(null);
       }

--- a/src/components/board/portfolio-filter-bar.tsx
+++ b/src/components/board/portfolio-filter-bar.tsx
@@ -75,4 +75,3 @@ export const PortfolioFilterBar = memo(function PortfolioFilterBar({
     </div>
   );
 });
-

--- a/src/components/board/portfolio-filter-bar.tsx
+++ b/src/components/board/portfolio-filter-bar.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { memo } from 'react';
+import { Layers3 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useI18n } from '@/lib/i18n';
+import { getProjectColor } from '@/lib/constants/project-strip';
+import type { ProjectGroup } from '@/types/chat';
+
+interface PortfolioFilterBarProps {
+  projects: ProjectGroup[];
+  activeProjectId: string | null;
+  onProjectFilter: (projectId: string | null) => void;
+}
+
+export const PortfolioFilterBar = memo(function PortfolioFilterBar({
+  projects,
+  activeProjectId,
+  onProjectFilter,
+}: PortfolioFilterBarProps) {
+  const { t } = useI18n();
+
+  return (
+    <div
+      className="flex min-w-0 shrink-0 items-center gap-2 border-b border-(--divider) bg-(--board-bg) px-3 py-2"
+      data-testid="portfolio-filter-bar"
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto scrollbar-none">
+        <button
+          type="button"
+          onClick={() => onProjectFilter(null)}
+          aria-pressed={activeProjectId === null}
+          className={cn(
+            'inline-flex shrink-0 items-center gap-1.5 rounded-2xl border px-3 py-1',
+            'text-[0.75rem] font-medium whitespace-nowrap transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35',
+            activeProjectId === null
+              ? 'border-(--accent) bg-(--accent) text-white'
+              : 'border-transparent bg-(--sidebar-hover) text-(--text-muted) hover:bg-(--sidebar-active) hover:text-(--text-primary)',
+          )}
+          data-testid="portfolio-filter-all"
+        >
+          <Layers3 className="h-3 w-3" />
+          <span>{t('projectStrip.allProjects')}</span>
+        </button>
+
+        {projects.map((project) => {
+          const isActive = activeProjectId === project.encodedDir;
+          return (
+            <button
+              key={project.encodedDir}
+              type="button"
+              onClick={() => onProjectFilter(isActive ? null : project.encodedDir)}
+              aria-pressed={isActive}
+              className={cn(
+                'inline-flex shrink-0 items-center gap-1.5 rounded-2xl border px-2.5 py-1',
+                'text-[0.75rem] font-medium whitespace-nowrap transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35',
+                isActive
+                  ? 'border-[color-mix(in_srgb,var(--accent)_45%,var(--divider))] bg-(--sidebar-active) text-(--text-primary)'
+                  : 'border-transparent bg-(--sidebar-hover) text-(--text-muted) hover:bg-(--sidebar-active) hover:text-(--text-primary)',
+              )}
+              data-testid={`portfolio-filter-${project.encodedDir}`}
+            >
+              <span
+                className="h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: getProjectColor(project.displayName) }}
+                aria-hidden="true"
+              />
+              <span>{project.displayName}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+});
+

--- a/src/components/tab/project-view-mode-toggle.tsx
+++ b/src/components/tab/project-view-mode-toggle.tsx
@@ -2,7 +2,6 @@
 
 import { memo, useCallback } from 'react';
 import { useBoardStore } from '@/stores/board-store';
-import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
 import { saveCurrentKanbanScrollPosition } from '@/lib/kanban-scroll-position';
 import { cn } from '@/lib/utils';
 import { ViewModeToggle } from './view-mode-toggle';
@@ -32,7 +31,7 @@ export const ProjectViewModeToggle = memo(function ProjectViewModeToggle({
     [activeCollectionFilter, selectedProjectDir, setViewMode, viewMode],
   );
 
-  if (!selectedProjectDir || selectedProjectDir === ALL_PROJECTS_SENTINEL) return null;
+  if (!selectedProjectDir) return null;
 
   return (
     <div

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1050,6 +1050,7 @@ export const en: I18nMessages = {
       totalTasks: '{{count}} tasks',
       running: '{{count}} running',
       emptyColumn: 'Drop here',
+      selectProjectToCreate: 'Select a project above to create work',
       viewList: 'List view',
       viewBoard: 'Board view',
       viewListShort: 'List',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -1050,6 +1050,7 @@ export const ja: I18nMessages = {
       totalTasks: '{{count}} タスク',
       running: '{{count}} 実行中',
       emptyColumn: 'ここにドロップ',
+      selectProjectToCreate: '上でプロジェクトを選択して作業を作成します',
       viewList: 'リストビュー',
       viewBoard: 'ボードビュー',
       viewListShort: 'リスト',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -1057,6 +1057,7 @@ export const ko: I18nMessages = {
       totalTasks: '{{count}}개 태스크',
       running: '{{count}}개 실행 중',
       emptyColumn: '여기에 드롭',
+      selectProjectToCreate: '새 작업을 만들 프로젝트를 위에서 선택하세요',
       viewList: '리스트 보기',
       viewBoard: '보드 보기',
       viewListShort: '리스트',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -1055,6 +1055,7 @@ export interface I18nMessages {
       totalTasks: string;
       running: string;
       emptyColumn: string;
+      selectProjectToCreate: string;
       viewList: string;
       viewBoard: string;
       viewListShort: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -1050,6 +1050,7 @@ export const zh: I18nMessages = {
       totalTasks: '{{count}} 个任务',
       running: '{{count}} 个运行中',
       emptyColumn: '拖放到此处',
+      selectProjectToCreate: '请先在上方选择要创建工作的项目',
       viewList: '列表视图',
       viewBoard: '看板视图',
       viewListShort: '列表',

--- a/src/lib/kanban/board-scope.ts
+++ b/src/lib/kanban/board-scope.ts
@@ -1,0 +1,55 @@
+import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
+import type { ProjectGroup, UnifiedSession } from '@/types/chat';
+import type { Collection } from '@/types/collection';
+import type { TaskEntity } from '@/types/task-entity';
+
+export type KanbanScope =
+  | { kind: 'project'; projectId: string }
+  | { kind: 'all-projects'; projectIds: string[] };
+
+export interface KanbanScopeData {
+  projects: ProjectGroup[];
+  sessions: UnifiedSession[];
+  tasks: TaskEntity[];
+  collectionsByProject: Record<string, Collection[]>;
+}
+
+export function resolveKanbanScope(
+  selectedProjectDir: string | null,
+  projects: ProjectGroup[],
+): KanbanScope | null {
+  if (!selectedProjectDir) return null;
+  if (selectedProjectDir === ALL_PROJECTS_SENTINEL) {
+    return {
+      kind: 'all-projects',
+      projectIds: projects.map((project) => project.encodedDir),
+    };
+  }
+  return { kind: 'project', projectId: selectedProjectDir };
+}
+
+export function getKanbanScopeProjectIds(scope: KanbanScope | null): string[] {
+  if (!scope) return [];
+  return scope.kind === 'all-projects' ? scope.projectIds : [scope.projectId];
+}
+
+export function collectKanbanScopeData(
+  scope: KanbanScope | null,
+  projects: ProjectGroup[],
+  tasksByProject: Record<string, TaskEntity[]>,
+  collectionsByProject: Record<string, Collection[]>,
+): KanbanScopeData {
+  const projectIds = getKanbanScopeProjectIds(scope);
+  const projectIdSet = new Set(projectIds);
+  const scopedProjects = projects.filter((project) => projectIdSet.has(project.encodedDir));
+
+  return {
+    projects: scopedProjects,
+    sessions: scopedProjects.flatMap((project) => project.sessions),
+    tasks: projectIds.flatMap((projectId) => tasksByProject[projectId] ?? []),
+    collectionsByProject: Object.fromEntries(
+      projectIds.map((projectId) => [projectId, collectionsByProject[projectId] ?? []]),
+    ),
+  };
+}
+

--- a/src/lib/kanban/board-scope.ts
+++ b/src/lib/kanban/board-scope.ts
@@ -13,7 +13,6 @@ export interface KanbanScopeData {
   tasks: TaskEntity[];
   collectionsByProject: Record<string, Collection[]>;
 }
-
 export function resolveKanbanScope(
   selectedProjectDir: string | null,
   projects: ProjectGroup[],
@@ -52,4 +51,3 @@ export function collectKanbanScopeData(
     ),
   };
 }
-

--- a/src/stores/board-store.ts
+++ b/src/stores/board-store.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
 import { captureTelemetryEvent } from '@/lib/telemetry/client';
 import {
   readUiStorageItem,
@@ -238,7 +237,6 @@ function resolveProjectViewMode(
   projectViewModes: Record<string, ViewMode>,
   fallback: ViewMode,
 ): ViewMode {
-  if (projectDir === ALL_PROJECTS_SENTINEL) return 'list';
   if (projectDir && projectViewModes[projectDir]) return projectViewModes[projectDir];
   return fallback;
 }
@@ -247,12 +245,10 @@ export const useBoardStore = create<BoardState>((set, get) => ({
   viewMode: loadViewMode(),
   projectViewModes: loadProjectViewModes(),
   setViewMode: (mode) => {
-    // All Projects mode only supports list view — block board switch
-    if (mode === 'board' && get().selectedProjectDir === ALL_PROJECTS_SENTINEL) return;
     if (get().viewMode === mode) return;
     set((state) => {
       const nextProjectViewModes =
-        state.selectedProjectDir && state.selectedProjectDir !== ALL_PROJECTS_SENTINEL
+        state.selectedProjectDir
           ? {
               ...state.projectViewModes,
               [state.selectedProjectDir]: mode,
@@ -365,7 +361,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
   setSelectedProjectDir: (dir) => {
     set((state) => {
       const nextProjectViewModes =
-        state.selectedProjectDir && state.selectedProjectDir !== ALL_PROJECTS_SENTINEL
+        state.selectedProjectDir
           ? {
               ...state.projectViewModes,
               [state.selectedProjectDir]: state.viewMode,

--- a/tests/all-projects-board-view-mode.test.ts
+++ b/tests/all-projects-board-view-mode.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
+import { useBoardStore } from '@/stores/board-store';
+
+test('all projects can select and restore its own board view mode', () => {
+  const previous = useBoardStore.getState();
+
+  try {
+    useBoardStore.setState({
+      selectedProjectDir: ALL_PROJECTS_SENTINEL,
+      viewMode: 'list',
+      projectViewModes: {},
+    });
+
+    useBoardStore.getState().setViewMode('board');
+    assert.equal(useBoardStore.getState().viewMode, 'board');
+
+    useBoardStore.getState().setSelectedProjectDir('alpha');
+    useBoardStore.getState().setViewMode('list');
+    useBoardStore.getState().setSelectedProjectDir(ALL_PROJECTS_SENTINEL);
+
+    assert.equal(useBoardStore.getState().viewMode, 'board');
+    assert.equal(useBoardStore.getState().projectViewModes[ALL_PROJECTS_SENTINEL], 'board');
+  } finally {
+    useBoardStore.setState({
+      selectedProjectDir: previous.selectedProjectDir,
+      viewMode: previous.viewMode,
+      projectViewModes: previous.projectViewModes,
+    });
+  }
+});
+

--- a/tests/all-projects-board-view-mode.test.ts
+++ b/tests/all-projects-board-view-mode.test.ts
@@ -30,4 +30,3 @@ test('all projects can select and restore its own board view mode', () => {
     });
   }
 });
-

--- a/tests/kanban-board-scope.test.ts
+++ b/tests/kanban-board-scope.test.ts
@@ -79,7 +79,6 @@ test('all-projects scope exposes every project without treating the sentinel as 
   assert.deepEqual(data.tasks.map((item) => item.id), ['task-alpha', 'task-beta']);
   assert.deepEqual(Object.keys(data.collectionsByProject), ['alpha', 'beta']);
 });
-
 test('single-project scope keeps sessions, tasks, and collections project-local', () => {
   const scope = resolveKanbanScope('beta', projects);
   assert.deepEqual(scope, { kind: 'project', projectId: 'beta' });
@@ -90,4 +89,3 @@ test('single-project scope keeps sessions, tasks, and collections project-local'
   assert.deepEqual(data.tasks.map((item) => item.id), ['task-beta']);
   assert.deepEqual(Object.keys(data.collectionsByProject), ['beta']);
 });
-

--- a/tests/kanban-board-scope.test.ts
+++ b/tests/kanban-board-scope.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  collectKanbanScopeData,
+  resolveKanbanScope,
+} from '@/lib/kanban/board-scope';
+import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
+import type { ProjectGroup, UnifiedSession } from '@/types/chat';
+import type { Collection } from '@/types/collection';
+import type { TaskEntity } from '@/types/task-entity';
+
+function session(id: string, projectDir: string): UnifiedSession {
+  return {
+    id,
+    title: id,
+    projectDir,
+    isRunning: false,
+    status: 'completed',
+    lastModified: '2026-07-14T00:00:00.000Z',
+    createdAt: '2026-07-14T00:00:00.000Z',
+    archived: false,
+    sortOrder: 0,
+  };
+}
+
+function project(id: string, sessions: UnifiedSession[]): ProjectGroup {
+  return {
+    encodedDir: id,
+    displayName: id.toUpperCase(),
+    decodedPath: `/work/${id}`,
+    isCurrent: false,
+    sessions,
+    totalSessions: sessions.length,
+    allLoaded: true,
+    loadedCount: sessions.length,
+    nextCursor: null,
+    loadBatchIndex: 0,
+  };
+}
+
+function task(id: string, projectId: string): TaskEntity {
+  return {
+    id,
+    projectId,
+    title: id,
+    workflowStatus: 'todo',
+    sortOrder: 0,
+    sessions: [],
+    createdAt: '2026-07-14T00:00:00.000Z',
+    updatedAt: '2026-07-14T00:00:00.000Z',
+  };
+}
+
+const projects = [
+  project('alpha', [session('chat-alpha', 'alpha')]),
+  project('beta', [session('chat-beta', 'beta')]),
+];
+
+const tasksByProject: Record<string, TaskEntity[]> = {
+  alpha: [task('task-alpha', 'alpha')],
+  beta: [task('task-beta', 'beta')],
+};
+
+const collectionsByProject: Record<string, Collection[]> = {
+  alpha: [{ id: 'collection-alpha', projectId: 'alpha', label: 'Alpha', color: '#111111', sortOrder: 0 }],
+  beta: [{ id: 'collection-beta', projectId: 'beta', label: 'Beta', color: '#222222', sortOrder: 0 }],
+};
+
+test('all-projects scope exposes every project without treating the sentinel as a project id', () => {
+  const scope = resolveKanbanScope(ALL_PROJECTS_SENTINEL, projects);
+  assert.deepEqual(scope, {
+    kind: 'all-projects',
+    projectIds: ['alpha', 'beta'],
+  });
+
+  const data = collectKanbanScopeData(scope, projects, tasksByProject, collectionsByProject);
+  assert.deepEqual(data.projects.map((item) => item.encodedDir), ['alpha', 'beta']);
+  assert.deepEqual(data.sessions.map((item) => item.id), ['chat-alpha', 'chat-beta']);
+  assert.deepEqual(data.tasks.map((item) => item.id), ['task-alpha', 'task-beta']);
+  assert.deepEqual(Object.keys(data.collectionsByProject), ['alpha', 'beta']);
+});
+
+test('single-project scope keeps sessions, tasks, and collections project-local', () => {
+  const scope = resolveKanbanScope('beta', projects);
+  assert.deepEqual(scope, { kind: 'project', projectId: 'beta' });
+
+  const data = collectKanbanScopeData(scope, projects, tasksByProject, collectionsByProject);
+  assert.deepEqual(data.projects.map((item) => item.encodedDir), ['beta']);
+  assert.deepEqual(data.sessions.map((item) => item.id), ['chat-beta']);
+  assert.deepEqual(data.tasks.map((item) => item.id), ['task-beta']);
+  assert.deepEqual(Object.keys(data.collectionsByProject), ['beta']);
+});
+

--- a/tests/kanban-collection-menu-contract.test.mjs
+++ b/tests/kanban-collection-menu-contract.test.mjs
@@ -14,14 +14,14 @@ const collectionMoveSubmenuSource = fs.readFileSync(
 test('kanban cards render the Other collection label for uncategorized cards', () => {
   assert.match(
     kanbanCardSource,
-    /function CollectionLabel\(\{ collectionId, isActive \}: \{ collectionId\?: string \| null;/,
+    /function CollectionLabel\(\{[\s\S]*collectionId,[\s\S]*projectId,[\s\S]*isActive,[\s\S]*collectionId\?: string \| null;[\s\S]*projectId: string;/,
   );
   assert.match(
     kanbanCardSource,
     /const label = collectionId \? config\?\.label : t\('task\.creation\.noCollection'\);/,
   );
-  assert.match(kanbanCardSource, /<CollectionLabel collectionId=\{session\.collectionId\}/);
-  assert.match(kanbanCardSource, /<CollectionLabel collectionId=\{task\.collectionId\}/);
+  assert.match(kanbanCardSource, /collectionId=\{session\.collectionId\}[\s\S]*projectId=\{session\.projectDir\}/);
+  assert.match(kanbanCardSource, /collectionId=\{task\.collectionId\}[\s\S]*projectId=\{task\.projectId\}/);
 });
 
 test('collection move submenu tolerates cursor travel from trigger to submenu', () => {

--- a/tests/kanban-cross-project-dnd-feedback-contract.test.mjs
+++ b/tests/kanban-cross-project-dnd-feedback-contract.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const boardSource = readFileSync('src/components/board/kanban-board.tsx', 'utf8');
+const columnSource = readFileSync('src/components/board/kanban-column.tsx', 'utf8');
+
+test('cross-project chat card positions show the native forbidden drop indicator', () => {
+  assert.match(
+    boardSource,
+    /draggingSession\.projectDir !== targetSession\.projectDir[\s\S]*?e\.preventDefault\(\);[\s\S]*?e\.stopPropagation\(\);[\s\S]*?e\.dataTransfer\.dropEffect = 'none';/,
+  );
+});
+
+test('cross-project task card positions show the native forbidden drop indicator', () => {
+  assert.match(
+    columnSource,
+    /draggingTask\.projectId !== targetTask\.projectId[\s\S]*?e\.preventDefault\(\);[\s\S]*?e\.stopPropagation\(\);[\s\S]*?e\.dataTransfer\.dropEffect = 'none';/,
+  );
+});

--- a/tests/kanban-project-header-create-contract.test.mjs
+++ b/tests/kanban-project-header-create-contract.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const boardSource = readFileSync(
+  new URL('../src/components/board/kanban-board.tsx', import.meta.url),
+  'utf8',
+);
+const columnSource = readFileSync(
+  new URL('../src/components/board/kanban-column.tsx', import.meta.url),
+  'utf8',
+);
+
+test('all-projects kanban exposes quick create from project headers', () => {
+  assert.equal(boardSource.match(/groupByProject=\{isAllProjects\}/g)?.length, 2);
+  assert.match(columnSource, /testId=\{`kanban-project-add-\$\{column\}-\$\{project\.encodedDir\}`\}/);
+  assert.match(columnSource, /projectDir=\{project\.decodedPath\}/);
+  assert.match(columnSource, /projectId=\{project\.encodedDir\}/);
+});
+
+test('single-project kanban keeps quick create in column headers', () => {
+  assert.equal(columnSource.match(/!groupByProject && \(/g)?.length, 2);
+  assert.match(columnSource, /testId="kanban-column-add-btn"/);
+  assert.match(columnSource, /testId="kanban-workflow-column-add-btn"/);
+});
+
+test('project headers remain available as create targets when their column is empty', () => {
+  assert.doesNotMatch(
+    columnSource,
+    /\.filter\(\(group\) => group\.chats\.length > 0\)/,
+  );
+  assert.doesNotMatch(
+    columnSource,
+    /\.filter\(\(group\) => group\.tasks\.length \+ group\.chats\.length > 0\)/,
+  );
+});


### PR DESCRIPTION
## Summary

- add an all-projects Kanban scope with per-project grouping
- add portfolio filtering and project-level create actions
- prevent invalid cross-project drag and drop with clear cursor feedback
- preserve separate board view preferences for individual projects and the all-projects view

## Impact

Users can manage sessions and tasks across projects from one Kanban board without accidentally moving work between project boundaries.

## Validation

- 10 focused Kanban tests
- ESLint on the changed board and store modules
- `npx tsc --noEmit`
- `git diff --check origin/dev...HEAD`