### PR TITLE
feat: track PTY background work and input waits

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -11,10 +11,9 @@ import { useArchiveConfirm } from '@/hooks/use-archive-confirm';
 import { useCollectionStore } from '@/stores/collection-store';
 import { useBoardStore } from '@/stores/board-store';
 import {
-  selectAnyAwaitingUserPrompt,
-  selectIsAwaitingUserPrompt,
-  useChatStore,
-} from '@/stores/chat-store';
+  useAnySessionAwaitingUser,
+  useIsSessionAwaitingUser,
+} from '@/hooks/use-session-awaiting-user';
 import { useProvidersStore } from '@/stores/providers-store';
 import { useSettingsStore } from '@/stores/settings-store';
 import { useSessionStore } from '@/stores/session-store';
@@ -155,7 +154,7 @@ export const KanbanChatCard = memo(function KanbanChatCard({
   const isSelected = useSelectionStore((s) => s.selectedIds.has(session.id));
   const showProviderIcons = useSettingsStore((s) => s.settings.showProviderIcons);
   const isProcessing = useIsSessionProcessing(session.id, session.kind);
-  const isAwaitingUser = useChatStore(selectIsAwaitingUserPrompt(session.id));
+  const isAwaitingUser = useIsSessionAwaitingUser(session.id, session.kind);
   const isGeneratingTitle = useSessionStore((s) => s.generatingTitleIds.has(session.id));
   const isJustDropped = useBoardStore((s) => s.justDroppedId === session.id);
   const isDragging = useBoardStore((s) => s.draggingTaskId === session.id);
@@ -650,7 +649,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
     hasProcessingSession,
     hasTerminalProcessingSession,
   } = useSessionProcessingSummary(task.sessions);
-  const hasAwaitingUserSession = useChatStore(selectAnyAwaitingUserPrompt(taskSessionIds));
+  const hasAwaitingUserSession = useAnySessionAwaitingUser(task.sessions);
   const hasUnreadSession = useSessionStore((state) =>
     !isActive && taskSessionIds.some((id) => {
       if (id === activeSessionId) return false;
@@ -1215,7 +1214,7 @@ function KanbanSubSessionItem({
   });
   const liveUnreadCount = liveSession?.unreadCount ?? 0;
   const hasLiveUnread = !isActive && liveUnreadCount > 0;
-  const isAwaitingUser = useChatStore(selectIsAwaitingUserPrompt(session.id));
+  const isAwaitingUser = useIsSessionAwaitingUser(session.id, session.kind);
   const displayTitle = liveSession?.title ?? session.title;
   const isArchived = liveSession?.archived ?? false;
   const canOpenMenu = Boolean(

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -27,10 +27,9 @@ import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 import { useBoardStore } from '@/stores/board-store';
 import {
-  selectAnyAwaitingUserPrompt,
-  selectIsAwaitingUserPrompt,
-  useChatStore,
-} from '@/stores/chat-store';
+  useAnySessionAwaitingUser,
+  useIsSessionAwaitingUser,
+} from '@/hooks/use-session-awaiting-user';
 import { useCollectionStore } from '@/stores/collection-store';
 import { useProvidersStore } from '@/stores/providers-store';
 import { useSelectionStore } from '@/stores/selection-store';
@@ -487,7 +486,7 @@ function SubSessionRow({
   const isSelected = useSelectionStore((state) => state.selectedIds.has(sess.id));
   const showProviderIcons = useSettingsStore((state) => state.settings.showProviderIcons);
   const isProcessing = useIsSessionProcessing(sess.id, sess.kind);
-  const isAwaitingUser = useChatStore(selectIsAwaitingUserPrompt(sess.id));
+  const isAwaitingUser = useIsSessionAwaitingUser(sess.id, sess.kind);
   const liveSession = useSessionStore((state) => {
     for (const project of state.projects) {
       const session = project.sessions.find((item) => item.id === sess.id);
@@ -735,7 +734,7 @@ export function TaskItemRow({
     hasProcessingSession,
     hasTerminalProcessingSession,
   } = useSessionProcessingSummary(task.sessions);
-  const hasAwaitingUserSession = useChatStore(selectAnyAwaitingUserPrompt(taskSessionIds));
+  const hasAwaitingUserSession = useAnySessionAwaitingUser(task.sessions);
   const hasUnreadSession = useSessionStore((state) =>
     !isTaskActive &&
     taskSessionIds.some((id) => {
@@ -1186,7 +1185,7 @@ export function ChatItemRow({
   const showProviderIcons = useSettingsStore((state) => state.settings.showProviderIcons);
   const [isHovered, setIsHovered] = useState(false);
   const isProcessing = useIsSessionProcessing(session.id, session.kind);
-  const isAwaitingUser = useChatStore(selectIsAwaitingUserPrompt(session.id));
+  const isAwaitingUser = useIsSessionAwaitingUser(session.id, session.kind);
   const liveSession = useSessionStore((state) => state.getSession(session.id));
   const liveIsRunning = liveSession?.isRunning ?? session.isRunning;
   const runtimePresentation = resolveSessionRuntimePresentation({

--- a/src/components/chat/collection-group.tsx
+++ b/src/components/chat/collection-group.tsx
@@ -13,10 +13,8 @@ import { getProviderSessionRuntimeConfig } from '@/lib/settings/provider-default
 import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 import { captureTelemetryEvent } from '@/lib/telemetry/client';
 import { useBoardStore } from '@/stores/board-store';
-import {
-  selectAnyAwaitingUserPrompt,
-  useChatStore,
-} from '@/stores/chat-store';
+import { useAnySessionAwaitingUser } from '@/hooks/use-session-awaiting-user';
+import { useChatStore } from '@/stores/chat-store';
 import { useCollectionStore } from '@/stores/collection-store';
 import { usePanelStore, selectActiveTab } from '@/stores/panel-store';
 import { useSessionStore } from '@/stores/session-store';
@@ -285,7 +283,7 @@ export const CollectionGroup = memo(function CollectionGroup({
       return (snapshot.unreadCount ?? 0) > 0;
     }),
   );
-  const hasAwaitingUserSession = useChatStore(selectAnyAwaitingUserPrompt(collectionSessionIds));
+  const hasAwaitingUserSession = useAnySessionAwaitingUser(collectionSessionSnapshots);
   const collectionIndicatorStatus = getPrioritizedCollectionIndicatorStatus({
     hasVisibleRuntimeSession,
     hasProcessingSession,

--- a/src/components/chat/header.tsx
+++ b/src/components/chat/header.tsx
@@ -7,7 +7,7 @@ import { useSessionStore } from '@/stores/session-store';
 import { useTaskStore } from '@/stores/task-store';
 import { usePanelStore, selectActiveTab, EMPTY_PANELS, TabIdContext } from '@/stores/panel-store';
 import { useSessionCrud } from '@/hooks/use-session-crud';
-import { selectIsAwaitingUserPrompt, useChatStore } from '@/stores/chat-store';
+import { useIsSessionAwaitingUser } from '@/hooks/use-session-awaiting-user';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 import { TaskContextMenu } from './task-context-menu';
@@ -55,7 +55,7 @@ export function Header({ sessionId, panelId, isSinglePanel = false, search }: He
   const isGeneratingTitle = useSessionStore((state) => state.generatingTitleIds.has(sessionId));
   const { renameSession, generateTitle, deleteSession } = useSessionCrud();
   const isProcessing = useIsSessionProcessing(sessionId);
-  const isAwaitingUser = useChatStore(selectIsAwaitingUserPrompt(sessionId));
+  const isAwaitingUser = useIsSessionAwaitingUser(sessionId, session?.kind);
 
   // Multi-panel unread indicator — active panel's unread is auto-cleared by
   // panel-wrapper, so this only appears on inactive panel headers.

--- a/src/components/tab/tab-item.tsx
+++ b/src/components/tab/tab-item.tsx
@@ -6,7 +6,7 @@ import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSessionStore } from '@/stores/session-store';
 import { usePanelStore, selectActiveTab } from '@/stores/panel-store';
-import { hasAnyAwaitingUserPrompt, useChatStore } from '@/stores/chat-store';
+import { useAnySessionAwaitingUser } from '@/hooks/use-session-awaiting-user';
 import { useI18n } from '@/lib/i18n';
 import { useTabStore } from '@/stores/tab-store';
 import type { Tab } from '@/types/tab';
@@ -253,14 +253,8 @@ export const TabItem = memo(function TabItem({
     panelSessionIds ? panelSessionIds.split(',') : [],
   );
 
-  const isAwaitingUser = useChatStore(
-    useCallback(
-      (state) => {
-        if (!panelSessionIds) return false;
-        return hasAnyAwaitingUserPrompt(state, panelSessionIds.split(','));
-      },
-      [panelSessionIds],
-    ),
+  const isAwaitingUser = useAnySessionAwaitingUser(
+    panelSessionIds ? panelSessionIds.split(',') : [],
   );
 
   // Unread indicator — any session in this tab has unreadCount > 0.

--- a/src/hooks/use-session-awaiting-user.ts
+++ b/src/hooks/use-session-awaiting-user.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { hasAnyAwaitingUserPrompt, isAwaitingUserPrompt, useChatStore } from '@/stores/chat-store';
+import {
+  isTerminalAwaitingInput,
+  selectIsTerminalAwaitingInput,
+  useTerminalSessionStore,
+} from '@/stores/terminal-session-store';
+import { useSessionStore } from '@/stores/session-store';
+import { resolveIsTerminalSession } from './use-session-processing';
+import type { UnifiedSession } from '@/types/chat';
+
+type SessionAwaitingTarget = string | Pick<UnifiedSession, 'id' | 'kind'>;
+
+/**
+ * "사용자 입력 대기"(노란 깜빡점) 판정을 GUI/PTY lifecycle을 섞지 않고 합성한다.
+ * GUI 세션은 기존 chat-store activeInteractivePrompt만, PTY 세션은
+ * terminal-session-store의 input_required만 읽는다 — use-session-processing과
+ * 같은 분기 구조라 챗 GUI 모드의 데이터 흐름에는 어떤 영향도 없다.
+ */
+export function useIsSessionAwaitingUser(
+  sessionId: string,
+  fallbackKind?: UnifiedSession['kind'],
+): boolean {
+  const isTerminal = useSessionStore(
+    (state) => resolveIsTerminalSession(
+      state.getSession(sessionId)?.kind,
+      fallbackKind,
+    ),
+  );
+  const guiAwaiting = useChatStore(
+    useCallback(
+      (state) => !isTerminal && isAwaitingUserPrompt(state, sessionId),
+      [isTerminal, sessionId],
+    ),
+  );
+  const terminalAwaiting = useTerminalSessionStore(selectIsTerminalAwaitingInput(sessionId));
+  return isTerminal ? terminalAwaiting : guiAwaiting;
+}
+
+/** 여러 세션 중 하나라도 입력 대기인지 — 탭/컬렉션/칸반 집계용. */
+export function useAnySessionAwaitingUser(
+  sessions: readonly SessionAwaitingTarget[],
+): boolean {
+  const targetsKey = JSON.stringify(
+    sessions
+      .map((session) => typeof session === 'string'
+        ? { id: session, kind: undefined }
+        : { id: session.id, kind: session.kind })
+      .sort((left, right) => left.id.localeCompare(right.id)),
+  );
+  const targets = useMemo(
+    () => JSON.parse(targetsKey) as Array<{ id: string; kind?: UnifiedSession['kind'] }>,
+    [targetsKey],
+  );
+  const ids = useMemo(() => targets.map((target) => target.id), [targets]);
+  const fallbackKinds = useMemo(
+    () => new Map(targets.map((target) => [target.id, target.kind])),
+    [targets],
+  );
+
+  const terminalIdsKey = useSessionStore(useCallback(
+    (state) => ids
+      .filter((sessionId) => resolveIsTerminalSession(
+        state.getSession(sessionId)?.kind,
+        fallbackKinds.get(sessionId),
+      ))
+      .join(','),
+    [fallbackKinds, ids],
+  ));
+  const terminalIds = useMemo(
+    () => terminalIdsKey ? terminalIdsKey.split(',') : [],
+    [terminalIdsKey],
+  );
+  const terminalIdSet = useMemo(() => new Set(terminalIds), [terminalIds]);
+  const guiIds = useMemo(
+    () => ids.filter((sessionId) => !terminalIdSet.has(sessionId)),
+    [ids, terminalIdSet],
+  );
+
+  const hasGuiAwaiting = useChatStore(useCallback(
+    (state) => hasAnyAwaitingUserPrompt(state, guiIds),
+    [guiIds],
+  ));
+  const hasTerminalAwaiting = useTerminalSessionStore(useCallback(
+    (state) => terminalIds.some((sessionId) => isTerminalAwaitingInput(state, sessionId)),
+    [terminalIds],
+  ));
+
+  return hasGuiAwaiting || hasTerminalAwaiting;
+}

--- a/src/lib/cli/hook-receiver.ts
+++ b/src/lib/cli/hook-receiver.ts
@@ -11,7 +11,11 @@ import logger from '@/lib/logger';
 import { terminalManager } from '@/lib/terminal/shared-terminal-manager';
 import { refreshSessionDiffStateInBackground } from '@/lib/git/session-diff-refresh';
 import { applyImmediateSessionTitle } from '@/lib/session/immediate-session-title';
-import { mapClaudeHookLifecycle } from '@/lib/cli/providers/claude-code/terminal-hook-lifecycle';
+import {
+  CLAUDE_LIFECYCLE_EVENTS,
+  mapClaudeHookLifecycle,
+} from '@/lib/cli/providers/claude-code/terminal-hook-lifecycle';
+import { classifyAskUserQuestionEvent } from '@/lib/cli/providers/claude-code/ask-user-question-status';
 
 const MAX_BODY_BYTES = 1_000_000;
 
@@ -88,11 +92,22 @@ function mapClaudeEventToStatus(
   event: string,
   payload: Record<string, unknown>,
 ): { status: TerminalSessionStatus; preview?: string } | null {
+  // AskUserQuestion 질문 카드가 뜬 동안은 input_required(사이드바 노란 깜빡점),
+  // 답변 제출(PostToolUse) 시 running 복귀. lifecycle tracker는 이 이벤트를 모른다.
+  const askUserQuestion = classifyAskUserQuestionEvent(event, payload);
+  if (askUserQuestion) return askUserQuestion;
   const lifecycle = mapClaudeHookLifecycle(terminalId, event, payload);
   if (lifecycle) {
-    if (event === 'Stop' && lifecycle.status === 'completed') return completedStatus(payload);
+    // Stop/StopFailure가 턴을 닫으면 assistant preview를 실어 완료로 보낸다.
+    // (StopFailure payload엔 통상 텍스트가 없어 preview는 undefined가 된다.)
+    if ((event === 'Stop' || event === 'StopFailure') && lifecycle.status === 'completed') {
+      return completedStatus(payload);
+    }
     return lifecycle;
   }
+  // lifecycle 소유 이벤트의 null은 "의도적 무시"(턴 종료 후 늦은 curl 등)다.
+  // 범용 폴백이 PostToolUse→running으로 되살리면 tombstone이 무력화된다.
+  if (CLAUDE_LIFECYCLE_EVENTS.has(event)) return null;
   return mapEventToStatus(event, payload);
 }
 

--- a/src/lib/cli/providers/claude-code/ask-user-question-status.ts
+++ b/src/lib/cli/providers/claude-code/ask-user-question-status.ts
@@ -1,0 +1,41 @@
+/**
+ * AskUserQuestion 도구의 hook 이벤트를 터미널 세션 상태로 분류한다.
+ *
+ * AskUserQuestion은 auto-allow 도구라 PermissionRequest를 내지 않고, Notification도
+ * 발생하지 않는다(실측). 유일한 신호는 PreToolUse(tool_name="AskUserQuestion")이며,
+ * 질문 카드가 뜬 동안 스피너 대신 "입력 대기"로 보여주기 위해 input_required로
+ * 매핑한다. 답변이 제출되면 PostToolUse가 와서 running으로 복귀한다.
+ *
+ * hook 등록은 matcher "AskUserQuestion"으로 좁혀져 있지만, 사용자 전역 설정의
+ * 광역 matcher와 병합될 수 있으므로 tool_name을 방어적으로 재검사한다.
+ */
+
+const ASK_USER_QUESTION_TOOL = 'AskUserQuestion';
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/** payload.tool_input.questions[0].question — 알림 preview용 질문 본문. */
+function firstQuestionPreview(payload: Record<string, unknown>): string | undefined {
+  const input = payload.tool_input;
+  if (typeof input !== 'object' || input === null) return undefined;
+  const questions = (input as Record<string, unknown>).questions;
+  if (!Array.isArray(questions) || questions.length === 0) return undefined;
+  const first = questions[0];
+  if (typeof first !== 'object' || first === null) return undefined;
+  const question = readString((first as Record<string, unknown>).question);
+  return question || undefined;
+}
+
+export function classifyAskUserQuestionEvent(
+  event: string,
+  payload: Record<string, unknown>,
+): { status: 'input_required' | 'running'; preview?: string } | null {
+  if (event !== 'PreToolUse' && event !== 'PostToolUse') return null;
+  if (readString(payload.tool_name) !== ASK_USER_QUESTION_TOOL) return null;
+  if (event === 'PreToolUse') {
+    return { status: 'input_required', preview: firstQuestionPreview(payload) };
+  }
+  return { status: 'running' };
+}

--- a/src/lib/cli/providers/claude-code/claude-subagent-roster.ts
+++ b/src/lib/cli/providers/claude-code/claude-subagent-roster.ts
@@ -1,0 +1,166 @@
+/**
+ * Claude 터미널 세션의 subagent/teammate 명단(roster)과 그 조작.
+ *
+ * hook은 fire-and-forget curl이라 SubagentStart/SubagentStop이 유실·재정렬될 수
+ * 있다. 이벤트 델타만 누적하면(Set 카운터) 드리프트가 나 스피너가 갇힌다. 그래서
+ * lead Stop payload의 `background_tasks` 스냅샷을 명단에 fold해 실제 상태로 교정한다.
+ *
+ * 이 명단은 UI로 나가지 않는다 — "working child가 하나라도 있는가"를 판정하는
+ * 서버 내부 구조다. (Orca의 out/shared/claude-subagent-roster.js를 판정 목적에
+ * 맞게 축약 이식: agentType/description 등 UI 표시 필드는 생략.)
+ */
+
+export type SubagentState = 'working' | 'idle';
+
+export interface TrackedSubagent {
+  state: SubagentState;
+  /**
+   * 이 id를 background_tasks가 authoritative하게 관리하는지. lifecycle(SubagentStart)로
+   * 들어온 항목은 background_tasks에 안 나타날 수 있어(특히 teammate) 부재로 강등하면
+   * 안 된다. fold가 스스로 만든 항목만 표시해, 다음 fold에서 리스트에 빠지면 idle로
+   * 강등하는 대상으로 삼는다.
+   */
+  backgroundTasksAuthoritative?: boolean;
+}
+
+export type SubagentRoster = Map<string, TrackedSubagent>;
+
+/** wire 정규화의 id 상한과 동일. 상한 초과 id가 명단만 'working'으로 잡는 걸 막는다. */
+const SUBAGENT_ID_MAX_LENGTH = 64;
+/** pane당 명단 상한. runaway spawner 방어. */
+const MAX_SUBAGENTS = 32;
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/** id를 working으로 upsert. 상한 초과 시 가장 오래된 idle을 쫓아내고 자리 확보. */
+export function upsertWorkingSubagent(roster: SubagentRoster, id: string): void {
+  if (id.length === 0 || id.length > SUBAGENT_ID_MAX_LENGTH) return;
+  const existing = roster.get(id);
+  if (existing) {
+    existing.state = 'working';
+    // 라이브 활동은 lifecycle 스트림이 이 id를 다시 소유한다는 증거다.
+    // background_tasks 부재로 인한 강등을 멈춘다(fold가 필요 시 재표시한다).
+    existing.backgroundTasksAuthoritative = undefined;
+    return;
+  }
+  if (roster.size >= MAX_SUBAGENTS && !evictOldestIdle(roster)) return;
+  roster.set(id, { state: 'working' });
+}
+
+/** 삽입 순서상 가장 오래된 idle 항목을 제거. 없으면 false. */
+function evictOldestIdle(roster: SubagentRoster): boolean {
+  for (const [id, tracked] of roster) {
+    if (tracked.state === 'idle') {
+      roster.delete(id);
+      return true;
+    }
+  }
+  return false;
+}
+
+export function markSubagentIdle(roster: SubagentRoster, id: string): void {
+  const existing = roster.get(id);
+  if (existing) existing.state = 'idle';
+}
+
+export function rosterHasWorkingSubagent(roster: SubagentRoster): boolean {
+  for (const tracked of roster.values()) {
+    if (tracked.state === 'working') return true;
+  }
+  return false;
+}
+
+export interface BackgroundAgentTask {
+  id: string;
+  running: boolean;
+  teammate: boolean;
+}
+
+/**
+ * hook payload의 `background_tasks` 중 에이전트 작업(subagent/teammate)만 읽는다.
+ * dev 서버·워처 같은 셸 작업이나 예약 cron은 "연산 중"이 아니므로 제외한다.
+ * `present: false`는 필드 자체가 없음/malformed(older Claude builds) — 호출자는
+ * 명단을 비우지 말고 lifecycle로 추적한 기존 명단을 유지해야 한다.
+ */
+export function readBackgroundAgentTasks(
+  payload: Record<string, unknown>,
+): { present: boolean; tasks: BackgroundAgentTask[] } {
+  const raw = payload['background_tasks'];
+  if (!Array.isArray(raw)) return { present: false, tasks: [] };
+  const tasks: BackgroundAgentTask[] = [];
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) continue;
+    const obj = item as Record<string, unknown>;
+    if (obj.type !== 'subagent' && obj.type !== 'teammate') continue;
+    const id = readString(obj.id).trim();
+    if (id.length === 0) continue;
+    tasks.push({
+      id,
+      running: obj.status === 'running',
+      teammate: obj.type === 'teammate',
+    });
+    if (tasks.length >= MAX_SUBAGENTS) break;
+  }
+  return { present: true, tasks };
+}
+
+/**
+ * lead Stop의 background_tasks를 lifecycle 추적 명단에 fold한다. replace가 아니다:
+ * teammate는 살아있는 동안 idle이어도 `status: running`으로 보고하고 그 task id가
+ * SubagentStart/Stop의 agent_id와 다르므로, 리스트만으로 teammate working 여부를
+ * 결정하거나 lifecycle 항목에 매핑할 수 없다. 명확한 신호만 취한다:
+ *  - 빈 리스트는 살아있는 게 없다는 증거 → 명단 clear
+ *  - id-exact 매치(one-shot subagent는 agent_id를 task id로 재사용) → 신뢰, run 상태 반영
+ *  - 매치 안 되는 RUNNING non-teammate → 시작을 못 본 one-shot subagent(재시작 등)
+ *    → 재생성해 pane이 child 살아있는데 done으로 읽는 걸 막음
+ *  - task id로 알려진(authoritative) 항목이 리스트에 없으면 끝난 것 → idle로 강등
+ */
+export function foldBackgroundTasksIntoRoster(
+  roster: SubagentRoster,
+  tasks: BackgroundAgentTask[],
+): void {
+  if (tasks.length === 0) {
+    roster.clear();
+    return;
+  }
+  const listedIds = new Set<string>();
+  for (const task of tasks) {
+    listedIds.add(task.id);
+    const existing = roster.get(task.id);
+    if (existing) {
+      existing.state = task.running ? 'working' : 'idle';
+      continue;
+    }
+    if (task.teammate || !task.running) continue;
+    upsertWorkingSubagent(roster, task.id);
+    const created = roster.get(task.id);
+    if (created) created.backgroundTasksAuthoritative = true;
+  }
+  for (const [id, tracked] of roster) {
+    if (tracked.backgroundTasksAuthoritative && tracked.state === 'working' && !listedIds.has(id)) {
+      tracked.state = 'idle';
+    }
+  }
+}
+
+/**
+ * lifecycle agent id가 이름붙은 teammate에 속하는지. teammate id는 이름을
+ * `a<name>-<hex>`로 임베드한다. 하이픈 없는 suffix를 요구해 teammate "rev"가
+ * "rev-two"의 id(`arev-two-<hex>`)에 잘못 매치되는 걸 막는다.
+ */
+export function teammateIdMatchesName(id: string, name: string): boolean {
+  const prefix = `a${name}-`;
+  return id.startsWith(prefix) && !id.slice(prefix.length).includes('-');
+}
+
+/**
+ * TeammateIdle(이름 기반)로 해당 teammate의 명단 항목을 idle로 표시한다.
+ * 이름붙은 teammate는 `agent_id`에 이름을 임베드하므로 그 id 매칭만 쓴다.
+ */
+export function markTeammateIdleByName(roster: SubagentRoster, name: string): void {
+  for (const [id, tracked] of roster) {
+    if (teammateIdMatchesName(id, name)) tracked.state = 'idle';
+  }
+}

--- a/src/lib/cli/providers/claude-code/terminal-hook-lifecycle.ts
+++ b/src/lib/cli/providers/claude-code/terminal-hook-lifecycle.ts
@@ -1,45 +1,49 @@
+import {
+  type SubagentRoster,
+  upsertWorkingSubagent,
+  markSubagentIdle,
+  markTeammateIdleByName,
+  rosterHasWorkingSubagent,
+  readBackgroundAgentTasks,
+  foldBackgroundTasksIntoRoster,
+} from './claude-subagent-roster';
+
 export type ClaudeHookLifecycleStatus = 'running' | 'completed' | 'idle';
 
 interface ClaudeTerminalLifecycle {
-  activeSubagentIds: Set<string>;
-  leadStoppedWithBackground: boolean;
+  /**
+   * subagent/teammate 명단. Set 카운터가 아니라 상태 있는 Map이라, lead Stop의
+   * background_tasks 스냅샷을 fold해 이벤트 유실로 어긋난 상태를 교정할 수 있다.
+   */
+  subagents: SubagentRoster;
+  /** lead가 Stop을 냈지만 child가 남아 아직 완료로 못 넘긴 상태. */
+  leadStopped: boolean;
   /**
    * 마지막 턴이 completed로 닫힌 뒤인지. hook은 fire-and-forget curl이라 턴 종료 후에도
    * 후처리 워커의 SubagentStart/Stop이 늦게 도착할 수 있고, 상태를 지워버리면 그 이벤트가
    * getOrCreate로 턴을 되살려 다음 입력까지 running에 갇힌다. 묘비로 남겨 선별적으로 무시한다.
    */
   turnEnded: boolean;
+  /** 턴이 completed로 닫힌 시각(ms). 재기동 턴 판정의 유예 기준. */
+  turnEndedAt: number;
 }
+
+/**
+ * 턴 종료 직후 이 유예 안에 도착한 PreToolUse는 그 턴의 마지막 도구가 늦게 배달된
+ * curl(-m 2 타임아웃)일 수 있어 무시한다. 유예를 넘긴 PreToolUse는 백그라운드 작업
+ * 완료로 Claude가 자동으로 깨어난 재기동 턴이다 — UserPromptSubmit 없이 시작되므로
+ * 도구 이벤트가 유일한 활동 신호다.
+ */
+const REVIVED_TURN_GRACE_MS = 5_000;
 
 function readString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-function hasTaskRegistry(payload: Record<string, unknown>): boolean {
-  return Array.isArray(payload.background_tasks) || Array.isArray(payload.session_crons);
-}
-
-/**
- * 스피너를 잡아야 하는 registry 항목은 에이전트 작업(subagent/teammate)뿐이다.
- * 백그라운드 셸 작업(dev 서버·워처 등 장수 프로세스)과 session_crons(예약된 미래 작업)는
- * "연산 중"이 아니므로 잡지 않는다 — 잡으면 프로세스가 사는 동안 스피너가 영원히 돈다.
- * 알 수 없는 type도 잡지 않는다: 이르게 초록이 되는 쪽이 영원히 도는 쪽보다 덜 해롭다.
- */
-function isAgentWorkEntry(value: unknown): boolean {
-  if (!value || typeof value !== 'object') return false;
-  const type = readString((value as Record<string, unknown>).type);
-  return type === 'subagent' || type === 'teammate';
-}
-
-function registryHasPendingWork(payload: Record<string, unknown>): boolean {
-  return Array.isArray(payload.background_tasks)
-    && payload.background_tasks.some(isAgentWorkEntry);
-}
-
 /**
  * Claude can emit the lead Stop while background children are still alive.
- * Keep the terminal turn running until the task registry or child lifecycle
- * confirms that the pending work has drained.
+ * Keep the terminal turn running until the roster (reconciled against the Stop
+ * payload's background_tasks) confirms the pending work has drained.
  */
 export class ClaudeHookLifecycleTracker {
   private readonly terminals = new Map<string, ClaudeTerminalLifecycle>();
@@ -48,6 +52,7 @@ export class ClaudeHookLifecycleTracker {
     terminalId: string,
     event: string,
     payload: Record<string, unknown>,
+    now = Date.now(),
   ): { status: ClaudeHookLifecycleStatus } | null {
     if (event === 'SessionStart') {
       this.terminals.delete(terminalId);
@@ -56,8 +61,28 @@ export class ClaudeHookLifecycleTracker {
 
     if (event === 'UserPromptSubmit') {
       const state = this.getOrCreate(terminalId);
-      state.leadStoppedWithBackground = false;
+      state.subagents.clear();
+      state.leadStopped = false;
       state.turnEnded = false;
+      return { status: 'running' };
+    }
+
+    if (event === 'PreToolUse' || event === 'PostToolUse' || event === 'PostToolUseFailure') {
+      const state = this.getOrCreate(terminalId);
+      if (state.turnEnded) {
+        // 재기동 턴 감지는 PreToolUse만 신뢰한다. PostToolUse는 턴 마지막 도구의
+        // 완료 직후 Stop이 따라붙어 curl 역전 가능성이 크다.
+        if (event !== 'PreToolUse' || now - state.turnEndedAt < REVIVED_TURN_GRACE_MS) {
+          return null;
+        }
+        state.subagents.clear();
+        state.leadStopped = false;
+        state.turnEnded = false;
+        return { status: 'running' };
+      }
+      // 진행 중 턴의 도구 활동. subagent 발 이벤트면 그 child가 살아있다는 증거다.
+      const agentId = readString(payload.agent_id) || readString(payload.agentId);
+      if (agentId) upsertWorkingSubagent(state.subagents, agentId);
       return { status: 'running' };
     }
 
@@ -66,62 +91,76 @@ export class ClaudeHookLifecycleTracker {
       // 턴 종료 후의 후처리 워커(요약 생성 등)는 사용자 관점의 연산이 아니다.
       if (state.turnEnded) return null;
       const agentId = readString(payload.agent_id) || readString(payload.agentId);
-      if (agentId) state.activeSubagentIds.add(agentId);
+      if (agentId) upsertWorkingSubagent(state.subagents, agentId);
       return { status: 'running' };
+    }
+
+    if (event === 'SubagentStop') {
+      const state = this.terminals.get(terminalId);
+      // 모르는 터미널이나 종료된 턴의 SubagentStop은 끝낼 작업이 없다.
+      if (!state || state.turnEnded) return null;
+      const agentId = readString(payload.agent_id) || readString(payload.agentId);
+      if (agentId) markSubagentIdle(state.subagents, agentId);
+      return this.resolveAfterChildDrain(state, now);
     }
 
     if (event === 'TeammateIdle') {
       const state = this.terminals.get(terminalId);
       if (!state || state.turnEnded) return null;
+      const teammateName = readString(payload.teammate_name) || readString(payload.teammateName);
+      // idle 표시만 한다. TeammateIdle 자체는 완료 트리거가 아니다(살아있는 teammate가
+      // 곧 다시 활동할 수 있다) — 이후 SubagentStop이나 다음 Stop의 reconcile이 완료를
+      // 판정하며, 이 idle 표시가 그 판정에서 이 teammate를 빼 준다.
+      if (teammateName) markTeammateIdleByName(state.subagents, teammateName);
       return { status: 'running' };
     }
 
-    if (event === 'Stop') {
+    if (event === 'Stop' || event === 'StopFailure') {
       const state = this.getOrCreate(terminalId);
-      // A reachable Stop task registry is authoritative. This lets a later empty
-      // Stop heal a missed SubagentStop; older Claude versions fall back to IDs.
-      const hasPendingWork = hasTaskRegistry(payload)
-        ? registryHasPendingWork(payload)
-        : state.activeSubagentIds.size > 0;
-      if (hasPendingWork) {
-        state.leadStoppedWithBackground = true;
+      // background_tasks가 있으면(present) 명단을 그 스냅샷으로 reconcile한다. 없으면
+      // (older Claude builds) lifecycle로 증분 추적한 명단을 그대로 신뢰한다.
+      const background = readBackgroundAgentTasks(payload);
+      if (background.present) {
+        foldBackgroundTasksIntoRoster(state.subagents, background.tasks);
+      }
+      if (rosterHasWorkingSubagent(state.subagents)) {
+        state.leadStopped = true;
         return { status: 'running' };
       }
-      this.markTurnEnded(state);
+      this.markTurnEnded(state, now);
       return { status: 'completed' };
-    }
-
-    if (event === 'SubagentStop') {
-      const state = this.terminals.get(terminalId);
-      // 모르는 터미널의 SubagentStop은 끝낼 작업이 없다 — 턴을 시작시키면 안 된다.
-      if (!state || state.turnEnded) return null;
-      const agentId = readString(payload.agent_id) || readString(payload.agentId);
-      if (agentId) state.activeSubagentIds.delete(agentId);
-
-      const hasPendingWork = registryHasPendingWork(payload) || state.activeSubagentIds.size > 0;
-      if (state.leadStoppedWithBackground && !hasPendingWork) {
-        this.markTurnEnded(state);
-        return { status: 'completed' };
-      }
-      return { status: 'running' };
     }
 
     return null;
   }
 
-  private markTurnEnded(state: ClaudeTerminalLifecycle): void {
-    state.activeSubagentIds.clear();
-    state.leadStoppedWithBackground = false;
+  /** lead가 이미 Stop했고 명단에 working이 없으면 턴 완료. 아니면 계속 running. */
+  private resolveAfterChildDrain(
+    state: ClaudeTerminalLifecycle,
+    now: number,
+  ): { status: ClaudeHookLifecycleStatus } {
+    if (state.leadStopped && !rosterHasWorkingSubagent(state.subagents)) {
+      this.markTurnEnded(state, now);
+      return { status: 'completed' };
+    }
+    return { status: 'running' };
+  }
+
+  private markTurnEnded(state: ClaudeTerminalLifecycle, now: number): void {
+    state.subagents.clear();
+    state.leadStopped = false;
     state.turnEnded = true;
+    state.turnEndedAt = now;
   }
 
   private getOrCreate(terminalId: string): ClaudeTerminalLifecycle {
     const existing = this.terminals.get(terminalId);
     if (existing) return existing;
     const created: ClaudeTerminalLifecycle = {
-      activeSubagentIds: new Set(),
-      leadStoppedWithBackground: false,
+      subagents: new Map(),
+      leadStopped: false,
       turnEnded: false,
+      turnEndedAt: 0,
     };
     this.terminals.set(terminalId, created);
     return created;
@@ -129,6 +168,21 @@ export class ClaudeHookLifecycleTracker {
 }
 
 const terminalHookLifecycle = new ClaudeHookLifecycleTracker();
+
+/** apply()가 소유하는 이벤트 — 이들이 null을 반환하면 "의도적 무시"이므로
+ *  hook-receiver의 범용 폴백(mapEventToStatus)으로 되살리면 안 된다. */
+export const CLAUDE_LIFECYCLE_EVENTS = new Set([
+  'SessionStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'SubagentStart',
+  'SubagentStop',
+  'TeammateIdle',
+  'Stop',
+  'StopFailure',
+]);
 
 /** Process-lifetime Claude hook adapter used by the shared HTTP receiver. */
 export function mapClaudeHookLifecycle(

--- a/src/lib/terminal/claude-hook-settings.ts
+++ b/src/lib/terminal/claude-hook-settings.ts
@@ -16,6 +16,11 @@ function lifecycleHook() {
   return [{ hooks: [{ type: 'command', timeout: 5, command: HOOK_CURL }] }];
 }
 
+/** 특정 도구에만 발화하는 tool hook. matcher로 좁혀 매 도구 curl 부하를 피한다. */
+function toolHook(matcher: string) {
+  return [{ matcher, hooks: [{ type: 'command', timeout: 5, command: HOOK_CURL }] }];
+}
+
 export function buildClaudeHookSettings(): Record<string, unknown> {
   return {
     hooks: {
@@ -24,11 +29,22 @@ export function buildClaudeHookSettings(): Record<string, unknown> {
       // AI 자동 타이틀이 되게 한다(codex는 이미 등록됨).
       UserPromptSubmit: lifecycleHook(),
       Stop: lifecycleHook(),
+      // 일부 빌드는 API/모델 에러 뒤 정상 Stop을 건너뛰고 StopFailure를 낸다.
+      // 등록하지 않으면 그 턴의 스피너가 영영 돌아 갇힌다. 오래된 Claude 빌드는
+      // 등록되지 않은 이벤트명을 무시하므로 추가는 안전하다.
+      StopFailure: lifecycleHook(),
       // Claude의 lead turn이 먼저 끝나도 background child가 계속 실행될 수 있다.
       // child/team lifecycle을 받아 terminal 상태를 완료로 조기 전환하지 않게 한다.
       SubagentStart: lifecycleHook(),
       SubagentStop: lifecycleHook(),
       TeammateIdle: lifecycleHook(),
+      // 모든 도구의 PreToolUse/PostToolUse를 받는다(Orca와 동일). 핵심 목적은
+      // 백그라운드 셸 작업(빌드 등)이 끝나 Claude가 자동으로 깨어난 "재기동 턴"의
+      // 감지다 — 그 턴에는 UserPromptSubmit이 없어서 도구 이벤트가 유일한 활동
+      // 신호다. AskUserQuestion의 input_required 분류는 서버가 tool_name으로
+      // 판별한다(ask-user-question-status.ts).
+      PreToolUse: toolHook('*'),
+      PostToolUse: toolHook('*'),
     },
   };
 }

--- a/src/lib/terminal/layout-settle-runner.ts
+++ b/src/lib/terminal/layout-settle-runner.ts
@@ -40,6 +40,7 @@ export class LayoutSettleRunner {
     options: {
       initial: LayoutSettleInitialRun;
       onFinish?: () => void;
+      settledOperation?: () => void;
     },
   ): void {
     this.cancel();
@@ -63,7 +64,9 @@ export class LayoutSettleRunner {
     });
     pending.frameIds.push(firstFrameId);
     pending.timerId = this.scheduler.setTimeout(() => {
-      invoke();
+      if (!pending.cancelled) {
+        (options.settledOperation ?? operation)();
+      }
       this.finish(pending);
     }, 80);
   }

--- a/src/lib/terminal/provider-launch.ts
+++ b/src/lib/terminal/provider-launch.ts
@@ -12,6 +12,16 @@ export interface ProviderTerminalLaunch {
   args: string[];    // 서버가 조립한 provider argv
 }
 
+/** Server-owned environment needed for consistent native PTY behavior. */
+export function buildProviderTerminalEnv(providerId: string): Record<string, string> | undefined {
+  if (providerId !== 'claude-code') return undefined;
+
+  // Claude's fullscreen virtual scroller owns history outside xterm's normal
+  // buffer. Keeping Claude on the normal buffer lets xterm own the scrollbar,
+  // wheel momentum, and resize reflow just like the other terminal providers.
+  return { CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN: '1' };
+}
+
 /**
  * 클라 argv 불신. {providerId, sessionId, resume, ...} 만 받아 서버가 최소 argv 전량 조립.
  *  - claude: hooks는 --settings 인라인 주입.

--- a/src/lib/terminal/shared-terminal-manager.ts
+++ b/src/lib/terminal/shared-terminal-manager.ts
@@ -42,6 +42,12 @@ function createSharedState(): SharedTerminalManagerState {
           sessionId,
           running,
         });
+        // 런타임 (재)시작 시 마지막 hook 상태를 재전송해, 이전에 runtime 신호와
+        // 어긋난 순서로 도착해 클라이언트가 버렸을 수 있는 상태를 복구한다.
+        if (running) {
+          const lastState = state.manager.getSessionStateForSession(sessionId, userId);
+          if (lastState) state.sendToUser?.(userId, lastState);
+        }
       },
     },
   );

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -901,6 +901,20 @@ export class TerminalManager {
       .map((runtime) => runtime.lastSessionState!);
   }
 
+  getSessionStateForSession(sessionId: string, userId: string): TerminalSessionStateMessage | null {
+    for (const runtime of this.terminals.values()) {
+      if (
+        runtime.userId === userId
+        && runtime.sessionId === sessionId
+        && !runtime.ended
+        && runtime.lastSessionState
+      ) {
+        return runtime.lastSessionState;
+      }
+    }
+    return null;
+  }
+
   resize(
     terminalId: string,
     userId: string,

--- a/src/lib/terminal/terminal-scroll-controller.ts
+++ b/src/lib/terminal/terminal-scroll-controller.ts
@@ -31,16 +31,43 @@ export interface TerminalScrollSnapshot {
 }
 
 export interface TerminalScrollRestorePoint {
+  readonly baseY: number;
+  readonly bottomOffset: number;
   readonly bufferType: 'normal' | 'alternate';
   readonly intent: TerminalScrollIntent;
   readonly marker?: TerminalScrollMarker;
   readonly revision: number;
-  readonly viewportY: number;
 }
 
 export type TerminalScrollScheduler = LayoutSettleScheduler;
 
 const BOTTOM_TOLERANCE_ROWS = 1;
+
+/**
+ * Tracks a wheel/key scroll while xterm applies its viewport change.
+ *
+ * A fullscreen TUI can consume the input without moving xterm. Preserve the
+ * provisional pin for the early frames, then classify from the real viewport
+ * at settle time so a pin at the bottom cannot survive into the next resize.
+ */
+export function scheduleTerminalScrollIntentSync(
+  controller: TerminalScrollController,
+  settler: LayoutSettleRunner,
+  preservePinnedAtBottom: boolean,
+  canSync: () => boolean = () => true,
+): void {
+  const sync = () => {
+    if (canSync()) controller.syncFromViewport({ preservePinnedAtBottom });
+  };
+  settler.run(sync, {
+    initial: 'microtask',
+    settledOperation: preservePinnedAtBottom
+      ? () => {
+          if (canSync()) controller.syncFromViewport();
+        }
+      : sync,
+  });
+}
 
 function isAtBottom(target: TerminalScrollTarget): boolean {
   const { baseY, viewportY } = target.buffer.active;
@@ -58,8 +85,11 @@ function safelyScroll(operation: () => void): boolean {
 }
 
 export class TerminalScrollController {
+  private bufferRebuildActive = false;
+  private lastObservedBaseY: number;
   private readonly listeners = new Set<() => void>();
   private readonly layoutSettler: LayoutSettleRunner;
+  private pinnedBottomOffset: number | null = null;
   private revision = 0;
   private snapshot: TerminalScrollSnapshot;
 
@@ -68,11 +98,15 @@ export class TerminalScrollController {
     scheduler?: TerminalScrollScheduler,
   ) {
     this.layoutSettler = new LayoutSettleRunner(scheduler);
+    this.lastObservedBaseY = target.buffer.active.baseY;
     const atBottom = isAtBottom(target);
     this.snapshot = {
       intent: atBottom ? 'follow-output' : 'pinned-viewport',
       isAtBottom: atBottom,
     };
+    if (!atBottom) {
+      this.pinnedBottomOffset = Math.max(0, target.buffer.active.baseY - target.buffer.active.viewportY);
+    }
   }
 
   getSnapshot = (): TerminalScrollSnapshot => this.snapshot;
@@ -85,21 +119,40 @@ export class TerminalScrollController {
   captureRestorePoint(): TerminalScrollRestorePoint {
     const buffer = this.target.buffer.active;
     const intent = this.snapshot.intent;
-    return {
+    // A resize redraw can clear scrollback before the previous write callback
+    // runs. Do not let later chunks create fresh line-0 markers during that gap.
+    if (
+      intent === 'pinned-viewport'
+      && buffer.type === 'normal'
+      && buffer.baseY === 0
+      && this.lastObservedBaseY > 0
+    ) {
+      this.bufferRebuildActive = true;
+    }
+    if (!this.bufferRebuildActive) this.lastObservedBaseY = buffer.baseY;
+    const point: TerminalScrollRestorePoint = {
+      baseY: buffer.baseY,
+      bottomOffset: intent === 'pinned-viewport'
+        ? this.pinnedBottomOffset ?? Math.max(0, buffer.baseY - buffer.viewportY)
+        : 0,
       bufferType: buffer.type,
       intent,
-      marker: intent === 'pinned-viewport' && buffer.type === 'normal'
+      marker: intent === 'pinned-viewport'
+        && buffer.type === 'normal'
+        && !this.bufferRebuildActive
         ? this.target.registerMarker(buffer.viewportY - (buffer.baseY + buffer.cursorY))
         : undefined,
       revision: this.revision,
-      viewportY: buffer.viewportY,
     };
+    return point;
   }
 
   scrollToBottom(): void {
     this.cancelPendingRestore();
     this.revision += 1;
     safelyScroll(() => this.target.scrollToBottom());
+    this.finishBufferRebuild();
+    this.pinnedBottomOffset = null;
     this.updateSnapshot('follow-output');
   }
 
@@ -107,12 +160,17 @@ export class TerminalScrollController {
     this.cancelPendingRestore();
     this.revision += 1;
     safelyScroll(() => this.target.scrollToLine(0));
+    this.finishBufferRebuild();
+    this.pinnedBottomOffset = this.target.buffer.active.baseY;
     this.updateSnapshot('pinned-viewport');
   }
 
   pinViewport(): void {
     this.cancelPendingRestore();
     this.revision += 1;
+    const buffer = this.target.buffer.active;
+    this.finishBufferRebuild();
+    this.pinnedBottomOffset = Math.max(0, buffer.baseY - buffer.viewportY);
     this.updateSnapshot('pinned-viewport');
   }
 
@@ -129,6 +187,16 @@ export class TerminalScrollController {
       && atBottom
       ? 'pinned-viewport'
       : atBottom ? 'follow-output' : 'pinned-viewport';
+    if (intent === 'follow-output') {
+      this.finishBufferRebuild();
+      this.pinnedBottomOffset = null;
+    } else if (!atBottom) {
+      this.finishBufferRebuild();
+      this.pinnedBottomOffset = Math.max(
+        0,
+        this.target.buffer.active.baseY - this.target.buffer.active.viewportY,
+      );
+    }
     this.updateSnapshot(intent);
   }
 
@@ -162,6 +230,11 @@ export class TerminalScrollController {
     this.listeners.clear();
   }
 
+  finishBufferRebuild(): void {
+    this.bufferRebuildActive = false;
+    this.lastObservedBaseY = this.target.buffer.active.baseY;
+  }
+
   private restoreNow(point: TerminalScrollRestorePoint): boolean {
     if (point.revision !== this.revision) return false;
     const buffer = this.target.buffer.active;
@@ -169,13 +242,28 @@ export class TerminalScrollController {
 
     if (point.intent === 'follow-output') {
       if (!safelyScroll(() => this.target.scrollToBottom())) return false;
+      this.pinnedBottomOffset = null;
     } else {
-      const markerLine = point.marker && !point.marker.isDisposed ? point.marker.line : -1;
-      if (!safelyScroll(() => this.target.scrollToLine(Math.min(
-        markerLine >= 0 ? markerLine : point.viewportY,
+      if (buffer.baseY < point.baseY) this.bufferRebuildActive = true;
+      const markerLine = !this.bufferRebuildActive
+        && point.marker
+        && !point.marker.isDisposed
+        ? point.marker.line
+        : -1;
+      const targetLine = Math.min(
+        markerLine >= 0
+          ? markerLine
+          // Once a TUI clears and rebuilds the buffer, absolute rows and old
+          // markers are invalid. Preserve the reader's distance from bottom.
+          : Math.max(0, buffer.baseY - point.bottomOffset),
         buffer.baseY,
-      )))) return false;
+      );
+      if (!safelyScroll(() => this.target.scrollToLine(targetLine))) return false;
+      this.pinnedBottomOffset = markerLine >= 0
+        ? Math.max(0, buffer.baseY - buffer.viewportY)
+        : point.bottomOffset;
     }
+    if (!this.bufferRebuildActive) this.lastObservedBaseY = buffer.baseY;
     this.updateSnapshot(point.intent);
     return true;
   }

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -35,6 +35,7 @@ import {
   type ElectronTerminalClipboardApi,
 } from './terminal-clipboard-paste';
 import {
+  scheduleTerminalScrollIntentSync,
   TerminalScrollController,
   type TerminalScrollRestorePoint,
   type TerminalScrollTarget,
@@ -183,6 +184,7 @@ export class TerminalSurface {
   private unsubscribeScrollController: (() => void) | null = null;
   private scrollTrackingCleanup: (() => void) | null = null;
   private pendingScrollStateFrameId: number | null = null;
+  private scrollRebuildSettleTimerId: number | null = null;
   private readonly scrollSyncSettler = new LayoutSettleRunner();
   private pasteListener: ((event: ClipboardEvent) => void) | null = null;
   private compositionEndListener: ((event: CompositionEvent) => void) | null = null;
@@ -500,6 +502,10 @@ export class TerminalSurface {
     this.cancelPendingFit();
     this.cancelScheduledScrollSync();
     this.cancelScheduledSurfaceScrollStateSync();
+    if (this.scrollRebuildSettleTimerId !== null) {
+      window.clearTimeout(this.scrollRebuildSettleTimerId);
+      this.scrollRebuildSettleTimerId = null;
+    }
     this.inputDisposable?.dispose();
     this.inputDisposable = null;
     this.scrollDisposable?.dispose();
@@ -864,6 +870,7 @@ export class TerminalSurface {
       this.terminal?.reset();
       this.terminal?.write(message.data, () => {
         if (restorePoint) this.scrollController?.restore(restorePoint);
+        this.scheduleScrollRebuildSettle();
         if (this.serverGeneration === message.generation) {
           this.replaying = false;
         }
@@ -880,6 +887,7 @@ export class TerminalSurface {
       const shouldRecoverRenderer = this.backgroundSgrDetector.consume(message.data);
       this.terminal?.write(message.data, () => {
         if (restorePoint) this.scrollController?.restore(restorePoint);
+        this.scheduleScrollRebuildSettle();
         this.scheduleSurfaceScrollStateSync();
         if (shouldRecoverRenderer) this.recoverRendererAfterBackgroundRedraw();
       });
@@ -984,12 +992,12 @@ export class TerminalSurface {
     controller: TerminalScrollController,
     preservePinnedAtBottom: boolean,
   ): void {
-    const sync = () => {
-      if (!this.disposed && this.scrollController === controller) {
-        controller.syncFromViewport({ preservePinnedAtBottom });
-      }
-    };
-    this.scrollSyncSettler.run(sync, { initial: 'microtask' });
+    scheduleTerminalScrollIntentSync(
+      controller,
+      this.scrollSyncSettler,
+      preservePinnedAtBottom,
+      () => !this.disposed && this.scrollController === controller,
+    );
   }
 
   private cancelScheduledScrollSync(): void {
@@ -1180,6 +1188,16 @@ export class TerminalSurface {
       this.pendingScrollStateFrameId = null;
       if (!this.disposed) this.syncScrollStateFromController();
     });
+  }
+
+  private scheduleScrollRebuildSettle(): void {
+    if (this.scrollRebuildSettleTimerId !== null) {
+      window.clearTimeout(this.scrollRebuildSettleTimerId);
+    }
+    this.scrollRebuildSettleTimerId = window.setTimeout(() => {
+      this.scrollRebuildSettleTimerId = null;
+      this.scrollController?.finishBufferRebuild();
+    }, TERMINAL_RESIZE_SETTLE_DELAY_MS);
   }
 
   private cancelScheduledSurfaceScrollStateSync(): void {

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -107,10 +107,11 @@ export function handleIncomingServerMessage({
       return { wasReconnect };
 
     case 'session_state': {
-      const runtimeIsRunning = sessionStore.getSession(msg.sessionId)?.isRunning;
-      const changed = msg.status === 'running' && runtimeIsRunning === false
-        ? false
-        : useTerminalSessionStore.getState().applySessionState(msg);
+      // 유령 running 방지는 store의 runtimeExited 마커가 담당한다. 세션 목록의
+      // isRunning으로 여기서 드롭하면, 목록이 낡아 있는 동안(HTTP refetch 전)
+      // 도착한 진짜 running이 영구 유실된다 — session_state는 hook 이벤트
+      // 시점에만 push되고 재전송이 없다.
+      const changed = useTerminalSessionStore.getState().applySessionState(msg);
       if (changed && msg.status === 'running') {
         const location = useTabStore.getState().findSessionLocation(msg.sessionId);
         if (location) useTabStore.getState().pinTab(location.tabId);
@@ -123,7 +124,9 @@ export function handleIncomingServerMessage({
 
     case 'terminal_session_runtime':
       sessionStore.setSessionRunning(msg.sessionId, msg.running);
-      if (!msg.running) {
+      if (msg.running) {
+        useTerminalSessionStore.getState().markRuntimeStarted(msg.sessionId);
+      } else {
         useTerminalSessionStore.getState().markRuntimeStopped(msg.sessionId);
         retireStoppedTerminalSessionSurface(msg.sessionId);
       }
@@ -132,6 +135,9 @@ export function handleIncomingServerMessage({
     case 'terminal_session_runtime_snapshot': {
       sessionStore.applyTerminalRuntimeSnapshot(msg.activeSessionIds);
       const activeTerminalIds = new Set(msg.activeSessionIds);
+      for (const sessionId of msg.activeSessionIds) {
+        useTerminalSessionStore.getState().markRuntimeStarted(sessionId);
+      }
       for (const project of sessionStore.projects) {
         for (const session of project.sessions) {
           if (session.kind === 'terminal' && !activeTerminalIds.has(session.id)) {

--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -17,7 +17,10 @@ import {
   releaseTerminalHandoffByTerminal,
 } from '../terminal/terminal-handoff-lock';
 import { mintPaneToken } from '../terminal/pane-token-registry';
-import { buildProviderTerminalLaunch } from '../terminal/provider-launch';
+import {
+  buildProviderTerminalEnv,
+  buildProviderTerminalLaunch,
+} from '../terminal/provider-launch';
 import { createCodexOverlay } from '../terminal/codex-overlay';
 import { buildClaudeHookSettingsJson } from '../terminal/claude-hook-settings';
 import { createOpenCodeOverlay } from '../terminal/opencode-overlay';
@@ -608,6 +611,10 @@ export async function routeClientTransportMessage({
       }
 
       if (!terminalExists && providerId) {
+        const providerTerminalEnv = buildProviderTerminalEnv(providerId);
+        if (providerTerminalEnv) {
+          launchEnv = { ...launchEnv, ...providerTerminalEnv };
+        }
         const appearanceProvider = cliProviderRegistry.getProvider(providerId);
         appearanceChangePolicy = appearanceProvider.getTerminalAppearanceChangePolicy();
         if (appearanceChangePolicy === 'restart' && structured) {

--- a/src/stores/terminal-session-store.ts
+++ b/src/stores/terminal-session-store.ts
@@ -9,6 +9,14 @@ export interface TerminalSessionState {
   terminalId: string;
   preview?: string;
   updatedAt: number;
+  /**
+   * 이 세션의 런타임이 종료됐다는 명시 신호(terminal_session_runtime running=false /
+   * runtime snapshot 부재)를 받은 뒤인지. hook curl은 fire-and-forget이라 런타임이
+   * 죽은 뒤에도 running/input_required가 늦게 도착할 수 있고, 이 마커가 그런 유령
+   * 상태의 저장을 막는다. 세션 목록의 isRunning은 HTTP refetch 전까지 낡을 수 있어
+   * 판단 기준으로 쓰지 않는다 — 같은 WS 스트림의 runtime 신호만 신뢰한다.
+   */
+  runtimeExited?: boolean;
 }
 
 type SessionStateMessage = Extract<AppServerMessage, { type: 'session_state' }>;
@@ -18,6 +26,7 @@ interface TerminalSessionStore {
   /** Returns false when the server replayed an identical cached state. */
   applySessionState: (msg: SessionStateMessage) => boolean;
   markRuntimeStopped: (sessionId: string) => void;
+  markRuntimeStarted: (sessionId: string) => void;
   clearSession: (sessionId: string) => void;
 }
 
@@ -31,12 +40,31 @@ export function isTerminalTurnProcessing(
 export const selectIsTerminalTurnProcessing = (sessionId: string) =>
   (state: TerminalSessionStore): boolean => isTerminalTurnProcessing(state, sessionId);
 
+/** AskUserQuestion 카드 등 사람 입력 대기 상태 — 사이드바 노란 깜빡점의 PTY 소스. */
+export function isTerminalAwaitingInput(
+  state: TerminalSessionStore,
+  sessionId: string,
+): boolean {
+  return state.bySessionId[sessionId]?.status === 'input_required';
+}
+
+export const selectIsTerminalAwaitingInput = (sessionId: string) =>
+  (state: TerminalSessionStore): boolean => isTerminalAwaitingInput(state, sessionId);
+
 // PTY hook 상태는 GUI chat-store의 turn lifecycle과 별개의 상태 머신이다.
 // 터미널 패널 헤더/사이드바/보드/탭은 이 store를 processing의 SSoT로 구독한다.
 export const useTerminalSessionStore = create<TerminalSessionStore>((set) => ({
   bySessionId: {},
   applySessionState: (msg) => {
     const current = useTerminalSessionStore.getState().bySessionId[msg.sessionId];
+    // 종료가 확인된 런타임에는 활동 상태를 되살리지 않는다(늦은 curl 유령 방지).
+    // completed/idle은 죽은 뒤에도 사실이므로 통과시킨다.
+    if (
+      current?.runtimeExited
+      && (msg.status === 'running' || msg.status === 'input_required')
+    ) {
+      return false;
+    }
     if (
       current
       && current.status === msg.status
@@ -55,6 +83,7 @@ export const useTerminalSessionStore = create<TerminalSessionStore>((set) => ({
           terminalId: msg.terminalId,
           preview: msg.preview,
           updatedAt: Date.now(),
+          ...(current?.runtimeExited ? { runtimeExited: true } : {}),
         },
       },
     }));
@@ -63,16 +92,34 @@ export const useTerminalSessionStore = create<TerminalSessionStore>((set) => ({
   markRuntimeStopped: (sessionId) =>
     set((prev) => {
       const current = prev.bySessionId[sessionId];
-      if (!current || current.status !== 'running') return prev;
+      if (!current) return prev;
+      // 죽은 런타임은 입력을 받을 수 없다 — input_required를 남겨두면 답할 수 없는
+      // 질문에 노란 점이 영영 깜빡인다. running과 함께 idle로 강등하고, 이후 늦게
+      // 도착하는 활동 이벤트를 막기 위해 runtimeExited 마커를 남긴다.
+      const demote = current.status === 'running' || current.status === 'input_required';
+      if (!demote && current.runtimeExited) return prev;
       return {
         bySessionId: {
           ...prev.bySessionId,
           [sessionId]: {
             ...current,
-            status: 'idle',
-            hookEvent: 'RuntimeExit',
+            ...(demote ? { status: 'idle' as const, hookEvent: 'RuntimeExit' } : {}),
+            runtimeExited: true,
             updatedAt: Date.now(),
           },
+        },
+      };
+    }),
+  markRuntimeStarted: (sessionId) =>
+    set((prev) => {
+      const current = prev.bySessionId[sessionId];
+      if (!current?.runtimeExited) return prev;
+      const next = { ...current, updatedAt: Date.now() };
+      delete next.runtimeExited;
+      return {
+        bySessionId: {
+          ...prev.bySessionId,
+          [sessionId]: next,
         },
       };
     }),

--- a/tests/ask-user-question-status.test.ts
+++ b/tests/ask-user-question-status.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { classifyAskUserQuestionEvent } from '@/lib/cli/providers/claude-code/ask-user-question-status';
+
+test('PreToolUse for AskUserQuestion maps to input_required with the question preview', () => {
+  assert.deepEqual(
+    classifyAskUserQuestionEvent('PreToolUse', {
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [{ question: '어느 방식으로 할까요?', header: '방식', options: [] }],
+      },
+    }),
+    { status: 'input_required', preview: '어느 방식으로 할까요?' },
+  );
+});
+
+test('PreToolUse without a readable question still maps to input_required', () => {
+  assert.deepEqual(
+    classifyAskUserQuestionEvent('PreToolUse', { tool_name: 'AskUserQuestion' }),
+    { status: 'input_required', preview: undefined },
+  );
+});
+
+test('PostToolUse for AskUserQuestion resumes running', () => {
+  assert.deepEqual(
+    classifyAskUserQuestionEvent('PostToolUse', {
+      tool_name: 'AskUserQuestion',
+      tool_response: {},
+    }),
+    { status: 'running' },
+  );
+});
+
+test('other tools and events are ignored even if a broad matcher forwards them', () => {
+  assert.equal(classifyAskUserQuestionEvent('PreToolUse', { tool_name: 'Bash' }), null);
+  assert.equal(classifyAskUserQuestionEvent('PostToolUse', { tool_name: 'Edit' }), null);
+  assert.equal(classifyAskUserQuestionEvent('Stop', { tool_name: 'AskUserQuestion' }), null);
+  assert.equal(classifyAskUserQuestionEvent('PreToolUse', {}), null);
+});

--- a/tests/claude-hook-lifecycle.test.ts
+++ b/tests/claude-hook-lifecycle.test.ts
@@ -184,3 +184,131 @@ test('a later authoritative Stop can drain an idle teammate without SubagentStop
     session_crons: [],
   }), { status: 'completed' });
 });
+
+// ─── reconcile: Stop의 background_tasks 스냅샷으로 명단을 self-heal ───
+
+test('a lost SubagentStop is healed by the Stop payload marking the child done', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-lost-subagentstop';
+
+  tracker.apply(terminalId, 'UserPromptSubmit', {});
+  tracker.apply(terminalId, 'SubagentStart', { agent_id: 'agent-a' });
+  // SubagentStop이 유실됐지만, Stop payload가 agent-a를 running이 아닌 상태로 보고하면
+  // reconcile이 그 child를 idle로 강등해 턴을 완료시킨다.
+  assert.deepEqual(tracker.apply(terminalId, 'Stop', {
+    background_tasks: [{ id: 'agent-a', type: 'subagent', status: 'completed' }],
+  }), { status: 'completed' });
+});
+
+test('a running subagent never observed via SubagentStart is recreated from the Stop payload', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-restart-midrun';
+
+  tracker.apply(terminalId, 'UserPromptSubmit', {});
+  // SubagentStart를 놓쳤어도(서버/relay 재시작) Stop의 background_tasks에 running으로
+  // 있으면 명단에 재생성해 pane이 child 살아있는데 done으로 읽지 않게 한다.
+  assert.deepEqual(tracker.apply(terminalId, 'Stop', {
+    background_tasks: [{ id: 'agent-x', type: 'subagent', status: 'running' }],
+  }), { status: 'running' });
+  // 그 child가 다음 Stop에서 리스트에 없으면(끝남) 완료로 강등된다.
+  assert.deepEqual(tracker.apply(terminalId, 'Stop', {
+    background_tasks: [],
+  }), { status: 'completed' });
+});
+
+// ─── 재기동 턴: 백그라운드 작업 완료로 Claude가 자동으로 깨어난 턴의 감지 ───
+
+test('a PreToolUse after the revive grace reopens a completed turn as running', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-revived-by-build';
+  const t0 = 1_000_000;
+
+  tracker.apply(terminalId, 'UserPromptSubmit', {}, t0);
+  // 백그라운드 빌드를 남긴 채 턴 종료 — 셸 작업은 스피너를 잡지 않는다(의도).
+  assert.deepEqual(tracker.apply(terminalId, 'Stop', {
+    background_tasks: [{ id: 'bash-build', type: 'local_shell', status: 'running' }],
+  }, t0 + 1_000), { status: 'completed' });
+
+  // 빌드가 끝나 Claude가 깨어나 결과를 확인한다 — UserPromptSubmit 없이 도구부터 쓴다.
+  assert.deepEqual(tracker.apply(terminalId, 'PreToolUse', {
+    tool_name: 'Bash',
+  }, t0 + 60_000), { status: 'running' });
+
+  assert.deepEqual(tracker.apply(terminalId, 'Stop', {
+    background_tasks: [],
+  }, t0 + 65_000), { status: 'completed' });
+});
+
+test('a PreToolUse inside the revive grace is treated as a late curl and ignored', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-late-pretooluse';
+  const t0 = 2_000_000;
+
+  tracker.apply(terminalId, 'UserPromptSubmit', {}, t0);
+  tracker.apply(terminalId, 'Stop', { background_tasks: [] }, t0 + 1_000);
+
+  // 턴 마지막 도구의 PreToolUse curl이 Stop보다 늦게 배달된 역전 — 턴을 되살리면 안 된다.
+  assert.equal(tracker.apply(terminalId, 'PreToolUse', {
+    tool_name: 'Read',
+  }, t0 + 2_000), null);
+});
+
+test('a late PostToolUse never reopens a completed turn regardless of delay', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-late-posttooluse';
+  const t0 = 3_000_000;
+
+  tracker.apply(terminalId, 'UserPromptSubmit', {}, t0);
+  tracker.apply(terminalId, 'Stop', { background_tasks: [] }, t0 + 1_000);
+
+  assert.equal(tracker.apply(terminalId, 'PostToolUse', {
+    tool_name: 'Bash',
+  }, t0 + 60_000), null);
+});
+
+test('tool events during a live turn keep it running and refresh subagent liveness', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-tool-activity';
+
+  tracker.apply(terminalId, 'UserPromptSubmit', {});
+  assert.deepEqual(tracker.apply(terminalId, 'PreToolUse', { tool_name: 'Bash' }),
+    { status: 'running' });
+  assert.deepEqual(tracker.apply(terminalId, 'PostToolUse', { tool_name: 'Bash' }),
+    { status: 'running' });
+
+  // subagent 발 도구 이벤트는 그 child가 살아있다는 증거 — SubagentStart가 유실됐어도
+  // 명단에 올라 Stop의 done 게이트가 그 child를 기다리게 된다.
+  tracker.apply(terminalId, 'PreToolUse', { tool_name: 'Grep', agent_id: 'agent-live' });
+  assert.deepEqual(tracker.apply(terminalId, 'Stop', {}), { status: 'running' });
+  assert.deepEqual(tracker.apply(terminalId, 'SubagentStop', {
+    agent_id: 'agent-live',
+    background_tasks: [],
+  }), { status: 'completed' });
+});
+
+// ─── StopFailure: 에러로 끝난 턴도 Stop처럼 닫는다 ───
+
+test('StopFailure closes a turn with no live children just like Stop', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-stopfailure';
+
+  tracker.apply(terminalId, 'UserPromptSubmit', {});
+  assert.deepEqual(tracker.apply(terminalId, 'StopFailure', {
+    background_tasks: [],
+  }), { status: 'completed' });
+});
+
+test('StopFailure keeps the turn running while a child is still working', () => {
+  const tracker = new ClaudeHookLifecycleTracker();
+  const terminalId = 'terminal-stopfailure-with-child';
+
+  tracker.apply(terminalId, 'UserPromptSubmit', {});
+  tracker.apply(terminalId, 'SubagentStart', { agent_id: 'agent-a' });
+  assert.deepEqual(tracker.apply(terminalId, 'StopFailure', {
+    background_tasks: [{ id: 'agent-a', type: 'subagent', status: 'running' }],
+  }), { status: 'running' });
+  assert.deepEqual(tracker.apply(terminalId, 'SubagentStop', {
+    agent_id: 'agent-a',
+    background_tasks: [],
+  }), { status: 'completed' });
+});

--- a/tests/claude-subagent-roster.test.ts
+++ b/tests/claude-subagent-roster.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  type SubagentRoster,
+  upsertWorkingSubagent,
+  markSubagentIdle,
+  markTeammateIdleByName,
+  rosterHasWorkingSubagent,
+  readBackgroundAgentTasks,
+  foldBackgroundTasksIntoRoster,
+  teammateIdMatchesName,
+} from '@/lib/cli/providers/claude-code/claude-subagent-roster';
+
+function roster(): SubagentRoster {
+  return new Map();
+}
+
+test('upsert/markIdle drive rosterHasWorkingSubagent', () => {
+  const r = roster();
+  assert.equal(rosterHasWorkingSubagent(r), false);
+  upsertWorkingSubagent(r, 'a');
+  assert.equal(rosterHasWorkingSubagent(r), true);
+  markSubagentIdle(r, 'a');
+  assert.equal(rosterHasWorkingSubagent(r), false);
+});
+
+test('upsert rejects empty and over-long ids', () => {
+  const r = roster();
+  upsertWorkingSubagent(r, '');
+  upsertWorkingSubagent(r, 'x'.repeat(65));
+  assert.equal(r.size, 0);
+});
+
+test('readBackgroundAgentTasks marks absent field as not present', () => {
+  assert.deepEqual(readBackgroundAgentTasks({}), { present: false, tasks: [] });
+  assert.deepEqual(readBackgroundAgentTasks({ background_tasks: 'oops' }), { present: false, tasks: [] });
+});
+
+test('readBackgroundAgentTasks keeps only subagent/teammate entries', () => {
+  const result = readBackgroundAgentTasks({
+    background_tasks: [
+      { id: 'a', type: 'subagent', status: 'running' },
+      { id: 'shell', type: 'local_shell', status: 'running' },
+      { id: 't', type: 'teammate', status: 'running' },
+      { id: '', type: 'subagent', status: 'running' },
+      { type: 'subagent', status: 'running' },
+      null,
+    ],
+  });
+  assert.equal(result.present, true);
+  assert.deepEqual(result.tasks, [
+    { id: 'a', running: true, teammate: false },
+    { id: 't', running: true, teammate: true },
+  ]);
+});
+
+test('readBackgroundAgentTasks reads non-running status as not running', () => {
+  const result = readBackgroundAgentTasks({
+    background_tasks: [{ id: 'a', type: 'subagent', status: 'completed' }],
+  });
+  assert.deepEqual(result.tasks, [{ id: 'a', running: false, teammate: false }]);
+});
+
+test('fold with empty list clears the roster', () => {
+  const r = roster();
+  upsertWorkingSubagent(r, 'a');
+  foldBackgroundTasksIntoRoster(r, []);
+  assert.equal(r.size, 0);
+});
+
+test('fold reflects an id-exact run state onto a tracked child', () => {
+  const r = roster();
+  upsertWorkingSubagent(r, 'a');
+  foldBackgroundTasksIntoRoster(r, [{ id: 'a', running: false, teammate: false }]);
+  assert.equal(rosterHasWorkingSubagent(r), false);
+});
+
+test('fold recreates an unobserved running subagent as authoritative', () => {
+  const r = roster();
+  foldBackgroundTasksIntoRoster(r, [{ id: 'x', running: true, teammate: false }]);
+  assert.equal(rosterHasWorkingSubagent(r), true);
+  // authoritative이므로 다음 fold에서 리스트에 빠지면 idle로 강등된다.
+  foldBackgroundTasksIntoRoster(r, [{ id: 'other', running: true, teammate: false }]);
+  assert.equal(r.get('x')?.state, 'idle');
+});
+
+test('fold does not create teammate entries, nor non-running ones', () => {
+  const r = roster();
+  foldBackgroundTasksIntoRoster(r, [
+    { id: 'team', running: true, teammate: true },
+    { id: 'done-oneshot', running: false, teammate: false },
+  ]);
+  assert.equal(r.has('team'), false);
+  assert.equal(r.has('done-oneshot'), false);
+});
+
+test('fold does not demote a lifecycle-tracked child absent from the list', () => {
+  const r = roster();
+  upsertWorkingSubagent(r, 'lifecycle-child'); // not authoritative
+  foldBackgroundTasksIntoRoster(r, [{ id: 'other', running: true, teammate: false }]);
+  // teammate ids never appear in background_tasks — absence must not demote them.
+  assert.equal(r.get('lifecycle-child')?.state, 'working');
+});
+
+test('teammateIdMatchesName distinguishes rev from rev-two', () => {
+  assert.equal(teammateIdMatchesName('arev-123', 'rev'), true);
+  assert.equal(teammateIdMatchesName('arev-two-123', 'rev'), false);
+  assert.equal(teammateIdMatchesName('arev-two-123', 'rev-two'), true);
+  assert.equal(teammateIdMatchesName('agent-a', 'rev'), false);
+});
+
+test('markTeammateIdleByName idles matching teammate ids only', () => {
+  const r = roster();
+  upsertWorkingSubagent(r, 'arev-123');
+  upsertWorkingSubagent(r, 'aother-456');
+  markTeammateIdleByName(r, 'rev');
+  assert.equal(r.get('arev-123')?.state, 'idle');
+  assert.equal(r.get('aother-456')?.state, 'working');
+});

--- a/tests/provider-terminal-launch.test.ts
+++ b/tests/provider-terminal-launch.test.ts
@@ -1,6 +1,17 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { buildProviderTerminalLaunch } from '@/lib/terminal/provider-launch';
+import {
+  buildProviderTerminalEnv,
+  buildProviderTerminalLaunch,
+} from '@/lib/terminal/provider-launch';
+
+test('Claude PTY keeps scrollback in xterm instead of its fullscreen virtual scroller', () => {
+  assert.deepEqual(buildProviderTerminalEnv('claude-code'), {
+    CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN: '1',
+  });
+  assert.equal(buildProviderTerminalEnv('codex'), undefined);
+  assert.equal(buildProviderTerminalEnv('opencode'), undefined);
+});
 
 test('Codex PTY starts with pre-trusted overlay hooks and no trust-bypass warning flag', () => {
   assert.deepEqual(

--- a/tests/terminal-hook-settings.test.ts
+++ b/tests/terminal-hook-settings.test.ts
@@ -10,9 +10,15 @@ import {
 const BASE_LIFECYCLE_EVENTS = ['SessionStart', 'UserPromptSubmit', 'Stop'];
 const CLAUDE_LIFECYCLE_EVENTS = [
   ...BASE_LIFECYCLE_EVENTS,
+  // 에러로 정상 Stop을 건너뛴 턴을 닫기 위한 이벤트.
+  'StopFailure',
   'SubagentStart',
   'SubagentStop',
   'TeammateIdle',
+  // 도구 활동 신호. 백그라운드 작업 완료로 깨어난 재기동 턴(UserPromptSubmit 없음)의
+  // 유일한 감지 수단이라 모든 도구('*')에 발화한다. AskUserQuestion 분류도 겸한다.
+  'PreToolUse',
+  'PostToolUse',
 ];
 
 function hooks(settingsJson: string): Record<string, unknown> {
@@ -27,6 +33,17 @@ function assertEvents(actual: Record<string, unknown>, expected: string[]): void
 
 test('Claude terminal settings include child-agent lifecycle hooks', () => {
   assertEvents(hooks(buildClaudeHookSettingsJson()), CLAUDE_LIFECYCLE_EVENTS);
+});
+
+test('Claude tool hooks fire for every tool to detect background-revived turns', () => {
+  const claudeHooks = hooks(buildClaudeHookSettingsJson()) as Record<
+    string,
+    Array<{ matcher?: string }>
+  >;
+  assert.equal(claudeHooks.PreToolUse[0]?.matcher, '*');
+  assert.equal(claudeHooks.PostToolUse[0]?.matcher, '*');
+  // lifecycle hook들은 matcher가 없어야 한다(모든 발생에 발화).
+  assert.equal(claudeHooks.Stop[0]?.matcher, undefined);
 });
 
 test('Codex terminal overlay keeps the base lifecycle hooks', () => {

--- a/tests/terminal-scroll-controller.test.ts
+++ b/tests/terminal-scroll-controller.test.ts
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  scheduleTerminalScrollIntentSync,
   TerminalScrollController,
   type TerminalScrollScheduler,
   type TerminalScrollTarget,
 } from '@/lib/terminal/terminal-scroll-controller';
+import { LayoutSettleRunner } from '@/lib/terminal/layout-settle-runner';
 
 function createScheduler() {
   let nextId = 1;
@@ -135,6 +137,29 @@ test('pinned viewport follows the same first visible line through wrapped-line r
   });
 });
 
+test('a pinned viewport keeps its bottom offset while a TUI rebuilds the buffer', () => {
+  const { active, calls, markerOffsets, target } = createTarget({ viewportY: 150 });
+  const controller = new TerminalScrollController(target);
+  const beforeClear = controller.captureRestorePoint();
+
+  active.baseY = 0;
+  active.viewportY = 0;
+  const duringRebuild = controller.captureRestorePoint();
+  beforeClear.marker?.dispose();
+  controller.restore(beforeClear);
+
+  active.baseY = 120;
+  active.viewportY = 0;
+  controller.restore(duringRebuild);
+
+  assert.deepEqual(calls, [
+    { type: 'line', line: 0 },
+    { type: 'line', line: 70 },
+  ]);
+  assert.deepEqual(markerOffsets, [-70]);
+  assert.equal(active.viewportY, 70);
+});
+
 test('a user follow-output request wins over an older pinned restore point', () => {
   const { active, calls, setMarkerLine, target, wasMarkerDisposed } = createTarget({
     viewportY: 150,
@@ -240,6 +265,43 @@ test('wheel-up intent pins immediately before the browser viewport catches up', 
 
   active.viewportY = 150;
   controller.syncFromViewport({ preservePinnedAtBottom: true });
+  assert.deepEqual(controller.getSnapshot(), {
+    intent: 'pinned-viewport',
+    isAtBottom: false,
+  });
+});
+
+test('a wheel consumed by a TUI does not leave a phantom pin at the bottom', () => {
+  const { target } = createTarget();
+  const { scheduler, runNextTimer } = createScheduler();
+  const controller = new TerminalScrollController(target);
+
+  controller.pinViewport();
+  scheduleTerminalScrollIntentSync(
+    controller,
+    new LayoutSettleRunner(scheduler),
+    true,
+  );
+
+  assert.equal(controller.getSnapshot().intent, 'pinned-viewport');
+  runNextTimer();
+  assert.equal(controller.getSnapshot().intent, 'follow-output');
+});
+
+test('settled wheel tracking keeps a viewport that actually moved pinned', () => {
+  const { active, target } = createTarget();
+  const { scheduler, runNextTimer } = createScheduler();
+  const controller = new TerminalScrollController(target);
+
+  controller.pinViewport();
+  scheduleTerminalScrollIntentSync(
+    controller,
+    new LayoutSettleRunner(scheduler),
+    true,
+  );
+  active.viewportY = 150;
+  runNextTimer();
+
   assert.deepEqual(controller.getSnapshot(), {
     intent: 'pinned-viewport',
     isAtBottom: false,

--- a/tests/terminal-session-runtime-state.test.ts
+++ b/tests/terminal-session-runtime-state.test.ts
@@ -474,6 +474,181 @@ test('PTY runtime exit clears terminal processing when no Stop hook arrives', ()
   assert.equal(useTabStore.getState().tabs[0]?.isPreview, true);
 });
 
+test('a running hook state is kept even while the session list still reads stale isRunning=false', () => {
+  // 세션 목록(HTTP)이 낡아 isRunning=false인 동안 hook의 running이 먼저 도착하는
+  // 실측 시나리오 — runtime 종료 신호를 받은 적이 없으므로 버려선 안 된다.
+  // (버리면 session_state는 재전송이 없어 다음 hook 이벤트까지 스피너가 영영 없다.)
+  assert.equal(useSessionStore.getState().getSession(SESSION_ID)?.isRunning, false);
+
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'running',
+    hookEvent: 'UserPromptSubmit',
+  });
+
+  assert.equal(
+    useTerminalSessionStore.getState().bySessionId[SESSION_ID]?.status,
+    'running',
+  );
+});
+
+test('a runtime restart lifts the ghost-state guard for subsequent hook activity', () => {
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: true,
+  } as ServerTransportMessage);
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'running',
+    hookEvent: 'UserPromptSubmit',
+  });
+
+  // 런타임 종료 — 이후의 늦은 활동 이벤트는 무시된다.
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: false,
+  } as ServerTransportMessage);
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'running',
+    hookEvent: 'PostToolUse',
+  });
+  assert.notEqual(
+    useTerminalSessionStore.getState().bySessionId[SESSION_ID]?.status,
+    'running',
+  );
+
+  // 런타임 재시작 — 가드가 풀려 다음 턴의 running이 정상 반영된다.
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: true,
+  } as ServerTransportMessage);
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'running',
+    hookEvent: 'UserPromptSubmit',
+  });
+  assert.equal(
+    useTerminalSessionStore.getState().bySessionId[SESSION_ID]?.status,
+    'running',
+  );
+});
+
+test('PTY AskUserQuestion marks input_required without touching the GUI prompt map', () => {
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: true,
+  } as ServerTransportMessage);
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'running',
+    hookEvent: 'UserPromptSubmit',
+  });
+
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'input_required',
+    hookEvent: 'PreToolUse',
+    preview: '어느 방식으로 할까요?',
+  });
+
+  assert.equal(
+    useTerminalSessionStore.getState().bySessionId[SESSION_ID]?.status,
+    'input_required',
+  );
+  // GUI 노란점 소스(chat-store activeInteractivePrompt)는 건드리지 않는다.
+  assert.equal(useChatStore.getState().activeInteractivePrompt.has(SESSION_ID), false);
+
+  // 답변 제출(PostToolUse) → running 복귀.
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'running',
+    hookEvent: 'PostToolUse',
+  });
+  assert.equal(
+    useTerminalSessionStore.getState().bySessionId[SESSION_ID]?.status,
+    'running',
+  );
+});
+
+test('PTY runtime exit clears a lingering input_required state', () => {
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: true,
+  } as ServerTransportMessage);
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'input_required',
+    hookEvent: 'PreToolUse',
+  });
+
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: false,
+  } as ServerTransportMessage);
+
+  // 죽은 런타임의 질문에는 답할 수 없다 — 노란 점이 영영 깜빡이면 안 된다.
+  assert.notEqual(
+    useTerminalSessionStore.getState().bySessionId[SESSION_ID]?.status,
+    'input_required',
+  );
+});
+
+test('GUI session-list reconciliation cannot clear PTY input_required state', () => {
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    running: true,
+  } as ServerTransportMessage);
+  receive({
+    type: 'session_state',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    status: 'input_required',
+    hookEvent: 'PreToolUse',
+  });
+
+  receive({
+    type: 'session_list',
+    sessions: [{
+      id: SESSION_ID,
+      status: 'running',
+      isGenerating: false,
+      createdAt: '2026-07-14T00:00:00.000Z',
+      activeInteractivePrompt: null,
+      todoSnapshot: [],
+    }],
+    titleGeneratingSessionIds: [],
+  });
+
+  assert.equal(
+    useTerminalSessionStore.getState().bySessionId[SESSION_ID]?.status,
+    'input_required',
+  );
+});
+
 test('new PTY sessions are stopped until their terminal is opened', () => {
   useSessionStore.setState({ projects: [] });
 


### PR DESCRIPTION
## Summary

- maintain a Claude subagent and teammate roster from native lifecycle events
- keep PTY turns active until tracked background agents drain
- surface AskUserQuestion as an awaiting-user state without touching the GUI prompt map
- block late hook events from reviving completed turns while allowing real subsequent work
- preserve PTY scroll intent when resize redraws rebuild the terminal buffer

## Architecture

Claude-specific events are normalized into the shared terminal session-state contract. GUI processing and awaiting-user state remain sourced from the existing structured chat path.

## Validation

- 76 focused hook, roster, wait-state, scroll, and runtime tests
- full ESLint run with no errors (two pre-existing warnings)
- `npx tsc --noEmit`
- `git diff --check origin/dev...HEAD`