### PR TITLE
feat: generate immediate session titles and support tab renaming

### DIFF
--- a/docs/research/orca-title-generation.md
+++ b/docs/research/orca-title-generation.md
@@ -1,0 +1,132 @@
+# Orca title generation research
+
+Checked against the official [`stablyai/orca`](https://github.com/stablyai/orca) repository at commit [`67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98`](https://github.com/stablyai/orca/commit/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98) on 2026-07-14.
+
+## Conclusion
+
+Orca has two separate naming systems that are easy to conflate:
+
+1. **Agent terminal tab/session title:** deterministic, local string processing with **no LLM call**. It is currently **opt-in and off by default**. There is no second, LLM-backed tab-title option in the current source.
+2. **New workspace / branch auto-rename:** LLM-backed generation through a configured agent CLI. It is **on by default**, starts on the first live `working` event with a prompt, and may take up to 60 seconds. For a folder workspace this generated branch slug is also used to create the workspace/sidebar display name.
+
+For a Tessera-style conversation/session title, Orca's first system is the relevant comparison. The user's proposed design is therefore close to Orca's implementation strategy, but not to its current defaults: Orca has the fast deterministic implementation, yet keeps it off by default and offers no LLM refinement mode for tab titles.
+
+### Local installed Orca check
+
+The installed `/Applications/Orca.app` is version `1.4.137`. Its unpacked production artifact at `/Applications/Orca.app/Contents/Resources/app.asar.unpacked/out/shared/agent-tab-title.js` contains the same synchronous `deriveGeneratedTabTitle` implementation, including the 512-character scan limit and 40-character output cap (lines 3–110). This confirms the heuristic is shipped behavior, not only unbuilt repository code.
+
+This machine's persisted Orca profile has both features enabled:
+
+- `~/Library/Application Support/orca/profiles/local-default/orca-data.json`: `autoRenameBranchFromWork: true` at line 153 and `tabAutoGenerateTitle: true` at line 336.
+- The legacy/root `~/Library/Application Support/orca/orca-data.json` also has the two values set to `true` at lines 97 and 266.
+
+These are **current per-user values**, not product defaults. The upstream default remains `tabAutoGenerateTitle: false` and `autoRenameBranchFromWork: true`, as documented below. Thus this user's observed Orca behavior can look like fast auto-title is “the default” even though it was enabled in the saved profile.
+
+## 1. Agent terminal tab/session titles
+
+### Default and setting
+
+- The setting is `tabAutoGenerateTitle`; its default is `false`. The type comment says generated titles are subjective, so they remain opt-in and manual renames represent stronger intent. [Default setting](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/constants.ts#L341-L347), [type rationale](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/types.ts#L2862-L2867)
+- Settings exposes a single switch labelled “Auto-generate tab titles.” Its description explicitly says it derives a short stable tab name from the first known agent prompt and manual renames win. [Settings UI](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/components/settings/AgentsPane.tsx#L985-L1004), [copy](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/components/settings/agent-generated-tab-title-copy.ts#L9-L17)
+- The implementing PR describes the behavior as “deterministically from the first known agent prompt, with no model call.” [PR #3224](https://github.com/stablyai/orca/pull/3224)
+- A source search finds no `titleModel`, tab-title model selector, or LLM execution path connected to `tabAutoGenerateTitle`. The only call from title state to generation is the pure `deriveGeneratedTabTitle(prompt)` function. [Write path](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/store/slices/terminals.ts#L1583-L1609)
+
+### Exact timing
+
+The normal local Codex/Claude path is:
+
+```text
+agent emits UserPromptSubmit hook
+  -> main normalizes/caches it as a working status with prompt
+  -> main immediately sends agentStatus:set IPC
+  -> renderer calls setAgentStatus(...)
+  -> after that state write, renderer calls setGeneratedTabTitleFromAgentPrompt(...)
+  -> deriveGeneratedTabTitle(prompt) runs synchronously
+  -> generated title is written to tab state
+```
+
+- Hook prompt extraction reads the provider's `prompt`, `user_prompt`, `userPrompt`, and related fields and trims it. [Prompt extraction](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/agent-hook-listener.ts#L394-L431)
+- The main process records the status and invokes its listener directly, with no completion wait. [Status apply](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/main/agent-hooks/server.ts#L815-L830)
+- The listener forwards `agentStatus:set` immediately to the renderer. [Main IPC](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/main/index.ts#L1025-L1057)
+- Renderer IPC calls `setAgentStatus`. [Renderer IPC](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/hooks/useIpcEvents.ts#L3103-L3125)
+- `setAgentStatus` retains the current status entry and then immediately calls `setGeneratedTabTitleFromAgentPrompt`; it does not require `done` or an assistant response. [Trigger after status update](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/store/slices/agent-status.ts#L1563-L1607)
+- Agent launch paths that already know a prompt can seed a `working` status even earlier; Command Code has explicit seed paths because it lacks a prompt-start hook. [Initial launch status](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/components/terminal-pane/pty-connection.ts#L2551-L2574), [Command Code seed](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/lib/command-code-prompt-status-seed.ts#L4-L23)
+
+Consequently, the title calculation itself has no network/process latency, timeout, retry, or post-response wait. Any delay is limited to when the agent/provider exposes the first prompt status event.
+
+### Deterministic algorithm
+
+`deriveGeneratedTabTitle`:
+
+- scans at most the first 512 prompt characters;
+- takes the first sentence/clause;
+- strips URLs, Markdown punctuation, emoji/special characters, and common filler prefixes such as “please” and “can you”;
+- preserves Unicode letters and numbers;
+- promotes issue/PR/MR/ticket identifiers when present;
+- capitalizes the result and truncates it to at most 40 characters, preferring a word boundary;
+- returns `null` when no useful text remains.
+
+[Algorithm and limits](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/agent-tab-title.ts#L7-L128), [examples and empty-input behavior](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/agent-tab-title.test.ts#L12-L111)
+
+The title is normally first-write-wins: if a generated title already exists, later prompts do not replace it. An exception allows matching Orca orchestration metadata to upgrade a dispatched worker's raw prompt-derived title to the task/display label. [Write guards](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/store/slices/terminals.ts#L1583-L1634), [orchestration replacement](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/store/slices/agent-status.ts#L1563-L1607)
+
+### Priority and fallback
+
+Visible terminal-tab title priority is:
+
+```text
+manual custom title
+  > quick-command label
+  > generated title, only when setting is enabled
+  > live PTY/agent title
+  > caller fallback
+```
+
+[Resolution function](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/tab-title-resolution.ts#L3-L28), [priority tests](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/tab-title-resolution.test.ts#L4-L75)
+
+Fallback behavior follows directly from that priority:
+
+- setting off: the live PTY/agent title remains visible;
+- algorithm returns `null`: no generated title is written, so the live title remains visible;
+- manual rename or quick-command label exists: title generation refuses to overwrite it;
+- no LLM fallback or refinement is attempted.
+
+The generated title is persisted in terminal-tab session metadata and restored during hydration. [Session schema](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/workspace-session-schema.ts#L65-L80), [hydration](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/store/slices/tabs-hydration.ts#L65-L93)
+
+## 2. Workspace/sidebar title and branch auto-rename
+
+This is a separate feature and is genuinely LLM-backed.
+
+### Default and setting
+
+- `autoRenameBranchFromWork` is `true` by default; migration logic also changes old unguarded profiles to on while preserving explicit opt-outs. [Default](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/constants.ts#L189-L198), [normalization](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/auto-rename-branch-from-work-settings.ts#L8-L20)
+- Settings describes it as renaming an Orca-generated branch after an agent starts, never overwriting a user-named branch and never renaming after push. It also exposes the branch-name command template under Advanced. [Settings UI](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx#L125-L193)
+- Source Control AI is itself on by default and follows the user's default supported agent/model unless explicitly configured. [AI defaults](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/constants.ts#L390-L405), [operation agent resolution](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/source-control-ai.ts#L1145-L1176)
+
+### Timing and generation
+
+- It fires on the first **live**, non-replay `working` event that has a prompt; it does not wait for the first turn to finish. In-flight and settled worktree sets deduplicate concurrent/later hook events. [First-work gates](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/main/agent-hooks/first-work-branch-rename.ts#L77-L148)
+- It launches the configured agent CLI through shared Source Control AI generation machinery. The prompt asks for a 2–4 word lowercase kebab-case name and can include an assistant initial response if one is already available. [Prompt](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/branch-name-from-work.ts#L94-L128), [generation call](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/main/text-generation/commit-message-text-generation.ts#L985-L1035)
+- The generation timeout is 60 seconds. [Timeout constant and enforcement](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/main/text-generation/commit-message-text-generation.ts#L57-L58), [local timeout](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/main/text-generation/commit-message-text-generation.ts#L640-L646)
+- For a non-git folder workspace, the same generated slug is humanized into the workspace/sidebar display name. [Folder workspace rename](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/main/agent-hooks/first-work-workspace-title-rename.ts#L9-L64), [display-name derivation](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/shared/display-name-from-work.ts#L56-L75)
+
+### Fallback and retry
+
+- Eligibility failures such as a user-chosen branch or an already-pushed branch are terminal skips; Orca preserves the existing name.
+- Transient failures such as unavailable agent environment, detached HEAD, or generation failure return a retry-later verdict, allowing a later live status event to try again.
+- Generation errors are stored for a visible failure badge. There is no deterministic branch/workspace-name fallback derived from the prompt; the pre-existing creature/workspace name remains until a retry succeeds or the user renames it.
+
+[Eligibility and retry semantics](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/main/agent-hooks/first-work-branch-rename.ts#L150-L266), [folder generation failure path](https://github.com/stablyai/orca/blob/67fdb1c2b929927b07bdb2bfcdb66dc15f8a6f98/src/main/agent-hooks/first-work-workspace-title-rename.ts#L22-L64)
+
+## Implication for Tessera
+
+Orca's source supports this product direction for chat/session titles:
+
+```text
+immediately show deterministic title from first user message
+  -> preserve manual rename as highest priority
+  -> optionally launch LLM refinement in background
+  -> keep deterministic title on timeout/failure
+```
+
+The first three steps are not Orca's exact tab-title implementation—Orca currently has no LLM refinement path—but they combine Orca's fast deterministic tab-title technique with a safer optional refinement layer. If Tessera adopts this, the deterministic title should be the default baseline, while LLM generation should be a separately named option rather than blocking the initial title.

--- a/src/components/settings/notification-settings.tsx
+++ b/src/components/settings/notification-settings.tsx
@@ -48,20 +48,20 @@ export default function NotificationSettings() {
 
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-0.5">
-          <label htmlFor="autoGenerateTitle" className="text-sm text-(--text-secondary)">
-            {t('settings.autoGenerateTitle')}
+          <label htmlFor="aiTitleRefinement" className="text-sm text-(--text-secondary)">
+            {t('settings.aiTitleRefinement')}
           </label>
           <span className="text-[11px] text-(--text-tertiary)">
-            {t('settings.autoGenerateTitleDesc')}
+            {t('settings.aiTitleRefinementDesc')}
           </span>
         </div>
         <input
           type="checkbox"
-          id="autoGenerateTitle"
-          checked={notifications.autoGenerateTitle ?? true}
+          id="aiTitleRefinement"
+          checked={notifications.aiTitleRefinement ?? false}
           onChange={(e) =>
             updateSettings({
-              notifications: { ...notifications, autoGenerateTitle: e.target.checked },
+              notifications: { ...notifications, aiTitleRefinement: e.target.checked },
             })
           }
           className="w-4 h-4 accent-(--accent)"

--- a/src/components/tab/tab-carousel-nav.tsx
+++ b/src/components/tab/tab-carousel-nav.tsx
@@ -24,6 +24,7 @@ const MIN_MARGIN_PX = 50;
 interface AdjacentTab {
   tabId: string;
   sessionId: string | null;
+  customTitle: string | null;
   title: string;
 }
 
@@ -47,13 +48,13 @@ function useAdjacentTabs(): { left: AdjacentTab | null; right: AdjacentTab | nul
         ? (tabData.panels[tabData.activePanelId]?.sessionId ?? null)
         : null;
       let title = t('chat.newTabDefault');
-      if (sessionId && isSpecialSession(sessionId)) {
+      if (tab.title) {
+        title = tab.title;
+      } else if (sessionId && isSpecialSession(sessionId)) {
         const titleKey = getSpecialSessionTitleKey(sessionId);
         title = titleKey ? t(titleKey) : getSpecialSessionTitle(sessionId, t) ?? t('chat.newTabDefault');
-      } else if (tab.title) {
-        title = tab.title;
       }
-      return { tabId: tab.id, sessionId, title };
+      return { tabId: tab.id, sessionId, customTitle: tab.title, title };
     };
 
     const left = activeIdx > 0 ? resolveTab(tabs[activeIdx - 1]) : null;
@@ -117,9 +118,11 @@ function useContentEdges(enabled: boolean) {
 
 const SideNavTitle = memo(function SideNavTitle({
   sessionId,
+  customTitle,
   fallbackTitle,
 }: {
   sessionId: string | null;
+  customTitle: string | null;
   fallbackTitle: string;
 }) {
   const { t } = useI18n();
@@ -131,6 +134,7 @@ const SideNavTitle = memo(function SideNavTitle({
       [sessionId],
     ),
   );
+  if (customTitle) return <>{customTitle}</>;
   if (titleKey) return <>{t(titleKey)}</>;
   if (specialTitle) return <>{specialTitle}</>;
   return <>{session?.title ?? fallbackTitle}</>;
@@ -201,7 +205,11 @@ const ContentPill = memo(function ContentPill({
           )}
         >
           <span className="text-[0.6875rem] whitespace-nowrap max-w-[140px] truncate text-(--text-secondary)">
-            <SideNavTitle sessionId={adjacent.sessionId} fallbackTitle={adjacent.title} />
+            <SideNavTitle
+              sessionId={adjacent.sessionId}
+              customTitle={adjacent.customTitle}
+              fallbackTitle={adjacent.title}
+            />
           </span>
         </div>
       </button>
@@ -283,7 +291,11 @@ const EdgeOverlay = memo(function EdgeOverlay({
             )}
           >
             <span className="text-[0.6875rem] font-medium text-(--accent)">
-              <SideNavTitle sessionId={adjacent.sessionId} fallbackTitle={adjacent.title} />
+              <SideNavTitle
+                sessionId={adjacent.sessionId}
+                customTitle={adjacent.customTitle}
+                fallbackTitle={adjacent.title}
+              />
             </span>
           </div>
         </button>

--- a/src/components/tab/tab-item.tsx
+++ b/src/components/tab/tab-item.tsx
@@ -298,15 +298,52 @@ export const TabItem = memo(function TabItem({
   const hoverActivateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const suppressClickAfterDragRef = useRef(false);
   const [isSessionDragHover, setIsSessionDragHover] = useState(false);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [titleInput, setTitleInput] = useState(displayTitle);
 
   // Event handlers — all stable references via useCallback
 
   const handleClick = useCallback(
     function handleClick() {
-      if (suppressClickAfterDragRef.current) return;
+      if (suppressClickAfterDragRef.current || isEditingTitle) return;
       onActivate(tab.id);
     },
-    [onActivate, tab.id],
+    [isEditingTitle, onActivate, tab.id],
+  );
+
+  const handleDoubleClick = useCallback(
+    function handleDoubleClick(e: React.MouseEvent) {
+      e.stopPropagation();
+      setTitleInput(displayTitle);
+      setIsEditingTitle(true);
+    },
+    [displayTitle],
+  );
+
+  const commitTitleEdit = useCallback(() => {
+    const nextTitle = titleInput.trim();
+    if (nextTitle && nextTitle !== displayTitle) {
+      useTabStore.getState().renameTab(tab.id, nextTitle);
+    }
+    setIsEditingTitle(false);
+  }, [displayTitle, tab.id, titleInput]);
+
+  const cancelTitleEdit = useCallback(() => {
+    setTitleInput(displayTitle);
+    setIsEditingTitle(false);
+  }, [displayTitle]);
+
+  const handleTitleInputKeyDown = useCallback(
+    function handleTitleInputKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        commitTitleEdit();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        cancelTitleEdit();
+      }
+    },
+    [cancelTitleEdit, commitTitleEdit],
   );
 
   const handleCloseMouseDown = useCallback(
@@ -438,7 +475,7 @@ export const TabItem = memo(function TabItem({
 
   return (
     <div
-      draggable
+      draggable={!isEditingTitle}
       role="tab"
       aria-selected={isActive}
       aria-controls={`${tab.id}-panel`}
@@ -459,6 +496,7 @@ export const TabItem = memo(function TabItem({
         isSessionDragHover && !isDragOver && 'border-b-(--accent) bg-(--accent)/10',
       )}
       onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
@@ -490,9 +528,27 @@ export const TabItem = memo(function TabItem({
       ) : null}
 
       {/* Title area — truncated with ellipsis (BR-UI-022) */}
-      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
-        {label}
-      </span>
+      {isEditingTitle ? (
+        <input
+          type="text"
+          value={titleInput}
+          onChange={(e) => setTitleInput(e.target.value)}
+          onBlur={commitTitleEdit}
+          onKeyDown={handleTitleInputKeyDown}
+          onClick={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+          onFocus={(e) => e.currentTarget.select()}
+          aria-label={t('chat.renameTab', { title: displayTitle })}
+          className="h-6 min-w-0 flex-1 rounded border border-(--input-border) bg-(--input-bg) px-1.5 text-sm font-medium text-(--text-primary) outline-none focus:ring-1 focus:ring-(--accent)"
+          data-testid="tab-title-input"
+          autoFocus
+        />
+      ) : (
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
+          {label}
+        </span>
+      )}
 
       {/* Close button — always visible (BR-UI-024) */}
       <ShortcutTooltip id="close-tab" label={t('shortcut.closeTab')}>

--- a/src/components/tab/tab-item.tsx
+++ b/src/components/tab/tab-item.tsx
@@ -207,12 +207,12 @@ export const TabItem = memo(function TabItem({
   // Derive display values
   // Active tab: use live panel-store data; inactive tab: use snapshot
   let displayTitle = t('chat.newTabDefault');
-  if (specialTitleKey) {
+  if (tab.title !== null) {
+    displayTitle = tab.title;
+  } else if (specialTitleKey) {
     displayTitle = t(specialTitleKey);
   } else if (activePanelSessionId && isSpecialSession(activePanelSessionId)) {
     displayTitle = getSpecialSessionTitle(activePanelSessionId, t) ?? displayTitle;
-  } else if (tab.title !== null) {
-    displayTitle = tab.title;
   } else if (activePanelTerminalId) {
     displayTitle = 'Terminal';
   } else if (activePanelSessionId && session) {
@@ -322,11 +322,13 @@ export const TabItem = memo(function TabItem({
 
   const commitTitleEdit = useCallback(() => {
     const nextTitle = titleInput.trim();
-    if (nextTitle && nextTitle !== displayTitle) {
+    if (!nextTitle && tab.title !== null) {
+      useTabStore.getState().renameTab(tab.id, null);
+    } else if (nextTitle && nextTitle !== displayTitle) {
       useTabStore.getState().renameTab(tab.id, nextTitle);
     }
     setIsEditingTitle(false);
-  }, [displayTitle, tab.id, titleInput]);
+  }, [displayTitle, tab.id, tab.title, titleInput]);
 
   const cancelTitleEdit = useCallback(() => {
     setTitleInput(displayTitle);
@@ -542,6 +544,7 @@ export const TabItem = memo(function TabItem({
           aria-label={t('chat.renameTab', { title: displayTitle })}
           className="h-6 min-w-0 flex-1 rounded border border-(--input-border) bg-(--input-bg) px-1.5 text-sm font-medium text-(--text-primary) outline-none focus:ring-1 focus:ring-(--accent)"
           data-testid="tab-title-input"
+          data-tab-title-editor="true"
           autoFocus
         />
       ) : (

--- a/src/lib/cli/hook-receiver.ts
+++ b/src/lib/cli/hook-receiver.ts
@@ -11,6 +11,7 @@ import { maybeAutoGenerateProtocolTitle } from './protocol-adapter-auto-title';
 import logger from '@/lib/logger';
 import { terminalManager } from '@/lib/terminal/shared-terminal-manager';
 import { refreshSessionDiffStateInBackground } from '@/lib/git/session-diff-refresh';
+import { applyImmediateSessionTitle } from '@/lib/session/immediate-session-title';
 
 const MAX_BODY_BYTES = 1_000_000;
 
@@ -141,14 +142,27 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
         markTerminalLaunched(entry.sessionId);
       }
     }
-    // 터미널 세션 AI 자동 타이틀용: 사용자 프롬프트를 Tessera session-history에 user_message로
-    // 기록한다(jsonl 원본 파싱이 아니라 hook payload.prompt 활용). generateAITitle이 이걸 읽는다.
+    // 첫 프롬프트에서 동기 로컬 제목을 즉시 적용한다. 같은 프롬프트를 history에도
+    // 기록해 사용자가 AI 개선을 켠 경우 Stop 시점의 선택적 생성 입력으로 활용한다.
     if (event === 'UserPromptSubmit' && entry.sessionId) {
       const prompt = readString(payload.prompt);
-      if (prompt) sessionHistory.recordUserMessage(entry.sessionId, prompt);
+      if (prompt) {
+        sessionHistory.recordUserMessage(entry.sessionId, prompt);
+        const titleUpdate = applyImmediateSessionTitle(entry.sessionId, prompt);
+        if (titleUpdate) {
+          wsServer.sendToUser(entry.userId, {
+            type: 'session_title_updated',
+            sessionId: entry.sessionId,
+            title: titleUpdate.title,
+            previousTitle: titleUpdate.previousTitle,
+            hasCustomTitle: false,
+            silent: true,
+          });
+        }
+      }
     }
-    // 턴 종료(Stop) 시 자동 타이틀 1회 — headless의 result 트리거는 터미널 세션엔 오지 않으므로
-    // 여기서 발화한다(커스텀 타이틀 없고 미발화일 때만; maybeAutoGenerateProtocolTitle 내부 가드).
+    // 턴 종료(Stop) 시 선택적 AI 제목 개선 — headless의 result 트리거는 터미널
+    // 세션엔 오지 않으므로 여기서 발화한다. 설정/중복 여부는 내부에서 확인한다.
     if (event === 'Stop' && entry.sessionId) {
       refreshSessionDiffStateInBackground(entry.sessionId, entry.userId, 'terminal Stop hook');
       maybeAutoGenerateProtocolTitle({

--- a/src/lib/cli/process-manager-message-dispatch.ts
+++ b/src/lib/cli/process-manager-message-dispatch.ts
@@ -167,9 +167,9 @@ export function applyManagedParsedMessageSideEffect({
       }
       return;
     case 'auto_generate_title':
-      // Fired on every successful turn completion (all providers). Auto-title
-      // self-gates to once-per-session; output translation gates on its own
-      // settings + per-message dedup.
+      // Fired on every successful turn completion (all providers). Optional AI
+      // refinement self-gates to once per session; output translation gates on
+      // its own settings and per-message deduplication.
       autoGenerateTitle(sessionId, userId);
       translateAssistantMessage(sessionId, userId);
       return;

--- a/src/lib/cli/protocol-adapter-auto-title.ts
+++ b/src/lib/cli/protocol-adapter-auto-title.ts
@@ -32,7 +32,7 @@ export function maybeAutoGenerateProtocolTitle({
       }
 
       const settings = await SettingsManager.load(userId);
-      if (settings.notifications?.autoGenerateTitle === false) {
+      if (!settings.notifications?.aiTitleRefinement) {
         autoTitleTriggered.delete(sessionId);
         return;
       }

--- a/src/lib/cli/protocol-adapter.ts
+++ b/src/lib/cli/protocol-adapter.ts
@@ -275,7 +275,7 @@ export class ProtocolAdapter {
   /**
    * Trigger background AI title generation if eligible:
    *  - Session has no custom title (has_custom_title=0)
-   *  - User has autoGenerateTitle enabled in settings
+   *  - User has AI title refinement enabled in settings
    * Fire-and-forget: errors are logged but never thrown.
    */
   maybeAutoGenerateTitle(sessionId: string, userId: string): void {

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -470,6 +470,7 @@ export const en: I18nMessages = {
     newTabDefault: 'New Tab',
     openGitPanel: 'Open right Git panel',
     closeGitPanel: 'Close right Git panel',
+    renameTab: 'Rename tab: {{title}}',
     closeTab: 'Close tab: {{title}}',
     closeOtherTabs: 'Close Other Tabs',
     closeTabsToLeft: 'Close Tabs to the Left',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -44,8 +44,8 @@ export const en: I18nMessages = {
     notifications: 'Notifications',
     sound: 'Sound',
     toast: 'Toast Notifications',
-    autoGenerateTitle: 'Auto-generate Title',
-    autoGenerateTitleDesc: 'Automatically generate AI title after first response',
+    aiTitleRefinement: 'AI title refinement',
+    aiTitleRefinementDesc: 'Replace the instant local title with an AI title after the first response',
     translate: {
       title: 'Translation',
       enabled: 'Auto-translate',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -470,6 +470,7 @@ export const ja: I18nMessages = {
     newTabDefault: '新しいタブ',
     openGitPanel: '右側の Git パネルを開く',
     closeGitPanel: '右側の Git パネルを閉じる',
+    renameTab: 'タブ名を変更: {{title}}',
     closeTab: 'タブを閉じる: {{title}}',
     closeOtherTabs: '他のタブをすべて閉じる',
     closeTabsToLeft: '左側のタブをすべて閉じる',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -44,8 +44,8 @@ export const ja: I18nMessages = {
     notifications: '通知設定',
     sound: 'サウンド',
     toast: 'トースト通知',
-    autoGenerateTitle: 'タイトル自動生成',
-    autoGenerateTitleDesc: '最初の応答後にAIタイトルを自動生成します',
+    aiTitleRefinement: 'AIによるタイトル改善',
+    aiTitleRefinementDesc: '即時生成されたローカルタイトルを最初の応答後にAIタイトルへ置き換えます',
     translate: {
       title: '翻訳',
       enabled: '自動翻訳',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -44,8 +44,8 @@ export const ko: I18nMessages = {
     notifications: '알림 설정',
     sound: '사운드',
     toast: '토스트 알림',
-    autoGenerateTitle: '타이틀 자동 생성',
-    autoGenerateTitleDesc: '첫 번째 응답 완료 후 AI 타이틀을 자동으로 생성합니다',
+    aiTitleRefinement: 'AI 제목 개선',
+    aiTitleRefinementDesc: '즉시 생성된 로컬 제목을 첫 응답 후 AI 제목으로 바꿉니다',
     translate: {
       title: '번역',
       enabled: '자동 번역',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -472,6 +472,7 @@ export const ko: I18nMessages = {
     newTabDefault: '새 탭',
     openGitPanel: '오른쪽 Git 패널 열기',
     closeGitPanel: '오른쪽 Git 패널 닫기',
+    renameTab: '탭 이름 변경: {{title}}',
     closeTab: '탭 닫기: {{title}}',
     closeOtherTabs: '다른 탭 모두 닫기',
     closeTabsToLeft: '왼쪽 탭 모두 닫기',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -464,6 +464,7 @@ export interface I18nMessages {
     newTabDefault: string;
     openGitPanel: string;
     closeGitPanel: string;
+    renameTab: string;
     closeTab: string;
     closeOtherTabs: string;
     closeTabsToLeft: string;

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -36,8 +36,8 @@ export interface I18nMessages {
     notifications: string;
     sound: string;
     toast: string;
-    autoGenerateTitle: string;
-    autoGenerateTitleDesc: string;
+    aiTitleRefinement: string;
+    aiTitleRefinementDesc: string;
     translate: {
       title: string;
       enabled: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -470,6 +470,7 @@ export const zh: I18nMessages = {
     newTabDefault: '新标签',
     openGitPanel: '打开右侧 Git 面板',
     closeGitPanel: '关闭右侧 Git 面板',
+    renameTab: '重命名标签: {{title}}',
     closeTab: '关闭标签: {{title}}',
     closeOtherTabs: '关闭其他标签',
     closeTabsToLeft: '关闭左侧标签',

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -44,8 +44,8 @@ export const zh: I18nMessages = {
     notifications: '通知设置',
     sound: '声音',
     toast: '提示通知',
-    autoGenerateTitle: '自动生成标题',
-    autoGenerateTitleDesc: '首次回复后自动生成AI标题',
+    aiTitleRefinement: 'AI 标题优化',
+    aiTitleRefinementDesc: '首次回复后，用 AI 标题替换即时生成的本地标题',
     translate: {
       title: '翻译',
       enabled: '自动翻译',

--- a/src/lib/session/focus-session-panel.ts
+++ b/src/lib/session/focus-session-panel.ts
@@ -16,6 +16,7 @@ function queryPanelElement(panelId: string): HTMLElement | null {
 function focusPanelControlNow(panelId: string): void {
   const panelEl = queryPanelElement(panelId);
   if (!panelEl || panelEl.dataset.active !== 'true') return;
+  if (document.activeElement?.getAttribute('data-tab-title-editor') === 'true') return;
 
   const prompt = panelEl.querySelector<HTMLElement>('[data-interactive-prompt]');
   if (prompt) {

--- a/src/lib/session/immediate-session-title.ts
+++ b/src/lib/session/immediate-session-title.ts
@@ -1,0 +1,54 @@
+import * as dbSessions from '@/lib/db/sessions';
+import logger from '@/lib/logger';
+import { syncSingleSessionTaskTitleFromSession } from '@/lib/task-title-sync';
+import { generateSessionTitle } from './title-generator';
+
+const PLACEHOLDER_TITLES = new Set([
+  'New Task',
+  '새 태스크',
+  '新しいタスク',
+  '新建任务',
+]);
+
+export interface ImmediateSessionTitleUpdate {
+  previousTitle: string;
+  title: string;
+}
+
+function isPlaceholderTitle(title: string): boolean {
+  const normalized = title.trim();
+  return /^Session \d+$/u.test(normalized) || PLACEHOLDER_TITLES.has(normalized);
+}
+
+/**
+ * Replace an untouched placeholder using the synchronous local title generator.
+ * Manual and already-generated titles always take precedence.
+ */
+export function applyImmediateSessionTitle(
+  sessionId: string,
+  prompt: string,
+): ImmediateSessionTitleUpdate | null {
+  try {
+    const session = dbSessions.getSession(sessionId);
+    if (
+      !session
+      || session.has_custom_title
+      || !isPlaceholderTitle(session.title)
+    ) {
+      return null;
+    }
+
+    const title = generateSessionTitle(prompt);
+    if (!title) {
+      return null;
+    }
+
+    const previousTitle = session.title;
+    dbSessions.updateSession(sessionId, { title }, { skipTimestamp: true });
+    syncSingleSessionTaskTitleFromSession(sessionId, title);
+    return { previousTitle, title };
+  } catch (error) {
+    logger.warn({ sessionId, error }, 'Failed to apply immediate session title');
+    return null;
+  }
+}

--- a/src/lib/session/title-generator.ts
+++ b/src/lib/session/title-generator.ts
@@ -1,34 +1,34 @@
 /**
  * Session Title Generator
  *
- * Generates human-readable session titles from first user message.
+ * Generates concise, deterministic session titles from the first user message.
+ * This path must stay synchronous so a useful title appears as soon as a prompt
+ * is sent, without waiting for a provider or model response.
  */
+
+const TITLE_SCAN_LIMIT = 512;
+const TITLE_MAX_LENGTH = 40;
+
+const PROMPT_FILLER_PATTERNS = [
+  /^(?:can|could|would|will) you (?:please )?/iu,
+  /^please\s+/iu,
+  /^help me(?:\s+to)?\s+/iu,
+  /^i (?:want|need) you to\s+/iu,
+];
 
 /**
- * Generate a session title from a user message
+ * Generate a session title from a user message.
  *
- * Rules:
- * - If message starts with "!", use command as title
- * - Otherwise, use first line of message (full length — UI handles overflow via CSS)
- * - Sanitize special characters (command path only)
- *
- * @param message - User's first message
- * @returns Generated title, or empty string if message is empty
- *
- * @example
- * generateSessionTitle("!git status") // "git status"
- * generateSessionTitle("Can you help me with React?") // "Can you help me with React?"
+ * The first request clause is cleaned and capped at a word boundary. Bang
+ * commands retain their existing shortcut behavior.
  */
 export function generateSessionTitle(message: string): string {
-  // Remove leading/trailing whitespace
   const cleaned = message.trim();
 
-  // If empty, return empty string (caller will use default "Session N")
   if (!cleaned) {
     return '';
   }
 
-  // If starts with "!", extract command
   if (cleaned.startsWith('!')) {
     const commandMatch = cleaned.match(/^!(\S+)/);
     if (commandMatch) {
@@ -36,42 +36,74 @@ export function generateSessionTitle(message: string): string {
     }
   }
 
-  // Use full first line — UI layers (header, tab, kanban card, sidebar, etc.)
-  // apply CSS truncation/line-clamp so titles fit whatever width they render in.
-  return cleaned.split('\n')[0];
+  let candidate = takeCodePointPrefix(cleaned, TITLE_SCAN_LIMIT);
+
+  // Keep Markdown link labels, then remove destinations and standalone URLs.
+  candidate = candidate.replace(/\[([^\]]+)\]\([^)]+\)/gu, '$1');
+  const hadUrl = /(?:https?:\/\/|www\.)[^\s;!?]+/iu.test(candidate);
+  candidate = candidate.replace(/(?:https?:\/\/|www\.)[^\s;!?]+/giu, ' ');
+
+  // A short first clause reads more like a title than an entire prompt.
+  candidate = candidate.split(/(?:\r?\n|[!?！？]+|[。；]|[.;](?=\s|$))/u, 1)[0] ?? '';
+  candidate = candidate
+    .replace(/[*~`>#]+/gu, '')
+    .replace(/[^\p{L}\p{N}\s\-_]/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim();
+
+  for (const pattern of PROMPT_FILLER_PATTERNS) {
+    if (pattern.test(candidate)) {
+      candidate = candidate.replace(pattern, '').trim();
+      break;
+    }
+  }
+
+  if (hadUrl) {
+    candidate = candidate.replace(/\b(?:at|on|in|from|to|via|for)$/iu, '').trim();
+  }
+
+  candidate = capitalizeFirstCodePoint(candidate);
+  return truncateAtWordBoundary(candidate, TITLE_MAX_LENGTH);
+}
+
+function capitalizeFirstCodePoint(value: string): string {
+  const [first = '', ...rest] = Array.from(value);
+  return `${first.toUpperCase()}${rest.join('')}`;
+}
+
+function takeCodePointPrefix(value: string, limit: number): string {
+  let prefix = '';
+  let count = 0;
+  for (const codePoint of value) {
+    if (count >= limit) {
+      break;
+    }
+    prefix += codePoint;
+    count += 1;
+  }
+  return prefix;
+}
+
+function truncateAtWordBoundary(value: string, maxLength: number): string {
+  const codePoints = Array.from(value);
+  if (codePoints.length <= maxLength) {
+    return value;
+  }
+
+  const clipped = codePoints.slice(0, maxLength).join('');
+  const lastSpace = clipped.lastIndexOf(' ');
+  return (lastSpace > 0 ? clipped.slice(0, lastSpace) : clipped).trim();
 }
 
 /**
- * Sanitize a title by removing special characters
- *
- * Allows:
- * - Alphanumeric (a-z, A-Z, 0-9)
- * - Spaces
- * - Dashes (-)
- * - Underscores (_)
- *
- * @param title - Raw title string
- * @returns Sanitized title
- *
- * @example
- * sanitizeTitle("Hello<script>World") // "HelloscriptWorld"
- * sanitizeTitle("test-file_name") // "test-file_name"
+ * Sanitize a title by retaining Unicode letters, numbers, spaces, dashes, and
+ * underscores.
  */
 export function sanitizeTitle(title: string): string {
-  // Allow Unicode letters/digits (\p{L}, \p{N}), spaces, dashes, underscores
   return title.replace(/[^\p{L}\p{N}\s\-_]/gu, '').trim();
 }
 
-/**
- * Generate default session title with incrementing number
- *
- * @param sessionCount - Current number of sessions
- * @returns Default title like "Session 1", "Session 2", etc.
- *
- * @example
- * generateDefaultTitle(0) // "Session 1"
- * generateDefaultTitle(5) // "Session 6"
- */
+/** Generate a numbered fallback when no title can be derived. */
 export function generateDefaultTitle(sessionCount: number): string {
   return `Session ${sessionCount + 1}`;
 }

--- a/src/lib/settings/provider-defaults.ts
+++ b/src/lib/settings/provider-defaults.ts
@@ -512,7 +512,7 @@ export function normalizeUserSettings(raw: Partial<UserSettings> | null | undefi
     notifications: {
       soundEnabled: true,
       showToast: true,
-      autoGenerateTitle: true,
+      aiTitleRefinement: false,
     },
     translate: {
       enabled: false,
@@ -632,8 +632,10 @@ export function normalizeUserSettings(raw: Partial<UserSettings> | null | undefi
     windowsCloseBehavior: normalizeWindowsCloseBehavior(raw?.windowsCloseBehavior),
     profile: normalizeProfileSettings(raw?.profile, defaults.profile),
     notifications: {
-      ...defaults.notifications,
-      ...(raw?.notifications ?? {}),
+      soundEnabled: raw?.notifications?.soundEnabled ?? defaults.notifications.soundEnabled,
+      showToast: raw?.notifications?.showToast ?? defaults.notifications.showToast,
+      aiTitleRefinement:
+        raw?.notifications?.aiTitleRefinement ?? defaults.notifications.aiTitleRefinement,
     },
     translate: {
       ...defaults.translate,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -53,7 +53,8 @@ export interface UserSettings {
   notifications: {
     soundEnabled: boolean;
     showToast: boolean;
-    autoGenerateTitle: boolean;
+    /** Optional LLM replacement for the deterministic title shown immediately. */
+    aiTitleRefinement: boolean;
   };
   translate: {
     enabled: boolean;

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -505,6 +505,9 @@ function handleSessionTitleUpdatedMessage(
 
   sessionStore.updateSessionTitle(msg.sessionId, nextTitle, msg.hasCustomTitle ?? true);
   useTaskStore.getState().syncLinkedTaskTitle(msg.sessionId, nextTitle);
+  if (msg.silent) {
+    return;
+  }
   useNotificationStore.getState().showToastWithAction(
     `"${nextTitle}"`,
     'success',

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -429,6 +429,8 @@ export type AppServerMessage =
       previousTitle: string;
       /** False for a deterministic placeholder that remains eligible for AI replacement. */
       hasCustomTitle?: boolean;
+      /** Suppress rename feedback for automatic local placeholder replacement. */
+      silent?: boolean;
     }
   | {
       type: 'session_title_generation';

--- a/src/lib/ws/server-session-actions.ts
+++ b/src/lib/ws/server-session-actions.ts
@@ -6,10 +6,9 @@ import type { AskUserQuestionItem } from '@/types/cli-jsonl-schemas';
 import * as dbSessions from '../db/sessions';
 import logger from '../logger';
 import { sessionOrchestrator } from '../session/session-orchestrator';
-import { generateSessionTitle } from '../session/title-generator';
+import { applyImmediateSessionTitle } from '../session/immediate-session-title';
 import { sessionHistory } from '../session-history';
 import { persistCreatedSessionRecord } from '../session/session-persistence';
-import { syncSingleSessionTaskTitleFromSession } from '../task-title-sync';
 import { buildCodexSkillContent } from '../chat/build-codex-skill-content';
 import {
   classifyCodexSlashCommand,
@@ -58,13 +57,6 @@ const CODEX_REQUEST_USER_INPUT_TOOL_NAME = 'CodexRequestUserInput';
 const CODEX_MCP_ELICITATION_TOOL_NAME = 'CodexMcpElicitation';
 const CODEX_PERMISSIONS_REQUEST_TOOL_NAME = 'CodexPermissionsRequest';
 const LIVE_EVENT_VERSION = 1;
-
-const AUTO_TITLE_PLACEHOLDER_TITLES = new Set([
-  'New Task',
-  '새 태스크',
-  '新しいタスク',
-  '新建任务',
-]);
 
 type SessionControlRequest = Pick<
   Extract<ClientMessage, { sessionId: string }>,
@@ -422,7 +414,7 @@ async function sendSessionMessageFromWebSocketUnlocked({
     await translateOutgoingContent(content, userId, forceTranslateInput === true);
 
   sessionHistory.recordUserMessage(sessionId, resolvedDisplayContent, undefined, messageId);
-  await maybeAutoSetSessionTitle(sessionId, resolvedDisplayContent);
+  maybeAutoSetSessionTitle(sessionId, resolvedDisplayContent);
 
   // Attach the translated (sent) text to the user's message as a message_translation
   // event — resolving the optimistic "translating…" state on the client. Persisted via
@@ -966,31 +958,11 @@ export function runProcessManagerControlAction({
   logger.info({ userId, sessionId, success, ...logMetadata }, logMessage);
 }
 
-function isAutoTitlePlaceholderTitle(title: string): boolean {
-  const normalized = title.trim();
-  return normalized.startsWith('Session ') || AUTO_TITLE_PLACEHOLDER_TITLES.has(normalized);
-}
-
-async function maybeAutoSetSessionTitle(
+function maybeAutoSetSessionTitle(
   sessionId: string,
   displayContent: string | ContentBlock[],
-): Promise<void> {
+): void {
   try {
-    const dbSession = dbSessions.getSession(sessionId);
-    if (
-      !dbSession ||
-      dbSession.has_custom_title ||
-      !isAutoTitlePlaceholderTitle(dbSession.title)
-    ) {
-      return;
-    }
-
-    const events = await sessionHistory.readEvents(sessionId);
-    const userMessageCount = events.filter((event) => event.type === 'user_message').length;
-    if (userMessageCount !== 1) {
-      return;
-    }
-
     const titleText =
       typeof displayContent === 'string'
         ? displayContent
@@ -998,11 +970,7 @@ async function maybeAutoSetSessionTitle(
             .filter((block): block is TextContentBlock => block.type === 'text')
             .map((block) => block.text)
             .join(' ');
-    const autoTitle = generateSessionTitle(titleText);
-    if (autoTitle) {
-      dbSessions.updateSession(sessionId, { title: autoTitle }, { skipTimestamp: true });
-      syncSingleSessionTaskTitleFromSession(sessionId, autoTitle);
-    }
+    applyImmediateSessionTitle(sessionId, titleText);
   } catch (err) {
     logger.warn({ sessionId, error: err }, 'Failed to auto-set session title');
   }

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -734,6 +734,17 @@ export const useTabStore = create<TabStore>()((set, get) => ({
     });
   },
 
+  renameTab: (tabId: string, title: string): void => {
+    const state = get();
+    if (!state.tabs.some((tab) => tab.id === tabId)) return;
+
+    set({
+      tabs: state.tabs.map((tab): Tab =>
+        tab.id === tabId ? { ...tab, title } : tab,
+      ),
+    });
+  },
+
   syncTabProjectFromSession: (tabId: string, sessionId: string | null): void => {
     const state = get();
     const tab = state.tabs.find((item) => item.id === tabId);

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -734,13 +734,15 @@ export const useTabStore = create<TabStore>()((set, get) => ({
     });
   },
 
-  renameTab: (tabId: string, title: string): void => {
+  renameTab: (tabId: string, title: string | null): void => {
     const state = get();
     if (!state.tabs.some((tab) => tab.id === tabId)) return;
 
     set({
       tabs: state.tabs.map((tab): Tab =>
-        tab.id === tabId ? { ...tab, title } : tab,
+        tab.id === tabId
+          ? { ...tab, title, isPreview: title === null ? tab.isPreview : false }
+          : tab,
       ),
     });
   },

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -39,7 +39,7 @@ export interface TabSnapshot {
  *
  * 불변 조건:
  * - INV-TAB-01: id는 생성 후 불변
- * - INV-TAB-02: MVP에서 title은 항상 null
+ * - INV-TAB-02: title은 null이거나 사용자가 지정한 탭 이름
  *
  * 주의: 패널 상태는 panel-store.tabPanels[tab.id]에서 읽어야 함.
  * snapshot 필드는 제거됨 — panel-store가 단일 진실 공급원(SSOT).
@@ -49,7 +49,7 @@ export interface Tab {
   readonly id: string;
   /** 이 탭이 속한 프로젝트. null이면 모든 프로젝트에서 보이는 전역 탭. */
   projectDir: string | null;
-  /** 수동 지정 탭 이름. MVP에서는 항상 null (P1 기능). */
+  /** 수동 지정 탭 이름. null이면 활성 패널의 제목을 사용한다. */
   title: string | null;
   /** 프리뷰 탭 여부. 채팅 프리뷰와 파일 프리뷰는 서로 다른 슬롯으로 재사용됨. */
   isPreview: boolean;
@@ -166,6 +166,11 @@ export interface TabStoreActions {
    * 프리뷰 탭을 고정 탭으로 변환 (isPreview → false).
    */
   pinTab(tabId: string): void;
+
+  /**
+   * 탭에 수동 지정 이름을 저장한다.
+   */
+  renameTab(tabId: string, title: string): void;
 
   /**
    * 탭이 표시하는 세션을 기준으로 탭의 프로젝트 소유권을 보정.

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -168,9 +168,10 @@ export interface TabStoreActions {
   pinTab(tabId: string): void;
 
   /**
-   * 탭에 수동 지정 이름을 저장한다.
+   * 탭에 수동 지정 이름을 저장하고 프리뷰를 고정한다.
+   * null이면 파생 제목으로 되돌린다.
    */
-  renameTab(tabId: string, title: string): void;
+  renameTab(tabId: string, title: string | null): void;
 
   /**
    * 탭이 표시하는 세션을 기준으로 탭의 프로젝트 소유권을 보정.

--- a/tests/immediate-session-title.test.ts
+++ b/tests/immediate-session-title.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-immediate-title-'));
+process.env.TESSERA_DATA_DIR = dataDir;
+process.env.TESSERA_PRODUCTION_DB = '1';
+
+let applyImmediateSessionTitle:
+  typeof import('../src/lib/session/immediate-session-title')['applyImmediateSessionTitle'];
+let database: typeof import('../src/lib/db/database');
+let dbProjects: typeof import('../src/lib/db/projects');
+let dbSessions: typeof import('../src/lib/db/sessions');
+let dbTasks: typeof import('../src/lib/db/tasks');
+
+test.before(async () => {
+  database = await import('../src/lib/db/database');
+  dbProjects = await import('../src/lib/db/projects');
+  dbSessions = await import('../src/lib/db/sessions');
+  dbTasks = await import('../src/lib/db/tasks');
+  ({ applyImmediateSessionTitle } = await import('../src/lib/session/immediate-session-title'));
+
+  await database.initDatabase();
+  dbProjects.registerProject('project-title', dataDir, 'Title Project', 'codex');
+});
+
+test.after(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+test('replaces a placeholder and synchronizes its single linked task', () => {
+  dbTasks.createTask({ id: 'task-title', projectId: 'project-title', title: 'New Task' });
+  dbSessions.createSession('session-title', 'project-title', 'Session 1', 'codex', {
+    taskId: 'task-title',
+    workDir: dataDir,
+  });
+
+  const update = applyImmediateSessionTitle(
+    'session-title',
+    'Can you please fix the terminal title timing?',
+  );
+
+  assert.deepEqual(update, { previousTitle: 'Session 1', title: 'Fix the terminal title timing' });
+  assert.equal(dbSessions.getSession('session-title')?.title, 'Fix the terminal title timing');
+  assert.equal(dbSessions.getSession('session-title')?.has_custom_title, 0);
+  assert.equal(dbTasks.getTask('task-title')?.title, 'Fix the terminal title timing');
+});
+
+test('never replaces a manually chosen title', () => {
+  dbSessions.createSession('manual-title', 'project-title', 'Keep this title', 'codex');
+  dbSessions.updateSession('manual-title', { has_custom_title: 1 });
+
+  assert.equal(applyImmediateSessionTitle('manual-title', 'Please replace this'), null);
+  assert.equal(dbSessions.getSession('manual-title')?.title, 'Keep this title');
+});
+
+test('does not mistake a generated title beginning with Session for a placeholder', () => {
+  dbSessions.createSession('generated-title', 'project-title', 'Session architecture', 'codex');
+
+  assert.equal(applyImmediateSessionTitle('generated-title', 'Please replace this'), null);
+  assert.equal(dbSessions.getSession('generated-title')?.title, 'Session architecture');
+});

--- a/tests/session-activation-focus-contract.test.mjs
+++ b/tests/session-activation-focus-contract.test.mjs
@@ -34,6 +34,10 @@ test('tab clicks refocus the active panel even when the tab is already active', 
   assert.doesNotMatch(tabBar, /if \(tabId === tabStore\.activeTabId\) return/);
 });
 
+test('tab click focus restoration does not steal focus from the title editor', () => {
+  assert.match(focusHelper, /activeElement\?\.getAttribute\('data-tab-title-editor'\) === 'true'/);
+});
+
 test('session-open surfaces activate the located panel instead of only activeSessionId', () => {
   for (const source of [
     clickHandlers,

--- a/tests/session-title-generator.test.ts
+++ b/tests/session-title-generator.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { generateSessionTitle } from '@/lib/session/title-generator';
+
+test('creates a concise action title from the first request without an LLM', () => {
+  assert.equal(
+    generateSessionTitle('Can you please refactor the auth middleware to use JWT tokens?'),
+    'Refactor the auth middleware to use JWT',
+  );
+});
+
+test('keeps Unicode text while removing prompt filler and trailing punctuation', () => {
+  assert.equal(
+    generateSessionTitle('Please fix the 한국어 검색 결과 정렬 문제!!!'),
+    'Fix the 한국어 검색 결과 정렬 문제',
+  );
+});
+
+test('uses only the first clause and removes markdown and URLs', () => {
+  assert.equal(
+    generateSessionTitle('Please fix **authentication** at https://example.com/auth; then add tests'),
+    'Fix authentication',
+  );
+});
+
+test('limits generated titles to 40 code points at a word boundary', () => {
+  const title = generateSessionTitle(
+    'Implement a deterministic session title generator that works without any model calls',
+  );
+
+  assert.equal(title, 'Implement a deterministic session title');
+  assert.ok(Array.from(title).length <= 40);
+});
+
+test('keeps the existing bang-command shortcut behavior', () => {
+  assert.equal(generateSessionTitle('!git status'), 'git');
+});
+
+test('preserves generic type contents and identifier underscores', () => {
+  assert.equal(
+    generateSessionTitle('Please fix user_id and Map<string, User>'),
+    'Fix user_id and Map string User',
+  );
+});
+
+test('scans only the bounded prefix of a very large prompt', () => {
+  assert.equal(
+    generateSessionTitle(`Fix the title generator now ${'ignored '.repeat(100_000)}`),
+    'Fix the title generator now ignored',
+  );
+});
+
+test('stops at full-width sentence punctuation', () => {
+  assert.equal(generateSessionTitle('修正第一项。然后处理第二项'), '修正第一项');
+  assert.equal(generateSessionTitle('첫 번째 문제 수정！다음 문제도 수정'), '첫 번째 문제 수정');
+});

--- a/tests/tab-title-rename.test.ts
+++ b/tests/tab-title-rename.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { useTabStore } from '@/stores/tab-store';
+
+test('a tab can be given a custom title without changing its identity', () => {
+  const tab = {
+    id: 'rename-me',
+    projectDir: '/workspace',
+    title: null,
+    isPreview: false,
+  };
+
+  useTabStore.setState({
+    tabs: [tab],
+    activeTabId: tab.id,
+    lruTabIds: [tab.id],
+  });
+
+  useTabStore.getState().renameTab(tab.id, 'Release checklist');
+
+  assert.deepEqual(useTabStore.getState().tabs, [
+    { ...tab, title: 'Release checklist' },
+  ]);
+});

--- a/tests/tab-title-rename.test.ts
+++ b/tests/tab-title-rename.test.ts
@@ -23,3 +23,43 @@ test('a tab can be given a custom title without changing its identity', () => {
     { ...tab, title: 'Release checklist' },
   ]);
 });
+
+test('renaming a preview pins it before it can be reused for unrelated content', () => {
+  const tab = {
+    id: 'preview-tab',
+    projectDir: '/workspace',
+    title: null,
+    isPreview: true,
+  };
+
+  useTabStore.setState({
+    tabs: [tab],
+    activeTabId: tab.id,
+    lruTabIds: [tab.id],
+  });
+
+  useTabStore.getState().renameTab(tab.id, 'Keep this tab');
+
+  assert.deepEqual(useTabStore.getState().tabs, [
+    { ...tab, title: 'Keep this tab', isPreview: false },
+  ]);
+});
+
+test('clearing a custom title restores derived-title behavior', () => {
+  const tab = {
+    id: 'custom-tab',
+    projectDir: '/workspace',
+    title: 'Temporary name',
+    isPreview: false,
+  };
+
+  useTabStore.setState({
+    tabs: [tab],
+    activeTabId: tab.id,
+    lruTabIds: [tab.id],
+  });
+
+  useTabStore.getState().renameTab(tab.id, null);
+
+  assert.deepEqual(useTabStore.getState().tabs, [{ ...tab, title: null }]);
+});

--- a/tests/terminal-title-contract.test.mjs
+++ b/tests/terminal-title-contract.test.mjs
@@ -22,6 +22,10 @@ const generateTitleRouteSource = fs.readFileSync(
   new URL('../src/app/api/sessions/[id]/generate-title/route.ts', import.meta.url),
   'utf8',
 );
+const hookReceiverSource = fs.readFileSync(
+  new URL('../src/lib/cli/hook-receiver.ts', import.meta.url),
+  'utf8',
+);
 
 test('Claude title generation uses a title-only system prompt', () => {
   assert.match(claudeAdapterSource, /const TITLE_SYSTEM_PROMPT/);
@@ -41,4 +45,12 @@ test('automatic title fallback remains eligible for a later Stop retry', () => {
   assert.match(autoTitleSource, /catch \(error: any\) \{\s*autoTitleTriggered\.delete\(sessionId\)/);
   assert.match(clientMessageHandlersSource, /msg\.hasCustomTitle \?\? true/);
   assert.doesNotMatch(generateTitleRouteSource, /fallbackToFirstUserMessage/);
+});
+
+test('terminal prompts apply the immediate local title before the Stop event', () => {
+  assert.match(
+    hookReceiverSource,
+    /event === 'UserPromptSubmit'[\s\S]*applyImmediateSessionTitle\(entry\.sessionId, prompt\)/,
+  );
+  assert.match(hookReceiverSource, /type: 'session_title_updated'[\s\S]*silent: true/);
 });

--- a/tests/title-generation-settings.test.ts
+++ b/tests/title-generation-settings.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeUserSettings } from '@/lib/settings/provider-defaults';
+
+test('new installations use the immediate local title without AI refinement', () => {
+  assert.equal(normalizeUserSettings({}).notifications.aiTitleRefinement, false);
+});
+
+test('the old automatic-title default does not opt existing users into AI refinement', () => {
+  assert.equal(
+    normalizeUserSettings({
+      notifications: { soundEnabled: true, showToast: true, autoGenerateTitle: true },
+    } as never).notifications.aiTitleRefinement,
+    false,
+  );
+});
+
+test('AI refinement runs only after the new option is explicitly enabled', () => {
+  const settings = normalizeUserSettings({
+    notifications: { soundEnabled: true, showToast: true, aiTitleRefinement: true },
+  });
+
+  assert.equal(settings.notifications.aiTitleRefinement, true);
+});


### PR DESCRIPTION
## Summary

- generate a concise local title immediately from the first user request
- keep optional AI title refinement behind an explicit setting
- synchronize generated titles with their linked worktree item
- support inline custom tab titles and preserve them across preview reuse

## Impact

New sessions become identifiable before the first provider response, and users can pin a custom title without changing session identity.

## Validation

- 23 focused title and tab tests
- ESLint on the changed title and tab modules
- `npx tsc --noEmit`
- `git diff --check origin/dev...HEAD`