### PR TITLE
feat: refine terminal interaction and appearance

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,6 +16,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { createTray, destroyTray, updateTrayCloseBehavior } from './tray';
 import { getTesseraDataPath } from '../src/lib/tessera-data-dir';
+import { normalizeExternalHttpUrl } from '../src/lib/external-http-url';
 import { getTerminalClipboardKind, readTerminalClipboard } from './terminal-clipboard';
 
 type TitlebarMenuSection = 'file' | 'edit' | 'view' | 'window' | 'help';
@@ -1022,6 +1023,20 @@ ipcMain.on('ui-storage-set-item', (event, payload: unknown) => {
 ipcMain.on('ui-storage-remove-item', (event, key: unknown) => {
   removeUiStorageItem(key);
   event.returnValue = true;
+});
+ipcMain.handle('shell-open-external-url', async (_event, rawUrl: unknown) => {
+  const targetUrl = normalizeExternalHttpUrl(rawUrl);
+  if (!targetUrl) return { ok: false, error: 'invalid_url' };
+
+  try {
+    await shell.openExternal(targetUrl);
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 });
 ipcMain.handle('shell-open-path', async (_event, rawPath: unknown) => {
   const targetPath = resolveShellPath(rawPath);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -63,6 +63,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('open-board-window', payload),
   closeBoardPopouts: () => ipcRenderer.invoke('close-board-popouts'),
   getPopoutState: () => ipcRenderer.invoke('get-popout-state'),
+  openExternalUrl: (url: string) => ipcRenderer.invoke('shell-open-external-url', url),
   openFilePath: (path: string) => ipcRenderer.invoke('shell-open-path', path),
   revealFilePath: (path: string) => ipcRenderer.invoke('shell-show-item-in-folder', path),
   onPopoutStateChanged: (callback: (count: number) => void) => {

--- a/src/app/api/sessions/[id]/move/route.ts
+++ b/src/app/api/sessions/[id]/move/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import * as dbSessions from '@/lib/db/sessions';
 import * as dbProjects from '@/lib/db/projects';
-import { processManager } from '@/lib/cli/process-manager';
+import { getActiveSessionIds } from '@/lib/session/active-session-runtime';
 import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
@@ -21,6 +21,7 @@ export async function PATCH(
   if ('response' in auth) {
     return auth.response;
   }
+  const { userId } = auth;
 
   const { id: sessionId } = await params;
 
@@ -54,7 +55,7 @@ export async function PATCH(
   }
 
   // Block move for running sessions
-  const activeIds = processManager.getActiveSessionIds();
+  const activeIds = getActiveSessionIds(userId);
   if (activeIds.has(sessionId)) {
     return NextResponse.json(
       { error: 'Cannot move a running session. Stop it first.' },

--- a/src/app/api/sessions/projects/[encodedDir]/route.ts
+++ b/src/app/api/sessions/projects/[encodedDir]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { processManager } from '@/lib/cli/process-manager';
+import { getActiveSessionIds } from '@/lib/session/active-session-runtime';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import { validateEncodedPath } from '@/lib/validation/path';
 import * as dbProjects from '@/lib/db/projects';
@@ -63,7 +64,7 @@ export async function GET(
       );
     }
 
-    const activeSessionIds = processManager.getActiveSessionIds();
+    const activeSessionIds = getActiveSessionIds(userId);
     const generatingSessionIds = processManager.getGeneratingSessionIds();
     const runtimeConfigs = processManager.getSessionRuntimeConfigs();
 

--- a/src/app/api/sessions/projects/route.ts
+++ b/src/app/api/sessions/projects/route.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { NextRequest, NextResponse } from 'next/server';
 import { processManager } from '@/lib/cli/process-manager';
+import { getActiveSessionIds } from '@/lib/session/active-session-runtime';
 import { getAgentEnvironment } from '@/lib/cli/spawn-cli';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import * as dbProjects from '@/lib/db/projects';
@@ -40,7 +41,7 @@ export async function GET(req: NextRequest) {
     const limitPerStatus = parseInt(searchParams.get('limitPerStatus') || '100000', 10);
 
     // Get active/generating session IDs from process manager
-    const activeSessionIds = processManager.getActiveSessionIds();
+    const activeSessionIds = getActiveSessionIds(userId);
     const generatingSessionIds = processManager.getGeneratingSessionIds();
     const runtimeConfigs = processManager.getSessionRuntimeConfigs();
     const agentEnvironment = await getAgentEnvironment(userId);

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
-import { processManager } from '@/lib/cli/process-manager';
+import { getActiveSessionIds } from '@/lib/session/active-session-runtime';
 import * as dbTasks from '@/lib/db/tasks';
 import * as dbSessions from '@/lib/db/sessions';
 import { collectionExists } from '@/lib/db/collections';
@@ -31,11 +31,12 @@ export async function GET(
 ) {
   const auth = await requireAuthenticatedUserId(req);
   if ('response' in auth) return auth.response;
+  const { userId } = auth;
 
   const { id } = await params;
 
   try {
-    const activeSessionIds = processManager.getActiveSessionIds();
+    const activeSessionIds = getActiveSessionIds(userId);
     const task = dbTasks.getTask(id, activeSessionIds);
     if (!task) {
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
@@ -198,7 +199,7 @@ export async function DELETE(
 
   const { id } = await params;
 
-  const task = dbTasks.getTask(id, processManager.getActiveSessionIds());
+  const task = dbTasks.getTask(id, getActiveSessionIds());
   if (!task) {
     return NextResponse.json({ error: 'Task not found' }, { status: 404 });
   }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
-import { processManager } from '@/lib/cli/process-manager';
+import { getActiveSessionIds } from '@/lib/session/active-session-runtime';
 import * as dbTasks from '@/lib/db/tasks';
 import { collectionExists } from '@/lib/db/collections';
 import { generateTaskId } from '@/types/task-entity';
@@ -24,7 +24,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const activeSessionIds = processManager.getActiveSessionIds();
+    const activeSessionIds = getActiveSessionIds(userId);
     const rawTasks = dbTasks.getTasks(projectId, activeSessionIds);
     const worktreePresence = await Promise.all(
       rawTasks.map(async (task) => ({
@@ -110,7 +110,7 @@ export async function POST(req: NextRequest) {
       worktreeBranch: typeof worktreeBranch === 'string' ? worktreeBranch : undefined,
     });
 
-    const activeSessionIds = processManager.getActiveSessionIds();
+    const activeSessionIds = getActiveSessionIds();
     const task = dbTasks.getTask(id, activeSessionIds);
     logger.info({ taskId: id, projectId }, 'Task created via API');
     broadcastTaskMutation(auth.userId, {

--- a/src/app/dev-terminal-scroll-repro/page.tsx
+++ b/src/app/dev-terminal-scroll-repro/page.tsx
@@ -1,0 +1,10 @@
+import { notFound } from 'next/navigation';
+import { TerminalScrollReproClient } from './terminal-scroll-repro-client';
+
+export default function TerminalScrollReproPage() {
+  if (process.env.NODE_ENV !== 'development') {
+    notFound();
+  }
+
+  return <TerminalScrollReproClient />;
+}

--- a/src/app/dev-terminal-scroll-repro/terminal-scroll-repro-client.tsx
+++ b/src/app/dev-terminal-scroll-repro/terminal-scroll-repro-client.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { ScrollToBottomButton } from '@/components/ui/scroll-to-bottom-button';
+import { useIsDark } from '@/hooks/use-is-dark';
+import {
+  closeAndDisposeTerminalSurface,
+  getTerminalSurface,
+  type TerminalSurfaceSnapshot,
+} from '@/lib/terminal/terminal-surface-registry';
+import { getTerminalTheme } from '@/lib/terminal/terminal-theme';
+import { wsClient } from '@/lib/ws/client';
+import { useChatStore } from '@/stores/chat-store';
+import { useSettingsStore } from '@/stores/settings-store';
+import { getTerminalFontSize } from '@/lib/terminal/terminal-font-size';
+import { TerminalScrollbar } from '@/components/terminal/terminal-scrollbar';
+
+const REPRO_TERMINAL_ID = 'dev-terminal-scroll-repro';
+const INITIAL_SNAPSHOT: TerminalSurfaceSnapshot = {
+  status: 'starting',
+  subtitle: 'Starting terminal...',
+  isAtBottom: true,
+  scrollMetrics: { baseY: 0, viewportY: 0, rows: 1 },
+};
+
+interface ReproTerminalBuffer {
+  baseY: number;
+  viewportY: number;
+  getLine(line: number): { translateToString(trimRight?: boolean): string } | undefined;
+}
+
+interface ReproWindow extends Window {
+  __tesseraTerminalScrollRepro?: {
+    firstVisibleRowTag(): string | null;
+    isAtBottom(): boolean | null;
+    viewportY(): number | null;
+  };
+}
+
+export function TerminalScrollReproClient() {
+  const isDark = useIsDark();
+  const fontScale = useSettingsStore((state) => state.settings.fontSize);
+  const terminalFontSize = getTerminalFontSize(fontScale);
+  const connectionStatus = useChatStore((state) => state.connectionStatus);
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(true);
+  const surface = useMemo(() => getTerminalSurface({
+    registryKey: REPRO_TERMINAL_ID,
+    terminalId: REPRO_TERMINAL_ID,
+    theme: getTerminalTheme(isDark),
+    fontSize: terminalFontSize,
+    cwd: null,
+    sessionId: null,
+  }), [isDark, terminalFontSize]);
+  const snapshot = useSyncExternalStore(
+    surface.subscribe,
+    surface.getSnapshot,
+    () => INITIAL_SNAPSHOT,
+  );
+
+  useEffect(() => {
+    wsClient.connect('terminal-scroll-repro');
+  }, []);
+
+  useEffect(() => {
+    surface.setTheme(getTerminalTheme(isDark));
+  }, [isDark, surface]);
+
+  useEffect(() => {
+    surface.setFontSize(terminalFontSize);
+  }, [surface, terminalFontSize]);
+
+  useEffect(() => {
+    const reproWindow = window as ReproWindow;
+    reproWindow.__tesseraTerminalScrollRepro = {
+      firstVisibleRowTag: () => {
+        const terminal = (surface as unknown as {
+          terminal: { buffer: { active: ReproTerminalBuffer }; rows: number } | null;
+        }).terminal;
+        if (!terminal) return null;
+        const { active } = terminal.buffer;
+        for (let offset = 0; offset < terminal.rows; offset += 1) {
+          const text = active.getLine(active.viewportY + offset)?.translateToString(true) ?? '';
+          const match = text.match(/ROW_(\d{4})/);
+          if (match) return match[1];
+        }
+        return null;
+      },
+      isAtBottom: () => {
+        const active = (surface as unknown as {
+          terminal: { buffer: { active: ReproTerminalBuffer } } | null;
+        }).terminal?.buffer.active;
+        return active ? active.viewportY >= active.baseY - 1 : null;
+      },
+      viewportY: () => (
+        (surface as unknown as {
+          terminal: { buffer: { active: ReproTerminalBuffer } } | null;
+        }).terminal?.buffer.active.viewportY ?? null
+      ),
+    };
+    return () => {
+      delete reproWindow.__tesseraTerminalScrollRepro;
+    };
+  }, [surface]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!isVisible || !host) return;
+    void surface.mount(host);
+    return () => surface.unmount(host);
+  }, [isVisible, surface]);
+
+  useEffect(() => {
+    if (connectionStatus !== 'connected' || !isVisible) return;
+    void surface.ensureConnected().then((connected) => {
+      if (connected) surface.activate();
+    });
+  }, [connectionStatus, isVisible, surface]);
+
+  const theme = getTerminalTheme(isDark);
+
+  return (
+    <main className="flex h-screen flex-col bg-(--chat-bg) text-(--text-primary)">
+      <div className="flex h-12 shrink-0 items-center gap-3 border-b border-(--divider) px-4 text-xs">
+        <span data-testid="terminal-repro-status">{snapshot.status}</span>
+        <button
+          type="button"
+          className="rounded border border-(--divider) px-2 py-1"
+          data-testid="toggle-terminal-view"
+          onClick={() => setIsVisible((current) => !current)}
+        >
+          {isVisible ? 'Hide terminal' : 'Show terminal'}
+        </button>
+        <button
+          type="button"
+          className="rounded border border-(--divider) px-2 py-1"
+          data-testid="close-terminal-repro"
+          onClick={() => closeAndDisposeTerminalSurface(surface)}
+        >
+          Close terminal
+        </button>
+      </div>
+      <div
+        className="relative min-h-0 flex-1 overflow-hidden p-2"
+        data-testid="terminal-scroll-repro"
+        style={{ backgroundColor: theme.background, color: theme.foreground }}
+      >
+        {isVisible && (
+          <div className="flex h-full min-h-0 gap-1">
+            <div ref={hostRef} className="h-full min-w-0 flex-1 overflow-hidden" />
+            <TerminalScrollbar metrics={snapshot.scrollMetrics} />
+          </div>
+        )}
+        {!snapshot.isAtBottom && (
+          <ScrollToBottomButton
+            onClick={() => surface.scrollToBottom()}
+            title="Scroll to bottom"
+            testId="terminal-scroll-to-bottom-button"
+          />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,10 +3,16 @@ import ThemeInitializer from '@/components/theme-initializer';
 import '@xterm/xterm/css/xterm.css';
 import 'monaco-editor/min/vs/editor/editor.main.css';
 import './globals.css';
+import './terminal.css';
 import { I18nHtmlLang } from '@/components/i18n-html-lang';
 import { Agentation } from 'agentation';
 import { ElectronCloseDialog } from '@/components/layout/electron-close-dialog';
 import { TelemetryProvider } from '@/components/telemetry/telemetry-provider';
+import {
+  DEFAULT_FONT_SCALE,
+  FONT_SCALE_MIGRATIONS,
+  FONT_SCALE_OPTIONS,
+} from '@/lib/settings/provider-defaults';
 
 export const metadata: Metadata = {
   title: 'Tessera',
@@ -23,10 +29,11 @@ const themeScript = `
     var theme = settings.theme || 'auto';
     var isDark = theme === 'dark' || (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);
     if (isDark) document.documentElement.classList.add('dark');
-    var scales = [0.8125, 0.875, 1, 1.25];
-    var raw = typeof settings.fontSize === 'number' ? settings.fontSize : 0.875;
-    if (raw === 0.9375) raw = 1;
-    var scale = 0.875;
+    var scales = ${JSON.stringify(FONT_SCALE_OPTIONS)};
+    var migrations = ${JSON.stringify(FONT_SCALE_MIGRATIONS)};
+    var raw = typeof settings.fontSize === 'number' ? settings.fontSize : ${DEFAULT_FONT_SCALE};
+    if (migrations[raw] !== undefined) raw = migrations[raw];
+    var scale = ${DEFAULT_FONT_SCALE};
     if (raw < 2) {
       var best = scales[0];
       var bestDelta = Math.abs(raw - best);

--- a/src/app/terminal.css
+++ b/src/app/terminal.css
@@ -1,0 +1,25 @@
+:root {
+  --terminal-scrollbar-thumb: #858581;
+  --terminal-scrollbar-track: #e7e7e3;
+}
+
+:root.dark {
+  --terminal-scrollbar-thumb: #687078;
+  --terminal-scrollbar-track: #181b1e;
+}
+
+/*
+ * Chromium's native overlay scrollbar auto-hides on macOS regardless of the
+ * requested gutter. The persistent indicator is rendered beside xterm, so hide
+ * the native thumb to avoid a second scrollbar flashing over it while scrolling.
+ */
+.tessera-terminal-surface .xterm-viewport {
+  overflow-y: scroll !important;
+  scrollbar-width: none;
+}
+
+.tessera-terminal-surface .xterm-viewport::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none;
+}

--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -21,6 +21,7 @@ import { useTabStore } from "@/stores/tab-store";
 import { useI18n } from "@/lib/i18n";
 import { TerminalPanel } from "@/components/terminal/terminal-panel";
 import { getSessionTerminalId } from "@/lib/terminal/terminal-surface-registry";
+import { shouldShowSessionHeader } from "@/lib/terminal/session-header-visibility";
 
 interface ChatAreaProps {
   sessionId: string;
@@ -80,8 +81,8 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
   );
 
   // terminal-mode: 이 세션이 터미널 kind면 채팅 본문(메시지/컴포저) 대신 xterm 터미널을
-  // 렌더하고, 마운트 시 provider PTY를 프롬프트 없이 자동 기동한다. Header 등 세션 UI는
-  // 그대로 유지되어 제목편집·사이드바 선택·상태 인디케이터를 채팅창과 동일하게 흡수한다.
+  // 렌더하고, 마운트 시 provider PTY를 프롬프트 없이 자동 기동한다. 단일 패널에서는
+  // 탭 제목과 중복되는 Header를 숨기고, 멀티 패널에서는 패널 제어를 위해 유지한다.
   const sessionProvider = session?.provider;
   const isTerminalSession = session?.kind === "terminal";
   // 세션당 안정적 terminalId. 렌더러 메모리가 아니라 서버의 session binding이 실제
@@ -147,23 +148,25 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
 
   return (
     <div className="flex-1 flex flex-col h-full bg-(--chat-bg)">
-      <Header
-        sessionId={sessionId}
-        panelId={panelId}
-        isSinglePanel={isSinglePanel}
-        search={{
-          isOpen: messageSearch.isSearchOpen,
-          query: messageSearch.query,
-          matchCount: messageSearch.matches.length,
-          activeMatchIndex: messageSearch.activeMatchIndex,
-          hasMore,
-          onOpen: messageSearch.openSearch,
-          onClose: messageSearch.closeSearch,
-          onQueryChange: messageSearch.setQuery,
-          onNext: messageSearch.goToNextMatch,
-          onPrevious: messageSearch.goToPreviousMatch,
-        }}
-      />
+      {shouldShowSessionHeader({ isTerminalSession, isSinglePanel }) && (
+        <Header
+          sessionId={sessionId}
+          panelId={panelId}
+          isSinglePanel={isSinglePanel}
+          search={{
+            isOpen: messageSearch.isSearchOpen,
+            query: messageSearch.query,
+            matchCount: messageSearch.matches.length,
+            activeMatchIndex: messageSearch.activeMatchIndex,
+            hasMore,
+            onOpen: messageSearch.openSearch,
+            onClose: messageSearch.closeSearch,
+            onQueryChange: messageSearch.setQuery,
+            onNext: messageSearch.goToNextMatch,
+            onPrevious: messageSearch.goToPreviousMatch,
+          }}
+        />
+      )}
 
       <div className="flex-1 overflow-hidden">
         {isTerminalSession ? (

--- a/src/components/chat/message-list-sections.tsx
+++ b/src/components/chat/message-list-sections.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { ArrowDown, ArrowUp, MessageSquare } from 'lucide-react';
+import { ArrowUp, MessageSquare } from 'lucide-react';
 import type { ToolCallMessage } from '@/types/chat';
 import { ToolCallDetailPanel } from './tool-call-detail-panel';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
+import { ScrollToBottomButton } from '@/components/ui/scroll-to-bottom-button';
 import { LoadingIndicator } from './loading-indicator';
 
 interface MessageListScrollAreaProps {
@@ -132,16 +133,5 @@ export function MessageListScrollToBottomButton({
   onClick,
   title,
 }: MessageListScrollToBottomButtonProps) {
-  return (
-    <Button
-      variant="outline"
-      size="icon"
-      className="absolute bottom-4 left-1/2 z-10 h-9 w-9 -translate-x-1/2 rounded-full border-(--divider) bg-(--chat-bg)/95 text-(--text-secondary) shadow-[0_10px_24px_rgba(0,0,0,0.14),0_1px_4px_rgba(0,0,0,0.10)] backdrop-blur hover:bg-(--sidebar-hover) hover:text-(--text-primary)"
-      onClick={onClick}
-      title={title}
-      data-testid="scroll-to-bottom-button"
-    >
-      <ArrowDown className="h-4 w-4" />
-    </Button>
-  );
+  return <ScrollToBottomButton onClick={onClick} title={title} />;
 }

--- a/src/components/tab/tab-panel-host.tsx
+++ b/src/components/tab/tab-panel-host.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTabStore } from '@/stores/tab-store';
 import { usePanelStore, TabIdContext } from '@/stores/panel-store';
 import PanelContainer from '@/components/panel/panel-container';
+import { orderMountedTabIds } from '@/lib/tab/mounted-tab-order';
 
 /**
  * Manages the LRU-bounded set of mounted PanelContainer instances.
@@ -47,15 +48,23 @@ const TabSlot = memo(function TabSlot({ tabId, isActive }: { tabId: string; isAc
 });
 
 export const TabPanelHost = memo(function TabPanelHost() {
+  const tabs = useTabStore((state) => state.tabs);
   const lruTabIds = useTabStore((state) => state.lruTabIds);
   const activeTabId = useTabStore((state) => state.activeTabId);
+  // LRU order changes on every activation. Rendering in that order moves the
+  // existing xterm DOM between siblings, which resets its native scrollTop.
+  // Keep LRU membership while using the stable tab-bar order for the DOM.
+  const mountedTabIds = useMemo(
+    () => orderMountedTabIds(tabs, lruTabIds),
+    [lruTabIds, tabs],
+  );
 
   return (
     <div
       style={{ position: 'relative', flex: 1, overflow: 'hidden' }}
       data-testid="tab-panel-host"
     >
-      {lruTabIds.map((tabId) => (
+      {mountedTabIds.map((tabId) => (
         <TabSlot key={tabId} tabId={tabId} isActive={tabId === activeTabId} />
       ))}
     </div>

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -9,11 +9,14 @@ import {
   useSyncExternalStore,
   type DragEvent,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { GripVertical, RotateCcw, Terminal as TerminalIcon, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { ScrollToBottomButton } from '@/components/ui/scroll-to-bottom-button';
 import { TabIdContext, usePanelStore } from '@/stores/panel-store';
 import { useTabStore } from '@/stores/tab-store';
 import { useChatStore } from '@/stores/chat-store';
+import { useSettingsStore } from '@/stores/settings-store';
 import { getSessionSelectionId } from '@/lib/constants/special-sessions';
 import { getInitialTerminalCwd } from '@/lib/terminal/client-terminal-cwd';
 import {
@@ -23,6 +26,8 @@ import {
 import { setPanelNodeDragData } from '@/lib/dnd/panel-session-drag';
 import { useIsDark } from '@/hooks/use-is-dark';
 import { getTerminalTheme } from '@/lib/terminal/terminal-theme';
+import { getTerminalFontSize } from '@/lib/terminal/terminal-font-size';
+import { TerminalScrollbar } from './terminal-scrollbar';
 
 interface TerminalPanelProps {
   panelId: string;
@@ -61,7 +66,10 @@ export function TerminalPanel({
   launch,
 }: TerminalPanelProps) {
   const tabId = useContext(TabIdContext);
+  const { t } = useTranslation();
   const isDark = useIsDark();
+  const fontScale = useSettingsStore((state) => state.settings.fontSize);
+  const terminalFontSize = getTerminalFontSize(fontScale);
   const containerRef = useRef<HTMLDivElement>(null);
   const assignTerminal = usePanelStore((state) => state.assignTerminal);
   const connectionStatus = useChatStore((state) => state.connectionStatus);
@@ -72,11 +80,13 @@ export function TerminalPanel({
   const surface = useMemo(() => getTerminalSurface({
     registryKey: `${tabId}:${panelId}:${terminalId}`,
     terminalId,
+    theme: getTerminalTheme(isDark),
+    fontSize: terminalFontSize,
     cwd: getInitialTerminalCwd(terminalSessionId),
     sessionId: getSessionSelectionId(terminalSessionId),
     launch,
-  }), [launch, panelId, tabId, terminalId, terminalSessionId]);
-  const { status, subtitle } = useSyncExternalStore(
+  }), [isDark, launch, panelId, tabId, terminalFontSize, terminalId, terminalSessionId]);
+  const { status, subtitle, isAtBottom, scrollMetrics } = useSyncExternalStore(
     surface.subscribe,
     surface.getSnapshot,
     surface.getSnapshot,
@@ -86,6 +96,10 @@ export function TerminalPanel({
   useEffect(() => {
     surface.setTheme(getTerminalTheme(isDark));
   }, [isDark, surface]);
+
+  useEffect(() => {
+    surface.setFontSize(terminalFontSize);
+  }, [surface, terminalFontSize]);
 
   const handlePanelDragStart = useCallback((event: DragEvent<HTMLElement>) => {
     const didSet = setPanelNodeDragData(event.dataTransfer, { tabId, panelId });
@@ -198,7 +212,17 @@ export function TerminalPanel({
         </div>
       )}
       <div className="relative min-h-0 flex-1 overflow-hidden p-2">
-        <div ref={containerRef} className="h-full min-h-0 overflow-hidden" />
+        <div className="flex h-full min-h-0 gap-1">
+          <div ref={containerRef} className="h-full min-w-0 flex-1 overflow-hidden" />
+          <TerminalScrollbar metrics={scrollMetrics} />
+        </div>
+        {!isAtBottom && (
+          <ScrollToBottomButton
+            onClick={() => surface.scrollToBottom()}
+            title={t('chat.scrollToBottom')}
+            testId="terminal-scroll-to-bottom-button"
+          />
+        )}
         {sessionOwned && status !== 'running' && (
           <div
             role="status"

--- a/src/components/terminal/terminal-scrollbar.tsx
+++ b/src/components/terminal/terminal-scrollbar.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  getTerminalScrollbarGeometry,
+  type TerminalScrollMetrics,
+} from '@/lib/terminal/terminal-scrollbar-geometry';
+
+interface TerminalScrollbarProps {
+  metrics: TerminalScrollMetrics;
+}
+
+/**
+ * Persistent, non-interactive xterm scroll indicator.
+ *
+ * macOS hides Chromium's native overlay scrollbar at idle. Keeping this as a
+ * sibling of the xterm host reserves a real gutter and avoids covering terminal
+ * cells while still leaving all wheel, keyboard, and selection input to xterm.
+ */
+export function TerminalScrollbar({ metrics }: TerminalScrollbarProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [trackHeight, setTrackHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+
+    const measure = () => setTrackHeight(track.clientHeight);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(track);
+    return () => observer.disconnect();
+  }, []);
+
+  const geometry = useMemo(
+    () => getTerminalScrollbarGeometry(metrics, trackHeight),
+    [metrics, trackHeight],
+  );
+
+  return (
+    <div
+      ref={trackRef}
+      aria-hidden="true"
+      data-testid="terminal-scrollbar"
+      className="pointer-events-none relative h-full w-2 shrink-0 overflow-hidden rounded-full bg-(--terminal-scrollbar-track)"
+    >
+      <div
+        data-testid="terminal-scrollbar-thumb"
+        className="absolute inset-x-0 top-0 rounded-full bg-(--terminal-scrollbar-thumb)"
+        style={{
+          height: geometry.height,
+          transform: `translateY(${geometry.top}px)`,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/scroll-to-bottom-button.tsx
+++ b/src/components/ui/scroll-to-bottom-button.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { ArrowDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from './button';
+
+interface ScrollToBottomButtonProps {
+  onClick: () => void;
+  title: string;
+  className?: string;
+  testId?: string;
+}
+
+export function ScrollToBottomButton({
+  onClick,
+  title,
+  className,
+  testId = 'scroll-to-bottom-button',
+}: ScrollToBottomButtonProps) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      className={cn(
+        'absolute bottom-4 left-1/2 z-10 h-9 w-9 -translate-x-1/2 rounded-full border-(--divider) bg-(--chat-bg)/95 text-(--text-secondary) shadow-[0_10px_24px_rgba(0,0,0,0.14),0_1px_4px_rgba(0,0,0,0.10)] backdrop-blur transition-[background-color,color,opacity,transform] duration-200 hover:bg-(--sidebar-hover) hover:text-(--text-primary)',
+        className,
+      )}
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+      data-testid={testId}
+    >
+      <ArrowDown className="h-4 w-4" />
+    </Button>
+  );
+}

--- a/src/hooks/use-session-crud.ts
+++ b/src/hooks/use-session-crud.ts
@@ -186,7 +186,7 @@ export function useSessionCrud() {
 
         sessionStore.removeSession(tempSessionId);
 
-        // CLI is not spawned until the first message — see session_started event.
+        // No runtime exists yet. GUI starts on first input; PTY starts on first open.
         const newSession: UnifiedSession = {
           id: result.sessionId,
           title: result.title,
@@ -194,7 +194,7 @@ export function useSessionCrud() {
           workDir: options.workDir || result.projectDir,
           isRunning: false,
           hasStarted: false,
-          status: result.status,
+          status: result.kind === 'terminal' ? 'stopped' : result.status,
           createdAt: result.createdAt,
           lastModified: result.createdAt,
           tesseraSessionId: result.sessionId,

--- a/src/lib/archive/archive-service.ts
+++ b/src/lib/archive/archive-service.ts
@@ -4,6 +4,7 @@ import * as dbProjects from '@/lib/db/projects';
 import * as dbSessions from '@/lib/db/sessions';
 import * as dbTasks from '@/lib/db/tasks';
 import { processManager } from '@/lib/cli/process-manager';
+import { getActiveSessionIds } from '@/lib/session/active-session-runtime';
 import { getAgentEnvironment } from '@/lib/cli/spawn-cli';
 import { sessionOrchestrator } from '@/lib/session/session-orchestrator';
 import { isManagedWorktreePath, removeManagedWorktree } from '@/lib/worktrees/managed';
@@ -179,7 +180,7 @@ async function mapChat(row: SessionRow): Promise<ArchiveItem> {
       title: row.title,
       provider: row.provider,
       lastModified: row.updated_at,
-      isRunning: processManager.getActiveSessionIds().has(row.id),
+      isRunning: getActiveSessionIds().has(row.id),
     }],
   };
 }
@@ -210,7 +211,7 @@ async function mapTask(task: TaskEntity): Promise<ArchiveItem> {
 
 export async function listArchiveItems(options: ArchiveListOptions = {}): Promise<ArchiveListResult> {
   const normalizedProjectId = options.projectId && options.projectId !== 'all' ? options.projectId : undefined;
-  const activeSessionIds = processManager.getActiveSessionIds();
+  const activeSessionIds = getActiveSessionIds();
   const kind = options.kind ?? 'all';
   const limit = normalizePageLimit(options.limit);
   const offset = normalizeOffset(options.cursor);
@@ -297,7 +298,7 @@ export async function restoreArchivedChat(sessionId: string, userId?: string): P
 }
 
 export async function setTaskArchived(taskId: string, archived: boolean, userId?: string): Promise<void> {
-  const task = dbTasks.getTask(taskId, processManager.getActiveSessionIds());
+  const task = dbTasks.getTask(taskId, getActiveSessionIds());
   if (!task) {
     throw new Error('Task not found');
   }
@@ -339,7 +340,7 @@ export async function setTaskArchived(taskId: string, archived: boolean, userId?
 }
 
 export async function permanentlyDeleteArchivedTask(userId: string, taskId: string): Promise<void> {
-  const task = dbTasks.getTask(taskId, processManager.getActiveSessionIds());
+  const task = dbTasks.getTask(taskId, getActiveSessionIds());
   if (!task) {
     throw new Error('Task not found');
   }
@@ -372,7 +373,7 @@ export async function removeArchivedTaskWorktree(taskId: string, userId?: string
   if (!item.worktreeManaged) {
     throw new Error('Worktree is not managed by this app');
   }
-  const activeIds = processManager.getActiveSessionIds();
+  const activeIds = getActiveSessionIds();
   if (item.sessions.some((session) => activeIds.has(session.id))) {
     throw new Error('Cannot delete worktree while sessions are running');
   }
@@ -395,7 +396,7 @@ export async function removeArchivedWorktrees(
     projectId: options.projectId,
     query: options.query,
   });
-  const activeIds = processManager.getActiveSessionIds();
+  const activeIds = getActiveSessionIds();
   const runGit = await createArchiveGitRunner(userId);
 
   for (const item of items) {
@@ -444,7 +445,7 @@ async function removeArchivedWorktree(
   }
 
   try {
-    const activeIds = processManager.getActiveSessionIds();
+    const activeIds = getActiveSessionIds();
     if (item.sessions.some((session) => activeIds.has(session.id))) {
       return false;
     }

--- a/src/lib/cli/hook-receiver.ts
+++ b/src/lib/cli/hook-receiver.ts
@@ -12,6 +12,7 @@ import logger from '@/lib/logger';
 import { terminalManager } from '@/lib/terminal/shared-terminal-manager';
 import { refreshSessionDiffStateInBackground } from '@/lib/git/session-diff-refresh';
 import { applyImmediateSessionTitle } from '@/lib/session/immediate-session-title';
+import { mapClaudeHookLifecycle } from '@/lib/cli/providers/claude-code/terminal-hook-lifecycle';
 
 const MAX_BODY_BYTES = 1_000_000;
 
@@ -37,6 +38,10 @@ function readBody(req: IncomingMessage): Promise<string> {
 
 function readString(v: unknown): string {
   return typeof v === 'string' ? v : '';
+}
+
+function completedStatus(payload: Record<string, unknown>): { status: 'completed'; preview?: string } {
+  return { status: 'completed', preview: readString(payload.last_assistant_message) || undefined };
 }
 
 /**
@@ -71,12 +76,25 @@ function mapEventToStatus(
       return { status: 'running' };
     case 'Stop':
       // stock Stop payload엔 assistant 텍스트가 없다. 포크 필드가 있으면만 preview로.
-      return { status: 'completed', preview: readString(payload.last_assistant_message) || undefined };
+      return completedStatus(payload);
     case 'Notification':
       return classifyNotification(payload);
     default:
       return null;
   }
+}
+
+function mapClaudeEventToStatus(
+  terminalId: string,
+  event: string,
+  payload: Record<string, unknown>,
+): { status: TerminalSessionStatus; preview?: string } | null {
+  const lifecycle = mapClaudeHookLifecycle(terminalId, event, payload);
+  if (lifecycle) {
+    if (event === 'Stop' && lifecycle.status === 'completed') return completedStatus(payload);
+    return lifecycle;
+  }
+  return mapEventToStatus(event, payload);
 }
 
 /**
@@ -98,7 +116,7 @@ function mapCodexEventToStatus(
     case 'PermissionRequest':
       return { status: 'input_required' };
     case 'Stop':
-      return { status: 'completed', preview: readString(payload.last_assistant_message) || undefined };
+      return completedStatus(payload);
     default:
       return null;
   }
@@ -126,7 +144,9 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
     const isOpenCode = entry.providerId === 'opencode';
     const mapped = isCodex
       ? mapCodexEventToStatus(event, payload)
-      : mapEventToStatus(event, payload);
+      : isOpenCode
+        ? mapEventToStatus(event, payload)
+        : mapClaudeEventToStatus(entry.terminalId, event, payload);
     // brick finding: launched 마커는 SessionStart 수신 시 찍는다 = agent가 세션을 실제 persist한 시점.
     if (event === 'SessionStart' && entry.sessionId) {
       if (isCodex) {
@@ -161,10 +181,10 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
         }
       }
     }
-    // 턴 종료(Stop) 시 선택적 AI 제목 개선 — headless의 result 트리거는 터미널
-    // 세션엔 오지 않으므로 여기서 발화한다. 설정/중복 여부는 내부에서 확인한다.
-    if (event === 'Stop' && entry.sessionId) {
-      refreshSessionDiffStateInBackground(entry.sessionId, entry.userId, 'terminal Stop hook');
+    // 실제 턴 완료 시 선택적 AI 제목과 Git 상태를 확정한다. Claude는 lead Stop 뒤에도
+    // background child가 실행될 수 있으므로 mapped 상태를 완료 경계로 사용한다.
+    if (mapped?.status === 'completed' && entry.sessionId) {
+      refreshSessionDiffStateInBackground(entry.sessionId, entry.userId, 'terminal lifecycle completion');
       maybeAutoGenerateProtocolTitle({
         autoTitleTriggered: terminalAutoTitleTriggered,
         sendAppMessage: (uid, m) => wsServer.sendToUser(uid, m),

--- a/src/lib/cli/providers/claude-code/terminal-hook-lifecycle.ts
+++ b/src/lib/cli/providers/claude-code/terminal-hook-lifecycle.ts
@@ -1,0 +1,109 @@
+export type ClaudeHookLifecycleStatus = 'running' | 'completed' | 'idle';
+
+interface ClaudeTerminalLifecycle {
+  activeSubagentIds: Set<string>;
+  leadStoppedWithBackground: boolean;
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function hasTaskRegistry(payload: Record<string, unknown>): boolean {
+  return Array.isArray(payload.background_tasks) || Array.isArray(payload.session_crons);
+}
+
+function registryHasPendingWork(payload: Record<string, unknown>): boolean {
+  return (Array.isArray(payload.background_tasks) && payload.background_tasks.length > 0)
+    || (Array.isArray(payload.session_crons) && payload.session_crons.length > 0);
+}
+
+/**
+ * Claude can emit the lead Stop while background children are still alive.
+ * Keep the terminal turn running until the task registry or child lifecycle
+ * confirms that the pending work has drained.
+ */
+export class ClaudeHookLifecycleTracker {
+  private readonly terminals = new Map<string, ClaudeTerminalLifecycle>();
+
+  apply(
+    terminalId: string,
+    event: string,
+    payload: Record<string, unknown>,
+  ): { status: ClaudeHookLifecycleStatus } | null {
+    if (event === 'SessionStart') {
+      this.terminals.delete(terminalId);
+      return { status: 'idle' };
+    }
+
+    if (event === 'UserPromptSubmit') {
+      const state = this.terminals.get(terminalId);
+      if (state) state.leadStoppedWithBackground = false;
+      return { status: 'running' };
+    }
+
+    if (event === 'SubagentStart') {
+      const state = this.getOrCreate(terminalId);
+      const agentId = readString(payload.agent_id) || readString(payload.agentId);
+      if (agentId) state.activeSubagentIds.add(agentId);
+      return { status: 'running' };
+    }
+
+    if (event === 'TeammateIdle') {
+      if (!this.terminals.has(terminalId)) return null;
+      return { status: 'running' };
+    }
+
+    if (event === 'Stop') {
+      const state = this.getOrCreate(terminalId);
+      // A reachable Stop task registry is authoritative. This lets a later empty
+      // Stop heal a missed SubagentStop; older Claude versions fall back to IDs.
+      const hasPendingWork = hasTaskRegistry(payload)
+        ? registryHasPendingWork(payload)
+        : state.activeSubagentIds.size > 0;
+      if (hasPendingWork) {
+        state.leadStoppedWithBackground = true;
+        return { status: 'running' };
+      }
+      this.terminals.delete(terminalId);
+      return { status: 'completed' };
+    }
+
+    if (event === 'SubagentStop') {
+      const state = this.getOrCreate(terminalId);
+      const agentId = readString(payload.agent_id) || readString(payload.agentId);
+      if (agentId) state.activeSubagentIds.delete(agentId);
+
+      const hasPendingWork = registryHasPendingWork(payload) || state.activeSubagentIds.size > 0;
+      if (state.leadStoppedWithBackground && !hasPendingWork) {
+        this.terminals.delete(terminalId);
+        return { status: 'completed' };
+      }
+      return { status: 'running' };
+    }
+
+    return null;
+  }
+
+  private getOrCreate(terminalId: string): ClaudeTerminalLifecycle {
+    const existing = this.terminals.get(terminalId);
+    if (existing) return existing;
+    const created: ClaudeTerminalLifecycle = {
+      activeSubagentIds: new Set(),
+      leadStoppedWithBackground: false,
+    };
+    this.terminals.set(terminalId, created);
+    return created;
+  }
+}
+
+const terminalHookLifecycle = new ClaudeHookLifecycleTracker();
+
+/** Process-lifetime Claude hook adapter used by the shared HTTP receiver. */
+export function mapClaudeHookLifecycle(
+  terminalId: string,
+  event: string,
+  payload: Record<string, unknown>,
+): { status: ClaudeHookLifecycleStatus } | null {
+  return terminalHookLifecycle.apply(terminalId, event, payload);
+}

--- a/src/lib/db/sessions.ts
+++ b/src/lib/db/sessions.ts
@@ -477,6 +477,7 @@ export function mapSessionRowToApi(
 ) {
   const isRunning = activeSessionIds.has(row.id);
   const isGenerating = generatingSessionIds.has(row.id);
+  const kind = extractSessionKind(row.provider_state);
   const hasStarted = isRunning || hasProviderConversationState(row.provider_state) || hasSessionHistoryFile(row.id);
   return {
     id: row.id,
@@ -487,7 +488,7 @@ export function mapSessionRowToApi(
     isRunning,
     isGenerating,
     hasStarted,
-    status: isRunning ? 'running' : ('completed' as const),
+    status: isRunning ? ('running' as const) : kind === 'terminal' ? ('stopped' as const) : ('completed' as const),
     projectDir: row.project_id,
     workDir: row.work_dir ?? undefined,
     workflowStatus: row.workflow_status ?? undefined,
@@ -499,7 +500,7 @@ export function mapSessionRowToApi(
     model: row.model ?? undefined,
     reasoningEffort: row.reasoning_effort ?? undefined,
     serviceTier: row.service_tier ?? undefined,
-    kind: extractSessionKind(row.provider_state),
+    kind,
     taskId: row.task_id ?? undefined,
     collectionId: row.collection_id ?? undefined,
   };

--- a/src/lib/external-http-url.ts
+++ b/src/lib/external-http-url.ts
@@ -1,0 +1,12 @@
+export function normalizeExternalHttpUrl(rawUrl: unknown): string | null {
+  if (typeof rawUrl !== 'string') return null;
+
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/session/active-session-runtime.ts
+++ b/src/lib/session/active-session-runtime.ts
@@ -1,0 +1,13 @@
+import { processManager } from '@/lib/cli/process-manager';
+import { terminalManager } from '@/lib/terminal/shared-terminal-manager';
+
+/** All sessions with a live backing runtime, regardless of GUI or PTY execution mode. */
+export function getActiveSessionIds(userId?: string): Set<string> {
+  const guiSessionIds = userId === undefined
+    ? processManager.getActiveSessionIds()
+    : new Set(processManager.getUserProcesses(userId).map((process) => process.sessionId));
+  return new Set([
+    ...guiSessionIds,
+    ...terminalManager.getActiveSessionIds(userId),
+  ]);
+}

--- a/src/lib/settings/provider-defaults.ts
+++ b/src/lib/settings/provider-defaults.ts
@@ -23,8 +23,12 @@ import {
   DEFAULT_PROFILE_DISPLAY_NAME,
 } from './profile-defaults';
 
-export const FONT_SCALE_OPTIONS = [0.8125, 0.875, 1, 1.25] as const;
-export const DEFAULT_FONT_SCALE = 0.875;
+export const FONT_SCALE_OPTIONS = [0.8125, 1, 1.1875, 1.375] as const;
+export const DEFAULT_FONT_SCALE = 0.8125;
+export const FONT_SCALE_MIGRATIONS: Readonly<Record<number, number>> = {
+  0.9375: 1,
+  1.25: 1.375,
+};
 type ClaudeAccessMode = Extract<
   ProviderSessionAccessMode,
   'default' | 'acceptEdits' | 'dontAsk' | 'bypassPermissions'
@@ -40,8 +44,8 @@ type OpenCodeAccessMode = Extract<
 
 /**
  * Normalize fontSize to one of FONT_SCALE_OPTIONS. Legacy px values (12-20)
- * from prior versions collapse to 1 since the old setting never actually took
- * effect — users experienced the default size regardless of the stored number.
+ * from prior versions collapse to the default since the old setting never
+ * actually took effect.
  */
 export function normalizeFontScale(raw: unknown): number {
   if (typeof raw !== 'number' || !Number.isFinite(raw)) {
@@ -50,11 +54,8 @@ export function normalizeFontScale(raw: unknown): number {
   if (raw >= 2) {
     return DEFAULT_FONT_SCALE;
   }
-  // Preserve the semantic "large" choice for users upgrading from the old
-  // preset list, where 0.9375 sat exactly between the new medium and large.
-  if (raw === 0.9375) {
-    return 1;
-  }
+  const migratedScale = FONT_SCALE_MIGRATIONS[raw];
+  if (migratedScale !== undefined) return migratedScale;
   let best: number = FONT_SCALE_OPTIONS[0];
   let bestDelta = Math.abs(raw - best);
   for (const option of FONT_SCALE_OPTIONS) {

--- a/src/lib/tab/mounted-tab-order.ts
+++ b/src/lib/tab/mounted-tab-order.ts
@@ -1,0 +1,11 @@
+interface TabIdentity {
+  id: string;
+}
+
+export function orderMountedTabIds(
+  tabs: readonly TabIdentity[],
+  lruTabIds: readonly string[],
+): string[] {
+  const mountedIds = new Set(lruTabIds);
+  return tabs.map((tab) => tab.id).filter((tabId) => mountedIds.has(tabId));
+}

--- a/src/lib/terminal/claude-hook-settings.ts
+++ b/src/lib/terminal/claude-hook-settings.ts
@@ -24,6 +24,11 @@ export function buildClaudeHookSettings(): Record<string, unknown> {
       // AI 자동 타이틀이 되게 한다(codex는 이미 등록됨).
       UserPromptSubmit: lifecycleHook(),
       Stop: lifecycleHook(),
+      // Claude의 lead turn이 먼저 끝나도 background child가 계속 실행될 수 있다.
+      // child/team lifecycle을 받아 terminal 상태를 완료로 조기 전환하지 않게 한다.
+      SubagentStart: lifecycleHook(),
+      SubagentStop: lifecycleHook(),
+      TeammateIdle: lifecycleHook(),
     },
   };
 }

--- a/src/lib/terminal/codex-hook-settings.ts
+++ b/src/lib/terminal/codex-hook-settings.ts
@@ -1,5 +1,30 @@
 import { HOOK_CURL } from './claude-hook-settings';
 
+export const CODEX_HOOK_EVENT_LABEL = {
+  SessionStart: 'session_start',
+  UserPromptSubmit: 'user_prompt_submit',
+  Stop: 'stop',
+} as const;
+
+export type CodexHookEventName = keyof typeof CODEX_HOOK_EVENT_LABEL;
+
+export interface CodexHookCommand {
+  type: 'command';
+  timeout?: number;
+  command: string;
+  async?: boolean;
+  statusMessage?: string;
+}
+
+export interface CodexHookGroup {
+  matcher?: string;
+  hooks: CodexHookCommand[];
+}
+
+export interface CodexHookSettings {
+  hooks: Record<CodexHookEventName, CodexHookGroup[]>;
+}
+
 /**
  * codex CODEX_HOME/hooks.json 에 쓸 상태 훅 정의.
  * 스키마: { hooks: { <Event>: [ { hooks: [ { type, command, timeout } ] } ] } }.
@@ -8,19 +33,15 @@ import { HOOK_CURL } from './claude-hook-settings';
  * argv --settings가 아니라 CODEX_HOME/hooks.json 파일로 주입한다는 점.
  * 스크립트는 stdout을 오염시키지 않고 항상 성공 종료(|| true)하는 순수 lifecycle observer다.
  */
-const CODEX_EVENTS = [
-  'SessionStart',
-  'UserPromptSubmit',
-  'Stop',
-] as const;
-
-function group() {
+function group(): CodexHookGroup[] {
   return [{ hooks: [{ type: 'command', timeout: 5, command: HOOK_CURL }] }];
 }
 
-export function buildCodexHookSettings(): Record<string, unknown> {
-  const hooks: Record<string, unknown> = {};
-  for (const event of CODEX_EVENTS) hooks[event] = group();
+export function buildCodexHookSettings(): CodexHookSettings {
+  const hooks = {} as CodexHookSettings['hooks'];
+  for (const event of Object.keys(CODEX_HOOK_EVENT_LABEL) as CodexHookEventName[]) {
+    hooks[event] = group();
+  }
   return { hooks };
 }
 

--- a/src/lib/terminal/codex-overlay.ts
+++ b/src/lib/terminal/codex-overlay.ts
@@ -1,10 +1,17 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { createHash } from 'node:crypto';
 import logger from '@/lib/logger';
 import { getRuntimePlatform } from '@/lib/system/runtime-platform';
 import { getTesseraDataPath } from '@/lib/tessera-data-dir';
-import { buildCodexHookSettingsJson } from './codex-hook-settings';
+import {
+  buildCodexHookSettings,
+  CODEX_HOOK_EVENT_LABEL,
+  type CodexHookCommand,
+  type CodexHookEventName,
+  type CodexHookSettings,
+} from './codex-hook-settings';
 
 /**
  * 실 CODEX_HOME. process.env.CODEX_HOME은 절대 오버레이로 덮어쓰지 않는다
@@ -35,6 +42,101 @@ function stripHookStateSections(toml: string): string {
   return out.join('\n');
 }
 
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/** Codex command_hook_hash와 동일한 정규화·직렬화 계약. */
+function computeTrustedHash(
+  eventName: CodexHookEventName,
+  hook: CodexHookCommand,
+  matcher?: string,
+): string {
+  const normalizedHook: Record<string, unknown> = {
+    type: 'command',
+    command: hook.command,
+    timeout: Math.max(1, hook.timeout ?? 600),
+    async: hook.async ?? false,
+  };
+  if (hook.statusMessage !== undefined) normalizedHook.statusMessage = hook.statusMessage;
+
+  const identity: Record<string, unknown> = {
+    event_name: CODEX_HOOK_EVENT_LABEL[eventName],
+    hooks: [normalizedHook],
+  };
+  // Codex는 UserPromptSubmit/Stop의 matcher를 훅 identity에서 제외한다.
+  if (eventName === 'SessionStart' && matcher !== undefined) identity.matcher = matcher;
+  const digest = createHash('sha256')
+    .update(JSON.stringify(canonicalize(identity)))
+    .digest('hex');
+  return `sha256:${digest}`;
+}
+
+function usesWindowsPath(pathValue: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\');
+}
+
+function escapeTomlBasicString(value: string): string {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('"', '\\"')
+    .replaceAll('\b', '\\b')
+    .replaceAll('\f', '\\f')
+    .replaceAll('\n', '\\n')
+    .replaceAll('\r', '\\r')
+    .replaceAll('\t', '\\t');
+}
+
+function formatHookStateKey(key: string): string {
+  if (usesWindowsPath(key) && !key.includes("'")) return `'${key}'`;
+  return `"${escapeTomlBasicString(key)}"`;
+}
+
+function appendTrustedHookState(
+  configToml: string,
+  hooksPath: string,
+  settings: CodexHookSettings,
+): string {
+  const canonicalHooksPath = fs.realpathSync.native(hooksPath);
+  const blocks: string[] = [];
+  const windowsPath = usesWindowsPath(canonicalHooksPath);
+  if (windowsPath) blocks.push('[hooks.state]');
+
+  for (const [eventName, groups] of Object.entries(settings.hooks) as Array<
+    [CodexHookEventName, CodexHookSettings['hooks'][CodexHookEventName]]
+  >) {
+    groups.forEach((group, groupIndex) => {
+      group.hooks.forEach((hook, handlerIndex) => {
+        if (hook.type !== 'command' || !hook.command) return;
+        const suffix = `${CODEX_HOOK_EVENT_LABEL[eventName]}:${groupIndex}:${handlerIndex}`;
+        const sourcePaths = windowsPath
+          ? [canonicalHooksPath.replaceAll('/', '\\'), canonicalHooksPath.replaceAll('\\', '/')]
+          : [canonicalHooksPath];
+        const trustedHash = computeTrustedHash(eventName, hook, group.matcher);
+        for (const sourcePath of [...new Set(sourcePaths)]) {
+          const key = `${sourcePath}:${suffix}`;
+          blocks.push(
+            `[hooks.state.${formatHookStateKey(key)}]\n`
+            + 'enabled = true\n'
+            + `trusted_hash = "${trustedHash}"`,
+          );
+        }
+      });
+    });
+  }
+
+  const trimmed = configToml.trimEnd();
+  return `${trimmed}${trimmed ? '\n\n' : ''}${blocks.join('\n\n')}\n`;
+}
+
 /**
  * per-terminal CODEX_HOME 오버레이 생성. 반환값을 자식 CODEX_HOME env로 준다.
  *
@@ -53,6 +155,7 @@ export function createCodexOverlay(terminalId: string): string {
   fs.mkdirSync(overlayDir, { recursive: true });
 
   const systemHome = getSystemCodexHome();
+  let configToml = '';
   let entries: string[] = [];
   try {
     entries = fs.readdirSync(systemHome);
@@ -67,8 +170,7 @@ export function createCodexOverlay(terminalId: string): string {
     const target = path.join(overlayDir, entry);
     try {
       if (entry === 'config.toml') {
-        const toml = stripHookStateSections(fs.readFileSync(source, 'utf8'));
-        fs.writeFileSync(target, toml, { mode: 0o600 });
+        configToml = stripHookStateSections(fs.readFileSync(source, 'utf8'));
         continue;
       }
       const stat = fs.statSync(source); // dangling 심링크 스킵
@@ -79,9 +181,12 @@ export function createCodexOverlay(terminalId: string): string {
     }
   }
 
+  const hookSettings = buildCodexHookSettings();
+  const hooksPath = path.join(overlayDir, 'hooks.json');
+  fs.writeFileSync(hooksPath, JSON.stringify(hookSettings, null, 2) + '\n', { mode: 0o600 });
   fs.writeFileSync(
-    path.join(overlayDir, 'hooks.json'),
-    buildCodexHookSettingsJson() + '\n',
+    path.join(overlayDir, 'config.toml'),
+    appendTrustedHookState(configToml, hooksPath, hookSettings),
     { mode: 0o600 },
   );
 

--- a/src/lib/terminal/layout-settle-runner.ts
+++ b/src/lib/terminal/layout-settle-runner.ts
@@ -1,0 +1,83 @@
+export interface LayoutSettleScheduler {
+  cancelAnimationFrame(id: number): void;
+  clearTimeout(id: number): void;
+  queueMicrotask(callback: () => void): void;
+  requestAnimationFrame(callback: () => void): number;
+  setTimeout(callback: () => void, delayMs: number): number;
+}
+
+export type LayoutSettleInitialRun = 'microtask' | 'none';
+
+const browserScheduler: LayoutSettleScheduler = {
+  cancelAnimationFrame: (id) => cancelAnimationFrame(id),
+  clearTimeout: (id) => window.clearTimeout(id),
+  queueMicrotask: (callback) => queueMicrotask(callback),
+  requestAnimationFrame: (callback) => requestAnimationFrame(callback),
+  setTimeout: (callback, delayMs) => window.setTimeout(callback, delayMs),
+};
+
+interface PendingLayoutSettleRun {
+  cancelled: boolean;
+  frameIds: number[];
+  onFinish?: () => void;
+  timerId: number;
+}
+
+/**
+ * Repeats an operation while browser layout and xterm rendering settle.
+ *
+ * ResizeObserver, xterm reflow, and WebGL painting do not finish in the same
+ * frame. Keeping this schedule in one place prevents input tracking and marker
+ * restoration from drifting onto subtly different timing policies.
+ */
+export class LayoutSettleRunner {
+  private pending: PendingLayoutSettleRun | null = null;
+
+  constructor(private readonly scheduler: LayoutSettleScheduler = browserScheduler) {}
+
+  run(
+    operation: () => void,
+    options: {
+      initial: LayoutSettleInitialRun;
+      onFinish?: () => void;
+    },
+  ): void {
+    this.cancel();
+    const pending: PendingLayoutSettleRun = {
+      cancelled: false,
+      frameIds: [],
+      onFinish: options.onFinish,
+      timerId: 0,
+    };
+    this.pending = pending;
+
+    const invoke = () => {
+      if (!pending.cancelled) operation();
+    };
+    if (options.initial === 'microtask') this.scheduler.queueMicrotask(invoke);
+
+    const firstFrameId = this.scheduler.requestAnimationFrame(() => {
+      invoke();
+      if (pending.cancelled) return;
+      pending.frameIds.push(this.scheduler.requestAnimationFrame(invoke));
+    });
+    pending.frameIds.push(firstFrameId);
+    pending.timerId = this.scheduler.setTimeout(() => {
+      invoke();
+      this.finish(pending);
+    }, 80);
+  }
+
+  cancel(): void {
+    if (this.pending) this.finish(this.pending);
+  }
+
+  private finish(pending: PendingLayoutSettleRun): void {
+    if (pending.cancelled) return;
+    pending.cancelled = true;
+    for (const frameId of pending.frameIds) this.scheduler.cancelAnimationFrame(frameId);
+    this.scheduler.clearTimeout(pending.timerId);
+    pending.onFinish?.();
+    if (this.pending === pending) this.pending = null;
+  }
+}

--- a/src/lib/terminal/provider-launch.ts
+++ b/src/lib/terminal/provider-launch.ts
@@ -16,8 +16,7 @@ export interface ProviderTerminalLaunch {
  * 클라 argv 불신. {providerId, sessionId, resume, ...} 만 받아 서버가 최소 argv 전량 조립.
  *  - claude: hooks는 --settings 인라인 주입.
  *  - codex : hooks는 argv가 아니라 CODEX_HOME/hooks.json(오버레이)로 주입되므로 argv엔 없다.
- *            trust는 --dangerously-bypass-hook-trust(글로벌 플래그)로 통과 —
- *            hooks.json은 서버가 소유한 고정 loopback curl이라 인젝션 표면이 없다.
+ *            Tessera 훅의 trust hash도 오버레이 config.toml에 함께 기록한다.
  *            (approvals/sandbox는 절대 우회하지 않는다: --dangerously-bypass-approvals-and-sandbox 미사용.)
  */
 export function buildProviderTerminalLaunch(input: ProviderTerminalLaunchInput): ProviderTerminalLaunch {
@@ -30,12 +29,12 @@ export function buildProviderTerminalLaunch(input: ProviderTerminalLaunchInput):
   }
 
   if (input.providerId === 'codex') {
-    // 글로벌 플래그라 subcommand 앞/뒤 어디든 허용(0.144.1 확인). 신규는 세션식별 인자 없음
-    // (codex가 rollout id 자체 발급). resume는 이전 훅에서 캡처한 codexResumeId 필요.
+    // 신규는 세션식별 인자 없음(codex가 rollout id 자체 발급).
+    // resume는 이전 훅에서 캡처한 codexResumeId 필요.
     if (input.resume && input.codexResumeId) {
-      return { command: 'codex', args: ['resume', input.codexResumeId, '--dangerously-bypass-hook-trust'] };
+      return { command: 'codex', args: ['resume', input.codexResumeId] };
     }
-    return { command: 'codex', args: ['--dangerously-bypass-hook-trust'] };
+    return { command: 'codex', args: [] };
   }
 
   if (input.providerId === 'opencode') {

--- a/src/lib/terminal/session-header-visibility.ts
+++ b/src/lib/terminal/session-header-visibility.ts
@@ -1,0 +1,11 @@
+interface SessionHeaderVisibility {
+  isTerminalSession: boolean;
+  isSinglePanel: boolean;
+}
+
+export function shouldShowSessionHeader({
+  isTerminalSession,
+  isSinglePanel,
+}: SessionHeaderVisibility): boolean {
+  return !isTerminalSession || !isSinglePanel;
+}

--- a/src/lib/terminal/shared-terminal-manager.ts
+++ b/src/lib/terminal/shared-terminal-manager.ts
@@ -5,10 +5,12 @@ import { workspaceFileWatchManager } from '@/lib/workspace-files/workspace-file-
 import { TerminalManager } from './terminal-manager';
 
 type SendToConnection = (connectionId: string, message: ServerTransportMessage) => void;
+type SendToUser = (userId: string, message: ServerTransportMessage) => void;
 
 interface SharedTerminalManagerState {
   manager: TerminalManager;
   sendToConnection: SendToConnection | null;
+  sendToUser: SendToUser | null;
 }
 
 const SHARED_TERMINAL_MANAGER_KEY = Symbol.for('tessera.terminalManager');
@@ -17,6 +19,7 @@ const sharedGlobal = globalThis as unknown as Record<symbol, SharedTerminalManag
 function createSharedState(): SharedTerminalManagerState {
   const state = {} as SharedTerminalManagerState;
   state.sendToConnection = null;
+  state.sendToUser = null;
   state.manager = new TerminalManager(
     (connectionId, message) => {
       state.sendToConnection?.(connectionId, message);
@@ -32,6 +35,15 @@ function createSharedState(): SharedTerminalManagerState {
         onChange: (root) => scheduleRecompute(root, userId),
       });
     },
+    {
+      onSessionRuntimeStateChange: ({ sessionId, userId, running }) => {
+        state.sendToUser?.(userId, {
+          type: 'terminal_session_runtime',
+          sessionId,
+          running,
+        });
+      },
+    },
   );
   return state;
 }
@@ -44,4 +56,8 @@ export const terminalManager = sharedState.manager;
 export function bindTerminalSender(sendToConnection: SendToConnection): TerminalManager {
   sharedState.sendToConnection = sendToConnection;
   return terminalManager;
+}
+
+export function bindTerminalRuntimeSender(sendToUser: SendToUser): void {
+  sharedState.sendToUser = sendToUser;
 }

--- a/src/lib/terminal/terminal-external-link.ts
+++ b/src/lib/terminal/terminal-external-link.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { normalizeExternalHttpUrl } from '@/lib/external-http-url';
+
+interface ElectronExternalUrlApi {
+  isElectron?: boolean;
+  openExternalUrl?: (url: string) => Promise<{ ok: boolean; error?: string }>;
+}
+
+export type ExternalUrlOpener = (url: string) => void | Promise<unknown>;
+
+function getElectronExternalUrlApi(): ElectronExternalUrlApi | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return (window as Window & { electronAPI?: ElectronExternalUrlApi }).electronAPI;
+}
+
+export function openExternalHttpUrl(url: string): void {
+  const normalizedUrl = normalizeExternalHttpUrl(url);
+  if (!normalizedUrl || typeof window === 'undefined') return;
+
+  const electronApi = getElectronExternalUrlApi();
+  if (electronApi?.isElectron && electronApi.openExternalUrl) {
+    void electronApi.openExternalUrl(normalizedUrl);
+    return;
+  }
+
+  window.open(normalizedUrl, '_blank', 'noopener,noreferrer');
+}
+
+export function createTerminalExternalLinkHandlers(
+  openUrl: ExternalUrlOpener = openExternalHttpUrl,
+) {
+  const activate = (event: MouseEvent, rawUrl: string) => {
+    const normalizedUrl = normalizeExternalHttpUrl(rawUrl);
+    if (!normalizedUrl) return;
+
+    event.preventDefault();
+    void openUrl(normalizedUrl);
+  };
+
+  return {
+    webLinkHandler: activate,
+    oscLinkHandler: {
+      activate: (event: MouseEvent, uri: string, _range?: unknown) => activate(event, uri),
+    },
+  };
+}

--- a/src/lib/terminal/terminal-font-size.ts
+++ b/src/lib/terminal/terminal-font-size.ts
@@ -1,0 +1,7 @@
+import { normalizeFontScale } from '@/lib/settings/provider-defaults';
+
+const WEB_UI_TEXT_SIZE_PX = 14;
+
+export function getTerminalFontSize(fontScale: unknown): number {
+  return WEB_UI_TEXT_SIZE_PX * normalizeFontScale(fontScale);
+}

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -15,6 +15,7 @@ import { revokePaneTokensForTerminal } from './pane-token-registry';
 import { cleanupCodexOverlayForTerminal } from './codex-overlay';
 import { TerminalHeadlessModel } from './terminal-headless-model';
 import { normalizeTerminalColorEnv } from './terminal-color-env';
+import { createTerminalStartupColorQueryBridge } from './terminal-startup-color-query';
 import {
   ownsTerminalHandoffLock,
   releaseTerminalHandoffByTerminal,
@@ -152,6 +153,8 @@ interface TerminalRuntime {
   shell: string;
   process: TerminalProcessHandle;
   model: TerminalHeadlessModel;
+  cols: number;
+  rows: number;
   subscribers: Map<string, TerminalSubscriber>;
   viewportOwner: string | null;
   outputBuffer: string[];
@@ -177,6 +180,11 @@ export interface TerminalManagerOptions {
   closeExitGraceMs?: number;
   closeExitPollMs?: number;
   processIsAlive?: (pid: number) => boolean;
+  onSessionRuntimeStateChange?: (state: {
+    sessionId: string;
+    userId: string;
+    running: boolean;
+  }) => void;
 }
 
 function normalizeTerminalDimension(value: number | undefined, fallback: number, max: number): number {
@@ -513,6 +521,8 @@ export class TerminalManager {
         shell: shell.command,
         process: processHandle,
         model,
+        cols,
+        rows,
         subscribers: new Map(),
         viewportOwner: null,
         outputBuffer: [],
@@ -531,7 +541,22 @@ export class TerminalManager {
           this.getSessionKey(runtime.userId, runtime.sessionId),
           runtime.terminalId,
         );
+        this.managerOptions.onSessionRuntimeStateChange?.({
+          sessionId: runtime.sessionId,
+          userId: runtime.userId,
+          running: true,
+        });
       }
+
+      // Agent TUIs probe terminal colors immediately and can time out before
+      // the new browser surface receives its first output frame. Answer only
+      // during startup, then let xterm remain the protocol authority.
+      const startupColorBridge = options.launchSpec && options.colorQueryColors
+        ? createTerminalStartupColorQueryBridge(
+            options.colorQueryColors,
+            (reply) => processHandle.write(reply),
+          )
+        : null;
 
       // 미지원 슬래시 명령 fallback: provider TUI가 기동된 뒤 입력창이
       // 준비되면 prefillInput을 개행 없이 write한다(자동 실행 X, 사용자가 Enter).
@@ -597,7 +622,9 @@ export class TerminalManager {
         prefillHardTimer = setTimeout(sendPrefill, PREFILL_HARD_TIMEOUT_MS);
       }
 
-      processHandle.onData((data) => {
+      processHandle.onData((rawData) => {
+        const data = startupColorBridge?.consume(rawData) ?? rawData;
+        if (data.length === 0) return;
         // replay 버퍼: 원본 청크 순서/내용 그대로 즉시 누적 — coalescing과 독립.
         this.appendBufferedOutput(runtime, data);
         runtime.model.write(data);
@@ -622,6 +649,12 @@ export class TerminalManager {
       });
 
       processHandle.onExit((event) => {
+        const pendingColorQueryData = startupColorBridge?.drain() ?? '';
+        if (pendingColorQueryData) {
+          this.appendBufferedOutput(runtime, pendingColorQueryData);
+          runtime.model.write(pendingColorQueryData);
+          this.queueOutput(runtime, pendingColorQueryData);
+        }
         clearPrefillTimers();
         this.finalizeRuntimeExit(runtime, key, event);
       });
@@ -961,6 +994,13 @@ export class TerminalManager {
       this.clearSessionBinding(runtime);
       revokePaneTokensForTerminal(runtime.terminalId);
       cleanupCodexOverlayForTerminal(runtime.terminalId);
+      if (runtime.sessionId) {
+        this.managerOptions.onSessionRuntimeStateChange?.({
+          sessionId: runtime.sessionId,
+          userId: runtime.userId,
+          running: false,
+        });
+      }
     }
     if (runtime.handoffSessionId && ownsTerminalHandoffLock(
       runtime.handoffSessionId,
@@ -1064,6 +1104,15 @@ export class TerminalManager {
       sessionCount: runtimes.filter((runtime) => runtime.sessionId !== null).length
         + openingEntries.filter((key) => this.openingSessionByTerminalKey.get(key) != null).length,
     };
+  }
+
+  getActiveSessionIds(userId?: string): Set<string> {
+    return new Set(
+      [...this.terminals.values()]
+        .filter((runtime) => !runtime.ended && runtime.sessionId !== null)
+        .filter((runtime) => userId === undefined || runtime.userId === userId)
+        .map((runtime) => runtime.sessionId!),
+    );
   }
 
   resolveTerminalId(userId: string, requestedTerminalId: string, sessionId?: string | null): string {
@@ -1198,8 +1247,11 @@ export class TerminalManager {
   private resizeRuntime(runtime: TerminalRuntime, cols: number, rows: number): void {
     const normalizedCols = normalizeTerminalDimension(cols, 80, MAX_TERMINAL_COLS);
     const normalizedRows = normalizeTerminalDimension(rows, 24, MAX_TERMINAL_ROWS);
+    if (runtime.cols === normalizedCols && runtime.rows === normalizedRows) return;
     runtime.process.resize(normalizedCols, normalizedRows);
     runtime.model.resize(normalizedCols, normalizedRows);
+    runtime.cols = normalizedCols;
+    runtime.rows = normalizedRows;
   }
 
   // 코얼레싱 버퍼에 청크를 쌓고, 예약된 flush가 없으면 setImmediate 1개를 건다.

--- a/src/lib/terminal/terminal-scroll-controller.ts
+++ b/src/lib/terminal/terminal-scroll-controller.ts
@@ -1,0 +1,196 @@
+import {
+  LayoutSettleRunner,
+  type LayoutSettleScheduler,
+} from './layout-settle-runner';
+
+export type TerminalScrollIntent = 'follow-output' | 'pinned-viewport';
+
+export interface TerminalScrollMarker {
+  readonly isDisposed: boolean;
+  readonly line: number;
+  dispose(): void;
+}
+
+export interface TerminalScrollTarget {
+  buffer: {
+    active: {
+      readonly type: 'normal' | 'alternate';
+      readonly baseY: number;
+      readonly viewportY: number;
+      readonly cursorY: number;
+    };
+  };
+  registerMarker(offset?: number): TerminalScrollMarker | undefined;
+  scrollToBottom(): void;
+  scrollToLine(line: number): void;
+}
+
+export interface TerminalScrollSnapshot {
+  intent: TerminalScrollIntent;
+  isAtBottom: boolean;
+}
+
+export interface TerminalScrollRestorePoint {
+  readonly bufferType: 'normal' | 'alternate';
+  readonly intent: TerminalScrollIntent;
+  readonly marker?: TerminalScrollMarker;
+  readonly revision: number;
+  readonly viewportY: number;
+}
+
+export type TerminalScrollScheduler = LayoutSettleScheduler;
+
+const BOTTOM_TOLERANCE_ROWS = 1;
+
+function isAtBottom(target: TerminalScrollTarget): boolean {
+  const { baseY, viewportY } = target.buffer.active;
+  return viewportY >= baseY - BOTTOM_TOLERANCE_ROWS;
+}
+
+function safelyScroll(operation: () => void): boolean {
+  try {
+    operation();
+    return true;
+  } catch (error) {
+    if (error instanceof TypeError && /dimensions/.test(error.message)) return false;
+    throw error;
+  }
+}
+
+export class TerminalScrollController {
+  private readonly listeners = new Set<() => void>();
+  private readonly layoutSettler: LayoutSettleRunner;
+  private revision = 0;
+  private snapshot: TerminalScrollSnapshot;
+
+  constructor(
+    private readonly target: TerminalScrollTarget,
+    scheduler?: TerminalScrollScheduler,
+  ) {
+    this.layoutSettler = new LayoutSettleRunner(scheduler);
+    const atBottom = isAtBottom(target);
+    this.snapshot = {
+      intent: atBottom ? 'follow-output' : 'pinned-viewport',
+      isAtBottom: atBottom,
+    };
+  }
+
+  getSnapshot = (): TerminalScrollSnapshot => this.snapshot;
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  captureRestorePoint(): TerminalScrollRestorePoint {
+    const buffer = this.target.buffer.active;
+    const intent = this.snapshot.intent;
+    return {
+      bufferType: buffer.type,
+      intent,
+      marker: intent === 'pinned-viewport' && buffer.type === 'normal'
+        ? this.target.registerMarker(buffer.viewportY - (buffer.baseY + buffer.cursorY))
+        : undefined,
+      revision: this.revision,
+      viewportY: buffer.viewportY,
+    };
+  }
+
+  scrollToBottom(): void {
+    this.cancelPendingRestore();
+    this.revision += 1;
+    safelyScroll(() => this.target.scrollToBottom());
+    this.updateSnapshot('follow-output');
+  }
+
+  scrollToTop(): void {
+    this.cancelPendingRestore();
+    this.revision += 1;
+    safelyScroll(() => this.target.scrollToLine(0));
+    this.updateSnapshot('pinned-viewport');
+  }
+
+  pinViewport(): void {
+    this.cancelPendingRestore();
+    this.revision += 1;
+    this.updateSnapshot('pinned-viewport');
+  }
+
+  notifyViewportChanged(): void {
+    this.updateSnapshot(this.snapshot.intent);
+  }
+
+  syncFromViewport(options: { preservePinnedAtBottom?: boolean } = {}): void {
+    this.cancelPendingRestore();
+    this.revision += 1;
+    const atBottom = isAtBottom(this.target);
+    const intent = options.preservePinnedAtBottom
+      && this.snapshot.intent === 'pinned-viewport'
+      && atBottom
+      ? 'pinned-viewport'
+      : atBottom ? 'follow-output' : 'pinned-viewport';
+    this.updateSnapshot(intent);
+  }
+
+  restore(point: TerminalScrollRestorePoint): void {
+    try {
+      this.restoreNow(point);
+    } finally {
+      point.marker?.dispose();
+    }
+  }
+
+  restoreAfterLayout(point: TerminalScrollRestorePoint): void {
+    this.cancelPendingRestore();
+    if (!this.restoreNow(point)) {
+      point.marker?.dispose();
+      return;
+    }
+    this.layoutSettler.run(
+      () => {
+        this.restoreNow(point);
+      },
+      {
+        initial: 'none',
+        onFinish: () => point.marker?.dispose(),
+      },
+    );
+  }
+
+  dispose(): void {
+    this.cancelPendingRestore();
+    this.listeners.clear();
+  }
+
+  private restoreNow(point: TerminalScrollRestorePoint): boolean {
+    if (point.revision !== this.revision) return false;
+    const buffer = this.target.buffer.active;
+    if (point.bufferType === 'alternate' || buffer.type !== point.bufferType) return false;
+
+    if (point.intent === 'follow-output') {
+      if (!safelyScroll(() => this.target.scrollToBottom())) return false;
+    } else {
+      const markerLine = point.marker && !point.marker.isDisposed ? point.marker.line : -1;
+      if (!safelyScroll(() => this.target.scrollToLine(Math.min(
+        markerLine >= 0 ? markerLine : point.viewportY,
+        buffer.baseY,
+      )))) return false;
+    }
+    this.updateSnapshot(point.intent);
+    return true;
+  }
+
+  cancelPendingRestore(): void {
+    this.layoutSettler.cancel();
+  }
+
+  private updateSnapshot(intent: TerminalScrollIntent): void {
+    const next = { intent, isAtBottom: isAtBottom(this.target) };
+    if (
+      this.snapshot.intent === next.intent
+      && this.snapshot.isAtBottom === next.isAtBottom
+    ) return;
+    this.snapshot = next;
+    for (const listener of this.listeners) listener();
+  }
+}

--- a/src/lib/terminal/terminal-scrollbar-geometry.ts
+++ b/src/lib/terminal/terminal-scrollbar-geometry.ts
@@ -1,0 +1,49 @@
+export interface TerminalScrollMetrics {
+  baseY: number;
+  viewportY: number;
+  rows: number;
+}
+
+export interface TerminalScrollbarGeometry {
+  height: number;
+  top: number;
+}
+
+const DEFAULT_MIN_THUMB_HEIGHT = 28;
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+/**
+ * Convert xterm's row-based scroll state into a stable overlay thumb.
+ *
+ * The native Chromium scrollbar is intentionally not used here: on macOS it
+ * remains an auto-hiding overlay even when CSS requests a persistent gutter.
+ */
+export function getTerminalScrollbarGeometry(
+  metrics: TerminalScrollMetrics,
+  trackHeight: number,
+  minThumbHeight = DEFAULT_MIN_THUMB_HEIGHT,
+): TerminalScrollbarGeometry {
+  const safeTrackHeight = Math.max(0, trackHeight);
+  if (safeTrackHeight === 0) return { height: 0, top: 0 };
+
+  const rows = Math.max(1, metrics.rows);
+  const baseY = Math.max(0, metrics.baseY);
+  const totalRows = rows + baseY;
+  const naturalHeight = safeTrackHeight * (rows / totalRows);
+  const height = Math.min(
+    safeTrackHeight,
+    Math.max(Math.min(minThumbHeight, safeTrackHeight), naturalHeight),
+  );
+  const availableTravel = safeTrackHeight - height;
+  const progress = baseY === 0
+    ? 0
+    : clamp(metrics.viewportY / baseY, 0, 1);
+
+  return {
+    height,
+    top: availableTravel * progress,
+  };
+}

--- a/src/lib/terminal/terminal-startup-color-query.ts
+++ b/src/lib/terminal/terminal-startup-color-query.ts
@@ -1,0 +1,140 @@
+import type { TerminalColorQueryColors } from './types';
+
+type ColorSlot = 10 | 11;
+
+type QueryParseResult =
+  | { kind: 'match'; end: number; slots: readonly ColorSlot[] }
+  | { kind: 'partial' }
+  | { kind: 'none' };
+
+const OSC = '\x1b]';
+const ST = '\x1b\\';
+const BEL = '\x07';
+const MAX_PENDING_CHARS = 64;
+const STARTUP_WINDOW_MS = 5_000;
+
+/** Format the same 16-bit-channel X11 color response emitted by xterm. */
+export function formatTerminalOscColorReply(slot: ColorSlot, color: string): string | null {
+  const match = /^#([\da-f]{6})$/i.exec(color.trim());
+  if (!match) return null;
+
+  const [red, green, blue] = match[1].match(/.{2}/g) ?? [];
+  if (!red || !green || !blue) return null;
+  return `${OSC}${slot};rgb:${red}${red}/${green}${green}/${blue}${blue}${ST}`;
+}
+
+/**
+ * Answer an agent's initial OSC 10/11 probes before its output reaches the
+ * browser. The short-lived bridge prevents a startup race where a TUI times
+ * out before the renderer can report the active light/dark terminal colors.
+ */
+export function createTerminalStartupColorQueryBridge(
+  colors: TerminalColorQueryColors,
+  writeReply: (reply: string) => void,
+  now: () => number = Date.now,
+) {
+  const replies = {
+    10: formatTerminalOscColorReply(10, colors.foreground),
+    11: formatTerminalOscColorReply(11, colors.background),
+  } as const;
+  const enabled = Boolean(replies[10] && replies[11]);
+  const expiresAt = now() + STARTUP_WINDOW_MS;
+  const answered = new Set<ColorSlot>();
+  let pending = '';
+
+  const consume = (data: string): string => {
+    if (!enabled || answered.size === 2 || now() > expiresAt) {
+      const output = pending + data;
+      pending = '';
+      return output;
+    }
+
+    const input = pending + data;
+    pending = '';
+    let output = '';
+    let offset = 0;
+
+    while (offset < input.length) {
+      const candidate = input.indexOf('\x1b', offset);
+      if (candidate === -1) {
+        output += input.slice(offset);
+        break;
+      }
+      output += input.slice(offset, candidate);
+
+      const parsed = parseColorQuery(input, candidate);
+      if (parsed.kind === 'partial') {
+        const fragment = input.slice(candidate);
+        if (fragment.length <= MAX_PENDING_CHARS) pending = fragment;
+        else output += fragment;
+        break;
+      }
+      if (parsed.kind === 'none') {
+        output += input[candidate];
+        offset = candidate + 1;
+        continue;
+      }
+
+      try {
+        for (const slot of parsed.slots) {
+          const reply = replies[slot];
+          if (!reply) throw new Error('Missing terminal color reply');
+          writeReply(reply);
+          answered.add(slot);
+        }
+      } catch {
+        output += input.slice(candidate, parsed.end);
+      }
+      offset = parsed.end;
+    }
+
+    return output;
+  };
+
+  return {
+    consume,
+    drain(): string {
+      const output = pending;
+      pending = '';
+      return output;
+    },
+  };
+}
+
+function parseColorQuery(data: string, offset: number): QueryParseResult {
+  const fragment = data.slice(offset);
+  const prefixes = [`${OSC}10;`, `${OSC}11;`] as const;
+  const prefix = prefixes.find((candidate) => data.startsWith(candidate, offset));
+  if (!prefix) {
+    return prefixes.some((candidate) => candidate.startsWith(fragment))
+      ? { kind: 'partial' }
+      : { kind: 'none' };
+  }
+
+  const slot: ColorSlot = prefix === prefixes[0] ? 10 : 11;
+  const bodyStart = offset + prefix.length;
+  if (bodyStart >= data.length) return { kind: 'partial' };
+  if (data[bodyStart] !== '?') return { kind: 'none' };
+
+  let slots: readonly ColorSlot[] = [slot];
+  let terminatorStart = bodyStart + 1;
+  if (data[terminatorStart] === ';') {
+    if (slot !== 10) return { kind: 'none' };
+    if (terminatorStart + 1 >= data.length) return { kind: 'partial' };
+    if (data[terminatorStart + 1] !== '?') return { kind: 'none' };
+    slots = [10, 11];
+    terminatorStart += 2;
+  }
+
+  if (terminatorStart >= data.length) return { kind: 'partial' };
+  if (data[terminatorStart] === BEL) {
+    return { kind: 'match', slots, end: terminatorStart + BEL.length };
+  }
+  if (data.startsWith(ST, terminatorStart)) {
+    return { kind: 'match', slots, end: terminatorStart + ST.length };
+  }
+  if (data[terminatorStart] === '\x1b' && terminatorStart + 1 === data.length) {
+    return { kind: 'partial' };
+  }
+  return { kind: 'none' };
+}

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -13,10 +13,7 @@ import {
 } from './pending-terminal-launch';
 import { dispatchTerminalLaunchResult } from './terminal-launch-result';
 import { clearClientTerminalHandoff } from './client-terminal-handoff-state';
-import {
-  getTerminalTheme,
-  type TesseraTerminalTheme,
-} from './terminal-theme';
+import type { TesseraTerminalTheme } from './terminal-theme';
 import {
   detectTerminalClientPlatform,
   isTerminalPasteShortcut,
@@ -28,26 +25,38 @@ import {
   uploadTerminalClipboardImage,
   type ElectronTerminalClipboardApi,
 } from './terminal-clipboard-paste';
+import {
+  TerminalScrollController,
+  type TerminalScrollRestorePoint,
+  type TerminalScrollTarget,
+} from './terminal-scroll-controller';
+import { LayoutSettleRunner } from './layout-settle-runner';
+import type { TerminalScrollMetrics } from './terminal-scrollbar-geometry';
+import { createTerminalExternalLinkHandlers } from './terminal-external-link';
 
 export type TerminalSurfaceStatus = 'starting' | 'running' | 'exited' | 'error';
 
 export interface TerminalSurfaceSnapshot {
   status: TerminalSurfaceStatus;
   subtitle: string;
+  isAtBottom: boolean;
+  scrollMetrics: TerminalScrollMetrics;
 }
 
 export interface TerminalSurfaceOptions {
   registryKey: string;
   terminalId: string;
+  theme: TesseraTerminalTheme;
+  fontSize: number;
   cwd?: string | null;
   sessionId?: string | null;
   launch?: { providerId: string; sessionId: string };
 }
 
-type XtermLike = {
+type XtermLike = TerminalScrollTarget & {
   cols: number;
   rows: number;
-  options: { theme?: ITheme };
+  options: { theme?: ITheme; fontSize?: number };
   unicode: { activeVersion: string };
   attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void;
   loadAddon(addon: unknown): void;
@@ -57,9 +66,8 @@ type XtermLike = {
   write(data: string, callback?: () => void): void;
   reset(): void;
   refresh(start: number, end: number): void;
-  scrollToTop(): void;
-  scrollToBottom(): void;
   onData(callback: (data: string) => void): { dispose(): void };
+  onScroll(callback: (viewportY: number) => void): { dispose(): void };
   dispose(): void;
 };
 
@@ -107,19 +115,31 @@ export class TerminalSurface {
   private state: TerminalSurfaceSnapshot = {
     status: 'starting',
     subtitle: 'Starting terminal...',
+    isAtBottom: true,
+    scrollMetrics: { baseY: 0, viewportY: 0, rows: 1 },
   };
   private actualTerminalId: string;
-  private theme = getTerminalTheme(true);
+  private theme: TesseraTerminalTheme;
+  private fontSize: number;
   private terminal: XtermLike | null = null;
   private fitAddon: FitAddonLike | null = null;
   private webglAddon: { dispose(): void } | null = null;
   private inputDisposable: { dispose(): void } | null = null;
+  private scrollDisposable: { dispose(): void } | null = null;
+  private scrollController: TerminalScrollController | null = null;
+  private unsubscribeScrollController: (() => void) | null = null;
+  private scrollTrackingCleanup: (() => void) | null = null;
+  private pendingScrollStateFrameId: number | null = null;
+  private readonly scrollSyncSettler = new LayoutSettleRunner();
   private pasteListener: ((event: ClipboardEvent) => void) | null = null;
   private clipboardPasteQueue: Promise<void> = Promise.resolve();
   private root: HTMLDivElement | null = null;
   private intendedHost: HTMLElement | null = null;
   private mountedHost: HTMLElement | null = null;
   private resizeObserver: ResizeObserver | null = null;
+  private pendingFitFrameId: number | null = null;
+  private pendingFitClaim = false;
+  private resizeSettleTimerId: number | null = null;
   private initializePromise: Promise<boolean> | null = null;
   private attachedConnectionGeneration = 0;
   private pendingLaunch: PendingTerminalLaunch | null = null;
@@ -132,6 +152,8 @@ export class TerminalSurface {
   private readonly unsubscribeSessionStore: (() => void) | null;
 
   constructor(private readonly options: TerminalSurfaceOptions) {
+    this.theme = { ...options.theme };
+    this.fontSize = options.fontSize;
     this.actualTerminalId = options.terminalId;
     this.unsubscribeMessages = wsClient.subscribeServerMessages((message) => {
       this.handleServerMessage(message);
@@ -168,6 +190,14 @@ export class TerminalSurface {
     this.terminal.options.theme = this.theme;
   }
 
+  setFontSize(fontSize: number): void {
+    if (this.fontSize === fontSize) return;
+    this.fontSize = fontSize;
+    if (!this.terminal) return;
+    this.terminal.options.fontSize = fontSize;
+    this.requestStableFit(false);
+  }
+
   async mount(host: HTMLElement): Promise<void> {
     if (this.disposed) return;
     this.intendedHost = host;
@@ -177,12 +207,19 @@ export class TerminalSurface {
     host.appendChild(this.root);
     this.mountedHost = host;
     this.resizeObserver?.disconnect();
-    this.resizeObserver = new ResizeObserver(() => this.fitAndResize(false));
+    this.resizeObserver = new ResizeObserver(() => {
+      this.requestStableFit(false);
+      if (this.resizeSettleTimerId !== null) window.clearTimeout(this.resizeSettleTimerId);
+      this.resizeSettleTimerId = window.setTimeout(() => {
+        this.resizeSettleTimerId = null;
+        this.requestStableFit(false);
+      }, 150);
+    });
     this.resizeObserver.observe(host);
 
     requestAnimationFrame(() => {
       if (this.mountedHost !== host) return;
-      this.fitAndResize(false);
+      this.requestStableFit(false);
     });
   }
 
@@ -192,6 +229,8 @@ export class TerminalSurface {
 
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
+    this.cancelPendingFit();
+    this.scrollController?.cancelPendingRestore();
     this.mountedHost = null;
     if (this.root && !this.disposed) {
       getParkingLot().appendChild(this.root);
@@ -220,6 +259,10 @@ export class TerminalSurface {
       sessionId: this.options.sessionId,
       cols: dimensions?.cols,
       rows: dimensions?.rows,
+      colorQueryColors: {
+        foreground: this.theme.foreground,
+        background: this.theme.background,
+      },
       launchIntent: pendingLaunch?.intent,
       prefillInput: pendingLaunch?.prefillInput,
       launch: pendingLaunch?.launch ?? this.options.launch,
@@ -244,6 +287,10 @@ export class TerminalSurface {
     return wsClient.sendTerminalInput(this.actualTerminalId, this.surfaceId, data);
   }
 
+  scrollToBottom(): void {
+    this.scrollController?.scrollToBottom();
+  }
+
   matchesTerminal(terminalId: string): boolean {
     return this.options.terminalId === terminalId || this.actualTerminalId === terminalId;
   }
@@ -264,6 +311,7 @@ export class TerminalSurface {
     this.lastSequence = 0;
     this.replaying = false;
     this.terminal?.reset();
+    this.scrollController?.scrollToBottom();
     this.updateState('starting', 'Restarting terminal...');
     return this.ensureConnected();
   }
@@ -272,7 +320,7 @@ export class TerminalSurface {
     if (this.disposed || !this.isMountedHostVisible()) return;
     requestAnimationFrame(() => {
       if (!this.isMountedHostVisible()) return;
-      this.fitAndResize(true);
+      this.requestStableFit(true);
       this.terminal?.focus();
     });
   }
@@ -287,8 +335,19 @@ export class TerminalSurface {
     this.unsubscribeSessionStore?.();
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
+    this.cancelPendingFit();
+    this.cancelScheduledScrollSync();
+    this.cancelScheduledSurfaceScrollStateSync();
     this.inputDisposable?.dispose();
     this.inputDisposable = null;
+    this.scrollDisposable?.dispose();
+    this.scrollDisposable = null;
+    this.scrollTrackingCleanup?.();
+    this.scrollTrackingCleanup = null;
+    this.unsubscribeScrollController?.();
+    this.unsubscribeScrollController = null;
+    this.scrollController?.dispose();
+    this.scrollController = null;
     if (this.root && this.pasteListener) {
       this.root.removeEventListener('paste', this.pasteListener, true);
     }
@@ -347,17 +406,20 @@ export class TerminalSurface {
       if (this.disposed) return;
 
       const root = document.createElement('div');
-      root.className = 'h-full min-h-0 overflow-hidden';
+      root.className = 'tessera-terminal-surface h-full min-h-0 overflow-hidden';
       getParkingLot().appendChild(root);
 
+      const { webLinkHandler, oscLinkHandler } = createTerminalExternalLinkHandlers();
       const terminal = new Terminal({
         cursorBlink: true,
         convertEol: true,
         allowProposedApi: true,
+        minimumContrastRatio: 4.5,
         scrollback: 5_000,
         fontFamily: 'Menlo, Monaco, Consolas, "Liberation Mono", monospace',
-        fontSize: 12,
+        fontSize: this.fontSize,
         theme: this.theme,
+        linkHandler: oscLinkHandler,
       }) as XtermLike;
 
       terminal.open(root);
@@ -366,10 +428,7 @@ export class TerminalSurface {
       terminal.loadAddon(new SearchAddon());
       terminal.loadAddon(new SerializeAddon());
       terminal.loadAddon(new Unicode11Addon());
-      terminal.loadAddon(new WebLinksAddon((event: MouseEvent, uri: string) => {
-        event.preventDefault();
-        window.open(uri, '_blank', 'noopener,noreferrer');
-      }));
+      terminal.loadAddon(new WebLinksAddon(webLinkHandler));
       terminal.unicode.activeVersion = '11';
 
       try {
@@ -396,6 +455,12 @@ export class TerminalSurface {
       this.root = root;
       this.terminal = terminal;
       this.fitAddon = fitAddon;
+      const scrollController = new TerminalScrollController(terminal);
+      this.scrollController = scrollController;
+      this.unsubscribeScrollController = scrollController.subscribe(() => {
+        this.syncScrollStateFromController();
+      });
+      this.scrollTrackingCleanup = this.attachScrollTracking(root, scrollController);
       const inputContext = {
         platform: detectTerminalClientPlatform(navigator.userAgent),
       } as const;
@@ -403,6 +468,21 @@ export class TerminalSurface {
         window as Window & { electronAPI?: Partial<ElectronTerminalClipboardApi> }
       ).electronAPI;
       terminal.attachCustomKeyEventHandler((event) => {
+        if (
+          event.type === 'keydown'
+          && event.shiftKey
+          && !event.metaKey
+          && !event.ctrlKey
+          && !event.altKey
+        ) {
+          if (event.key === 'PageUp') {
+            scrollController.pinViewport();
+            this.scheduleScrollIntentSync(scrollController, true);
+          } else if (event.key === 'PageDown') {
+            this.scheduleScrollIntentSync(scrollController, false);
+          }
+        }
+
         if (
           typeof electronClipboard?.getTerminalClipboardKind === 'function'
           && typeof electronClipboard.readTerminalClipboard === 'function'
@@ -425,15 +505,20 @@ export class TerminalSurface {
         if (action.type === 'send-input') {
           this.sendInput(action.data);
         } else if (action.position === 'top') {
-          terminal.scrollToTop();
+          scrollController.scrollToTop();
         } else {
-          terminal.scrollToBottom();
+          scrollController.scrollToBottom();
         }
         return false;
       });
       this.inputDisposable = terminal.onData((data) => {
         this.sendInput(data);
       });
+      this.scrollDisposable = terminal.onScroll(() => {
+        scrollController.notifyViewportChanged();
+        this.scheduleSurfaceScrollStateSync();
+      });
+      this.syncScrollStateFromController();
       this.pasteListener = (event) => {
         if (event.clipboardData?.getData('text/plain')) return;
         const imageFile = Array.from(event.clipboardData?.items ?? [])
@@ -537,11 +622,14 @@ export class TerminalSurface {
       this.serverGeneration = message.generation;
       this.lastSequence = message.seq;
       this.replaying = true;
+      const restorePoint = this.scrollController?.captureRestorePoint();
       this.terminal?.reset();
       this.terminal?.write(message.data, () => {
+        if (restorePoint) this.scrollController?.restore(restorePoint);
         if (this.serverGeneration === message.generation) {
           this.replaying = false;
         }
+        this.scheduleSurfaceScrollStateSync();
       });
       return;
     }
@@ -549,7 +637,11 @@ export class TerminalSurface {
     if (message.type === 'terminal_output') {
       if (message.generation !== this.serverGeneration || message.seq <= this.lastSequence) return;
       this.lastSequence = message.seq;
-      this.terminal?.write(message.data);
+      const restorePoint = this.scrollController?.captureRestorePoint();
+      this.terminal?.write(message.data, () => {
+        if (restorePoint) this.scrollController?.restore(restorePoint);
+        this.scheduleSurfaceScrollStateSync();
+      });
       return;
     }
 
@@ -581,10 +673,115 @@ export class TerminalSurface {
     });
   }
 
-  private fitAndResize(claim: boolean): void {
+  private attachScrollTracking(
+    root: HTMLElement,
+    controller: TerminalScrollController,
+  ): () => void {
+    let pointerScrollActive = false;
+    const isScrollbarTarget = (target: EventTarget | null): boolean => (
+      target instanceof Element
+      && target.closest('.xterm-viewport, .xterm-scrollbar, .xterm-slider') !== null
+    );
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0) controller.pinViewport();
+      this.scheduleScrollIntentSync(controller, event.deltaY < 0);
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      pointerScrollActive = isScrollbarTarget(event.target);
+    };
+    const onPointerDone = () => {
+      if (!pointerScrollActive) return;
+      pointerScrollActive = false;
+      controller.syncFromViewport();
+    };
+    const onScroll = () => {
+      controller.notifyViewportChanged();
+      if (pointerScrollActive) controller.syncFromViewport();
+    };
+
+    root.addEventListener('wheel', onWheel, { capture: true, passive: true });
+    root.addEventListener('pointerdown', onPointerDown, true);
+    root.addEventListener('scroll', onScroll, true);
+    window.addEventListener('pointerup', onPointerDone, true);
+    window.addEventListener('pointercancel', onPointerDone, true);
+    return () => {
+      root.removeEventListener('wheel', onWheel, true);
+      root.removeEventListener('pointerdown', onPointerDown, true);
+      root.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('pointerup', onPointerDone, true);
+      window.removeEventListener('pointercancel', onPointerDone, true);
+    };
+  }
+
+  private scheduleScrollIntentSync(
+    controller: TerminalScrollController,
+    preservePinnedAtBottom: boolean,
+  ): void {
+    const sync = () => {
+      if (!this.disposed && this.scrollController === controller) {
+        controller.syncFromViewport({ preservePinnedAtBottom });
+      }
+    };
+    this.scrollSyncSettler.run(sync, { initial: 'microtask' });
+  }
+
+  private cancelScheduledScrollSync(): void {
+    this.scrollSyncSettler.cancel();
+  }
+
+  private requestStableFit(claim: boolean): void {
+    this.pendingFitClaim ||= claim;
+    if (this.pendingFitFrameId !== null || !this.isMountedHostVisible()) return;
+
+    let previous = this.getProposedDimensions();
+    let frameCount = 0;
+    const waitForStableGrid = () => {
+      this.pendingFitFrameId = requestAnimationFrame(() => {
+        this.pendingFitFrameId = null;
+        if (!this.isMountedHostVisible() || !this.terminal) {
+          this.pendingFitClaim = false;
+          return;
+        }
+
+        const next = this.getProposedDimensions();
+        frameCount += 1;
+        const matchesTerminal = next
+          && next.cols === this.terminal.cols
+          && next.rows === this.terminal.rows;
+        const dimensionsStable = next
+          && previous
+          && next.cols === previous.cols
+          && next.rows === previous.rows;
+        if (!next || matchesTerminal || dimensionsStable || frameCount >= 8) {
+          const pendingClaim = this.pendingFitClaim;
+          this.pendingFitClaim = false;
+          this.fitAndResize(pendingClaim, !matchesTerminal);
+          return;
+        }
+
+        previous = next;
+        waitForStableGrid();
+      });
+    };
+    waitForStableGrid();
+  }
+
+  private cancelPendingFit(): void {
+    if (this.pendingFitFrameId !== null) cancelAnimationFrame(this.pendingFitFrameId);
+    this.pendingFitFrameId = null;
+    this.pendingFitClaim = false;
+    if (this.resizeSettleTimerId !== null) window.clearTimeout(this.resizeSettleTimerId);
+    this.resizeSettleTimerId = null;
+  }
+
+  private fitAndResize(claim: boolean, shouldFit = true): void {
     if (!this.isMountedHostVisible() || !this.fitAddon || !this.terminal) return;
+    let restorePoint: TerminalScrollRestorePoint | null = null;
     try {
-      this.fitAddon.fit();
+      if (shouldFit) {
+        restorePoint = this.scrollController?.captureRestorePoint() ?? null;
+        this.fitAddon.fit();
+      }
       const dimensions = this.getDimensions();
       if (dimensions && this.attachedConnectionGeneration > 0) {
         wsClient.resizeTerminal(
@@ -597,6 +794,9 @@ export class TerminalSurface {
       }
     } catch {
       // A zero-sized panel can briefly make FitAddon unable to calculate cells.
+    } finally {
+      if (restorePoint) this.scrollController?.restoreAfterLayout(restorePoint);
+      this.scheduleSurfaceScrollStateSync();
     }
   }
 
@@ -612,9 +812,56 @@ export class TerminalSurface {
       ?? (this.terminal ? { cols: this.terminal.cols, rows: this.terminal.rows } : undefined);
   }
 
+  private getProposedDimensions(): { cols: number; rows: number } | undefined {
+    try {
+      return this.fitAddon?.proposeDimensions();
+    } catch {
+      return undefined;
+    }
+  }
+
   private updateState(status: TerminalSurfaceStatus, subtitle: string): void {
     if (this.state.status === status && this.state.subtitle === subtitle) return;
-    this.state = { status, subtitle };
+    this.state = { ...this.state, status, subtitle };
+    this.notifyListeners();
+  }
+
+  private syncScrollStateFromController(): void {
+    const isAtBottom = this.scrollController?.getSnapshot().isAtBottom ?? true;
+    const activeBuffer = this.terminal?.buffer.active;
+    const scrollMetrics: TerminalScrollMetrics = activeBuffer && this.terminal
+      ? {
+          baseY: activeBuffer.baseY,
+          viewportY: activeBuffer.viewportY,
+          rows: this.terminal.rows,
+        }
+      : this.state.scrollMetrics;
+    if (
+      this.state.isAtBottom === isAtBottom
+      && this.state.scrollMetrics.baseY === scrollMetrics.baseY
+      && this.state.scrollMetrics.viewportY === scrollMetrics.viewportY
+      && this.state.scrollMetrics.rows === scrollMetrics.rows
+    ) return;
+    this.state = { ...this.state, isAtBottom, scrollMetrics };
+    this.notifyListeners();
+  }
+
+  private scheduleSurfaceScrollStateSync(): void {
+    if (this.pendingScrollStateFrameId !== null || this.disposed) return;
+    this.pendingScrollStateFrameId = requestAnimationFrame(() => {
+      this.pendingScrollStateFrameId = null;
+      if (!this.disposed) this.syncScrollStateFromController();
+    });
+  }
+
+  private cancelScheduledSurfaceScrollStateSync(): void {
+    if (this.pendingScrollStateFrameId !== null) {
+      cancelAnimationFrame(this.pendingScrollStateFrameId);
+    }
+    this.pendingScrollStateFrameId = null;
+  }
+
+  private notifyListeners(): void {
     for (const listener of this.listeners) listener();
   }
 }

--- a/src/lib/terminal/terminal-theme.ts
+++ b/src/lib/terminal/terminal-theme.ts
@@ -5,56 +5,61 @@ export type TesseraTerminalTheme = ITheme & {
   foreground: string;
 };
 
-// The softer graphite background keeps dense agent TUI output legible without
-// turning every neutral cell into pure black.
+// Neutral Charcoal keeps the PTY in Tessera's dark surface family while using
+// a small luminance lift to preserve the workspace boundary.
 export const TERMINAL_DARK_THEME: TesseraTerminalTheme = {
-  background: '#282c34',
-  foreground: '#ffffff',
-  cursor: '#ffffff',
-  cursorAccent: '#282c34',
-  selectionBackground: '#5a7898',
-  selectionForeground: '#ffffff',
-  black: '#1d1f21',
-  red: '#cc6666',
-  green: '#b5bd68',
-  yellow: '#f0c674',
-  blue: '#81a2be',
-  magenta: '#b294bb',
-  cyan: '#8abeb7',
-  white: '#c5c8c6',
-  brightBlack: '#666666',
-  brightRed: '#d54e53',
-  brightGreen: '#b9ca4a',
-  brightYellow: '#e7c547',
-  brightBlue: '#7aa6da',
-  brightMagenta: '#c397d8',
-  brightCyan: '#70c0b1',
-  brightWhite: '#eaeaea',
+  background: '#161616',
+  foreground: '#e3e9ed',
+  cursor: '#e4edf2',
+  cursorAccent: '#161616',
+  selectionBackground: '#303030',
+  selectionForeground: '#f4f8fa',
+  black: '#141a1f',
+  red: '#df797c',
+  green: '#91c497',
+  yellow: '#d7bc70',
+  blue: '#80afd0',
+  magenta: '#b5a0c8',
+  cyan: '#72b9c1',
+  white: '#c9d1d7',
+  brightBlack: '#71818d',
+  brightRed: '#ee898c',
+  brightGreen: '#a1d4a7',
+  brightYellow: '#e6cb80',
+  brightBlue: '#90c0e1',
+  brightMagenta: '#c6b0d9',
+  brightCyan: '#82cad2',
+  brightWhite: '#f3f7f9',
 };
 
-// The light palette uses darker legacy ANSI accents than the original Tango
-// values so status text and agent diffs retain contrast on a white surface.
+// Lifted Neutral matches Tessera's warm near-white content surface while
+// softening saturated ANSI colors for long-running terminal sessions. The
+// initial theme is also exposed to OSC color queries before the PTY attaches.
 export const TERMINAL_LIGHT_THEME: TesseraTerminalTheme = {
-  background: '#ffffff',
-  foreground: '#2e3434',
-  cursor: '#2e3434',
-  cursorAccent: '#ffffff',
+  background: '#fafaf9',
+  foreground: '#25282b',
+  cursor: '#25282b',
+  cursorAccent: '#fafaf9',
   selectionBackground: '#accef7',
-  selectionForeground: '#2e3434',
-  black: '#2e3436',
-  red: '#cc0000',
-  green: '#4e9a06',
-  yellow: '#8e7700',
+  selectionForeground: '#25282b',
+  // Codex and Claude use ANSI black as a full-width user-message background.
+  // A light neutral keeps that surface distinct without producing a dark,
+  // high-contrast slab inside Tessera's light theme. xterm's contrast policy
+  // still darkens this slot automatically when an app uses it as foreground.
+  black: '#ecece8',
+  red: '#b83232',
+  green: '#4b821f',
+  yellow: '#806b00',
   blue: '#3465a4',
   magenta: '#75507b',
   cyan: '#05727e',
   white: '#6a6a6a',
   brightBlack: '#555753',
-  brightRed: '#ef2929',
-  brightGreen: '#1b7a1b',
-  brightYellow: '#6d5a00',
+  brightRed: '#d44747',
+  brightGreen: '#2f702c',
+  brightYellow: '#695900',
   brightBlue: '#204a87',
-  brightMagenta: '#ad7fa8',
+  brightMagenta: '#976a92',
   brightCyan: '#034b50',
   brightWhite: '#3d3d3d',
 };

--- a/src/lib/terminal/types.ts
+++ b/src/lib/terminal/types.ts
@@ -1,5 +1,10 @@
 export type TerminalShellKind = 'default' | 'cmd' | 'powershell' | 'wsl';
 
+export interface TerminalColorQueryColors {
+  foreground: string;
+  background: string;
+}
+
 /** Client-safe request. Executable, argv, and provider conversation ids are server-owned. */
 export type TerminalLaunchIntent =
   | { kind: 'claude-slash'; commandInput: string }
@@ -34,6 +39,8 @@ export interface TerminalCreateOptions {
   paneToken?: string;
   /** Native agent provider launched inside this PTY. */
   providerId?: string;
+  /** Renderer-resolved colors used to answer an agent's startup OSC queries. */
+  colorQueryColors?: TerminalColorQueryColors;
   /** Disposes provider resources created before PTY spawn. */
   launchObserverDisposer?: () => void;
   /** Server-owned environment overrides for the provider process. */

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -107,15 +107,34 @@ export function handleIncomingServerMessage({
 
     case 'session_state': {
       const changed = useTerminalSessionStore.getState().applySessionState(msg);
-      // 사이드바 배지·Running 카운트는 session.status가 아니라 isRunning(boolean)을 읽는다.
-      // 따라서 hook 상태를 isRunning 토글로 반영한다(idle은 상태 승격 안 함).
-      if (msg.status === 'completed') {
-        sessionStore.setSessionRunning(msg.sessionId, false);
-      } else if (msg.status === 'running' || msg.status === 'input_required') {
-        sessionStore.setSessionRunning(msg.sessionId, true);
+      const runtimeIsRunning = sessionStore.getSession(msg.sessionId)?.isRunning;
+      if (msg.status === 'running' && runtimeIsRunning !== false) {
+        startTurnInFlight(msg.sessionId);
+      } else {
+        stopTurnInFlight(msg.sessionId);
       }
       if (changed && (msg.status === 'completed' || msg.status === 'input_required')) {
         handleTerminalSessionStateMessage(msg, sessionStore.activeSessionId);
+      }
+      return { wasReconnect };
+    }
+
+    case 'terminal_session_runtime':
+      sessionStore.setSessionRunning(msg.sessionId, msg.running);
+      if (!msg.running) {
+        stopTurnInFlight(msg.sessionId);
+      }
+      return { wasReconnect };
+
+    case 'terminal_session_runtime_snapshot': {
+      sessionStore.applyTerminalRuntimeSnapshot(msg.activeSessionIds);
+      const activeTerminalIds = new Set(msg.activeSessionIds);
+      for (const project of sessionStore.projects) {
+        for (const session of project.sessions) {
+          if (session.kind === 'terminal' && !activeTerminalIds.has(session.id)) {
+            stopTurnInFlight(session.id);
+          }
+        }
       }
       return { wasReconnect };
     }
@@ -362,9 +381,8 @@ function addCreatedSession(
     (sum, project) => sum + project.sessions.length,
     0,
   );
-  // Session exists in DB but CLI isn't spawned until the first message.
-  // isRunning=false reflects the real process state; markSessionRunning flips
-  // it to true once the session_started event arrives.
+  // Session exists in DB but has no backing runtime yet. GUI sessions start on
+  // first input; PTY sessions start when their terminal view is first opened.
   sessionStore.addSession({
     id: msg.sessionId,
     title: i18n.t('chat.sessionDefaultTitle', { count: totalSessions + 1 }),
@@ -372,7 +390,7 @@ function addCreatedSession(
     workDir: msg.workDir,
     isRunning: false,
     hasStarted: false,
-    status: 'starting',
+    status: msg.kind === 'terminal' ? 'stopped' : 'starting',
     createdAt: new Date().toISOString(),
     lastModified: new Date().toISOString(),
     archived: false,

--- a/src/lib/ws/client.ts
+++ b/src/lib/ws/client.ts
@@ -8,7 +8,7 @@ import type {
 import type { ProviderMeta } from '@/lib/cli/providers/types';
 import type { CliStatusEntry } from '@/lib/cli/connection-checker';
 import type { ProviderRuntimeControls } from '@/lib/session/session-control-types';
-import type { TerminalLaunchIntent } from '@/lib/terminal/types';
+import type { TerminalColorQueryColors, TerminalLaunchIntent } from '@/lib/terminal/types';
 import { v4 as uuidv4 } from 'uuid';
 import { useChatStore, isTurnInFlight } from '@/stores/chat-store';
 import { useProvidersStore } from '@/stores/providers-store';
@@ -360,6 +360,7 @@ export class WebSocketClient {
     shellKind?: 'default' | 'cmd' | 'powershell' | 'wsl';
     cols?: number;
     rows?: number;
+    colorQueryColors?: TerminalColorQueryColors;
     launchIntent?: TerminalLaunchIntent;
     prefillInput?: string;
     launch?: { providerId: string; sessionId: string };

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -7,7 +7,11 @@ import type { SessionReplayEvent } from '@/lib/session-replay-types';
 import type { ProviderRateLimitsSnapshot } from '@/lib/status-display/types';
 import type { CliStatusEntry } from '@/lib/cli/connection-checker';
 import type { ProviderRuntimeControls } from '@/lib/session/session-control-types';
-import type { TerminalLaunchIntent, TerminalShellKind } from '@/lib/terminal/types';
+import type {
+  TerminalColorQueryColors,
+  TerminalLaunchIntent,
+  TerminalShellKind,
+} from '@/lib/terminal/types';
 
 // ========== ContentBlock 타입 정의 (클립보드 이미지 붙여넣기) ==========
 
@@ -93,6 +97,7 @@ export type ClientMessage =
       shellKind?: TerminalShellKind;
       cols?: number;
       rows?: number;
+      colorQueryColors?: TerminalColorQueryColors;
       launchIntent?: TerminalLaunchIntent;
       prefillInput?: string;
       launch?: { providerId: string; sessionId: string };
@@ -266,6 +271,15 @@ export type AppServerMessage =
       status: 'running' | 'completed' | 'input_required' | 'idle';
       hookEvent: string;
       preview?: string;
+    }
+  | {
+      type: 'terminal_session_runtime';
+      sessionId: string;
+      running: boolean;
+    }
+  | {
+      type: 'terminal_session_runtime_snapshot';
+      activeSessionIds: string[];
     }
   | { type: 'error'; sessionId?: string; code: string; message: string; requestId?: string }
   | { type: 'terminal_prefill_written'; terminalId: string }

--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -623,6 +623,7 @@ export async function routeClientTransportMessage({
           launchSpec,
           paneToken,
           providerId,
+          colorQueryColors: message.colorQueryColors,
           launchEnv,
           launchObserverDisposer,
         });

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -15,7 +15,7 @@ import logger from '../logger';
 import { sessionHistory } from '../session-history';
 import { installDiffStatsBroadcast } from '../git/worktree-diff-stats-broadcast';
 import { installGitPanelBroadcast } from '../git/git-panel-broadcast';
-import { terminalManager } from '../terminal/shared-terminal-manager';
+import { bindTerminalRuntimeSender, terminalManager } from '../terminal/shared-terminal-manager';
 import { workspaceFileWatchManager } from '../workspace-files/workspace-file-watch-manager';
 import { getGeneratingTitleSessionIds } from './title-generation-state';
 import {
@@ -67,6 +67,9 @@ export class WebSocketServer {
 
     // Setup protocol adapter callback
     protocolAdapter.setSendToUser((userId, message) => {
+      this.sendToUser(userId, message);
+    });
+    bindTerminalRuntimeSender((userId, message) => {
       this.sendToUser(userId, message);
     });
 
@@ -257,6 +260,10 @@ export class WebSocketServer {
       type: 'session_list',
       sessions,
       titleGeneratingSessionIds: getGeneratingTitleSessionIds(userId),
+    });
+    this.sendToConnection(ws, userId, {
+      type: 'terminal_session_runtime_snapshot',
+      activeSessionIds: [...terminalManager.getActiveSessionIds(userId)],
     });
 
     // Hook state is process state, not a transient WebSocket event. Replay the

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -42,11 +42,12 @@ export interface SessionState {
   ) => void;
   markSessionStopped: (sessionId: string) => void;
   /**
-   * isRunning만 가볍게 토글한다(사이드바 배지·Running 카운트가 읽는 필드).
-   * 터미널 세션의 hook 상태 반영 전용 — markSessionRunning과 달리 telemetry 발화나
+   * PTY 런타임 생존 상태를 가볍게 반영한다(사이드바 배지·Running 카운트가 읽는 필드).
+   * markSessionRunning과 달리 telemetry 발화나
    * tesseraSessionId/runtimeConfig 덮어쓰기 같은 부수효과가 없다.
    */
   setSessionRunning: (sessionId: string, running: boolean) => void;
+  applyTerminalRuntimeSnapshot: (activeSessionIds: string[]) => void;
   updateSessionRuntimeConfig: (
     sessionId: string,
     runtimeConfig: Partial<Pick<UnifiedSession, 'model' | 'reasoningEffort' | 'serviceTier' | 'fastMode' | 'sessionMode' | 'accessMode'>>,
@@ -838,7 +839,30 @@ export const useSessionStore = create<SessionState>((set, get) => ({
             ...s,
             isRunning: running,
             hasStarted: running ? true : s.hasStarted,
-            status: (running ? 'running' : 'completed') as SessionStatus,
+            status: (running ? 'running' : 'stopped') as SessionStatus,
+          };
+        }),
+      }));
+      return changed ? { projects } : {};
+    }),
+
+  applyTerminalRuntimeSnapshot: (activeSessionIds) =>
+    set((state) => {
+      const active = new Set(activeSessionIds);
+      let changed = false;
+      const projects = state.projects.map((project) => ({
+        ...project,
+        sessions: project.sessions.map((session) => {
+          if (session.kind !== 'terminal') return session;
+          const running = active.has(session.id);
+          const status = (running ? 'running' : 'stopped') as SessionStatus;
+          if (session.isRunning === running && session.status === status) return session;
+          changed = true;
+          return {
+            ...session,
+            isRunning: running,
+            hasStarted: running ? true : session.hasStarted,
+            status,
           };
         }),
       }));

--- a/tests/claude-hook-lifecycle.test.ts
+++ b/tests/claude-hook-lifecycle.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ClaudeHookLifecycleTracker } from '@/lib/cli/providers/claude-code/terminal-hook-lifecycle';
+
+test('Claude turn stays running until a background subagent drains after lead Stop', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-a';
+
+  assert.deepEqual(tracker.apply(terminalId, 'SubagentStart', {
+    agent_id: 'agent-a',
+  }), { status: 'running' });
+
+  assert.deepEqual(tracker.apply(terminalId, 'Stop', {
+    background_tasks: [{ id: 'agent-a', type: 'subagent', status: 'running' }],
+    session_crons: [],
+  }), { status: 'running' });
+
+  assert.deepEqual(tracker.apply(terminalId, 'SubagentStop', {
+    agent_id: 'agent-a',
+    background_tasks: [],
+    session_crons: [],
+  }), { status: 'completed' });
+});
+
+test('one child stopping cannot complete the turn while another tracked child remains', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-with-two-children';
+
+  tracker.apply(terminalId, 'SubagentStart', { agent_id: 'agent-a' });
+  tracker.apply(terminalId, 'SubagentStart', { agent_id: 'agent-b' });
+  tracker.apply(terminalId, 'Stop', {
+    background_tasks: [
+      { id: 'agent-a', type: 'subagent', status: 'running' },
+      { id: 'agent-b', type: 'subagent', status: 'running' },
+    ],
+  });
+
+  assert.deepEqual(tracker.apply(terminalId, 'SubagentStop', {
+    agent_id: 'agent-a',
+    background_tasks: [],
+  }), { status: 'running' });
+  assert.deepEqual(tracker.apply(terminalId, 'SubagentStop', {
+    agent_id: 'agent-b',
+    background_tasks: [],
+  }), { status: 'completed' });
+});
+
+test('a late TeammateIdle cannot move an already completed turn back to running', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'completed-terminal';
+
+  assert.deepEqual(tracker.apply(terminalId, 'Stop', {
+    background_tasks: [],
+    session_crons: [],
+  }), { status: 'completed' });
+  assert.equal(tracker.apply(terminalId, 'TeammateIdle', {
+    teammate_name: 'researcher',
+  }), null);
+});
+
+test('an idle-but-alive teammate stays running until its SubagentStop drains the turn', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-with-teammate';
+
+  tracker.apply(terminalId, 'SubagentStart', {
+    agent_id: 'aresearcher-123',
+    agent_type: 'researcher',
+  });
+  tracker.apply(terminalId, 'Stop', {
+    background_tasks: [{ id: 'team-task', type: 'teammate', status: 'running' }],
+  });
+
+  assert.deepEqual(tracker.apply(terminalId, 'TeammateIdle', {
+    teammate_name: 'researcher',
+  }), { status: 'running' });
+  assert.deepEqual(tracker.apply(terminalId, 'SubagentStop', {
+    agent_id: 'aresearcher-123',
+    background_tasks: [],
+  }), { status: 'completed' });
+});
+
+test('a later authoritative Stop can drain an idle teammate without SubagentStop', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-with-later-stop';
+
+  tracker.apply(terminalId, 'SubagentStart', { agent_id: 'agent-a' });
+  tracker.apply(terminalId, 'Stop', {
+    background_tasks: [{ id: 'team-task', type: 'teammate', status: 'running' }],
+    session_crons: [],
+  });
+  tracker.apply(terminalId, 'TeammateIdle', { teammate_name: 'researcher' });
+
+  assert.deepEqual(tracker.apply(terminalId, 'Stop', {
+    background_tasks: [],
+    session_crons: [],
+  }), { status: 'completed' });
+});

--- a/tests/codex-overlay-trust.test.ts
+++ b/tests/codex-overlay-trust.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  cleanupCodexOverlayForTerminal,
+  createCodexOverlay,
+} from '@/lib/terminal/codex-overlay';
+
+const EXPECTED_TRUSTED_HASHES = {
+  session_start: 'sha256:b110bff27560016b57f45a92f7ffd2a2c71261ccad6eafaab5e3d6badd538865',
+  user_prompt_submit: 'sha256:986f649fe8960d2fd766b18c74ed61b7c9f554806cc8d10f6dbe175851a47f89',
+  stop: 'sha256:60cf356001b94ca293e9eb42ccf9be0c5b2d21e878fd4509d575c550666ef584',
+} as const;
+
+test('Codex overlay pre-trusts exactly the lifecycle hooks it installs', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-codex-overlay-trust-'));
+  const systemHome = path.join(root, 'system-codex-home');
+  const dataDir = path.join(root, 'tessera-data');
+  fs.mkdirSync(systemHome, { recursive: true });
+  fs.writeFileSync(
+    path.join(systemHome, 'config.toml'),
+    'model = "gpt-5.4"\n\n[projects."/tmp/example"]\ntrust_level = "trusted"\n',
+  );
+
+  const previousCodexHome = process.env.CODEX_HOME;
+  const previousDataDir = process.env.TESSERA_DATA_DIR;
+  process.env.CODEX_HOME = systemHome;
+  process.env.TESSERA_DATA_DIR = dataDir;
+
+  try {
+    const originalSystemConfig = fs.readFileSync(path.join(systemHome, 'config.toml'), 'utf8');
+    const overlayDir = createCodexOverlay('terminal-trust-test');
+    const hooksPath = fs.realpathSync.native(path.join(overlayDir, 'hooks.json'));
+    const config = fs.readFileSync(path.join(overlayDir, 'config.toml'), 'utf8');
+
+    assert.match(config, /^model = "gpt-5\.4"$/m);
+    assert.match(config, /^\[projects\."\/tmp\/example"\]$/m);
+    for (const [eventLabel, trustedHash] of Object.entries(EXPECTED_TRUSTED_HASHES)) {
+      const key = `${hooksPath}:${eventLabel}:0:0`;
+      const escapedBasicKey = key
+        .replaceAll('\\', '\\\\')
+        .replaceAll('"', '\\"');
+      const header = [
+        `\\[hooks\\.state\\."${escapeRegExp(escapedBasicKey)}"\\]`,
+        `\\[hooks\\.state\\.'${escapeRegExp(key)}'\\]`,
+      ].join('|');
+      assert.match(
+        config,
+        new RegExp(
+          `(?:${header})\\nenabled = true\\ntrusted_hash = "${trustedHash}"`,
+        ),
+      );
+    }
+    assert.equal(
+      fs.readFileSync(path.join(systemHome, 'config.toml'), 'utf8'),
+      originalSystemConfig,
+      'creating an overlay must not mutate the user config',
+    );
+  } finally {
+    cleanupCodexOverlayForTerminal('terminal-trust-test');
+    restoreEnv('CODEX_HOME', previousCodexHome);
+    restoreEnv('TESSERA_DATA_DIR', previousDataDir);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/tests/external-http-url.test.ts
+++ b/tests/external-http-url.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeExternalHttpUrl } from '../src/lib/external-http-url';
+
+test('normalizes HTTP links, including loopback development servers', () => {
+  assert.deepEqual(
+    [
+      normalizeExternalHttpUrl('http://127.0.0.1:3100'),
+      normalizeExternalHttpUrl('https://example.com/docs?q=1'),
+    ],
+    [
+      'http://127.0.0.1:3100/',
+      'https://example.com/docs?q=1',
+    ],
+  );
+});
+
+test('rejects non-web protocols and malformed external URLs', () => {
+  assert.deepEqual(
+    [
+      normalizeExternalHttpUrl('javascript:alert(1)'),
+      normalizeExternalHttpUrl('file:///tmp/report.html'),
+      normalizeExternalHttpUrl('not a url'),
+      normalizeExternalHttpUrl(undefined),
+    ],
+    [null, null, null, null],
+  );
+});

--- a/tests/font-scale-and-status-indicator-contract.test.mjs
+++ b/tests/font-scale-and-status-indicator-contract.test.mjs
@@ -17,20 +17,23 @@ const layoutSource = fs.readFileSync(
   new URL('../src/app/layout.tsx', import.meta.url),
   'utf8',
 );
-test('font scale presets keep the default and provide a substantially larger maximum', () => {
-  const expectedScales = /\[0\.8125, 0\.875, 1, 1\.25\]/;
+test('font scale presets provide visibly distinct 13px, 16px, 19px, and 22px root sizes', () => {
+  const expectedScales = /\[0\.8125, 1, 1\.1875, 1\.375\]/;
 
-  assert.deepEqual(FONT_SCALE_OPTIONS, [0.8125, 0.875, 1, 1.25]);
+  assert.deepEqual(FONT_SCALE_OPTIONS, [0.8125, 1, 1.1875, 1.375]);
   assert.match(settingsDefaultsSource, expectedScales);
-  assert.match(layoutSource, expectedScales);
-  assert.match(settingsDefaultsSource, /DEFAULT_FONT_SCALE = 0\.875/);
+  assert.match(layoutSource, /JSON\.stringify\(FONT_SCALE_OPTIONS\)/);
+  assert.match(settingsDefaultsSource, /DEFAULT_FONT_SCALE = 0\.8125/);
 });
 
-test('legacy large font scale upgrades without shrinking', () => {
+test('stored font scales migrate to the matching new semantic preset', () => {
   assert.equal(normalizeFontScale(0.9375), 1);
-  assert.equal(normalizeFontScale(0.875), 0.875);
-  assert.equal(normalizeFontScale(1.25), 1.25);
-  assert.match(layoutSource, /if \(raw === 0\.9375\) raw = 1/);
+  assert.equal(normalizeFontScale(0.8125), 0.8125);
+  assert.equal(normalizeFontScale(0.875), 0.8125);
+  assert.equal(normalizeFontScale(1), 1);
+  assert.equal(normalizeFontScale(1.125), 1.1875);
+  assert.equal(normalizeFontScale(1.25), 1.375);
+  assert.match(layoutSource, /JSON\.stringify\(FONT_SCALE_MIGRATIONS\)/);
 });
 
 function renderStatusIndicator({

--- a/tests/mounted-tab-order.test.ts
+++ b/tests/mounted-tab-order.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { orderMountedTabIds } from '@/lib/tab/mounted-tab-order';
+
+test('mounted tab DOM order stays aligned with the tab bar when LRU order changes', () => {
+  const tabs = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+  assert.deepEqual(orderMountedTabIds(tabs, ['b', 'a']), ['a', 'b']);
+  assert.deepEqual(orderMountedTabIds(tabs, ['a', 'b']), ['a', 'b']);
+});
+
+test('mounted tab order still respects LRU membership and eviction', () => {
+  const tabs = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+  assert.deepEqual(orderMountedTabIds(tabs, ['c', 'b']), ['b', 'c']);
+});

--- a/tests/provider-terminal-launch.test.ts
+++ b/tests/provider-terminal-launch.test.ts
@@ -2,6 +2,35 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { buildProviderTerminalLaunch } from '@/lib/terminal/provider-launch';
 
+test('Codex PTY starts with pre-trusted overlay hooks and no trust-bypass warning flag', () => {
+  assert.deepEqual(
+    buildProviderTerminalLaunch({
+      providerId: 'codex',
+      sessionId: 'tessera-session',
+      resume: false,
+    }),
+    {
+      command: 'codex',
+      args: [],
+    },
+  );
+});
+
+test('Codex PTY resumes with pre-trusted overlay hooks and no trust-bypass warning flag', () => {
+  assert.deepEqual(
+    buildProviderTerminalLaunch({
+      providerId: 'codex',
+      sessionId: 'tessera-session',
+      resume: true,
+      codexResumeId: 'thread_123',
+    }),
+    {
+      command: 'codex',
+      args: ['resume', 'thread_123'],
+    },
+  );
+});
+
 test('OpenCode PTY starts the native TUI without observer-only launch flags', () => {
   assert.deepEqual(
     buildProviderTerminalLaunch({

--- a/tests/pty-ui-cleanup-contract.test.mjs
+++ b/tests/pty-ui-cleanup-contract.test.mjs
@@ -54,7 +54,7 @@ test('Goal is absent from UI, transport, persistence, and Codex provider integra
   }
 });
 
-test('session PTY owns a workspace listener and Stop performs final Git reconciliation', () => {
+test('session PTY owns a workspace listener and lifecycle completion performs final Git reconciliation', () => {
   const terminalManager = read('src/lib/terminal/terminal-manager.ts');
   const sharedManager = read('src/lib/terminal/shared-terminal-manager.ts');
   const watcher = read('src/lib/workspace-files/workspace-file-watch-manager.ts');
@@ -65,5 +65,8 @@ test('session PTY owns a workspace listener and Stop performs final Git reconcil
   assert.match(sharedManager, /subscribeRootChanges/);
   assert.match(sharedManager, /scheduleRecompute\(root, userId\)/);
   assert.match(watcher, /rootChangeListeners/);
-  assert.match(hookReceiver, /refreshSessionDiffStateInBackground\(entry\.sessionId, entry\.userId, 'terminal Stop hook'\)/);
+  assert.match(
+    hookReceiver,
+    /mapped\?\.status === 'completed'[\s\S]*refreshSessionDiffStateInBackground\(entry\.sessionId, entry\.userId, 'terminal lifecycle completion'\)/,
+  );
 });

--- a/tests/session-header-visibility.test.ts
+++ b/tests/session-header-visibility.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { shouldShowSessionHeader } from '@/lib/terminal/session-header-visibility';
+
+test('GUI sessions keep the header regardless of panel count', () => {
+  assert.equal(
+    shouldShowSessionHeader({ isTerminalSession: false, isSinglePanel: true }),
+    true,
+  );
+  assert.equal(
+    shouldShowSessionHeader({ isTerminalSession: false, isSinglePanel: false }),
+    true,
+  );
+});
+
+test('only a single-panel PTY session hides the redundant header', () => {
+  assert.equal(
+    shouldShowSessionHeader({ isTerminalSession: true, isSinglePanel: true }),
+    false,
+  );
+  assert.equal(
+    shouldShowSessionHeader({ isTerminalSession: true, isSinglePanel: false }),
+    true,
+  );
+});

--- a/tests/session-model-effort-persistence.test.ts
+++ b/tests/session-model-effort-persistence.test.ts
@@ -48,3 +48,16 @@ test('updateSession patches model + reasoningEffort + serviceTier (resume re-app
   assert.equal(row?.reasoning_effort, 'xhigh');
   assert.equal(row?.service_tier, 'default');
 });
+
+test('API mapping reports an unopened terminal session as stopped', async () => {
+  await initDatabase();
+  createSession('s-terminal-status', 'proj-1', 'Terminal', 'claude-code', {
+    providerState: JSON.stringify({ kind: 'terminal' }),
+  });
+
+  const row = getSession('s-terminal-status');
+  assert.ok(row, 'terminal session row should exist');
+
+  assert.equal(mapSessionRowToApi(row, new Set(), new Set()).status, 'stopped');
+  assert.equal(mapSessionRowToApi(row, new Set([row.id]), new Set()).status, 'running');
+});

--- a/tests/terminal-contract.test.mjs
+++ b/tests/terminal-contract.test.mjs
@@ -28,14 +28,21 @@ const worktreeDiffStatsSource = fs.readFileSync(new URL('../src/lib/git/worktree
 const gitPanelSource = fs.readFileSync(new URL('../src/lib/git/git-panel.ts', import.meta.url), 'utf8');
 const prStatusProviderSource = fs.readFileSync(new URL('../src/lib/github/pr-status-provider.ts', import.meta.url), 'utf8');
 const managedWorktreesSource = fs.readFileSync(new URL('../src/lib/worktrees/managed.ts', import.meta.url), 'utf8');
+const chatAreaSource = fs.readFileSync(new URL('../src/components/chat/chat-area.tsx', import.meta.url), 'utf8');
 const terminalPanelSource = fs.readFileSync(new URL('../src/components/terminal/terminal-panel.tsx', import.meta.url), 'utf8');
+const tabPanelHostSource = fs.readFileSync(new URL('../src/components/tab/tab-panel-host.tsx', import.meta.url), 'utf8');
 const terminalSurfaceSource = fs.readFileSync(new URL('../src/lib/terminal/terminal-surface-registry.ts', import.meta.url), 'utf8');
+const terminalScrollControllerSource = fs.readFileSync(new URL('../src/lib/terminal/terminal-scroll-controller.ts', import.meta.url), 'utf8');
+const layoutSettleRunnerSource = fs.readFileSync(new URL('../src/lib/terminal/layout-settle-runner.ts', import.meta.url), 'utf8');
+const scrollToBottomButtonSource = fs.readFileSync(new URL('../src/components/ui/scroll-to-bottom-button.tsx', import.meta.url), 'utf8');
 const electronMainSource = fs.readFileSync(new URL('../electron/main.ts', import.meta.url), 'utf8');
 const electronPreloadSource = fs.readFileSync(new URL('../electron/preload.ts', import.meta.url), 'utf8');
 const terminalThemeUrl = new URL('../src/lib/terminal/terminal-theme.ts', import.meta.url);
 const terminalThemeSource = fs.existsSync(terminalThemeUrl)
   ? fs.readFileSync(terminalThemeUrl, 'utf8')
   : '';
+const terminalCssSource = fs.readFileSync(new URL('../src/app/terminal.css', import.meta.url), 'utf8');
+const terminalScrollbarSource = fs.readFileSync(new URL('../src/components/terminal/terminal-scrollbar.tsx', import.meta.url), 'utf8');
 const emptyPanelStateSource = fs.readFileSync(new URL('../src/components/panel/empty-panel-state.tsx', import.meta.url), 'utf8');
 const wsClientSource = fs.readFileSync(new URL('../src/lib/ws/client.ts', import.meta.url), 'utf8');
 const panelWrapperSource = fs.readFileSync(new URL('../src/components/panel/panel-wrapper.tsx', import.meta.url), 'utf8');
@@ -55,11 +62,29 @@ test('terminal feature declares browser UI and server PTY dependencies', () => {
   assert.ok(packageJson.dependencies['node-pty']);
 });
 
+test('plain and OSC 8 terminal links share the validated Electron external URL bridge', () => {
+  assert.match(
+    terminalSurfaceSource,
+    /const \{ webLinkHandler, oscLinkHandler \} = createTerminalExternalLinkHandlers\(\)/,
+  );
+  assert.match(terminalSurfaceSource, /linkHandler: oscLinkHandler/);
+  assert.match(terminalSurfaceSource, /new WebLinksAddon\(webLinkHandler\)/);
+  assert.match(
+    electronPreloadSource,
+    /openExternalUrl: \(url: string\) => ipcRenderer\.invoke\('shell-open-external-url', url\)/,
+  );
+  assert.match(
+    electronMainSource,
+    /ipcMain\.handle\('shell-open-external-url',[\s\S]*normalizeExternalHttpUrl\(rawUrl\)[\s\S]*shell\.openExternal\(targetUrl\)/,
+  );
+});
+
 test('terminal exposes complete light and dark color palettes', () => {
   assert.match(terminalThemeSource, /export const TERMINAL_DARK_THEME/);
-  assert.match(terminalThemeSource, /background: '#282c34'/);
+  assert.match(terminalThemeSource, /background: '#161616'/);
   assert.match(terminalThemeSource, /export const TERMINAL_LIGHT_THEME/);
-  assert.match(terminalThemeSource, /background: '#ffffff'/);
+  assert.match(terminalThemeSource, /background: '#fafaf9'/);
+  assert.match(terminalThemeSource, /black: '#ecece8'/);
   for (const color of [
     'black',
     'red',
@@ -84,14 +109,39 @@ test('terminal exposes complete light and dark color palettes', () => {
 
 test('mounted terminals follow app theme changes without recreating the PTY', () => {
   assert.match(terminalPanelSource, /const isDark = useIsDark\(\)/);
+  assert.match(terminalPanelSource, /theme: getTerminalTheme\(isDark\)/);
+  assert.match(terminalSurfaceSource, /theme: TesseraTerminalTheme/);
+  assert.match(terminalSurfaceSource, /this\.theme = \{ \.\.\.options\.theme \}/);
+  assert.doesNotMatch(terminalSurfaceSource, /private theme = getTerminalTheme\(true\)/);
   assert.match(terminalPanelSource, /surface\.setTheme\(getTerminalTheme\(isDark\)\)/);
   assert.match(terminalSurfaceSource, /setTheme\(theme: TesseraTerminalTheme\)/);
   assert.match(terminalSurfaceSource, /this\.terminal\.options\.theme = this\.theme/);
   assert.match(terminalSurfaceSource, /theme: this\.theme/);
+  assert.match(terminalSurfaceSource, /minimumContrastRatio: 4\.5/);
+  assert.match(terminalSurfaceSource, /colorQueryColors: \{/);
+  assert.match(terminalManagerSource, /createTerminalStartupColorQueryBridge/);
+  assert.match(messageTypesSource, /colorQueryColors\?: TerminalColorQueryColors/);
   assert.match(
     terminalPanelSource,
     /}, \[panelId, sessionOwned, surface, tabId, terminalId, terminalSessionId\]\);/,
   );
+});
+
+test('terminal typography and scrollbar visibility follow Tessera appearance settings', () => {
+  assert.match(terminalPanelSource, /getTerminalFontSize\(fontScale\)/);
+  assert.match(terminalPanelSource, /surface\.setFontSize\(terminalFontSize\)/);
+  assert.match(terminalSurfaceSource, /fontSize: this\.fontSize/);
+  assert.match(terminalCssSource, /--terminal-scrollbar-thumb: #687078/);
+  assert.match(terminalCssSource, /scrollbar-width: none/);
+  assert.match(terminalScrollbarSource, /data-testid="terminal-scrollbar"/);
+  assert.match(terminalScrollbarSource, /TerminalScrollMetrics/);
+  assert.match(terminalPanelSource, /<TerminalScrollbar metrics=\{scrollMetrics\} \/>/);
+});
+
+test('mounted terminal DOM order stays stable when LRU activation order changes', () => {
+  assert.match(tabPanelHostSource, /orderMountedTabIds\(tabs, lruTabIds\)/);
+  assert.match(tabPanelHostSource, /mountedTabIds\.map/);
+  assert.doesNotMatch(tabPanelHostSource, /\{lruTabIds\.map/);
 });
 
 test('terminal routes modified keys through an explicit input policy before xterm encoding', () => {
@@ -100,6 +150,28 @@ test('terminal routes modified keys through an explicit input policy before xter
   assert.match(terminalSurfaceSource, /event\.preventDefault\(\)/);
   assert.match(terminalSurfaceSource, /this\.sendInput\(action\.data\)/);
   assert.match(terminalSurfaceSource, /return false/);
+});
+
+test('terminal preserves scroll position on resize and exposes the shared latest-output control', () => {
+  assert.match(terminalSurfaceSource, /new TerminalScrollController\(terminal\)/);
+  assert.match(terminalSurfaceSource, /requestStableFit/);
+  assert.match(terminalSurfaceSource, /captureRestorePoint/);
+  assert.match(terminalSurfaceSource, /restoreAfterLayout/);
+  assert.match(terminalSurfaceSource, /terminal\.onScroll/);
+  assert.match(terminalScrollControllerSource, /'follow-output' \| 'pinned-viewport'/);
+  assert.match(terminalScrollControllerSource, /registerMarker/);
+  assert.match(terminalScrollControllerSource, /LayoutSettleRunner/);
+  assert.match(layoutSettleRunnerSource, /requestAnimationFrame/);
+  assert.match(terminalPanelSource, /!isAtBottom/);
+  assert.match(terminalPanelSource, /surface\.scrollToBottom\(\)/);
+  assert.match(terminalPanelSource, /terminal-scroll-to-bottom-button/);
+  assert.match(scrollToBottomButtonSource, /aria-label=\{title\}/);
+});
+
+test('single-panel terminal sessions omit only the redundant session header', () => {
+  assert.match(chatAreaSource, /shouldShowSessionHeader\(\{ isTerminalSession, isSinglePanel \}\)/);
+  assert.match(chatAreaSource, /<Header/);
+  assert.match(chatAreaSource, /search=\{\{/);
 });
 
 test('terminal image paste crosses the Electron clipboard boundary through a narrow preload API', () => {
@@ -127,6 +199,8 @@ test('terminal websocket protocol covers process lifecycle', () => {
     'terminal_output',
     'terminal_exit',
     'terminal_error',
+    'terminal_session_runtime',
+    'terminal_session_runtime_snapshot',
   ]) {
     assert.match(messageTypesSource, new RegExp(`type: '${type}'`));
   }
@@ -226,6 +300,13 @@ test('websocket disconnect detaches surfaces without killing terminal processes'
   assert.match(wsServerSource, /terminalManager\.detachConnection\(ws\.connectionId\)/);
   assert.doesNotMatch(wsServerSource, /terminalManager\.closeAllForUser\(userId\)/);
   assert.match(wsServerSource, /terminalManager\.shutdownAll\(\)/);
+});
+
+test('terminal runtime lifecycle is broadcast and replayed to session clients', () => {
+  assert.match(sharedTerminalManagerSource, /type: 'terminal_session_runtime'/);
+  assert.match(wsServerSource, /bindTerminalRuntimeSender/);
+  assert.match(wsServerSource, /type: 'terminal_session_runtime_snapshot'/);
+  assert.match(wsServerSource, /terminalManager\.getActiveSessionIds\(userId\)/);
 });
 
 test('terminal cwd is server validated before spawning a PTY', () => {

--- a/tests/terminal-external-link.test.ts
+++ b/tests/terminal-external-link.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createTerminalExternalLinkHandlers } from '../src/lib/terminal/terminal-external-link';
+
+test('plain and OSC 8 terminal links use the same external URL opener', () => {
+  const opened: string[] = [];
+  let prevented = 0;
+  const event = { preventDefault: () => { prevented += 1; } } as MouseEvent;
+  const handlers = createTerminalExternalLinkHandlers((url) => {
+    opened.push(url);
+  });
+
+  handlers.webLinkHandler(event, 'http://127.0.0.1:3100');
+  handlers.oscLinkHandler.activate(event, 'https://example.com/docs', {
+    start: { x: 1, y: 1 },
+    end: { x: 10, y: 1 },
+  });
+
+  assert.deepEqual(opened, [
+    'http://127.0.0.1:3100/',
+    'https://example.com/docs',
+  ]);
+  assert.equal(prevented, 2);
+});
+
+test('terminal link handlers do not forward unsafe protocols', () => {
+  const opened: string[] = [];
+  const handlers = createTerminalExternalLinkHandlers((url) => {
+    opened.push(url);
+  });
+  const event = { preventDefault: () => undefined } as MouseEvent;
+
+  handlers.webLinkHandler(event, 'javascript:alert(1)');
+  handlers.oscLinkHandler.activate(event, 'file:///tmp/report.html');
+
+  assert.deepEqual(opened, []);
+});

--- a/tests/terminal-font-size.test.ts
+++ b/tests/terminal-font-size.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getTerminalFontSize } from '@/lib/terminal/terminal-font-size';
+
+test('terminal font size compensates for the monospace font appearing larger than the UI font', () => {
+  assert.equal(getTerminalFontSize(0.8125), 11.375);
+  assert.equal(getTerminalFontSize(1), 14);
+  assert.equal(getTerminalFontSize(1.1875), 16.625);
+  assert.equal(getTerminalFontSize(1.375), 19.25);
+});

--- a/tests/terminal-hook-settings.test.ts
+++ b/tests/terminal-hook-settings.test.ts
@@ -7,7 +7,13 @@ import {
   OPENCODE_TESSERA_LIFECYCLE_EVENTS,
 } from '@/lib/terminal/opencode-hook-plugin';
 
-const EXPECTED_EVENTS = ['SessionStart', 'UserPromptSubmit', 'Stop'];
+const BASE_LIFECYCLE_EVENTS = ['SessionStart', 'UserPromptSubmit', 'Stop'];
+const CLAUDE_LIFECYCLE_EVENTS = [
+  ...BASE_LIFECYCLE_EVENTS,
+  'SubagentStart',
+  'SubagentStop',
+  'TeammateIdle',
+];
 
 function hooks(settingsJson: string): Record<string, unknown> {
   const settings = JSON.parse(settingsJson) as { hooks?: unknown };
@@ -15,24 +21,22 @@ function hooks(settingsJson: string): Record<string, unknown> {
   return settings.hooks as Record<string, unknown>;
 }
 
-function assertMinimalEvents(actual: Record<string, unknown>): void {
-  assert.deepEqual(Object.keys(actual).sort(), [...EXPECTED_EVENTS].sort());
+function assertEvents(actual: Record<string, unknown>, expected: string[]): void {
+  assert.deepEqual(Object.keys(actual).sort(), [...expected].sort());
 }
 
-test('Claude terminal settings inject only the minimal lifecycle hooks', () => {
-  assertMinimalEvents(hooks(buildClaudeHookSettingsJson()));
+test('Claude terminal settings include child-agent lifecycle hooks', () => {
+  assertEvents(hooks(buildClaudeHookSettingsJson()), CLAUDE_LIFECYCLE_EVENTS);
 });
 
-test('Codex terminal overlay injects the same minimal lifecycle hooks as Claude', () => {
-  const claudeHooks = hooks(buildClaudeHookSettingsJson());
+test('Codex terminal overlay keeps the base lifecycle hooks', () => {
   const codexHooks = hooks(buildCodexHookSettingsJson());
-  assertMinimalEvents(codexHooks);
-  assert.deepEqual(codexHooks, claudeHooks);
+  assertEvents(codexHooks, BASE_LIFECYCLE_EVENTS);
 });
 
-test('OpenCode terminal plugin normalizes to the same minimal lifecycle events', () => {
-  assert.deepEqual([...OPENCODE_TESSERA_LIFECYCLE_EVENTS], EXPECTED_EVENTS);
+test('OpenCode terminal plugin normalizes to the base lifecycle events', () => {
+  assert.deepEqual([...OPENCODE_TESSERA_LIFECYCLE_EVENTS], BASE_LIFECYCLE_EVENTS);
   const emittedEvents = [...buildOpenCodeHookPluginSource().matchAll(/hook_event_name:\s*"([^"]+)"/g)]
     .map((match) => match[1]);
-  assert.deepEqual([...new Set(emittedEvents)].sort(), [...EXPECTED_EVENTS].sort());
+  assert.deepEqual([...new Set(emittedEvents)].sort(), [...BASE_LIFECYCLE_EVENTS].sort());
 });

--- a/tests/terminal-key-input.test.ts
+++ b/tests/terminal-key-input.test.ts
@@ -130,7 +130,7 @@ test('macOS Command editing chords match native terminal line operations', () =>
   );
 });
 
-test('macOS Command+Up and Command+Down navigate terminal scrollback', () => {
+test('macOS Command+Up and Command+Down navigate terminal scrollback without PTY input', () => {
   const context = { platform: 'mac' as const };
   assert.deepEqual(
     [

--- a/tests/terminal-manager-lifecycle.test.ts
+++ b/tests/terminal-manager-lifecycle.test.ts
@@ -145,6 +145,34 @@ test('concurrent session opens spawn once and disconnect only detaches its surfa
   assert.deepEqual(manager.getRuntimeSummary(), { activeCount: 0, sessionCount: 0 });
 });
 
+test('session PTY lifecycle reports running until the process exits', async () => {
+  const spawned: FakePty[] = [];
+  const runtimeStates: Array<{ sessionId: string; userId: string; running: boolean }> = [];
+  const manager = new TerminalManager(
+    () => {},
+    async () => createFactory(spawned),
+    undefined,
+    {
+      onSessionRuntimeStateChange: (state) => runtimeStates.push(state),
+    },
+  );
+
+  await manager.create(createOptions());
+  assert.deepEqual(runtimeStates, [{ sessionId: 'session-a', userId: 'user-a', running: true }]);
+  assert.deepEqual([...manager.getActiveSessionIds('user-a')], ['session-a']);
+
+  manager.detachConnection('connection-a');
+  assert.deepEqual(runtimeStates, [{ sessionId: 'session-a', userId: 'user-a', running: true }]);
+  assert.deepEqual([...manager.getActiveSessionIds('user-a')], ['session-a']);
+
+  spawned[0].emitExit(0);
+  assert.deepEqual(runtimeStates, [
+    { sessionId: 'session-a', userId: 'user-a', running: true },
+    { sessionId: 'session-a', userId: 'user-a', running: false },
+  ]);
+  assert.deepEqual([...manager.getActiveSessionIds('user-a')], []);
+});
+
 test('cold attach receives one snapshot boundary followed by monotonic live output', async () => {
   const delivered: Array<{ connectionId: string; message: ServerTransportMessage }> = [];
   const spawned: FakePty[] = [];
@@ -192,9 +220,14 @@ test('cold attach receives one snapshot boundary followed by monotonic live outp
 test('a late exit from an older generation cannot erase its replacement runtime', async () => {
   const delivered: Array<{ connectionId: string; message: ServerTransportMessage }> = [];
   const spawned: FakePty[] = [];
+  const runtimeStates: Array<{ sessionId: string; userId: string; running: boolean }> = [];
   const manager = new TerminalManager(
     (connectionId, message) => delivered.push({ connectionId, message }),
     async () => createFactory(spawned),
+    undefined,
+    {
+      onSessionRuntimeStateChange: (state) => runtimeStates.push(state),
+    },
   );
 
   await manager.create(createOptions());
@@ -209,8 +242,10 @@ test('a late exit from an older generation cannot erase its replacement runtime'
   if (firstStart?.type === 'terminal_started' && secondStart?.type === 'terminal_started') {
     assert.equal(secondStart.generation, firstStart.generation + 1);
   }
+  const runtimeStatesBeforeLateExit = [...runtimeStates];
 
   spawned[0].emitExit(0);
+  assert.deepEqual(runtimeStates, runtimeStatesBeforeLateExit);
   assert.deepEqual(manager.getRuntimeSummary(), { activeCount: 1, sessionCount: 1 });
   spawned[1].emitData('replacement-is-alive');
   await nextImmediate();
@@ -355,6 +390,19 @@ test('spawn and resize clamp hostile terminal dimensions', async () => {
   await manager.shutdownAll();
 });
 
+test('claiming an already-sized viewport does not send a redundant PTY resize', async () => {
+  const spawned: FakePty[] = [];
+  const manager = new TerminalManager(() => {}, async () => createFactory(spawned));
+
+  await manager.create(createOptions({ cols: 100, rows: 30 }));
+  manager.resize('terminal-a', 'user-a', 'connection-a', 'surface-a', 100, 30, true);
+  assert.deepEqual(spawned[0].resizes, []);
+
+  manager.resize('terminal-a', 'user-a', 'connection-a', 'surface-a', 120, 40, true);
+  assert.deepEqual(spawned[0].resizes, [{ cols: 120, rows: 40 }]);
+  await manager.shutdownAll();
+});
+
 test('PTY spawn normalizes inherited color opt-outs at the manager boundary', async () => {
   let spawnEnv: NodeJS.ProcessEnv | null = null;
   const factory: TerminalPtyFactory = {
@@ -380,6 +428,39 @@ test('PTY spawn normalizes inherited color opt-outs at the manager boundary', as
   assert.equal(spawnEnv.TERM, 'xterm-256color');
   assert.equal(spawnEnv.COLORTERM, 'truecolor');
   assert.equal(spawnEnv.TERM_PROGRAM, 'Tessera');
+
+  await manager.shutdownAll();
+});
+
+test('agent PTY startup answers color probes before forwarding renderer output', async () => {
+  const delivered: ServerTransportMessage[] = [];
+  const spawned: FakePty[] = [];
+  const manager = new TerminalManager(
+    (_connectionId, message) => delivered.push(message),
+    async () => createFactory(spawned),
+  );
+
+  await manager.create(createOptions({
+    launchSpec: { program: 'claude' },
+    colorQueryColors: {
+      foreground: '#25282b',
+      background: '#fafaf9',
+    },
+  }));
+  delivered.length = 0;
+
+  spawned[0].emitData('\x1b]10;?\x1b\\\x1b]11;?\x1b\\ready');
+  await nextImmediate();
+
+  assert.deepEqual(spawned[0].writes, [
+    '\x1b]10;rgb:2525/2828/2b2b\x1b\\',
+    '\x1b]11;rgb:fafa/fafa/f9f9\x1b\\',
+  ]);
+  assert.deepEqual(
+    delivered.filter((message) => message.type === 'terminal_output')
+      .map((message) => message.type === 'terminal_output' ? message.data : ''),
+    ['ready'],
+  );
 
   await manager.shutdownAll();
 });

--- a/tests/terminal-scroll-controller.test.ts
+++ b/tests/terminal-scroll-controller.test.ts
@@ -1,0 +1,272 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  TerminalScrollController,
+  type TerminalScrollScheduler,
+  type TerminalScrollTarget,
+} from '@/lib/terminal/terminal-scroll-controller';
+
+function createScheduler() {
+  let nextId = 1;
+  const frames = new Map<number, () => void>();
+  const timers = new Map<number, () => void>();
+  const scheduler: TerminalScrollScheduler = {
+    cancelAnimationFrame: (id) => frames.delete(id),
+    clearTimeout: (id) => timers.delete(id),
+    queueMicrotask: (callback) => callback(),
+    requestAnimationFrame: (callback) => {
+      const id = nextId++;
+      frames.set(id, callback);
+      return id;
+    },
+    setTimeout: (callback) => {
+      const id = nextId++;
+      timers.set(id, callback);
+      return id;
+    },
+  };
+  return {
+    scheduler,
+    runNextFrame: () => {
+      const entry = frames.entries().next().value as [number, () => void] | undefined;
+      assert.ok(entry);
+      frames.delete(entry[0]);
+      entry[1]();
+    },
+    runNextTimer: () => {
+      const entry = timers.entries().next().value as [number, () => void] | undefined;
+      assert.ok(entry);
+      timers.delete(entry[0]);
+      entry[1]();
+    },
+  };
+}
+
+function createTarget(overrides: Partial<TerminalScrollTarget['buffer']['active']> = {}) {
+  const calls: Array<{ type: 'bottom' } | { type: 'line'; line: number }> = [];
+  const markerOffsets: number[] = [];
+  let markerDisposed = false;
+  let markerLine = overrides.viewportY ?? 200;
+  const active = {
+    type: 'normal' as const,
+    baseY: 200,
+    viewportY: 200,
+    cursorY: 20,
+    ...overrides,
+  };
+  const target: TerminalScrollTarget = {
+    buffer: { active },
+    scrollToBottom: () => {
+      active.viewportY = active.baseY;
+      calls.push({ type: 'bottom' });
+    },
+    scrollToLine: (line) => {
+      active.viewportY = line;
+      calls.push({ type: 'line', line });
+    },
+    registerMarker: (offset = 0) => {
+      markerOffsets.push(offset);
+      return {
+        get isDisposed() {
+          return markerDisposed;
+        },
+        get line() {
+          return markerLine;
+        },
+        dispose: () => {
+          markerDisposed = true;
+        },
+      };
+    },
+  };
+  return {
+    active,
+    calls,
+    markerOffsets,
+    setMarkerLine: (line: number) => {
+      markerLine = line;
+    },
+    target,
+    wasMarkerDisposed: () => markerDisposed,
+  };
+}
+
+test('follow-output intent remains attached to live output after terminal reflow', () => {
+  const { active, calls, target } = createTarget();
+  const controller = new TerminalScrollController(target);
+  const restorePoint = controller.captureRestorePoint();
+
+  active.baseY = 260;
+  active.viewportY = 175;
+  controller.restore(restorePoint);
+
+  assert.deepEqual(calls, [{ type: 'bottom' }]);
+  assert.equal(active.viewportY, 260);
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'follow-output',
+    isAtBottom: true,
+  });
+});
+
+test('pinned viewport follows the same first visible line through wrapped-line reflow', () => {
+  const {
+    active,
+    calls,
+    markerOffsets,
+    setMarkerLine,
+    target,
+    wasMarkerDisposed,
+  } = createTarget({ viewportY: 150 });
+  const controller = new TerminalScrollController(target);
+  const restorePoint = controller.captureRestorePoint();
+
+  assert.deepEqual(markerOffsets, [-70]);
+  setMarkerLine(185);
+  active.baseY = 260;
+  active.viewportY = 260;
+  controller.restore(restorePoint);
+
+  assert.deepEqual(calls, [{ type: 'line', line: 185 }]);
+  assert.equal(active.viewportY, 185);
+  assert.equal(wasMarkerDisposed(), true);
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'pinned-viewport',
+    isAtBottom: false,
+  });
+});
+
+test('a user follow-output request wins over an older pinned restore point', () => {
+  const { active, calls, setMarkerLine, target, wasMarkerDisposed } = createTarget({
+    viewportY: 150,
+  });
+  const controller = new TerminalScrollController(target);
+  const staleRestorePoint = controller.captureRestorePoint();
+
+  setMarkerLine(120);
+  controller.scrollToBottom();
+  controller.restore(staleRestorePoint);
+
+  assert.deepEqual(calls, [{ type: 'bottom' }]);
+  assert.equal(active.viewportY, active.baseY);
+  assert.equal(wasMarkerDisposed(), true);
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'follow-output',
+    isAtBottom: true,
+  });
+});
+
+test('layout restore follows a marker until xterm reflow has settled', () => {
+  const { calls, setMarkerLine, target, wasMarkerDisposed } = createTarget({ viewportY: 150 });
+  const { scheduler, runNextFrame, runNextTimer } = createScheduler();
+  const controller = new TerminalScrollController(target, scheduler);
+  const restorePoint = controller.captureRestorePoint();
+
+  setMarkerLine(170);
+  controller.restoreAfterLayout(restorePoint);
+  setMarkerLine(180);
+  runNextFrame();
+  setMarkerLine(190);
+  runNextFrame();
+  setMarkerLine(200);
+  runNextTimer();
+
+  assert.deepEqual(calls, [
+    { type: 'line', line: 170 },
+    { type: 'line', line: 180 },
+    { type: 'line', line: 190 },
+    { type: 'line', line: 200 },
+  ]);
+  assert.equal(wasMarkerDisposed(), true);
+});
+
+test('viewport tracking distinguishes deliberate history reading from following output', () => {
+  const { active, target } = createTarget();
+  const controller = new TerminalScrollController(target);
+  let notifications = 0;
+  controller.subscribe(() => {
+    notifications += 1;
+  });
+
+  active.viewportY = 150;
+  controller.syncFromViewport();
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'pinned-viewport',
+    isAtBottom: false,
+  });
+
+  active.viewportY = active.baseY;
+  controller.syncFromViewport({ preservePinnedAtBottom: true });
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'pinned-viewport',
+    isAtBottom: true,
+  });
+
+  controller.syncFromViewport();
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'follow-output',
+    isAtBottom: true,
+  });
+  assert.equal(notifications, 3);
+});
+
+test('explicit scrollback navigation updates both viewport and output-following intent', () => {
+  const { active, calls, target } = createTarget();
+  const controller = new TerminalScrollController(target);
+
+  controller.scrollToTop();
+  assert.deepEqual(calls, [{ type: 'line', line: 0 }]);
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'pinned-viewport',
+    isAtBottom: false,
+  });
+
+  controller.scrollToBottom();
+  assert.equal(active.viewportY, active.baseY);
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'follow-output',
+    isAtBottom: true,
+  });
+});
+
+test('wheel-up intent pins immediately before the browser viewport catches up', () => {
+  const { active, target } = createTarget();
+  const controller = new TerminalScrollController(target);
+
+  controller.pinViewport();
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'pinned-viewport',
+    isAtBottom: true,
+  });
+
+  active.viewportY = 150;
+  controller.syncFromViewport({ preservePinnedAtBottom: true });
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'pinned-viewport',
+    isAtBottom: false,
+  });
+});
+
+test('programmatic viewport movement updates visibility without overwriting intent', () => {
+  const { active, target } = createTarget();
+  const controller = new TerminalScrollController(target);
+
+  active.viewportY = 150;
+  controller.notifyViewportChanged();
+
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'follow-output',
+    isAtBottom: false,
+  });
+});
+
+test('restore tolerates xterm renderer teardown and still releases its marker', () => {
+  const { target, wasMarkerDisposed } = createTarget({ viewportY: 150 });
+  const controller = new TerminalScrollController(target);
+  const restorePoint = controller.captureRestorePoint();
+  target.scrollToLine = () => {
+    throw new TypeError("Cannot read properties of undefined (reading 'dimensions')");
+  };
+
+  assert.doesNotThrow(() => controller.restore(restorePoint));
+  assert.equal(wasMarkerDisposed(), true);
+});

--- a/tests/terminal-scroll-reflow.e2e.mjs
+++ b/tests/terminal-scroll-reflow.e2e.mjs
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { chromium } from '@playwright/test';
+
+const appUrl = process.env.TESSERA_E2E_APP_URL
+  ?? 'http://127.0.0.1:3100/dev-terminal-scroll-repro';
+const browser = await chromium.launch({ headless: true, channel: 'chrome' });
+const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+
+async function terminalMetrics() {
+  return page.locator('.xterm-viewport').evaluate((viewport) => ({
+    clientHeight: viewport.clientHeight,
+    scrollHeight: viewport.scrollHeight,
+    scrollTop: viewport.scrollTop,
+  }));
+}
+
+async function firstVisibleRowTag() {
+  return page.evaluate(() => window.__tesseraTerminalScrollRepro?.firstVisibleRowTag() ?? null);
+}
+
+async function terminalViewportY() {
+  return page.evaluate(() => window.__tesseraTerminalScrollRepro?.viewportY() ?? null);
+}
+
+async function terminalIsAtBottom() {
+  return page.evaluate(() => window.__tesseraTerminalScrollRepro?.isAtBottom() ?? null);
+}
+
+async function waitForScrollHeight(minimumHeight) {
+  await page.waitForFunction((minimum) => (
+    (document.querySelector('.xterm-viewport')?.scrollHeight ?? 0) > minimum
+  ), minimumHeight, { timeout: 30_000 });
+}
+
+async function typeCommand(command) {
+  const input = page.locator('.xterm-helper-textarea');
+  await input.focus();
+  await page.keyboard.type(command);
+  await page.keyboard.press('Enter');
+}
+
+try {
+  await page.goto(appUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await page.getByTestId('terminal-repro-status').getByText('running').waitFor({ timeout: 30_000 });
+  await page.locator('.xterm-helper-textarea').waitFor({ state: 'attached', timeout: 30_000 });
+  const persistentScrollbar = page.getByTestId('terminal-scrollbar');
+  await persistentScrollbar.waitFor({ state: 'visible', timeout: 5_000 });
+  await page.waitForTimeout(1_000);
+  assert.equal(
+    await persistentScrollbar.isVisible(),
+    true,
+    'terminal scrollbar should remain visible while the terminal is idle',
+  );
+
+  const longRows = `node -e "for(let i=1;i<=450;i++){const tag='ROW_'+String(i).padStart(4,'0');console.log((tag+' abcdefghijklmnopqrstuvwxyz ').repeat(8))}"`;
+  await typeCommand(longRows);
+  await waitForScrollHeight(5_000);
+
+  const scrollbarTrack = await persistentScrollbar.boundingBox();
+  const scrollbarThumb = await page.getByTestId('terminal-scrollbar-thumb').boundingBox();
+  assert.ok(scrollbarTrack && scrollbarThumb, 'persistent scrollbar geometry should be measurable');
+  assert.ok(
+    scrollbarThumb.height < scrollbarTrack.height,
+    'scrollback should produce a position thumb smaller than its track',
+  );
+
+  let metrics = await terminalMetrics();
+  assert.ok(
+    metrics.scrollTop + metrics.clientHeight >= metrics.scrollHeight - 2,
+    'new terminal output should remain attached to the bottom',
+  );
+
+  await page.keyboard.press('Shift+PageUp');
+  await page.keyboard.press('Shift+PageUp');
+  const jumpButton = page.getByTestId('terminal-scroll-to-bottom-button');
+  await jumpButton.waitFor({ state: 'visible', timeout: 5_000 });
+  const pinnedMetrics = await terminalMetrics();
+  assert.ok(pinnedMetrics.scrollTop > 0, 'the test should pin inside scrollback, not at the top');
+  const pinnedTag = await firstVisibleRowTag();
+  assert.ok(pinnedTag, 'a tagged scrollback row should be visible before reflow');
+
+  await page.setViewportSize({ width: 720, height: 800 });
+  await page.waitForTimeout(300);
+  const afterReflow = await terminalMetrics();
+  assert.ok(
+    afterReflow.scrollTop > 0
+      && afterReflow.scrollTop + afterReflow.clientHeight < afterReflow.scrollHeight - 2,
+    'width reflow should keep the viewport pinned inside scrollback',
+  );
+  assert.equal(
+    await firstVisibleRowTag(),
+    pinnedTag,
+    'width reflow should keep the same first visible output row',
+  );
+
+  const beforeBackgroundOutput = await terminalMetrics();
+  const backgroundRows = `node -e "let i=451;const id=setInterval(()=>{console.log('ROW_'+String(i).padStart(4,'0')+' background-output');if(i++>=520)clearInterval(id)},10)"`;
+  await typeCommand(backgroundRows);
+  await page.keyboard.press('Shift+PageUp');
+  await page.waitForTimeout(1200);
+  const afterBackgroundOutput = await terminalMetrics();
+  assert.ok(
+    afterBackgroundOutput.scrollHeight > beforeBackgroundOutput.scrollHeight,
+    'background output should extend scrollback',
+  );
+  assert.ok(
+    afterBackgroundOutput.scrollTop + afterBackgroundOutput.clientHeight
+      < afterBackgroundOutput.scrollHeight - 2,
+    'background output must not pull a pinned viewport to the bottom',
+  );
+
+  const beforeViewChange = await firstVisibleRowTag();
+  assert.ok(beforeViewChange, 'a tagged row should remain visible before remounting');
+  await page.getByTestId('toggle-terminal-view').click();
+  await page.getByTestId('toggle-terminal-view').click();
+  await page.locator('.xterm-helper-textarea').waitFor({ state: 'attached', timeout: 5_000 });
+  await page.waitForTimeout(300);
+  assert.equal(
+    await firstVisibleRowTag(),
+    beforeViewChange,
+    'unmounting and remounting the terminal view should preserve scrollback position',
+  );
+
+  await jumpButton.click();
+  await jumpButton.waitFor({ state: 'hidden', timeout: 5_000 });
+  assert.equal(await terminalIsAtBottom(), true, 'the jump overlay should return to live output');
+
+  if (process.platform === 'darwin') {
+    await page.locator('.xterm-helper-textarea').focus();
+    await page.keyboard.press('Meta+ArrowUp');
+    await jumpButton.waitFor({ state: 'visible', timeout: 5_000 });
+    assert.equal(await terminalViewportY(), 0, 'Cmd+Up should jump to scrollback top');
+    await page.keyboard.press('Meta+ArrowDown');
+  }
+  await jumpButton.waitFor({ state: 'hidden', timeout: 5_000 });
+  assert.equal(await terminalIsAtBottom(), true, 'Cmd+Down should return to live output');
+} finally {
+  await page.getByTestId('close-terminal-repro').click().catch(() => {});
+  await browser.close();
+}

--- a/tests/terminal-scrollbar-geometry.test.ts
+++ b/tests/terminal-scrollbar-geometry.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getTerminalScrollbarGeometry } from '../src/lib/terminal/terminal-scrollbar-geometry';
+
+test('terminal scrollbar fills the track when there is no scrollback', () => {
+  assert.deepEqual(
+    getTerminalScrollbarGeometry({ baseY: 0, viewportY: 0, rows: 30 }, 300),
+    { height: 300, top: 0 },
+  );
+});
+
+test('terminal scrollbar keeps a usable minimum thumb and tracks the viewport', () => {
+  const middle = getTerminalScrollbarGeometry(
+    { baseY: 970, viewportY: 485, rows: 30 },
+    300,
+  );
+  assert.deepEqual(middle, { height: 28, top: 136 });
+
+  const bottom = getTerminalScrollbarGeometry(
+    { baseY: 970, viewportY: 970, rows: 30 },
+    300,
+  );
+  assert.deepEqual(bottom, { height: 28, top: 272 });
+});
+
+test('terminal scrollbar clamps stale viewport coordinates after reflow', () => {
+  assert.deepEqual(
+    getTerminalScrollbarGeometry({ baseY: 20, viewportY: 200, rows: 20 }, 100),
+    { height: 50, top: 50 },
+  );
+});

--- a/tests/terminal-session-runtime-state.test.ts
+++ b/tests/terminal-session-runtime-state.test.ts
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import test, { beforeEach } from 'node:test';
+import { handleIncomingServerMessage } from '@/lib/ws/client-message-handlers';
+import type { ServerTransportMessage } from '@/lib/ws/message-types';
+import { isTurnInFlight, useChatStore } from '@/stores/chat-store';
+import { useSessionStore } from '@/stores/session-store';
+import type { ProjectGroup, UnifiedSession } from '@/types/chat';
+
+const SESSION_ID = 'terminal-session-a';
+
+function terminalSession(id = SESSION_ID, isRunning = false): UnifiedSession {
+  return {
+    id,
+    title: 'PTY session',
+    projectDir: '/workspace',
+    workDir: '/workspace',
+    kind: 'terminal',
+    provider: 'claude-code',
+    isRunning,
+    hasStarted: isRunning,
+    status: isRunning ? 'running' : 'stopped',
+    createdAt: '2026-07-14T00:00:00.000Z',
+    lastModified: '2026-07-14T00:00:00.000Z',
+  };
+}
+
+function project(...sessions: UnifiedSession[]): ProjectGroup {
+  return {
+    encodedDir: '/workspace',
+    displayName: 'workspace',
+    decodedPath: '/workspace',
+    isCurrent: true,
+    sessions,
+    totalSessions: sessions.length,
+    allLoaded: true,
+    loadedCount: 1,
+    nextCursor: null,
+    loadBatchIndex: 0,
+  };
+}
+
+function receive(msg: ServerTransportMessage): void {
+  handleIncomingServerMessage({
+    msg,
+    providersListCallbacks: new Map(),
+    cliStatusCallbacks: new Map(),
+    wasReconnect: false,
+  });
+}
+
+beforeEach(() => {
+  useChatStore.setState({ turnInFlightBySession: {} });
+  useSessionStore.setState({
+    projects: [project(terminalSession())],
+    activeSessionId: null,
+    runningWorkflowSessionIds: new Set(),
+  });
+});
+
+test('PTY UserPromptSubmit marks the session as processing without changing runtime liveness', () => {
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: true,
+  } as ServerTransportMessage);
+
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'running',
+    hookEvent: 'UserPromptSubmit',
+  });
+
+  assert.equal(isTurnInFlight(useChatStore.getState(), SESSION_ID), true);
+  assert.equal(useSessionStore.getState().getSession(SESSION_ID)?.isRunning, true);
+});
+
+test('PTY runtime state owns the session Running indicator across completed turns', () => {
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: true,
+  } as ServerTransportMessage);
+  assert.equal(useSessionStore.getState().getSession(SESSION_ID)?.isRunning, true);
+
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'running',
+    hookEvent: 'UserPromptSubmit',
+  });
+  assert.equal(isTurnInFlight(useChatStore.getState(), SESSION_ID), true);
+
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'completed',
+    hookEvent: 'Stop',
+  });
+  assert.equal(isTurnInFlight(useChatStore.getState(), SESSION_ID), false);
+  assert.equal(useSessionStore.getState().getSession(SESSION_ID)?.isRunning, true);
+
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: false,
+  } as ServerTransportMessage);
+  const stopped = useSessionStore.getState().getSession(SESSION_ID);
+  assert.equal(stopped?.isRunning, false);
+  assert.equal(stopped?.status, 'stopped');
+});
+
+test('PTY runtime exit clears processing when no Stop hook arrives', () => {
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: true,
+  } as ServerTransportMessage);
+
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'running',
+    hookEvent: 'UserPromptSubmit',
+  });
+  assert.equal(isTurnInFlight(useChatStore.getState(), SESSION_ID), true);
+
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: false,
+  } as ServerTransportMessage);
+
+  assert.equal(isTurnInFlight(useChatStore.getState(), SESSION_ID), false);
+
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'running',
+    hookEvent: 'PostToolUse',
+  });
+  assert.equal(isTurnInFlight(useChatStore.getState(), SESSION_ID), false);
+});
+
+test('new PTY sessions are stopped until their terminal is opened', () => {
+  useSessionStore.setState({ projects: [] });
+
+  receive({
+    type: 'session_created',
+    sessionId: 'new-terminal-session',
+    status: 'ready',
+    workDir: '/workspace',
+    kind: 'terminal',
+    provider: 'claude-code',
+  });
+
+  const created = useSessionStore.getState().getSession('new-terminal-session');
+  assert.equal(created?.isRunning, false);
+  assert.equal(created?.status, 'stopped');
+});
+
+test('PTY runtime snapshot reconciles sessions after a WebSocket reconnect', () => {
+  const inactiveSessionId = 'terminal-session-inactive';
+  useSessionStore.setState({
+    projects: [project(
+      terminalSession(SESSION_ID, false),
+      terminalSession(inactiveSessionId, true),
+    )],
+  });
+  useChatStore.setState({
+    turnInFlightBySession: {
+      [SESSION_ID]: true,
+      [inactiveSessionId]: true,
+    },
+  });
+
+  receive({
+    type: 'terminal_session_runtime_snapshot',
+    activeSessionIds: [SESSION_ID],
+  } as ServerTransportMessage);
+
+  assert.equal(useSessionStore.getState().getSession(SESSION_ID)?.isRunning, true);
+  assert.equal(isTurnInFlight(useChatStore.getState(), SESSION_ID), true);
+  const inactive = useSessionStore.getState().getSession(inactiveSessionId);
+  assert.equal(inactive?.isRunning, false);
+  assert.equal(inactive?.status, 'stopped');
+  assert.equal(isTurnInFlight(useChatStore.getState(), inactiveSessionId), false);
+});

--- a/tests/terminal-startup-color-query.test.ts
+++ b/tests/terminal-startup-color-query.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  createTerminalStartupColorQueryBridge,
+  formatTerminalOscColorReply,
+} from '@/lib/terminal/terminal-startup-color-query';
+
+const COLORS = {
+  foreground: '#25282b',
+  background: '#fafaf9',
+};
+
+test('terminal startup color bridge answers and consumes OSC foreground/background queries', () => {
+  const replies: string[] = [];
+  const bridge = createTerminalStartupColorQueryBridge(COLORS, (reply) => replies.push(reply));
+
+  const output = bridge.consume('\x1b]10;?\x1b\\\x1b]11;?\x07ready');
+
+  assert.equal(output, 'ready');
+  assert.deepEqual(replies, [
+    '\x1b]10;rgb:2525/2828/2b2b\x1b\\',
+    '\x1b]11;rgb:fafa/fafa/f9f9\x1b\\',
+  ]);
+});
+
+test('terminal startup color bridge handles a combined query split across PTY chunks', () => {
+  const replies: string[] = [];
+  const bridge = createTerminalStartupColorQueryBridge(COLORS, (reply) => replies.push(reply));
+
+  assert.equal(bridge.consume('before\x1b]10;?;'), 'before');
+  assert.equal(bridge.consume('?\x1b\\after'), 'after');
+  assert.deepEqual(replies, [
+    '\x1b]10;rgb:2525/2828/2b2b\x1b\\',
+    '\x1b]11;rgb:fafa/fafa/f9f9\x1b\\',
+  ]);
+});
+
+test('terminal startup color bridge preserves unrelated and malformed OSC output', () => {
+  const replies: string[] = [];
+  const bridge = createTerminalStartupColorQueryBridge(COLORS, (reply) => replies.push(reply));
+  const data = '\x1b]0;title\x07\x1b]11;not-a-query\x1b\\ready';
+
+  assert.equal(bridge.consume(data), data);
+  assert.deepEqual(replies, []);
+});
+
+test('terminal OSC color replies reject values that could inject control sequences', () => {
+  assert.equal(formatTerminalOscColorReply(11, '#101214'), '\x1b]11;rgb:1010/1212/1414\x1b\\');
+  assert.equal(formatTerminalOscColorReply(11, 'red\x1b\\'), null);
+});

--- a/tests/terminal-theme.test.ts
+++ b/tests/terminal-theme.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getTerminalTheme } from '@/lib/terminal/terminal-theme';
+
+test('terminal exposes the approved Lifted Neutral light palette', () => {
+  assert.deepEqual(getTerminalTheme(false), {
+    background: '#fafaf9',
+    foreground: '#25282b',
+    cursor: '#25282b',
+    cursorAccent: '#fafaf9',
+    selectionBackground: '#accef7',
+    selectionForeground: '#25282b',
+    black: '#ecece8',
+    red: '#b83232',
+    green: '#4b821f',
+    yellow: '#806b00',
+    blue: '#3465a4',
+    magenta: '#75507b',
+    cyan: '#05727e',
+    white: '#6a6a6a',
+    brightBlack: '#555753',
+    brightRed: '#d44747',
+    brightGreen: '#2f702c',
+    brightYellow: '#695900',
+    brightBlue: '#204a87',
+    brightMagenta: '#976a92',
+    brightCyan: '#034b50',
+    brightWhite: '#3d3d3d',
+  });
+});
+
+test('terminal exposes the approved Neutral Charcoal dark palette', () => {
+  assert.deepEqual(getTerminalTheme(true), {
+    background: '#161616',
+    foreground: '#e3e9ed',
+    cursor: '#e4edf2',
+    cursorAccent: '#161616',
+    selectionBackground: '#303030',
+    selectionForeground: '#f4f8fa',
+    black: '#141a1f',
+    red: '#df797c',
+    green: '#91c497',
+    yellow: '#d7bc70',
+    blue: '#80afd0',
+    magenta: '#b5a0c8',
+    cyan: '#72b9c1',
+    white: '#c9d1d7',
+    brightBlack: '#71818d',
+    brightRed: '#ee898c',
+    brightGreen: '#a1d4a7',
+    brightYellow: '#e6cb80',
+    brightBlue: '#90c0e1',
+    brightMagenta: '#c6b0d9',
+    brightCyan: '#82cad2',
+    brightWhite: '#f3f7f9',
+  });
+});


### PR DESCRIPTION
## Summary

- preserve terminal scroll intent across output, reflow, remounts, and mounted-tab changes
- add app-aware terminal typography, light/dark palettes, scrollbar behavior, and external link handling
- hide redundant PTY-only session chrome without changing GUI session headers
- track PTY processing separately from process liveness
- keep Claude turns active while background subagents are still running
- add focused development and contract coverage for the terminal surface

## Architecture

Scroll, lifecycle, and presentation behavior live in shared terminal modules. Provider hooks only map native lifecycle events into that shared state, keeping GUI and PTY paths isolated.

## Validation

- 86 focused terminal and lifecycle tests
- full ESLint run with no errors (two pre-existing warnings)
- `npx tsc --noEmit`
- `git diff --check origin/dev...HEAD`