### PR TITLE
fix: harden PTY file drops and runtime completion

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import type {
   TerminalClipboardKind,
   TerminalClipboardPayload,
@@ -66,6 +66,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openExternalUrl: (url: string) => ipcRenderer.invoke('shell-open-external-url', url),
   openFilePath: (path: string) => ipcRenderer.invoke('shell-open-path', path),
   revealFilePath: (path: string) => ipcRenderer.invoke('shell-show-item-in-folder', path),
+  // Absolute host path for a File dragged in from Finder/Explorer. The renderer
+  // cannot read File.path directly (removed in Electron 32), so webUtils is the
+  // only supported way to resolve an OS-dropped file to a filesystem path.
+  getDroppedFilePath: (file: File): string => webUtils.getPathForFile(file),
   onPopoutStateChanged: (callback: (count: number) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: { count?: number }) => {
       if (typeof payload?.count === 'number') {

--- a/src/components/panel/panel-wrapper.tsx
+++ b/src/components/panel/panel-wrapper.tsx
@@ -23,6 +23,10 @@ import {
   insertFilePathIntoTerminal,
   resolvePanelTerminalId,
 } from '@/lib/terminal/terminal-file-path-insert';
+import {
+  getNativeFileDropAbsolutePaths,
+  isNativeFileDrag,
+} from '@/lib/dnd/native-file-drop';
 import { focusPanelControl } from '@/lib/session/focus-session-panel';
 
 /** Edge zone threshold — the outer 25% of each edge triggers a split. */
@@ -133,7 +137,16 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     hasWorkspaceFileDragData(e.dataTransfer) && resolveInsertTargetTerminalId() !== null
   ), [resolveInsertTargetTerminalId]);
 
+  // OS (Finder/Explorer) file drops behave like folder drags: insert-only,
+  // center-only, and accepted only over a terminal pane.
+  const isNativeFilePathInsertTarget = useCallback((e: React.DragEvent) => (
+    isNativeFileDrag(e.dataTransfer) && resolveInsertTargetTerminalId() !== null
+  ), [resolveInsertTargetTerminalId]);
+
   const isPanelCompatibleDrag = useCallback((e: React.DragEvent) => {
+    // OS file drags carry the synthetic 'Files' type and no in-app payload;
+    // accept only over a terminal pane, where the drop inserts the path.
+    if (isNativeFileDrag(e.dataTransfer)) return isNativeFilePathInsertTarget(e);
     // Insert-only drags (folders) carry no session payload — accept them only
     // over a terminal pane, where the drop inserts the path.
     if (isPathInsertOnlyDragData(e.dataTransfer)) return isTerminalPathInsertTarget(e);
@@ -149,7 +162,7 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     // Yield to session-ref drop zone (MessageInput) — let it handle the drop
     if (hasSessionDrag && (e.target as HTMLElement)?.closest?.('[data-session-ref-drop]')) return false;
     return true;
-  }, [panelId, tabId, isTerminalPathInsertTarget]);
+  }, [panelId, tabId, isTerminalPathInsertTarget, isNativeFilePathInsertTarget]);
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
     if (!isPanelCompatibleDrag(e)) return;
@@ -160,19 +173,24 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
   const handleDragOver = useCallback((e: React.DragEvent) => {
     if (!isPanelCompatibleDrag(e)) return;
     e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
+    const isNativeFile = isNativeFileDrag(e.dataTransfer);
+    e.dataTransfer.dropEffect = isNativeFile ? 'copy' : 'move';
 
     const rect = wrapperRef.current?.getBoundingClientRect();
     if (!rect) return;
 
-    // Insert-only drags have no split behavior, so the whole pane acts as center.
-    const edge = isPathInsertOnlyDragData(e.dataTransfer)
+    // Insert-only drags (folders, OS files) have no split behavior, so the
+    // whole pane acts as center.
+    const edge = isNativeFile || isPathInsertOnlyDragData(e.dataTransfer)
       ? 'center'
       : computeDropEdge(e.clientX, e.clientY, rect);
     dropEdgeRef.current = edge;
     setDropEdge(edge);
-    setInsertPathHint(edge === 'center' && isTerminalPathInsertTarget(e));
-  }, [isPanelCompatibleDrag, isTerminalPathInsertTarget]);
+    setInsertPathHint(
+      edge === 'center' &&
+      (isNativeFile ? isNativeFilePathInsertTarget(e) : isTerminalPathInsertTarget(e)),
+    );
+  }, [isPanelCompatibleDrag, isTerminalPathInsertTarget, isNativeFilePathInsertTarget]);
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     if (!isPanelCompatibleDrag(e)) return;
@@ -193,6 +211,23 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     dropEdgeRef.current = null;
     setDropEdge(null);
     setInsertPathHint(false);
+
+    // OS (Finder/Explorer) file drop → insert each absolute path into the PTY.
+    if (currentEdge === 'center' && isNativeFilePathInsertTarget(e)) {
+      const targetTerminalId = resolveInsertTargetTerminalId();
+      const paths = getNativeFileDropAbsolutePaths(e.dataTransfer);
+      if (targetTerminalId && paths.length > 0) {
+        let inserted = false;
+        for (const path of paths) {
+          if (insertFilePathIntoTerminal(targetTerminalId, path)) inserted = true;
+        }
+        if (inserted) {
+          usePanelStore.getState().setActivePanelId(panelId);
+          focusPanelControl(panelId);
+        }
+      }
+      return;
+    }
 
     if (currentEdge === 'center' && isTerminalPathInsertTarget(e)) {
       const filePath = getWorkspaceFileDragAbsolutePath(e.dataTransfer);
@@ -389,7 +424,7 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     if (session) {
       viewSession(session, { forceReload: true });
     }
-  }, [panelId, t, viewSession, isTerminalPathInsertTarget, resolveInsertTargetTerminalId]);
+  }, [panelId, t, viewSession, isTerminalPathInsertTarget, isNativeFilePathInsertTarget, resolveInsertTargetTerminalId]);
 
   return (
     <div

--- a/src/lib/cli/hook-receiver.ts
+++ b/src/lib/cli/hook-receiver.ts
@@ -211,6 +211,9 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
         terminalId: entry.terminalId,
         status: mapped.status,
         hookEvent: event,
+        // 이 상태 발생시각. recordSessionState가 저장해 replay 때 같은 값을 실으므로
+        // 클라의 알림 dedup 키가 재연결/재전송에도 안정적으로 같은 완료를 가리킨다.
+        stateAt: Date.now(),
         ...(mapped.preview ? { preview: mapped.preview } : {}),
       } as const;
       // 죽었거나 미소유인 pane의 늦은 curl은 브로드캐스트하지 않는다 — 이미

--- a/src/lib/dnd/native-file-drop.ts
+++ b/src/lib/dnd/native-file-drop.ts
@@ -1,0 +1,57 @@
+/**
+ * OS-native file drops (Finder / Windows Explorer) into the app.
+ *
+ * These differ fundamentally from in-app workspace-file drags: the OS fills
+ * `dataTransfer.files` with real File objects but provides no path string, and
+ * no custom MIME. The absolute host path can only be resolved through Electron's
+ * `webUtils.getPathForFile`, exposed on `window.electronAPI.getDroppedFilePath`.
+ *
+ * Outside Electron (e.g. the browser dev server) that bridge is absent, so path
+ * resolution yields nothing and the drop is silently ignored — the GUI is never
+ * affected.
+ */
+
+/** Guard against pathological multi-file drops (mirrors Orca's limit). */
+export const NATIVE_FILE_DROP_MAX_PATHS = 256;
+
+interface ElectronFilePathBridge {
+  getDroppedFilePath(file: File): string;
+}
+
+/**
+ * True for a drag originating from the OS file manager. Such drags expose the
+ * synthetic `'Files'` type; in-app drags only ever carry custom MIME types, so
+ * this never collides with panel/session/workspace drags.
+ *
+ * Note: `dataTransfer.files` is empty during dragover for security — only the
+ * `types` list is readable then, which is why this checks types alone.
+ */
+export function isNativeFileDrag(dataTransfer: Pick<DataTransfer, 'types'>): boolean {
+  return dataTransfer.types.includes('Files');
+}
+
+/**
+ * Resolve absolute host paths for OS-dropped files. Returns `[]` when running
+ * outside Electron, when there are no files, or when the count exceeds the
+ * guard limit. Only callable on `drop` (files are inaccessible during dragover).
+ */
+export function getNativeFileDropAbsolutePaths(
+  dataTransfer: Pick<DataTransfer, 'files'>,
+): string[] {
+  const bridge = (
+    window as Window & { electronAPI?: Partial<ElectronFilePathBridge> }
+  ).electronAPI;
+  if (typeof bridge?.getDroppedFilePath !== 'function') return [];
+
+  const files = dataTransfer.files;
+  if (!files || files.length === 0 || files.length > NATIVE_FILE_DROP_MAX_PATHS) {
+    return [];
+  }
+
+  const paths: string[] = [];
+  for (let i = 0; i < files.length; i++) {
+    const path = bridge.getDroppedFilePath(files[i]);
+    if (path) paths.push(path);
+  }
+  return paths;
+}

--- a/src/lib/dnd/panel-session-drag.ts
+++ b/src/lib/dnd/panel-session-drag.ts
@@ -227,7 +227,9 @@ export function setWorkspaceDirectoryDragData(
   };
   dataTransfer.setData(WORKSPACE_FILE_DRAG_MIME, JSON.stringify(payload));
   dataTransfer.setData('text/plain', directoryPath);
-  dataTransfer.effectAllowed = 'copy';
+  // Must stay compatible with the drop zone's dropEffect ('move') — a
+  // mismatch makes the browser cancel the drop without firing the event.
+  dataTransfer.effectAllowed = 'copyMove';
 }
 
 /**

--- a/src/lib/session/codex-thread-lifecycle.ts
+++ b/src/lib/session/codex-thread-lifecycle.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'fs';
+
 import {
   deleteCodexThread,
   renameCodexThread,
@@ -22,7 +24,12 @@ function getMutationTarget(
   const threadId = dbSessions.extractThreadId(session.provider_state);
   if (!threadId) return null;
   const projectWorkDir = dbProjects.getProject(session.project_id)?.decoded_path;
-  const sessionWorkDir = session.worktree_deleted_at ? null : session.work_dir;
+  // The worktree can vanish without worktree_deleted_at being recorded (e.g.
+  // removed via a path that skips the DB marker); spawning with a missing cwd
+  // fails with ENOENT, so trust the filesystem over the marker.
+  const sessionWorkDir = !session.worktree_deleted_at && session.work_dir && existsSync(session.work_dir)
+    ? session.work_dir
+    : null;
   return {
     sessionId: session.id,
     threadId,

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -461,15 +461,18 @@ function handleTerminalSessionStateMessage(
     return;
   }
 
-  notificationStore.addNotification({
+  const added = notificationStore.addNotification({
     sessionId: msg.sessionId,
     type: msg.status === 'completed' ? 'completed' : 'input_required',
     preview: msg.preview
       ?? (msg.status === 'completed'
         ? 'Terminal task completed'
         : 'Terminal is waiting for input'),
+    dedupKey: msg.stateAt != null
+      ? `${msg.sessionId}:${msg.status}:${msg.stateAt}`
+      : undefined,
   });
-  useSessionStore.getState().incrementUnreadCount(msg.sessionId);
+  if (added) useSessionStore.getState().incrementUnreadCount(msg.sessionId);
 }
 
 function handleInteractivePromptMessage(

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -286,6 +286,12 @@ export type AppServerMessage =
       status: 'running' | 'completed' | 'input_required' | 'idle';
       hookEvent: string;
       preview?: string;
+      /**
+       * 이 상태 인스턴스의 발생시각(epoch ms). 클라의 알림 dedup 키 재료. 서버가
+       * 상태 기록 시 한 번 찍어 저장하고 replay에도 같은 값을 실어, 재연결/리로드로
+       * 같은 완료가 다시 도착해도 알림이 중복 발화하지 않게 한다.
+       */
+      stateAt?: number;
     }
   | {
       type: 'terminal_session_runtime';

--- a/src/stores/notification-store.ts
+++ b/src/stores/notification-store.ts
@@ -23,7 +23,8 @@ interface NotificationState {
   toasts: ActionToast[];
 
   // Notification actions
-  addNotification: (notification: Omit<Notification, 'id' | 'timestamp' | 'read' | 'dismissed'>) => void;
+  /** Returns false when a notification with the same dedupKey already exists (nothing added). */
+  addNotification: (notification: Omit<Notification, 'id' | 'timestamp' | 'read' | 'dismissed'>) => boolean;
   dismissNotification: (id: string) => void;
   dismissToast: (id: string) => void;
   dismissAll: () => void;
@@ -47,7 +48,14 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
   soundTrigger: 0,
   toasts: [],
 
-  addNotification: (notification) =>
+  addNotification: (notification) => {
+    // Orca식 dedup: 같은 dedupKey가 이미 있으면(dismissed 무관) 재발화를 무시한다.
+    // 재연결/리로드 replay와 근접 이중(Stop+result)이 unread/sound를 부풀리는 걸 막는다.
+    if (notification.dedupKey) {
+      const seen = get().notifications.some((n) => n.dedupKey === notification.dedupKey);
+      if (seen) return false;
+    }
+
     set((state) => {
       const updatedExisting = state.notifications.map((n) =>
         n.sessionId === notification.sessionId && !n.dismissed
@@ -69,7 +77,9 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
       }
 
       return { notifications: updated };
-    }),
+    });
+    return true;
+  },
 
   dismissNotification: (id) =>
     set((state) => ({

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -7,6 +7,12 @@ export interface Notification {
   read: boolean;
   dismissed: boolean;
   actions?: NotificationAction[]; // NEW - for FEAT-003 (Interactive notification buttons)
+  /**
+   * Orca식 dedup 키. 같은 완료 인스턴스가 replay(재연결/리로드)나 근접 이중
+   * 발화로 여러 번 도착해도 하나만 남긴다. 서버가 완료 발생시각 등 안정적
+   * 식별자를 실어 보내면 그걸로 구성한다. 없으면 dedup하지 않는다(항상 추가).
+   */
+  dedupKey?: string;
 }
 
 // NEW: Action button definition for FEAT-003

--- a/tests/codex-session-lifecycle-sync.test.ts
+++ b/tests/codex-session-lifecycle-sync.test.ts
@@ -122,6 +122,28 @@ test('archive RPC failure preserves local state and task partial success is comp
   assert.equal(dbTasks.getTask('task-archive')?.archived, false);
 });
 
+test('archive falls back to the project work dir when the session worktree is gone', async () => {
+  const missingWorkDir = path.join(dataDir, 'worktrees', 'deleted-branch');
+  dbTasks.createTask({ id: 'task-missing-worktree', projectId: 'project-lifecycle', title: 'Missing worktree' });
+  dbSessions.createSession('archive-missing-worktree', 'project-lifecycle', 'Missing worktree', 'codex', {
+    workDir: missingWorkDir,
+    taskId: 'task-missing-worktree',
+    providerState: JSON.stringify({ threadId: 'thread-missing-worktree' }),
+  });
+
+  const workDirs: Array<string | undefined> = [];
+  setCodexThreadControlRequestExecutorForTests(async (context, method) => {
+    assert.equal(method, 'thread/archive');
+    workDirs.push(context.workDir);
+    return {};
+  });
+
+  await setTaskArchived('task-missing-worktree', true, 'user-1');
+
+  assert.deepEqual(workDirs, [dataDir]);
+  assert.equal(dbTasks.getTask('task-missing-worktree')?.archived, true);
+});
+
 test('archiving a chat stops its live PTY runtime', async (t) => {
   const sessionId = 'archive-live-pty';
   dbSessions.createSession(sessionId, 'project-lifecycle', 'Archive live PTY', 'claude-code', {

--- a/tests/notification-store-dedup.test.ts
+++ b/tests/notification-store-dedup.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { useNotificationStore } from '@/stores/notification-store';
+
+function reset(): void {
+  useNotificationStore.setState({ notifications: [] });
+}
+
+test('addNotification with a dedupKey ignores a second identical dedupKey and returns false', () => {
+  reset();
+  const store = useNotificationStore.getState();
+
+  const first = store.addNotification({
+    sessionId: 's1',
+    type: 'completed',
+    preview: 'done',
+    dedupKey: 's1:100',
+  });
+  const second = store.addNotification({
+    sessionId: 's1',
+    type: 'completed',
+    preview: 'done again',
+    dedupKey: 's1:100',
+  });
+
+  assert.equal(first, true);
+  assert.equal(second, false);
+  assert.equal(useNotificationStore.getState().notifications.length, 1);
+});
+
+test('different dedupKeys each add and return true', () => {
+  reset();
+  const store = useNotificationStore.getState();
+
+  const a = store.addNotification({ sessionId: 's1', type: 'completed', preview: 'x', dedupKey: 's1:100' });
+  const b = store.addNotification({ sessionId: 's1', type: 'completed', preview: 'y', dedupKey: 's1:200' });
+
+  assert.equal(a, true);
+  assert.equal(b, true);
+  assert.equal(useNotificationStore.getState().notifications.length, 2);
+});
+
+test('without a dedupKey every call adds (legacy behavior) and returns true', () => {
+  reset();
+  const store = useNotificationStore.getState();
+
+  const a = store.addNotification({ sessionId: 's1', type: 'completed', preview: 'x' });
+  const b = store.addNotification({ sessionId: 's1', type: 'completed', preview: 'x' });
+
+  assert.equal(a, true);
+  assert.equal(b, true);
+  // 같은 sessionId의 이전 알림은 dismissed 처리되지만 배열에는 남는다(기존 계약).
+  assert.equal(useNotificationStore.getState().notifications.length, 2);
+});


### PR DESCRIPTION
## Summary

- accept native OS file and folder drops on terminal panels
- normalize dropped paths before inserting them through the shared terminal input path
- fall back to the project directory when a Codex session worktree no longer exists
- deduplicate completion notifications by terminal state identity
- preserve final runtime and session state updates across WebSocket delivery

## Impact

PTY sessions handle real desktop drag-and-drop reliably, recover from deleted worktrees, and avoid duplicate completion notifications. GUI session input remains unchanged.

## Validation

- 58 focused lifecycle, notification, and terminal contract tests
- full ESLint run with no errors (two pre-existing warnings)
- `npx tsc --noEmit`
- `git diff --check origin/dev...HEAD`