### PR TITLE
feat: surface chat session status in workspace lists

### DIFF
--- a/src/app/api/sessions/projects/[encodedDir]/route.ts
+++ b/src/app/api/sessions/projects/[encodedDir]/route.ts
@@ -76,17 +76,20 @@ export async function GET(
       lastModified: maxActivityTimestamp(row.updated_at, getSessionHistoryModifiedAt(row.id)),
       ...(runtimeConfigs.get(row.id) ?? {}),
     }));
-    // Diff badge is only meaningful for sessions bound to a worktree branch.
+    // Diff badge shows for any session whose work dir is a git worktree —
+    // standalone chats included, not just worktree-branch-bound sessions. A
+    // chat created inside a worktree directory has a workDir but no
+    // worktreeBranch, yet still produces a real diff. computeWorktreeDiffStats
+    // returns null for non-git paths, so this stays safe for plain dirs.
     const diffStatsByWorkDir = getCachedOrScheduleBulk(
-      mapped.map((s) => (s.worktreeBranch ? s.workDir : undefined)),
+      mapped.map((s) => s.workDir ?? undefined),
       userId,
     );
     const sessions = mapped.map((s) => ({
       ...s,
-      diffStats:
-        s.worktreeBranch && s.workDir
-          ? diffStatsByWorkDir.get(s.workDir) ?? undefined
-          : undefined,
+      diffStats: s.workDir
+        ? diffStatsByWorkDir.get(s.workDir) ?? undefined
+        : undefined,
     }));
 
     const hasMore = result.nextCursor !== null;

--- a/src/app/api/sessions/projects/route.ts
+++ b/src/app/api/sessions/projects/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/projects/current-project';
 import logger from '@/lib/logger';
 import { getSessionHistoryModifiedAt } from '@/lib/session-history';
+import { getCachedOrScheduleBulk } from '@/lib/git/worktree-diff-stats-bulk';
 
 function maxActivityTimestamp(left: string, right: string | null): string {
   if (!right) return left;
@@ -70,11 +71,23 @@ export async function GET(req: NextRequest) {
     const projectResults = projects.map((project) => {
       const result = dbSessions.getSessionsByProjectGrouped(project.id, { limitPerStatus });
 
-      const sessions = result.sessions.map((row) => ({
+      const mapped = result.sessions.map((row) => ({
         ...dbSessions.mapSessionRowToApi(row, activeSessionIds, generatingSessionIds),
         lastModified: maxActivityTimestamp(row.updated_at, getSessionHistoryModifiedAt(row.id)),
         ...(runtimeConfigs.get(row.id) ?? {}),
         sortOrder: row.sort_order,
+      }));
+      // Diff badge for any session whose work dir is a git worktree (standalone
+      // chats included). Cache-miss workDirs schedule a compute + WS push.
+      const diffStatsByWorkDir = getCachedOrScheduleBulk(
+        mapped.map((s) => s.workDir ?? undefined),
+        userId,
+      );
+      const sessions = mapped.map((s) => ({
+        ...s,
+        diffStats: s.workDir
+          ? diffStatsByWorkDir.get(s.workDir) ?? undefined
+          : undefined,
       }));
 
       return {

--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -319,17 +319,34 @@ export const KanbanChatCard = memo(function KanbanChatCard({
       >
         {/* Main row: icon + content */}
         <div className="flex items-start gap-2.5">
-          {/* Provider mark with Discord-style status overlay */}
-          <span className="relative mt-[3px] flex h-3.5 w-3.5 shrink-0 items-center justify-center">
-            {showProviderIcons ? (
-              <ProviderLogoMark
-                providerId={session.provider}
-                className={KANBAN_PROVIDER_MARK_CLASS}
-                iconClassName={KANBAN_PROVIDER_ICON_CLASS}
-                data-testid={`kanban-chat-agent-icon-${session.id}`}
-              />
-            ) : (
-              workflowColor && workflowIconFill ? (
+          {/* Provider mark aligns with the first title line; the chat bubble sits
+              one text line below it, mirroring the worktree card's branch icon. */}
+          <span className="mt-[3px] flex flex-col shrink-0 items-center gap-[5px]">
+            {showProviderIcons && (
+              <span className="relative flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+                <ProviderLogoMark
+                  providerId={session.provider}
+                  className={KANBAN_PROVIDER_MARK_CLASS}
+                  iconClassName={KANBAN_PROVIDER_ICON_CLASS}
+                  data-testid={`kanban-chat-agent-icon-${session.id}`}
+                />
+                <ItemStatusIndicator
+                  isProcessing={isProcessing}
+                  isAwaitingUser={isAwaitingUser}
+                  hasUnread={hasUnread}
+                  isRunning={session.isRunning}
+                  placement="corner"
+                  surface="board"
+                />
+              </span>
+            )}
+            <span
+              className={cn(
+                'relative flex h-3.5 w-3.5 shrink-0 items-center justify-center',
+                showProviderIcons && 'translate-y-[1px]',
+              )}
+            >
+              {workflowColor && workflowIconFill ? (
                 <WorkflowMessageSquareIcon
                   className="h-3.5 w-3.5 opacity-95"
                   style={{ color: workflowColor }}
@@ -344,16 +361,18 @@ export const KanbanChatCard = memo(function KanbanChatCard({
                   )}
                   data-testid={`kanban-chat-bubble-${session.id}`}
                 />
-              )
-            )}
-            <ItemStatusIndicator
-              isProcessing={isProcessing}
-              isAwaitingUser={isAwaitingUser}
-              hasUnread={hasUnread}
-              isRunning={session.isRunning}
-              placement="corner"
-              surface="board"
-            />
+              )}
+              {!showProviderIcons && (
+                <ItemStatusIndicator
+                  isProcessing={isProcessing}
+                  isAwaitingUser={isAwaitingUser}
+                  hasUnread={hasUnread}
+                  isRunning={session.isRunning}
+                  placement="corner"
+                  surface="board"
+                />
+              )}
+            </span>
           </span>
 
           {/* Content */}
@@ -941,14 +960,9 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                   <span
                     title={prMismatchReason ?? undefined}
                     aria-label={prMismatchReason ?? undefined}
-                    className="absolute -bottom-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-(--board-card-bg) cursor-help"
+                    className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-(--status-error-text) ring-1 ring-(--board-card-bg) cursor-help"
                     data-testid="task-pr-mismatch-badge"
-                  >
-                    <TriangleAlert
-                      className="h-full w-full text-(--status-warning-text)"
-                      strokeWidth={2.5}
-                    />
-                  </span>
+                  />
                 )}
               </span>
             ) : null}
@@ -956,13 +970,10 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                 <span
                   title={prMismatchReason ?? undefined}
                   aria-label={prMismatchReason ?? undefined}
-                  className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full bg-(--board-card-bg) cursor-help"
+                  className="flex h-3.5 w-3.5 shrink-0 items-center justify-center cursor-help"
                   data-testid="task-pr-mismatch-badge"
                 >
-                  <TriangleAlert
-                    className="h-full w-full text-(--status-warning-text)"
-                    strokeWidth={2.5}
-                  />
+                  <span className="h-1.5 w-1.5 rounded-full bg-(--status-error-text)" />
                 </span>
             )}
           </span>

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -867,14 +867,9 @@ export function TaskItemRow({
             <span
               title={reason}
               aria-label={reason}
-              className="absolute -bottom-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-(--sidebar-bg) cursor-help"
+              className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-(--status-error-text) ring-1 ring-(--sidebar-bg) cursor-help"
               data-testid="task-pr-mismatch-badge"
-            >
-              <TriangleAlert
-                className="h-full w-full text-(--status-warning-text)"
-                strokeWidth={2.5}
-              />
-            </span>
+            />
           );
         })()}
         {task.worktreeMissing && (

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -1186,6 +1186,14 @@ export function ChatItemRow({
   const workflowIconFill = workflowStatus
     ? CHAT_WORKFLOW_ICON_FILL[workflowStatus]
     : null;
+  // Trailing badges mirror the worktree row's trailing group. The diff badge
+  // shows whenever the chat has worktree diff stats — provider icons on or off.
+  // With provider icons on, the leading slot holds the provider logo, so the
+  // chat bubble rides the trailing edge — ALWAYS shown for chats (colored by
+  // status when set, neutral gray when the chat has no status). Provider-off
+  // rows already carry the bubble in the leading slot instead.
+  const showTrailingDiff = !!session.diffStats && session.diffStats.changedFiles > 0;
+  const showTrailingBubble = showProviderIcons;
   const hasUnread = !isActive && (session.unreadCount ?? 0) > 0;
   const moreButtonRef = useRef<HTMLButtonElement>(null);
   const {
@@ -1336,6 +1344,36 @@ export function ChatItemRow({
             </span>
           )}
         </div>
+
+        {/* Trailing group mirrors the worktree row: diff first, then a status-
+            colored chat bubble. Diff shows regardless of provider icons; the
+            bubble only when the provider logo holds the leading slot. Hidden on
+            hover so the quick-action buttons show. */}
+        {!isRenaming && (showTrailingDiff || showTrailingBubble) && (
+          <span
+            className={cn(
+              'flex shrink-0 items-center gap-1.5 transition-opacity duration-150',
+              isHovered ? 'opacity-0' : 'opacity-100',
+            )}
+          >
+            <DiffStatsBadge stats={session.diffStats} />
+            {showTrailingBubble && (
+              workflowColor && workflowIconFill ? (
+                <WorkflowMessageSquareIcon
+                  className="h-3.5 w-3.5 opacity-95"
+                  style={{ color: workflowColor }}
+                  fillColor={workflowIconFill}
+                  testId={`collection-chat-status-bubble-${session.id}`}
+                />
+              ) : (
+                <MessageSquare
+                  className="h-3.5 w-3.5 text-(--text-secondary) opacity-80"
+                  data-testid={`collection-chat-status-bubble-${session.id}`}
+                />
+              )
+            )}
+          </span>
+        )}
 
         <div
           className={cn(

--- a/src/lib/git/session-diff-refresh.ts
+++ b/src/lib/git/session-diff-refresh.ts
@@ -8,7 +8,12 @@ import { flushRecompute } from './worktree-diff-stats-cache';
 
 export function getManagedSessionWorkDir(sessionId: string): string | null {
   const session = dbSessions.getSession(sessionId);
-  if (!session?.work_dir || !session.worktree_branch) return null;
+  // Any session with a work_dir gets live diff recompute (file-watch +
+  // per-tool + turn-end), not just worktree-branch-bound ones. Standalone
+  // chats working inside a git worktree keep their diff badge up to date the
+  // same way. computeWorktreeDiffStats returns null for non-git dirs, so this
+  // is safe for plain work_dirs.
+  if (!session?.work_dir) return null;
   return session.work_dir;
 }
 
@@ -38,7 +43,7 @@ export async function refreshSessionDiffState(
     }
   }
 
-  if (session.work_dir && session.worktree_branch) {
+  if (session.work_dir) {
     await runOperation(
       'worktree_diff_stats',
       flushRecompute(session.work_dir, userId),

--- a/src/lib/git/worktree-diff-stats-broadcast.ts
+++ b/src/lib/git/worktree-diff-stats-broadcast.ts
@@ -14,12 +14,11 @@ let unsubscribe: (() => void) | null = null;
 export function installDiffStatsBroadcast(): void {
   if (unsubscribe) return;
   unsubscribe = subscribeDiffStats((workDir, stats, userIds, previousStats) => {
-    // Only propagate stats to sessions/tasks that are actually bound to a
-    // worktree branch. Plain chats that happen to share a workDir should
-    // never show a diff badge.
-    const rows = dbSessions
-      .getSessionsByWorkDir(workDir)
-      .filter((r) => typeof r.worktree_branch === 'string' && r.worktree_branch.length > 0);
+    // Propagate stats to every session sharing this workDir — standalone chats
+    // included, not just worktree-branch-bound sessions. A chat working inside a
+    // git worktree produces a real diff and should show the badge too. Task
+    // auto-promotion below still keys off task_id, so it stays task-only.
+    const rows = dbSessions.getSessionsByWorkDir(workDir);
     if (rows.length === 0) return;
     const sessionIds = rows.map((r) => r.id);
     const taskIds = Array.from(


### PR DESCRIPTION
## Summary

- include chat-session diff statistics in project session responses
- refresh chat-session diffs through the same path used by worktree sessions
- show diff and status indicators in collection rows
- stack the chat workflow icon beneath provider marks on Kanban cards
- use a compact error dot for pull-request status mismatches

## Impact

Chat sessions now expose their working-tree activity consistently in the sidebar and board, while keeping provider and workflow identity visible together.

## Validation

- 6 focused provider-icon and Kanban contract tests
- ESLint on all changed modules
- `npx tsc --noEmit`
- `git diff --check origin/dev...HEAD`