### PR TITLE
feat: reconcile native CLI forks in PTY sessions

### DIFF
--- a/docs/research/orca-native-cli-fork.md
+++ b/docs/research/orca-native-cli-fork.md
@@ -1,0 +1,129 @@
+# Orca native CLI fork detection research
+
+2026-07-20 기준 공식 [`stablyai/orca`](https://github.com/stablyai/orca) 저장소의
+커밋 [`b19dccd9b74328daa39bf20955a57fdfc7279c3e`](https://github.com/stablyai/orca/commit/b19dccd9b74328daa39bf20955a57fdfc7279c3e)와
+공식 [`openai/codex`](https://github.com/openai/codex) 저장소의 커밋
+[`3e2f79727a4e8ddfc8e3acb838d496b121094b9e`](https://github.com/openai/codex/commit/3e2f79727a4e8ddfc8e3acb838d496b121094b9e)을 확인했다.
+로컬 설치 Orca는 v1.4.137이며, 그 태그에도 아래 AI Vault refresh, provider-session,
+session-scanner, terminal context-fork 모듈이 포함되어 있다.
+
+## 결론
+
+Orca는 CLI 안에서 발생한 native fork를 **새 PTY나 새 terminal tab으로 만들지 않는다.**
+같은 `paneKey`에 들어온 새 provider session ID로 현재 agent-status 행의 identity를
+교체한다. 별도 세션은 workspace/sidebar 행이 아니라 **AI Vault(Agent Session History)**가
+Claude/Codex의 새 JSONL transcript/rollout을 다시 스캔할 때 새 행으로 나타난다.
+
+```text
+Claude/Codex가 fork 수행 + 새 provider session ID/JSONL 생성
+  -> 기존 PTY의 hook이 같은 paneKey + 새 session_id를 Orca에 POST
+  -> 공통 AgentProviderSessionMetadata로 정규화
+  -> agentStatusByPaneKey[같은 paneKey]를 새 ID로 교체 (새 tab 없음)
+  -> AI Vault가 새 ID를 보고 강제 disk rescan
+  -> 새 JSONL을 별도 AiVaultSession row로 추가
+```
+
+따라서 Tessera에서 원하는 “fork가 메뉴에 새 세션으로 추가”는 terminal tab 생성과
+session-history 등록을 분리해 구현해야 한다. PTY는 그대로 유지하고, 메뉴용 세션 인덱스에
+새 provider session artifact를 upsert하는 것이 Orca와 같은 구조다.
+
+## 1. fork와 새 session ID의 주체
+
+- Claude Code는 history를 복사한 새 session ID를 만들고 원본은 그대로 둔다. 현재 CLI의
+  `/branch`는 현재 지점에서 새 대화 branch로 전환하며, 과거 지점은 `/rewind`로 선택한 뒤
+  branch할 수 있다. 세션은 `~/.claude/projects/`의 JSONL로 저장된다.
+  [공식 session 설명](https://code.claude.com/docs/en/how-claude-code-works#work-with-sessions),
+  [공식 command 설명](https://code.claude.com/docs/en/commands#built-in-commands)
+- Codex의 과거 prompt 편집은 선택한 prompt가 속한 turn을 찾고 `beforeTurnId`로
+  `thread/fork`를 호출한다. app-server는 그 turn 직전까지 history를 자르고 새 thread를
+  시작한다.
+  [TUI backtrack dispatch](https://github.com/openai/codex/blob/3e2f79727a4e8ddfc8e3acb838d496b121094b9e/codex-rs/tui/src/app/event_dispatch.rs#L233-L275),
+  [fork request](https://github.com/openai/codex/blob/3e2f79727a4e8ddfc8e3acb838d496b121094b9e/codex-rs/tui/src/app_server_session.rs#L576-L653),
+  [history truncate와 new thread](https://github.com/openai/codex/blob/3e2f79727a4e8ddfc8e3acb838d496b121094b9e/codex-rs/app-server/src/request_processors/thread_processor.rs#L4004-L4129)
+- Codex persistent fork는 자기 rollout을 즉시 만들고, 응답의 새 `thread.id`와
+  `forkedFromId`로 lineage를 표현한다.
+  [materialize와 response](https://github.com/openai/codex/blob/3e2f79727a4e8ddfc8e3acb838d496b121094b9e/codex-rs/app-server/src/request_processors/thread_processor.rs#L4195-L4253),
+  [공식 app-server 계약](https://github.com/openai/codex/blob/3e2f79727a4e8ddfc8e3acb838d496b121094b9e/codex-rs/app-server/README.md#thread-fork)
+
+Orca는 이 ID를 만들거나 native fork protocol을 호출하지 않는다. provider hook payload의
+`session_id`를 읽을 뿐이다. Claude/Codex는 같은 공통 metadata shape으로 들어오고,
+다른 provider의 필드명 차이만 이 switch에서 흡수한다.
+[공통 타입·provider 추출](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/shared/agent-session-resume.ts#L20-L31),
+[provider adapter switch](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/shared/agent-session-resume.ts#L171-L223)
+
+## 2. 실행 중 PTY에서 새 ID를 감지하는 방법
+
+Orca-launched PTY는 `ORCA_PANE_KEY`, tab/worktree metadata와 hook endpoint를 환경으로
+받는다. Claude/Codex managed hook은 CLI가 준 raw payload를 기존 pane identity와 함께
+loopback hook server에 보낸다. Codex는 `SessionStart`도 등록하지만 Claude의 현재 managed
+event 목록에는 `SessionStart`가 없으므로, Claude branch는 보통 다음
+`UserPromptSubmit`/tool lifecycle hook에서 새 ID가 관측된다.
+[Codex hook events](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/main/codex/hook-service.ts#L70-L106),
+[Claude hook events](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/main/claude/hook-settings.ts#L29-L61),
+[hook payload 전송](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/main/codex/hook-service.ts#L798-L854)
+
+공통 listener는 매 event에서 provider session을 추출해 status envelope에 싣고, main은
+그 값을 `agentStatus:set` IPC로 renderer에 전달한다.
+[listener normalization](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/shared/agent-hook-listener.ts#L3897-L3939),
+[main IPC](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/main/index.ts#L1131-L1182),
+[renderer 적용](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/hooks/useIpcEvents.ts#L3163-L3254)
+
+## 3. 새 tab/sidebar row가 아니라 같은 pane 갱신
+
+store는 기존 ID와 incoming ID를 비교해 `providerSessionChanged`를 계산하지만, 최종 write는
+항상 `agentStatusByPaneKey[paneKey] = entry`다. 새 tab/worktree 생성 action은 호출하지 않는다.
+[change detection](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/store/slices/agent-status.ts#L1714-L1774),
+[same-key write](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/store/slices/agent-status.ts#L1951-L1984)
+
+테스트도 같은 `tab-1:leaf-1`에 `codex-session-1` 다음 `codex-session-2`를 넣고, 같은 row의
+ID가 `session-2`로 바뀌는 것을 검증한다.
+[provider-session replacement test](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/store/slices/agent-status-quit-capture.test.ts#L363-L421)
+
+## 4. AI Vault에 별도 세션 행이 생기는 경로
+
+AI Vault panel은 live `agentStatusByPaneKey`의 provider session ID set을 구독한다. 보지 못한
+ID가 나타나면 5초 최소 간격으로 cache를 우회한 강제 rescan을 요청한다. panel이 꺼져
+있었다면 다음 mount/refocus에서 역시 강제 scan한다.
+[refresh/throttle](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts#L6-L22),
+[new-ID subscription](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts#L212-L242),
+[behavior test](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts#L327-L373)
+
+scanner는 공통 pipeline 아래에서 provider별 저장소와 parser를 쓴다.
+
+- Claude: `~/.claude/projects/**/*.jsonl`; record의 `sessionId`가 row session ID가 된다.
+  [source discovery](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/main/ai-vault/session-scanner-source-discovery.ts#L86-L109),
+  [Claude parser](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/main/ai-vault/session-scanner-primary-parsers.ts#L43-L79)
+- Codex: `$CODEX_HOME/sessions/**/*.jsonl`; `session_meta.payload.id`가 row session ID가 된다.
+  [source discovery](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/main/ai-vault/session-scanner-source-discovery.ts#L54-L82),
+  [Codex parser](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/main/ai-vault/session-scanner-codex-parser.ts#L107-L143)
+
+최종 row key는 `executionHostId + agent + sessionId + filePath`라서 fork가 만든 새 artifact는
+별도 행이 된다. 이것이 workspace sidebar가 아니라 session-history 메뉴에 새 세션이 보이는
+실제 경로다.
+[AiVaultSession 모델](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/shared/ai-vault-types.ts#L76-L104),
+[row identity](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/main/ai-vault/session-scanner-accumulator.ts#L75-L126)
+
+이 방식은 filesystem watcher가 아니라 hook-triggered scan이다. 새 ID hook보다 JSONL flush가
+늦으면 첫 scan에서 놓칠 수 있고, 이후 panel mount/refocus/manual refresh가 보정한다.
+
+## 5. Orca의 별도 “Fork Agent Session” 기능
+
+Orca terminal context menu의 fork는 위 native fork와 다르다. xterm scrollback 800줄을
+정리·제한한 prompt로 만들고, 새 git worktree를 생성한 뒤 같은 agent를 새 tab에서 실행한다.
+즉 정확한 provider history/turn 경계 복제가 아니라 **context copy**다.
+[context capture](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.ts#L129-L166),
+[new worktree + tab](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.ts#L215-L302),
+[bounded prompt](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/lib/agent-session-fork-context.ts#L1-L20)
+
+## Tessera 적용 시사점
+
+1. 공통 `ProviderSessionIdentity { provider, id, transcriptPath? }`를 PTY session/tab ID와
+   분리한다. provider adapter는 hook field와 artifact path만 정규화한다.
+2. PTY hook에서 같은 terminal의 provider ID가 바뀌면 terminal record를 교체하되, 메뉴용
+   session index에는 `(executionHost, provider, providerSessionId, artifactPath)`로 새 행을
+   upsert한다.
+3. hook은 빠른 invalidation signal로 쓰고, artifact scanner를 source of truth로 둔다.
+   scan miss를 막으려면 debounce/retry 또는 directory watcher를 추가한다.
+4. Claude/Codex별 UI 분기를 만들지 말고 공통 session registry + provider adapter 구조를 쓴다.
+5. 이 동작은 PTY mode adapter에서만 publish하고 GUI mode의 기존 session 생성 경로에는
+   연결하지 않아야 한다. native fork 때문에 자동으로 새 terminal tab을 만들지 않는다.

--- a/src/lib/cli/hook-receiver.ts
+++ b/src/lib/cli/hook-receiver.ts
@@ -17,6 +17,10 @@ import {
   mapClaudeHookLifecycle,
 } from '@/lib/cli/providers/claude-code/terminal-hook-lifecycle';
 import { classifyAskUserQuestionEvent } from '@/lib/cli/providers/claude-code/ask-user-question-status';
+import { extractTerminalProviderSessionIdentity } from '@/lib/terminal/provider-session-identity';
+import { getTerminalProviderSessionForTesseraSession } from '@/lib/db/terminal-provider-sessions';
+import { cliProviderRegistry } from '@/lib/cli/providers/registry';
+import { observeTerminalProviderSession } from '@/lib/terminal/provider-session-observation';
 
 const MAX_BODY_BYTES = 1_000_000;
 
@@ -162,35 +166,57 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
     const event = readString(payload.hook_event_name) || readString(payload.hookEventName);
     const isCodex = entry.providerId === 'codex';
     const isOpenCode = entry.providerId === 'opencode';
+    const activeSessionId = entry.sessionId
+      ? terminalManager.getSessionIdForTerminal(entry.terminalId, entry.userId)
+      : null;
+    let sessionId = activeSessionId ?? entry.sessionId;
+    const providerIdentity = extractTerminalProviderSessionIdentity(entry.providerId, payload);
+    if (activeSessionId && providerIdentity) {
+      const currentProviderSessionId = getTerminalProviderSessionForTesseraSession(activeSessionId)
+        ?.provider_session_id;
+      const discoveredInBackground = payload.tessera_session_activation === 'background'
+        || Boolean(currentProviderSessionId && cliProviderRegistry.getProvider(entry.providerId)
+          .isBackgroundTerminalSessionFork?.({
+          currentProviderSessionId,
+          observedProviderSessionId: providerIdentity.providerSessionId,
+        }));
+      const observation = observeTerminalProviderSession({
+        pane: entry,
+        identity: providerIdentity,
+        activation: discoveredInBackground ? 'background' : 'active',
+      });
+      if (observation.ignored) return send(204);
+      sessionId = observation.sessionId;
+    }
     const mapped = isCodex
       ? mapCodexEventToStatus(event, payload)
       : isOpenCode
         ? mapEventToStatus(event, payload)
         : mapClaudeEventToStatus(entry.terminalId, event, payload);
-    if (event === 'SessionStart' && entry.sessionId) {
+    if (event === 'SessionStart' && sessionId) {
       if (isCodex) {
         // codex rollout id를 provider_state에 캡처(resume용) + launched 마커 + kind.
-        markCodexTerminalSession(entry.sessionId, readString(payload.session_id));
+        markCodexTerminalSession(sessionId, readString(payload.session_id));
       } else if (isOpenCode) {
         // invocation plugin이 고정한 target id만 별도 키에 저장해 GUI session과 교차 resume하지 않는다.
-        const providerSessionId = readString(payload.session_id);
+        const providerSessionId = providerIdentity?.providerSessionId ?? '';
         if (providerSessionId) {
-          markOpenCodeTerminalSession(entry.sessionId, providerSessionId);
+          markOpenCodeTerminalSession(sessionId, providerSessionId);
         }
       }
-      terminalManager.refreshAppearanceRestartAvailability(entry.sessionId, entry.userId);
+      terminalManager.refreshAppearanceRestartAvailability(sessionId, entry.userId);
     }
     // 첫 프롬프트에서 동기 로컬 제목을 즉시 적용한다. 같은 프롬프트를 history에도
     // 기록해 사용자가 AI 개선을 켠 경우 Stop 시점의 선택적 생성 입력으로 활용한다.
-    if (event === 'UserPromptSubmit' && entry.sessionId) {
+    if (event === 'UserPromptSubmit' && sessionId) {
       const prompt = readString(payload.prompt);
       if (prompt) {
-        sessionHistory.recordUserMessage(entry.sessionId, prompt);
-        const titleUpdate = applyImmediateSessionTitle(entry.sessionId, prompt);
+        sessionHistory.recordUserMessage(sessionId, prompt);
+        const titleUpdate = applyImmediateSessionTitle(sessionId, prompt);
         if (titleUpdate) {
           wsServer.sendToUser(entry.userId, {
             type: 'session_title_updated',
-            sessionId: entry.sessionId,
+            sessionId,
             title: titleUpdate.title,
             previousTitle: titleUpdate.previousTitle,
             hasCustomTitle: false,
@@ -201,19 +227,19 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
     }
     // 실제 턴 완료 시 선택적 AI 제목과 Git 상태를 확정한다. Claude는 lead Stop 뒤에도
     // background child가 실행될 수 있으므로 mapped 상태를 완료 경계로 사용한다.
-    if (mapped?.status === 'completed' && entry.sessionId) {
-      refreshSessionDiffStateInBackground(entry.sessionId, entry.userId, 'terminal lifecycle completion');
+    if (mapped?.status === 'completed' && sessionId) {
+      refreshSessionDiffStateInBackground(sessionId, entry.userId, 'terminal lifecycle completion');
       maybeAutoGenerateProtocolTitle({
         autoTitleTriggered: terminalAutoTitleTriggered,
         sendAppMessage: (uid, m) => wsServer.sendToUser(uid, m),
-        sessionId: entry.sessionId,
+        sessionId,
         userId: entry.userId,
       });
     }
-    if (mapped && entry.sessionId) {
+    if (mapped && sessionId) {
       const message = {
         type: 'session_state',
-        sessionId: entry.sessionId,
+        sessionId,
         terminalId: entry.terminalId,
         status: mapped.status,
         hookEvent: event,

--- a/src/lib/cli/providers/claude-code/adapter.ts
+++ b/src/lib/cli/providers/claude-code/adapter.ts
@@ -43,6 +43,10 @@ import { getRuntimePlatform } from '@/lib/system/runtime-platform';
 import logger from '@/lib/logger';
 import { getRateLimitData } from '@/lib/rate-limit/fetcher';
 import { buildClaudeRateLimitSnapshot } from '@/lib/status-display/rate-limit-snapshots';
+import {
+  createClaudeTerminalSessionObserver,
+  isClaudeBackgroundTerminalSessionFork,
+} from './terminal-session-observer';
 
 const CLI_TIMEOUT_MS = 120_000;
 const STATUS_CHECK_TIMEOUT_MS = 5_000;
@@ -125,6 +129,10 @@ export class ClaudeCodeAdapter implements CliProvider {
   getTerminalInterruptInputPolicy(): 'single-escape' {
     return 'single-escape';
   }
+
+  createTerminalSessionObserver = createClaudeTerminalSessionObserver;
+
+  isBackgroundTerminalSessionFork = isClaudeBackgroundTerminalSessionFork;
 
   /**
    * Checks whether the Claude Code CLI binary is available.

--- a/src/lib/cli/providers/claude-code/terminal-session-observer.ts
+++ b/src/lib/cli/providers/claude-code/terminal-session-observer.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type {
+  ProviderTerminalSessionObserver,
+  ProviderTerminalSessionObserverOptions,
+} from '../provider-contract';
+import {
+  createTerminalSessionArtifactObserver,
+  type ProviderSessionArtifactCandidate,
+} from '../terminal-session-artifact-observer';
+
+function resolveJobsDir(jobsDir?: string): string {
+  if (jobsDir) return jobsDir;
+  const configDir = process.env.CLAUDE_CONFIG_DIR?.trim()
+    ? path.resolve(process.env.CLAUDE_CONFIG_DIR)
+    : path.join(os.homedir(), '.claude');
+  return path.join(configDir, 'jobs');
+}
+
+function readClaudeFork(filePath: string): ProviderSessionArtifactCandidate | null {
+  let state: Record<string, unknown>;
+  try {
+    state = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const providerSessionId = typeof state.forkSessionId === 'string'
+    ? state.forkSessionId.trim()
+    : '';
+  const previousProviderSessionId = typeof state.forkParentSessionId === 'string'
+    ? state.forkParentSessionId.trim()
+    : '';
+  if (
+    !providerSessionId
+    || !previousProviderSessionId
+    || providerSessionId === previousProviderSessionId
+    || state.interactiveLineage !== true
+  ) return null;
+  return {
+    activation: 'background',
+    providerSessionId,
+    previousProviderSessionId,
+  };
+}
+
+export function createClaudeTerminalSessionObserver(
+  options: ProviderTerminalSessionObserverOptions & { jobsDir?: string },
+): ProviderTerminalSessionObserver {
+  return createTerminalSessionArtifactObserver({
+    root: resolveJobsDir(options.jobsDir),
+    matchesPath: (relativePath) => path.basename(relativePath) === 'state.json',
+    readCandidate: readClaudeFork,
+    currentProviderSessionId: options.currentProviderSessionId,
+    onObservation: options.onObservation,
+  });
+}
+
+export function isClaudeBackgroundTerminalSessionFork(options: {
+  currentProviderSessionId: string;
+  observedProviderSessionId: string;
+  jobsDir?: string;
+}): boolean {
+  const jobDir = path.join(resolveJobsDir(options.jobsDir), options.observedProviderSessionId.slice(0, 8));
+  const candidate = readClaudeFork(path.join(jobDir, 'state.json'));
+  return candidate?.previousProviderSessionId === options.currentProviderSessionId
+    && candidate.providerSessionId === options.observedProviderSessionId
+    && candidate.activation === 'background';
+}

--- a/src/lib/cli/providers/codex/adapter.ts
+++ b/src/lib/cli/providers/codex/adapter.ts
@@ -36,6 +36,7 @@ import type {
   CliStatusResult,
   CliRawLogSink,
 } from '../types';
+import { createCodexTerminalSessionObserver } from './terminal-session-observer';
 import type { ContentBlock } from '@/lib/ws/message-types';
 import type { AgentEnvironment } from '@/lib/settings/types';
 import type {
@@ -272,6 +273,8 @@ export class CodexAdapter implements CliProvider {
   getTerminalInterruptInputPolicy(): 'single-escape' {
     return 'single-escape';
   }
+
+  createTerminalSessionObserver = createCodexTerminalSessionObserver;
 
   canResumeTerminalAfterRestart(providerState: string | null): boolean {
     if (!providerState) return false;

--- a/src/lib/cli/providers/codex/terminal-session-observer.ts
+++ b/src/lib/cli/providers/codex/terminal-session-observer.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { resolveCodexAccountHome } from '@/lib/codex-home';
+import type {
+  ProviderTerminalSessionObserver,
+  ProviderTerminalSessionObserverOptions,
+} from '../provider-contract';
+import {
+  createTerminalSessionArtifactObserver,
+  type ProviderSessionArtifactCandidate,
+} from '../terminal-session-artifact-observer';
+
+function readCodexFork(filePath: string): ProviderSessionArtifactCandidate | null {
+  let firstLine = '';
+  try {
+    const descriptor = fs.openSync(filePath, 'r');
+    try {
+      const buffer = Buffer.alloc(64 * 1024);
+      const size = fs.readSync(descriptor, buffer, 0, buffer.length, 0);
+      firstLine = buffer.subarray(0, size).toString('utf8').split('\n', 1)[0];
+    } finally {
+      fs.closeSync(descriptor);
+    }
+  } catch {
+    return null;
+  }
+  if (!firstLine) return null;
+
+  try {
+    const entry = JSON.parse(firstLine) as {
+      type?: unknown;
+      payload?: Record<string, unknown>;
+    };
+    if (entry.type !== 'session_meta' || !entry.payload) return null;
+    const providerSessionId = typeof entry.payload.session_id === 'string'
+      ? entry.payload.session_id.trim()
+      : typeof entry.payload.id === 'string'
+        ? entry.payload.id.trim()
+        : '';
+    const previousProviderSessionId = typeof entry.payload.forked_from_id === 'string'
+      ? entry.payload.forked_from_id.trim()
+      : '';
+    if (!providerSessionId || !previousProviderSessionId || providerSessionId === previousProviderSessionId) {
+      return null;
+    }
+    return {
+      activation: 'active',
+      providerSessionId,
+      previousProviderSessionId,
+      transcriptPath: filePath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function createCodexTerminalSessionObserver(
+  options: ProviderTerminalSessionObserverOptions & { sessionsDir?: string },
+): ProviderTerminalSessionObserver {
+  return createTerminalSessionArtifactObserver({
+    root: options.sessionsDir ?? path.join(resolveCodexAccountHome(), 'sessions'),
+    matchesPath: (relativePath) => relativePath.endsWith('.jsonl'),
+    readCandidate: readCodexFork,
+    currentProviderSessionId: options.currentProviderSessionId,
+    onObservation: options.onObservation,
+  });
+}

--- a/src/lib/cli/providers/provider-contract.ts
+++ b/src/lib/cli/providers/provider-contract.ts
@@ -41,6 +41,22 @@ export type TerminalResizeScrollbackPolicy = 'native' | 'preserve-on-ed3';
 /** How accepted terminal input indicates an agent-turn interrupt. */
 export type TerminalInterruptInputPolicy = 'none' | 'single-escape';
 
+export interface ProviderTerminalSessionObservation {
+  activation: 'active' | 'background';
+  providerSessionId: string;
+  transcriptPath?: string;
+}
+
+export interface ProviderTerminalSessionObserver {
+  ready(): Promise<void>;
+  dispose(): void;
+}
+
+export interface ProviderTerminalSessionObserverOptions {
+  currentProviderSessionId: () => string | undefined;
+  onObservation: (observation: ProviderTerminalSessionObservation) => void;
+}
+
 export interface CliProbeSummary {
   ok: boolean;
   failureKind: CliProbeFailureKind;
@@ -129,6 +145,17 @@ export interface CliProvider {
    * PTY can be followed by a lossless resume of the same provider session.
    */
   canResumeTerminalAfterRestart?(providerState: string | null): boolean;
+
+  /** Watches provider-owned artifacts for native CLI session forks. */
+  createTerminalSessionObserver?(
+    options: ProviderTerminalSessionObserverOptions,
+  ): ProviderTerminalSessionObserver;
+
+  /** Classifies a provider hook that may belong to a non-active fork child. */
+  isBackgroundTerminalSessionFork?(options: {
+    currentProviderSessionId: string;
+    observedProviderSessionId: string;
+  }): boolean;
 
   /**
    * Checks whether this CLI binary is available in the requested environment

--- a/src/lib/cli/providers/terminal-session-artifact-observer.ts
+++ b/src/lib/cli/providers/terminal-session-artifact-observer.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import chokidar from 'chokidar';
+import logger from '@/lib/logger';
+import type {
+  ProviderTerminalSessionObservation,
+  ProviderTerminalSessionObserver,
+} from './provider-contract';
+
+export interface ProviderSessionArtifactCandidate extends ProviderTerminalSessionObservation {
+  previousProviderSessionId: string;
+}
+
+export function createTerminalSessionArtifactObserver(options: {
+  root: string;
+  matchesPath: (relativePath: string) => boolean;
+  readCandidate: (filePath: string) => ProviderSessionArtifactCandidate | null;
+  currentProviderSessionId: () => string | undefined;
+  onObservation: (observation: ProviderTerminalSessionObservation) => void;
+}): ProviderTerminalSessionObserver {
+  fs.mkdirSync(options.root, { recursive: true });
+
+  const emitted = new Set<string>();
+  const retryTimers = new Set<ReturnType<typeof setTimeout>>();
+  let disposed = false;
+  let resolveReady!: () => void;
+  const readyPromise = new Promise<void>((resolve) => { resolveReady = resolve; });
+  let readySettled = false;
+  const markReady = () => {
+    if (readySettled) return;
+    readySettled = true;
+    resolveReady();
+  };
+
+  const inspect = (relativePath: string, attempt = 0): void => {
+    if (disposed || emitted.has(relativePath)) return;
+    const candidate = options.readCandidate(path.resolve(options.root, relativePath));
+    if (candidate && candidate.previousProviderSessionId === options.currentProviderSessionId()) {
+      emitted.add(relativePath);
+      options.onObservation({
+        activation: candidate.activation,
+        providerSessionId: candidate.providerSessionId,
+        ...(candidate.transcriptPath ? { transcriptPath: candidate.transcriptPath } : {}),
+      });
+      return;
+    }
+    if (attempt >= 5) return;
+    const timer = setTimeout(() => {
+      retryTimers.delete(timer);
+      inspect(relativePath, attempt + 1);
+    }, 20 * (2 ** attempt));
+    retryTimers.add(timer);
+  };
+
+  const watcher = chokidar.watch(options.root, {
+    atomic: true,
+    awaitWriteFinish: { stabilityThreshold: 50, pollInterval: 10 },
+    cwd: options.root,
+    followSymlinks: false,
+    ignoreInitial: true,
+    persistent: true,
+  });
+  watcher.on('add', (relativePath) => {
+    const normalized = String(relativePath);
+    if (options.matchesPath(normalized)) inspect(normalized);
+  });
+  watcher.on('change', (relativePath) => {
+    const normalized = String(relativePath);
+    if (options.matchesPath(normalized)) inspect(normalized);
+  });
+  watcher.on('ready', markReady);
+  watcher.on('error', (error) => {
+    markReady();
+    logger.warn({ error, root: options.root }, 'Provider session artifact watcher failed');
+  });
+
+  return {
+    ready: () => readyPromise,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      markReady();
+      void watcher.close();
+      for (const timer of retryTimers) clearTimeout(timer);
+      retryTimers.clear();
+    },
+  };
+}

--- a/src/lib/cli/providers/types.ts
+++ b/src/lib/cli/providers/types.ts
@@ -16,6 +16,9 @@ export type {
   TerminalAppearanceChangePolicy,
   TerminalInterruptInputPolicy,
   TerminalResizeScrollbackPolicy,
+  ProviderTerminalSessionObservation,
+  ProviderTerminalSessionObserver,
+  ProviderTerminalSessionObserverOptions,
   ProviderRateLimitOptions,
 } from './provider-contract';
 export type { ParsedMessage, ParsedMessageSideEffect } from './message-types';

--- a/src/lib/codex-home.ts
+++ b/src/lib/codex-home.ts
@@ -13,6 +13,35 @@ interface ResolveCodexAccountHomeOptions {
   homeDir?: string;
 }
 
+const CODEX_OVERLAY_MARKER = '.tessera-overlay.json';
+
+export function writeCodexOverlayMarker(overlayHome: string, accountHome: string): void {
+  fs.writeFileSync(path.join(overlayHome, CODEX_OVERLAY_MARKER), JSON.stringify({
+    kind: 'tessera-codex-overlay',
+    accountHome,
+  }) + '\n', { mode: 0o600 });
+}
+
+function readMarkedAccountHome(overlayHome: string): string | undefined {
+  try {
+    const marker = JSON.parse(
+      fs.readFileSync(path.join(overlayHome, CODEX_OVERLAY_MARKER), 'utf8'),
+    ) as Record<string, unknown>;
+    const accountHome = typeof marker.accountHome === 'string'
+      ? marker.accountHome.trim()
+      : '';
+    if (
+      marker.kind !== 'tessera-codex-overlay'
+      || !accountHome
+      || !path.isAbsolute(accountHome)
+      || path.resolve(accountHome) === path.resolve(overlayHome)
+    ) return undefined;
+    return path.resolve(accountHome);
+  } catch {
+    return undefined;
+  }
+}
+
 function isWithin(candidate: string, parent: string): boolean {
   const relative = path.relative(parent, candidate);
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
@@ -36,6 +65,8 @@ export function resolveCodexAccountHome(
     cwd: options.cwd,
     homeDir,
   });
+  const markedAccountHome = readMarkedAccountHome(resolvedHome);
+  if (markedAccountHome) return markedAccountHome;
   const overlayRoot = path.join(getTesseraDataDir({
     env,
     cwd: options.cwd,

--- a/src/lib/db/database.ts
+++ b/src/lib/db/database.ts
@@ -973,6 +973,23 @@ function runMigrations(db: DatabaseWrapper, fromVersion: number): void {
     addColumnIfMissing(db, 'sessions', 'service_tier', 'TEXT');
     logger.info('Migration v28 applied: sessions.service_tier column added');
   }
+
+  if (fromVersion < 29) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS terminal_provider_sessions (
+        provider_id         TEXT NOT NULL,
+        provider_session_id TEXT NOT NULL,
+        tessera_session_id  TEXT NOT NULL UNIQUE,
+        transcript_path     TEXT,
+        created_at          TEXT NOT NULL,
+        updated_at          TEXT NOT NULL,
+        PRIMARY KEY (provider_id, provider_session_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_terminal_provider_sessions_tessera
+        ON terminal_provider_sessions(tessera_session_id);
+    `);
+    logger.info('Migration v29 applied: terminal provider session registry added');
+  }
 }
 
 /**

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -4,7 +4,7 @@
  * This DB is the source of truth for projects, sessions, and conversation messages.
  */
 
-export const SCHEMA_VERSION = 28;
+export const SCHEMA_VERSION = 29;
 
 export const CREATE_TABLES = `
 CREATE TABLE IF NOT EXISTS _meta (
@@ -54,6 +54,16 @@ CREATE TABLE IF NOT EXISTS session_messages (
   role       TEXT NOT NULL,
   content    TEXT NOT NULL,
   created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS terminal_provider_sessions (
+  provider_id        TEXT NOT NULL,
+  provider_session_id TEXT NOT NULL,
+  tessera_session_id TEXT NOT NULL UNIQUE,
+  transcript_path   TEXT,
+  created_at        TEXT NOT NULL,
+  updated_at        TEXT NOT NULL,
+  PRIMARY KEY (provider_id, provider_session_id)
 );
 
 CREATE TABLE IF NOT EXISTS custom_columns (
@@ -133,6 +143,9 @@ CREATE INDEX IF NOT EXISTS idx_sessions_collection
 
 CREATE INDEX IF NOT EXISTS idx_session_messages_session
   ON session_messages(session_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_terminal_provider_sessions_tessera
+  ON terminal_provider_sessions(tessera_session_id);
 
 CREATE INDEX IF NOT EXISTS idx_collections_project_sort
   ON collections(project_id, sort_order ASC, created_at ASC);

--- a/src/lib/db/sessions.ts
+++ b/src/lib/db/sessions.ts
@@ -4,6 +4,7 @@
 
 import fs from 'fs';
 import { getDb } from './database';
+import { deleteTerminalProviderSessionsForTesseraSession } from './terminal-provider-sessions';
 import { getTesseraDataPath } from '@/lib/tessera-data-dir';
 
 export interface SessionRow {
@@ -165,6 +166,7 @@ export function createSession(
  * Delete a session record.
  */
 export function deleteSession(id: string): void {
+  deleteTerminalProviderSessionsForTesseraSession(id);
   getDb().prepare('DELETE FROM sessions WHERE id = ?').run(id);
 }
 

--- a/src/lib/db/terminal-provider-sessions.ts
+++ b/src/lib/db/terminal-provider-sessions.ts
@@ -1,0 +1,60 @@
+import { getDb } from './database';
+
+export interface TerminalProviderSessionRow {
+  provider_id: string;
+  provider_session_id: string;
+  tessera_session_id: string;
+  transcript_path: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export function getTerminalProviderSession(
+  providerId: string,
+  providerSessionId: string,
+): TerminalProviderSessionRow | undefined {
+  return getDb().prepare(`
+    SELECT * FROM terminal_provider_sessions
+    WHERE provider_id = ? AND provider_session_id = ?
+  `).get(providerId, providerSessionId) as TerminalProviderSessionRow | undefined;
+}
+
+export function getTerminalProviderSessionForTesseraSession(
+  tesseraSessionId: string,
+): TerminalProviderSessionRow | undefined {
+  return getDb().prepare(`
+    SELECT * FROM terminal_provider_sessions
+    WHERE tessera_session_id = ?
+  `).get(tesseraSessionId) as TerminalProviderSessionRow | undefined;
+}
+
+export function bindTerminalProviderSession(options: {
+  providerId: string;
+  providerSessionId: string;
+  tesseraSessionId: string;
+  transcriptPath?: string;
+}): void {
+  const now = new Date().toISOString();
+  getDb().prepare(`
+    INSERT INTO terminal_provider_sessions (
+      provider_id, provider_session_id, tessera_session_id,
+      transcript_path, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(provider_id, provider_session_id) DO UPDATE SET
+      tessera_session_id = excluded.tessera_session_id,
+      transcript_path = COALESCE(excluded.transcript_path, terminal_provider_sessions.transcript_path),
+      updated_at = excluded.updated_at
+  `).run(
+    options.providerId,
+    options.providerSessionId,
+    options.tesseraSessionId,
+    options.transcriptPath ?? null,
+    now,
+    now,
+  );
+}
+
+export function deleteTerminalProviderSessionsForTesseraSession(tesseraSessionId: string): void {
+  getDb().prepare('DELETE FROM terminal_provider_sessions WHERE tessera_session_id = ?')
+    .run(tesseraSessionId);
+}

--- a/src/lib/terminal/codex-overlay.ts
+++ b/src/lib/terminal/codex-overlay.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { createHash } from 'node:crypto';
 import logger from '@/lib/logger';
-import { resolveCodexAccountHome } from '@/lib/codex-home';
+import { resolveCodexAccountHome, writeCodexOverlayMarker } from '@/lib/codex-home';
 import { getRuntimePlatform } from '@/lib/system/runtime-platform';
 import { getTesseraDataPath } from '@/lib/tessera-data-dir';
 import {
@@ -150,6 +150,7 @@ export function createCodexOverlay(terminalId: string): string {
   fs.mkdirSync(overlayDir, { recursive: true });
 
   const systemHome = resolveCodexAccountHome();
+  writeCodexOverlayMarker(overlayDir, systemHome);
   let configToml = '';
   let entries: string[] = [];
   try {

--- a/src/lib/terminal/opencode-hook-plugin.ts
+++ b/src/lib/terminal/opencode-hook-plugin.ts
@@ -125,6 +125,22 @@ export const TesseraLifecyclePlugin = async ({ directory }) => {
     idleFinalizeTimer = undefined
   }
 
+  const activateTargetSession = (sessionID) => {
+    if (!sessionID || sessionID === targetSessionID) {
+      sendStart()
+      return
+    }
+    clearPromptFlushTimer()
+    clearIdleFinalizeTimer()
+    targetSessionID = sessionID
+    startSent = false
+    sessionIdle = false
+    turnHasSubmittedPrompt = false
+    userMessageIDs.clear()
+    textPartsByMessage.clear()
+    sendStart()
+  }
+
   const finalizeTurn = () => {
     idleFinalizeTimer = undefined
     clearPromptFlushTimer()
@@ -166,11 +182,11 @@ export const TesseraLifecyclePlugin = async ({ directory }) => {
           const parentID = readString(info?.parentID)
           if (!createdID || parentID) return
           if (directory && createdDirectory !== directory) return
+          candidateSessionIDs.add(createdID)
           if (targetSessionID) {
-            if (targetSessionID === createdID) sendStart()
+            activateTargetSession(createdID)
             return
           }
-          candidateSessionIDs.add(createdID)
           return
         }
 
@@ -179,10 +195,12 @@ export const TesseraLifecyclePlugin = async ({ directory }) => {
           const sessionID = readString(info?.sessionID)
           const messageID = readString(info?.id)
           if (!sessionID || !messageID) return
-          if (!targetSessionID && info?.role === "user") {
-            if (candidateSessionIDs.size > 0 && !candidateSessionIDs.has(sessionID)) return
-            targetSessionID = sessionID
-            sendStart()
+          if (info?.role === "user" && sessionID !== targetSessionID) {
+            if (
+              (targetSessionID && !candidateSessionIDs.has(sessionID))
+              || (!targetSessionID && candidateSessionIDs.size > 0 && !candidateSessionIDs.has(sessionID))
+            ) return
+            activateTargetSession(sessionID)
           }
           if (sessionID !== targetSessionID) return
           if (info?.role !== "user") {

--- a/src/lib/terminal/provider-launch.ts
+++ b/src/lib/terminal/provider-launch.ts
@@ -1,10 +1,11 @@
 export interface ProviderTerminalLaunchInput {
   providerId: string;       // 'claude-code' | 'codex' | 'opencode'
-  sessionId: string;        // tessera uuid (claude --session-id). codex는 argv에 안 씀.
+  sessionId: string;        // claude provider id (new sessions use Tessera id). codex는 argv에 안 씀.
   resume: boolean;          // claude: --resume vs --session-id / codex: resume 유무
   settingsJson?: string;    // claude 전용: buildClaudeHookSettingsJson()
   codexResumeId?: string;   // codex 전용: 캡처한 rollout session_id (codex resume <id>)
   opencodeResumeId?: string;
+  providerSessionActivation?: 'active' | 'background';
 }
 
 export interface ProviderTerminalLaunch {
@@ -34,6 +35,14 @@ export const TERMINAL_PROVIDER_COMMANDS: Readonly<Record<string, string>> = {
 export function buildProviderTerminalLaunch(input: ProviderTerminalLaunchInput): ProviderTerminalLaunch {
   if (input.providerId === 'claude-code') {
     if (!input.settingsJson) throw new Error('claude terminal launch requires settingsJson');
+    if (input.providerSessionActivation === 'background') {
+      return {
+        command: TERMINAL_PROVIDER_COMMANDS['claude-code'],
+        // The daemon inherited hooks when `/fork` created it. Claude's attach
+        // subcommand ignores trailing global flags and misparses leading ones.
+        args: ['attach', input.sessionId.slice(0, 8)],
+      };
+    }
     return {
       command: TERMINAL_PROVIDER_COMMANDS['claude-code'],
       args: [input.resume ? '--resume' : '--session-id', input.sessionId, '--settings', input.settingsJson],

--- a/src/lib/terminal/provider-session-identity.ts
+++ b/src/lib/terminal/provider-session-identity.ts
@@ -1,0 +1,111 @@
+import type { SessionRow } from '@/lib/db/sessions';
+import {
+  extractCodexTerminalSessionId,
+  extractOpenCodeTerminalSessionId,
+} from '@/lib/db/sessions';
+
+export interface TerminalProviderSessionIdentity {
+  providerId: string;
+  providerSessionId: string;
+  transcriptPath?: string;
+}
+
+export type TerminalProviderSessionActivation = 'active' | 'background';
+
+const MAX_PROVIDER_SESSION_ID_LENGTH = 512;
+
+function normalizeProviderValue(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  if (
+    normalized.length === 0
+    || normalized.length > MAX_PROVIDER_SESSION_ID_LENGTH
+    || /[\x00-\x1f\x7f]/u.test(normalized)
+  ) return undefined;
+  return normalized;
+}
+
+export function extractTerminalProviderSessionIdentity(
+  providerId: string,
+  payload: Record<string, unknown>,
+): TerminalProviderSessionIdentity | null {
+  const providerSessionId = providerId === 'opencode'
+    ? normalizeProviderValue(payload.sessionID ?? payload.session_id)
+    : normalizeProviderValue(payload.session_id);
+  if (!providerSessionId) return null;
+
+  const transcriptPath = normalizeProviderValue(payload.transcript_path ?? payload.transcriptPath);
+  return {
+    providerId,
+    providerSessionId,
+    ...(transcriptPath ? { transcriptPath } : {}),
+  };
+}
+
+export function readPersistedTerminalProviderSessionId(session: SessionRow): string | undefined {
+  const nativeForkSessionId = extractNativeForkProviderSessionId(session.provider_state);
+  if (nativeForkSessionId) return nativeForkSessionId;
+  if (session.provider === 'claude-code') return session.id;
+  if (session.provider === 'codex') return extractCodexTerminalSessionId(session.provider_state);
+  if (session.provider === 'opencode') return extractOpenCodeTerminalSessionId(session.provider_state);
+  return undefined;
+}
+
+export function extractNativeForkProviderSessionId(
+  providerState: string | null | undefined,
+): string | undefined {
+  if (!providerState) return undefined;
+  try {
+    const parsed = JSON.parse(providerState) as Record<string, unknown>;
+    return normalizeProviderValue(parsed.terminalProviderSessionId);
+  } catch {
+    return undefined;
+  }
+}
+
+export function extractTerminalProviderSessionActivation(
+  providerState: string | null | undefined,
+): TerminalProviderSessionActivation | undefined {
+  if (!providerState) return undefined;
+  try {
+    const activation = (JSON.parse(providerState) as Record<string, unknown>)
+      .terminalProviderSessionActivation;
+    return activation === 'active' || activation === 'background' ? activation : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveTerminalProviderSessionReference(
+  tesseraSessionId: string,
+  providerState: string | null | undefined,
+): {
+  providerSessionId: string;
+  nativeFork: boolean;
+  activation?: TerminalProviderSessionActivation;
+} {
+  const nativeForkSessionId = extractNativeForkProviderSessionId(providerState);
+  const activation = extractTerminalProviderSessionActivation(providerState);
+  return nativeForkSessionId
+    ? {
+        providerSessionId: nativeForkSessionId,
+        nativeFork: true,
+        ...(activation ? { activation } : {}),
+      }
+    : { providerSessionId: tesseraSessionId, nativeFork: false };
+}
+
+export function buildTerminalProviderState(
+  identity: TerminalProviderSessionIdentity,
+  activation?: TerminalProviderSessionActivation,
+): string {
+  const state: Record<string, unknown> = {
+    kind: 'terminal',
+    launched: true,
+    terminalProviderSessionId: identity.providerSessionId,
+  };
+  if (activation) state.terminalProviderSessionActivation = activation;
+  if (identity.providerId === 'codex') state.codexSessionId = identity.providerSessionId;
+  if (identity.providerId === 'opencode') state.opencodeTerminalSessionId = identity.providerSessionId;
+  return JSON.stringify(state);
+}

--- a/src/lib/terminal/provider-session-observation.ts
+++ b/src/lib/terminal/provider-session-observation.ts
@@ -1,0 +1,89 @@
+import logger from '@/lib/logger';
+import { broadcastSessionMutation } from '@/lib/ws/mutation-broadcast';
+import type { PaneTokenEntry } from './pane-token-registry';
+import type { TerminalProviderSessionIdentity } from './provider-session-identity';
+import { reconcileTerminalProviderSession } from './provider-session-reconciliation';
+import { terminalManager } from './shared-terminal-manager';
+
+/** Applies one provider identity observation to the common PTY session model. */
+export function observeTerminalProviderSession(options: {
+  pane: PaneTokenEntry;
+  identity: TerminalProviderSessionIdentity;
+  activation: 'active' | 'background';
+}): { ignored: boolean; sessionId: string | null } {
+  const { pane, identity, activation } = options;
+  const activeSessionId = pane.sessionId
+    ? terminalManager.getSessionIdForTerminal(pane.terminalId, pane.userId)
+    : null;
+  if (!activeSessionId) return { ignored: false, sessionId: pane.sessionId };
+
+  if (activation === 'background') {
+    terminalManager.markProviderSessionIdentityBackground(
+      pane.terminalId,
+      pane.userId,
+      identity.providerSessionId,
+    );
+  }
+  const isBackgroundIdentity = activation === 'background'
+    || terminalManager.isProviderSessionIdentityBackground(
+      pane.terminalId,
+      pane.userId,
+      identity.providerSessionId,
+    );
+  if (terminalManager.isProviderSessionIdentityRetired(
+    pane.terminalId,
+    pane.userId,
+    identity.providerSessionId,
+  )) {
+    logger.debug({
+      providerId: pane.providerId,
+      providerSessionId: identity.providerSessionId,
+      terminalId: pane.terminalId,
+    }, 'Retired terminal provider session observation ignored');
+    return { ignored: true, sessionId: activeSessionId };
+  }
+
+  const reconciliation = reconcileTerminalProviderSession({
+    sourceSessionId: activeSessionId,
+    identity,
+    activation,
+  });
+  if (reconciliation.kind === 'created') {
+    broadcastSessionMutation(pane.userId, {
+      kind: 'created',
+      projectId: reconciliation.projectId,
+    });
+  }
+  const rebound = !isBackgroundIdentity
+    && reconciliation.sessionId !== activeSessionId
+    && terminalManager.rebindSession(
+      pane.terminalId,
+      pane.userId,
+      activeSessionId,
+      reconciliation.sessionId,
+    );
+  if (!isBackgroundIdentity && (reconciliation.sessionId === activeSessionId || rebound)) {
+    terminalManager.activateProviderSessionIdentity(
+      pane.terminalId,
+      pane.userId,
+      identity.providerSessionId,
+      rebound ? reconciliation.previousProviderSessionId : undefined,
+    );
+  }
+
+  const sessionId = (rebound || (isBackgroundIdentity && reconciliation.sessionId !== activeSessionId))
+    ? reconciliation.sessionId
+    : activeSessionId;
+  if (rebound || (isBackgroundIdentity && reconciliation.sessionId !== activeSessionId)) {
+    logger.info({
+      providerId: pane.providerId,
+      providerSessionId: identity.providerSessionId,
+      previousSessionId: reconciliation.previousSessionId,
+      sessionId,
+      kind: reconciliation.kind,
+    }, isBackgroundIdentity
+      ? 'Background terminal provider session discovered'
+      : 'Terminal provider session reconciled');
+  }
+  return { ignored: false, sessionId };
+}

--- a/src/lib/terminal/provider-session-observer.ts
+++ b/src/lib/terminal/provider-session-observer.ts
@@ -1,0 +1,53 @@
+import type { CliProvider } from '@/lib/cli/providers/types';
+import logger from '@/lib/logger';
+import type { TerminalProviderSessionIdentity } from './provider-session-identity';
+
+export interface TerminalProviderSessionObservation {
+  activation: 'active' | 'background';
+  identity: TerminalProviderSessionIdentity;
+}
+
+export interface TerminalProviderSessionObserver {
+  ready(): Promise<void>;
+  dispose(): void;
+}
+
+const noopObserver = (): TerminalProviderSessionObserver => ({
+  ready: async () => {},
+  dispose: () => {},
+});
+
+/**
+ * Provider-neutral bridge from an optional CLI-provider capability to
+ * Tessera's shared session identity and reconciliation flow.
+ */
+export function createTerminalProviderSessionObserver(options: {
+  provider: CliProvider;
+  currentProviderSessionId: () => string | undefined;
+  onObservation: (observation: TerminalProviderSessionObservation) => void;
+}): TerminalProviderSessionObserver {
+  const createObserver = options.provider.createTerminalSessionObserver;
+  if (!createObserver) return noopObserver();
+  let observer: TerminalProviderSessionObserver;
+  try {
+    observer = createObserver({
+      currentProviderSessionId: options.currentProviderSessionId,
+      onObservation: (observation) => options.onObservation({
+        activation: observation.activation,
+        identity: {
+          providerId: options.provider.getProviderId(),
+          providerSessionId: observation.providerSessionId,
+          ...(observation.transcriptPath ? { transcriptPath: observation.transcriptPath } : {}),
+        },
+      }),
+    });
+  } catch (error) {
+    logger.warn({ error, providerId: options.provider.getProviderId() },
+      'Provider session observer could not start');
+    return noopObserver();
+  }
+  return {
+    ready: () => observer.ready(),
+    dispose: () => observer.dispose(),
+  };
+}

--- a/src/lib/terminal/provider-session-reconciliation.ts
+++ b/src/lib/terminal/provider-session-reconciliation.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from 'node:crypto';
+import * as dbSessions from '@/lib/db/sessions';
+import { getDb } from '@/lib/db/database';
+import {
+  bindTerminalProviderSession,
+  getTerminalProviderSession,
+  getTerminalProviderSessionForTesseraSession,
+} from '@/lib/db/terminal-provider-sessions';
+import {
+  buildTerminalProviderState,
+  readPersistedTerminalProviderSessionId,
+  type TerminalProviderSessionActivation,
+  type TerminalProviderSessionIdentity,
+} from './provider-session-identity';
+
+export type TerminalProviderSessionReconciliationResult = {
+  kind: 'ignored' | 'unchanged' | 'existing' | 'created';
+  sessionId: string;
+  previousSessionId: string;
+  previousProviderSessionId?: string;
+  projectId?: string;
+};
+
+function forkTitle(sourceTitle: string): string {
+  const suffix = ' (Fork)';
+  return `${sourceTitle.slice(0, Math.max(1, 100 - suffix.length))}${suffix}`;
+}
+
+function registerIdentity(
+  tesseraSessionId: string,
+  identity: TerminalProviderSessionIdentity,
+): void {
+  bindTerminalProviderSession({
+    providerId: identity.providerId,
+    providerSessionId: identity.providerSessionId,
+    tesseraSessionId,
+    transcriptPath: identity.transcriptPath,
+  });
+}
+
+function createForkSession(
+  source: dbSessions.SessionRow,
+  identity: TerminalProviderSessionIdentity,
+  activation?: TerminalProviderSessionActivation,
+): string {
+  const sessionId = randomUUID();
+  getDb().transaction(() => {
+    dbSessions.createSession(sessionId, source.project_id, forkTitle(source.title), source.provider, {
+      workDir: source.work_dir ?? undefined,
+      worktreeManaged: source.worktree_managed === 1,
+      taskId: source.task_id ?? undefined,
+      collectionId: source.collection_id ?? undefined,
+      model: source.model ?? undefined,
+      reasoningEffort: source.reasoning_effort,
+      serviceTier: source.service_tier,
+      providerState: buildTerminalProviderState(identity, activation),
+    });
+    dbSessions.updateSession(sessionId, {
+      worktree_branch: source.worktree_branch,
+      worktree_managed: source.worktree_managed ?? 0,
+      chat_workflow_status: source.chat_workflow_status,
+    });
+    registerIdentity(sessionId, identity);
+  })();
+  return sessionId;
+}
+
+export function reconcileTerminalProviderSession(options: {
+  sourceSessionId: string;
+  identity: TerminalProviderSessionIdentity;
+  activation?: TerminalProviderSessionActivation;
+}): TerminalProviderSessionReconciliationResult {
+  const { activation, identity, sourceSessionId } = options;
+  const source = dbSessions.getSession(sourceSessionId);
+  if (
+    !source
+    || source.deleted === 1
+    || source.provider !== identity.providerId
+    || dbSessions.extractSessionKind(source.provider_state) !== 'terminal'
+  ) {
+    return { kind: 'ignored', sessionId: sourceSessionId, previousSessionId: sourceSessionId };
+  }
+
+  let sourceBinding = getTerminalProviderSessionForTesseraSession(sourceSessionId);
+  if (!sourceBinding) {
+    const persistedProviderSessionId = readPersistedTerminalProviderSessionId(source);
+    const sourceProviderSessionId = persistedProviderSessionId ?? identity.providerSessionId;
+    registerIdentity(sourceSessionId, {
+      providerId: identity.providerId,
+      providerSessionId: sourceProviderSessionId,
+      ...(sourceProviderSessionId === identity.providerSessionId && identity.transcriptPath
+        ? { transcriptPath: identity.transcriptPath }
+        : {}),
+    });
+    sourceBinding = getTerminalProviderSessionForTesseraSession(sourceSessionId);
+  }
+
+  if (sourceBinding?.provider_session_id === identity.providerSessionId) {
+    registerIdentity(sourceSessionId, identity);
+    return { kind: 'unchanged', sessionId: sourceSessionId, previousSessionId: sourceSessionId };
+  }
+
+  const existing = getTerminalProviderSession(identity.providerId, identity.providerSessionId);
+  const existingSession = existing ? dbSessions.getSession(existing.tessera_session_id) : undefined;
+  if (existingSession && existingSession.deleted === 0) {
+    registerIdentity(existingSession.id, identity);
+    return {
+      kind: 'existing',
+      sessionId: existingSession.id,
+      previousSessionId: sourceSessionId,
+      previousProviderSessionId: sourceBinding?.provider_session_id,
+    };
+  }
+
+  const sessionId = createForkSession(source, identity, activation);
+  return {
+    kind: 'created',
+    sessionId,
+    previousSessionId: sourceSessionId,
+    previousProviderSessionId: sourceBinding?.provider_session_id,
+    projectId: source.project_id,
+  };
+}

--- a/src/lib/terminal/shared-terminal-manager.ts
+++ b/src/lib/terminal/shared-terminal-manager.ts
@@ -36,10 +36,11 @@ function createSharedState(): SharedTerminalManagerState {
       });
     },
     {
-      onSessionRuntimeStateChange: ({ sessionId, userId, running }) => {
+      onSessionRuntimeStateChange: ({ sessionId, terminalId, userId, running }) => {
         state.sendToUser?.(userId, {
           type: 'terminal_session_runtime',
           sessionId,
+          terminalId,
           running,
         });
         // 런타임 (재)시작 시 마지막 hook 상태를 재전송해, 이전에 runtime 신호와
@@ -51,6 +52,14 @@ function createSharedState(): SharedTerminalManagerState {
       },
       onSessionStateChange: ({ message, userId }) => {
         state.sendToUser?.(userId, message);
+      },
+      onSessionRuntimeRebound: ({ previousSessionId, sessionId, terminalId, userId }) => {
+        state.sendToUser?.(userId, {
+          type: 'terminal_session_rebound',
+          previousSessionId,
+          sessionId,
+          terminalId,
+        });
       },
     },
   );

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { randomUUID } from 'node:crypto';
 import { createRequire } from 'module';
 import logger from '@/lib/logger';
 import { buildSpawnEnv, getAgentEnvironment } from '@/lib/cli/spawn-cli';
@@ -189,6 +190,10 @@ interface TerminalRuntime {
   cancelPrefill?: () => void;
   disposeSessionObservers: Array<() => void>;
   lastSessionState?: TerminalSessionStateMessage;
+  providerSessionId?: string;
+  retiredProviderSessionIds: Set<string>;
+  backgroundProviderSessionIds: Set<string>;
+  reboundFromSessionIds: Set<string>;
   previewOwnerToken?: string;
 }
 
@@ -211,6 +216,7 @@ export interface TerminalManagerOptions {
   createHeadlessModel?: (cols: number, rows: number) => TerminalHeadlessModelLike;
   onSessionRuntimeStateChange?: (state: {
     sessionId: string;
+    terminalId: string;
     userId: string;
     running: boolean;
   }) => void;
@@ -220,6 +226,12 @@ export interface TerminalManagerOptions {
     userId: string;
   }) => void;
   interruptSettleMs?: number;
+  onSessionRuntimeRebound?: (state: {
+    previousSessionId: string;
+    sessionId: string;
+    terminalId: string;
+    userId: string;
+  }) => void;
 }
 
 function normalizeTerminalDimension(value: number | undefined, fallback: number, max: number): number {
@@ -331,6 +343,8 @@ export class TerminalManager {
   private readonly openingSessionByTerminalKey = new Map<string, string | null>();
   private readonly openingPreviewOwnerByTerminalKey = new Map<string, string>();
   private readonly sessionBindings = new Map<string, string>();
+  private readonly terminalReservations = new Map<string, string>();
+  private readonly reservedSessionByTerminalKey = new Map<string, string>();
   private readonly generationByTerminal = new Map<string, number>();
   private readonly disconnectedConnections = new Set<string>();
   private readonly blockedSessions = new Set<string>();
@@ -349,6 +363,7 @@ export class TerminalManager {
       ? this.getSessionKey(options.userId, options.sessionId)
       : null;
     if (this.shuttingDown || (blockedSessionKey && this.blockedSessions.has(blockedSessionKey))) {
+      if (options.sessionId) this.clearTerminalReservation(options.userId, options.sessionId);
       if (options.launchSpec?.handoffSessionId) {
         releaseTerminalHandoffByTerminal(options.userId, options.terminalId);
       }
@@ -366,12 +381,12 @@ export class TerminalManager {
       return;
     }
 
-    const boundTerminalId = options.sessionId
-      ? this.sessionBindings.get(this.getSessionKey(options.userId, options.sessionId))
-      : undefined;
+    const resolvedTerminalId = options.sessionId
+      ? this.reserveTerminalId(options.userId, options.terminalId, options.sessionId)
+      : options.terminalId;
     const resolvedOptions: TerminalCreateOptions = {
       ...options,
-      terminalId: boundTerminalId ?? options.terminalId,
+      terminalId: resolvedTerminalId,
     };
     const key = this.getKey(resolvedOptions.userId, resolvedOptions.terminalId);
     const openingKey = this.getOpeningKey(
@@ -612,6 +627,9 @@ export class TerminalManager {
         disposeSessionObservers: options.launchObserverDisposer
           ? [options.launchObserverDisposer]
           : [],
+        retiredProviderSessionIds: new Set(),
+        backgroundProviderSessionIds: new Set(),
+        reboundFromSessionIds: new Set(),
         previewOwnerToken: options.previewOwnerToken,
       };
       if (options.appearance) {
@@ -622,12 +640,14 @@ export class TerminalManager {
       }
       this.terminals.set(key, runtime);
       if (runtime.sessionId) {
+        this.clearTerminalReservation(runtime.userId, runtime.sessionId, runtime.terminalId);
         this.sessionBindings.set(
           this.getSessionKey(runtime.userId, runtime.sessionId),
           runtime.terminalId,
         );
         this.managerOptions.onSessionRuntimeStateChange?.({
           sessionId: runtime.sessionId,
+          terminalId: runtime.terminalId,
           userId: runtime.userId,
           running: true,
         });
@@ -743,6 +763,9 @@ export class TerminalManager {
 
       return runtime;
     } catch (error) {
+      if (options.sessionId) {
+        this.clearTerminalReservation(options.userId, options.sessionId, options.terminalId);
+      }
       if (options.launchSpec?.handoffSessionId) {
         releaseTerminalHandoffByTerminal(options.userId, options.terminalId);
       }
@@ -1233,6 +1256,7 @@ export class TerminalManager {
       if (runtime.sessionId) {
         this.managerOptions.onSessionRuntimeStateChange?.({
           sessionId: runtime.sessionId,
+          terminalId: runtime.terminalId,
           userId: runtime.userId,
           running: false,
         });
@@ -1252,15 +1276,17 @@ export class TerminalManager {
   private startSessionObserver(runtime: TerminalRuntime): void {
     if (!runtime.sessionId || !this.observeSessionRuntime) return;
 
+    const observedSessionId = runtime.sessionId;
+
     void Promise.resolve().then(() => this.observeSessionRuntime?.({
       cwd: runtime.cwd,
       generation: runtime.generation,
-      sessionId: runtime.sessionId!,
+      sessionId: observedSessionId,
       terminalId: runtime.terminalId,
       userId: runtime.userId,
     })).then((dispose) => {
       if (!dispose) return;
-      if (runtime.ended) {
+      if (runtime.ended || runtime.sessionId !== observedSessionId) {
         dispose();
         return;
       }
@@ -1303,7 +1329,10 @@ export class TerminalManager {
     // Session deletion can race an async native PTY load/spawn. Wait for that
     // one in-flight create and immediately tear it down instead of orphaning it.
     const opening = this.openingTerminals.get(this.getSessionOpeningKey(userId, sessionId));
-    if (!opening) return;
+    if (!opening) {
+      this.clearTerminalReservation(userId, sessionId);
+      return;
+    }
     try {
       const runtime = await opening;
       this.closeRuntime(runtime);
@@ -1313,7 +1342,9 @@ export class TerminalManager {
   }
 
   preventSessionOpen(sessionId: string, userId: string): void {
-    this.blockedSessions.add(this.getSessionKey(userId, sessionId));
+    const sessionKey = this.getSessionKey(userId, sessionId);
+    this.blockedSessions.add(sessionKey);
+    this.clearTerminalReservation(userId, sessionId);
   }
 
   allowSessionOpen(sessionId: string, userId: string): void {
@@ -1328,6 +1359,8 @@ export class TerminalManager {
     for (const runtime of runtimes) {
       this.closeRuntime(runtime);
     }
+    this.terminalReservations.clear();
+    this.reservedSessionByTerminalKey.clear();
   }
 
   getRuntimeSummary(): { activeCount: number; sessionCount: number } {
@@ -1351,9 +1384,147 @@ export class TerminalManager {
     );
   }
 
+  getSessionReboundsForUser(userId: string): Array<{
+    previousSessionId: string;
+    sessionId: string;
+    terminalId: string;
+  }> {
+    const activeRuntimes = [...this.terminals.values()]
+      .filter((runtime) => runtime.userId === userId && !runtime.ended && runtime.sessionId);
+    const activeSessionIds = new Set(activeRuntimes.map((runtime) => runtime.sessionId!));
+    return activeRuntimes
+      .flatMap((runtime) => [...runtime.reboundFromSessionIds].map((previousSessionId) => ({
+        previousSessionId,
+        sessionId: runtime.sessionId!,
+        terminalId: runtime.terminalId,
+      })))
+      .filter((rebound) => !activeSessionIds.has(rebound.previousSessionId));
+  }
+
+  getSessionIdForTerminal(terminalId: string, userId: string): string | null {
+    const runtime = this.getOwnedTerminal(terminalId, userId);
+    return runtime && !runtime.ended ? runtime.sessionId : null;
+  }
+
+  isProviderSessionIdentityRetired(
+    terminalId: string,
+    userId: string,
+    providerSessionId: string,
+  ): boolean {
+    return this.getOwnedTerminal(terminalId, userId)?.retiredProviderSessionIds
+      .has(providerSessionId) ?? false;
+  }
+
+  markProviderSessionIdentityBackground(
+    terminalId: string,
+    userId: string,
+    providerSessionId: string,
+  ): boolean {
+    const runtime = this.getOwnedTerminal(terminalId, userId);
+    if (!runtime || runtime.ended || runtime.providerSessionId === providerSessionId) return false;
+    runtime.backgroundProviderSessionIds.add(providerSessionId);
+    return true;
+  }
+
+  isProviderSessionIdentityBackground(
+    terminalId: string,
+    userId: string,
+    providerSessionId: string,
+  ): boolean {
+    return this.getOwnedTerminal(terminalId, userId)?.backgroundProviderSessionIds
+      .has(providerSessionId) ?? false;
+  }
+
+  activateProviderSessionIdentity(
+    terminalId: string,
+    userId: string,
+    providerSessionId: string,
+    previousProviderSessionId?: string,
+  ): boolean {
+    const runtime = this.getOwnedTerminal(terminalId, userId);
+    if (!runtime || runtime.ended || runtime.retiredProviderSessionIds.has(providerSessionId)) {
+      return false;
+    }
+    if (runtime.providerSessionId && runtime.providerSessionId !== providerSessionId) {
+      runtime.retiredProviderSessionIds.add(runtime.providerSessionId);
+    }
+    if (previousProviderSessionId && previousProviderSessionId !== providerSessionId) {
+      runtime.retiredProviderSessionIds.add(previousProviderSessionId);
+    }
+    runtime.backgroundProviderSessionIds.delete(providerSessionId);
+    runtime.providerSessionId = providerSessionId;
+    return true;
+  }
+
+  /** Keep one live PTY while moving its ownership from a parent conversation
+   *  to the provider-created child conversation. */
+  rebindSession(
+    terminalId: string,
+    userId: string,
+    sourceSessionId: string,
+    destinationSessionId: string,
+  ): boolean {
+    if (sourceSessionId === destinationSessionId) return true;
+    const runtime = this.getOwnedTerminal(terminalId, userId);
+    if (!runtime || runtime.ended || runtime.sessionId !== sourceSessionId) return false;
+
+    const destinationKey = this.getSessionKey(userId, destinationSessionId);
+    const existingDestination = this.sessionBindings.get(destinationKey);
+    if (existingDestination && existingDestination !== terminalId) return false;
+
+    this.disposeSessionObserver(runtime);
+    this.clearSessionBinding(runtime);
+    runtime.lastSessionState = undefined;
+    runtime.sessionId = destinationSessionId;
+    runtime.reboundFromSessionIds.add(sourceSessionId);
+    this.sessionBindings.set(destinationKey, terminalId);
+    this.managerOptions.onSessionRuntimeRebound?.({
+      previousSessionId: sourceSessionId,
+      sessionId: destinationSessionId,
+      terminalId,
+      userId,
+    });
+    this.startSessionObserver(runtime);
+    return true;
+  }
+
   resolveTerminalId(userId: string, requestedTerminalId: string, sessionId?: string | null): string {
     if (!sessionId) return requestedTerminalId;
-    return this.sessionBindings.get(this.getSessionKey(userId, sessionId)) ?? requestedTerminalId;
+    const sessionKey = this.getSessionKey(userId, sessionId);
+    return this.sessionBindings.get(sessionKey)
+      ?? this.terminalReservations.get(sessionKey)
+      ?? requestedTerminalId;
+  }
+
+  reserveTerminalId(userId: string, requestedTerminalId: string, sessionId: string): string {
+    const sessionKey = this.getSessionKey(userId, sessionId);
+    const existing = this.sessionBindings.get(sessionKey) ?? this.terminalReservations.get(sessionKey);
+    if (existing) return existing;
+
+    let terminalId = requestedTerminalId;
+    while (true) {
+      const key = this.getKey(userId, terminalId);
+      const runtime = this.terminals.get(key);
+      const openingSessionId = this.openingSessionByTerminalKey.get(key);
+      const reservedSessionKey = this.reservedSessionByTerminalKey.get(key);
+      if (
+        (!runtime || runtime.sessionId === sessionId)
+        && (openingSessionId === undefined || openingSessionId === sessionId)
+        && (reservedSessionKey === undefined || reservedSessionKey === sessionKey)
+      ) break;
+      terminalId = `${requestedTerminalId}-${randomUUID()}`;
+    }
+    this.terminalReservations.set(sessionKey, terminalId);
+    this.reservedSessionByTerminalKey.set(this.getKey(userId, terminalId), sessionKey);
+    return terminalId;
+  }
+
+  releaseTerminalReservation(
+    userId: string,
+    sessionId: string,
+    expectedTerminalId?: string,
+  ): void {
+    this.clearTerminalReservation(userId, sessionId, expectedTerminalId);
   }
 
   hasOrIsOpening(
@@ -1362,7 +1533,8 @@ export class TerminalManager {
     sessionId?: string | null,
   ): boolean {
     const key = this.getKey(userId, terminalId);
-    return this.terminals.has(key)
+    const runtime = this.terminals.get(key);
+    return Boolean(runtime && (!sessionId || runtime.sessionId === sessionId))
       || this.openingTerminals.has(this.getOpeningKey(userId, terminalId, sessionId));
   }
 
@@ -1382,6 +1554,21 @@ export class TerminalManager {
 
   private getSessionKey(userId: string, sessionId: string): string {
     return `${userId}:${sessionId}`;
+  }
+
+  private clearTerminalReservation(
+    userId: string,
+    sessionId: string,
+    expectedTerminalId?: string,
+  ): void {
+    const sessionKey = this.getSessionKey(userId, sessionId);
+    const terminalId = this.terminalReservations.get(sessionKey);
+    if (!terminalId || (expectedTerminalId && terminalId !== expectedTerminalId)) return;
+    this.terminalReservations.delete(sessionKey);
+    const terminalKey = this.getKey(userId, terminalId);
+    if (this.reservedSessionByTerminalKey.get(terminalKey) === sessionKey) {
+      this.reservedSessionByTerminalKey.delete(terminalKey);
+    }
   }
 
   private getSessionOpeningKey(userId: string, sessionId: string): string {

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -14,6 +14,7 @@ import { useTerminalSessionStore } from '@/stores/terminal-session-store';
 import { useCommandStore } from '@/stores/command-store';
 import { useGitPanelStore } from '@/stores/git-panel-store';
 import { useNotificationStore } from '@/stores/notification-store';
+import { usePanelStore } from '@/stores/panel-store';
 import { useRateLimitStore } from '@/stores/rate-limit-store';
 import { useSessionStore } from '@/stores/session-store';
 import { useSessionPrStore } from '@/stores/session-pr-store';
@@ -34,6 +35,13 @@ interface HandleIncomingServerMessageOptions {
   cliStatusCallbacks: Map<string, (results: CliStatusEntry[] | null) => void>;
   wasReconnect: boolean;
 }
+
+interface PendingTerminalRebound {
+  destinationSessionId: string;
+  sourceSessionIds: Set<string>;
+}
+
+const pendingTerminalRebounds = new Map<string, PendingTerminalRebound>();
 
 export function handleIncomingServerMessage({
   msg,
@@ -125,16 +133,42 @@ export function handleIncomingServerMessage({
     case 'terminal_session_runtime':
       sessionStore.setSessionRunning(msg.sessionId, msg.running);
       if (msg.running) {
+        removePendingTerminalReboundSource(msg.terminalId, msg.sessionId);
         useTerminalSessionStore.getState().markRuntimeStarted(msg.sessionId);
       } else {
         useTerminalSessionStore.getState().markRuntimeStopped(msg.sessionId);
+        cancelPendingTerminalReboundsForDestination(msg.sessionId);
         retireStoppedTerminalSessionSurface(msg.sessionId);
       }
       return { wasReconnect };
 
+    case 'terminal_session_rebound':
+      applyTerminalSessionRebound(msg.terminalId, msg.previousSessionId, msg.sessionId);
+      return { wasReconnect };
+
     case 'terminal_session_runtime_snapshot': {
+      const authoritativeReboundTerminalIds = new Set(
+        (msg.reboundSessions ?? []).map((rebound) => rebound.terminalId),
+      );
+      for (const terminalId of pendingTerminalRebounds.keys()) {
+        if (!authoritativeReboundTerminalIds.has(terminalId)) {
+          pendingTerminalRebounds.delete(terminalId);
+        }
+      }
+      for (const rebound of msg.reboundSessions ?? []) {
+        applyTerminalSessionRebound(
+          rebound.terminalId,
+          rebound.previousSessionId,
+          rebound.sessionId,
+        );
+      }
       sessionStore.applyTerminalRuntimeSnapshot(msg.activeSessionIds);
       const activeTerminalIds = new Set(msg.activeSessionIds);
+      for (const pending of [...pendingTerminalRebounds.values()]) {
+        if (!activeTerminalIds.has(pending.destinationSessionId)) {
+          cancelPendingTerminalReboundsForDestination(pending.destinationSessionId);
+        }
+      }
       for (const sessionId of msg.activeSessionIds) {
         useTerminalSessionStore.getState().markRuntimeStarted(sessionId);
       }
@@ -150,6 +184,7 @@ export function handleIncomingServerMessage({
         for (const session of project.sessions) {
           if (session.kind === 'terminal' && !activeTerminalIds.has(session.id)) {
             useTerminalSessionStore.getState().markRuntimeStopped(session.id);
+            if (isPendingTerminalReboundSource(session.id)) continue;
             retireStoppedTerminalSessionSurface(session.id);
           }
         }
@@ -333,6 +368,74 @@ export function handleIncomingServerMessage({
     default:
       return { wasReconnect };
   }
+}
+
+function applyTerminalSessionRebound(
+  terminalId: string,
+  previousSessionId: string,
+  sessionId: string,
+): void {
+  const terminalStore = useTerminalSessionStore.getState();
+  terminalStore.markRuntimeStopped(previousSessionId);
+  terminalStore.markRuntimeStarted(sessionId);
+  useSessionStore.getState().setSessionRunning(previousSessionId, false);
+
+  const pending = pendingTerminalRebounds.get(terminalId) ?? {
+    destinationSessionId: sessionId,
+    sourceSessionIds: new Set<string>(),
+  };
+  pending.sourceSessionIds.add(previousSessionId);
+  pending.destinationSessionId = sessionId;
+  pendingTerminalRebounds.set(terminalId, pending);
+  if (tryApplyPendingTerminalRebound(terminalId)) {
+    return;
+  }
+  void Promise.resolve(useSessionStore.getState().loadProjects()).then(
+    () => { tryApplyPendingTerminalRebound(terminalId); },
+    () => {},
+  );
+}
+
+function tryApplyPendingTerminalRebound(terminalId: string): boolean {
+  const pending = pendingTerminalRebounds.get(terminalId);
+  if (!pending) return true;
+  const terminalState = useTerminalSessionStore.getState()
+    .bySessionId[pending.destinationSessionId];
+  if (terminalState?.runtimeExited) {
+    cancelPendingTerminalReboundsForDestination(pending.destinationSessionId);
+    return true;
+  }
+  const sessionStore = useSessionStore.getState();
+  if (!sessionStore.getSession(pending.destinationSessionId)) return false;
+
+  for (const sourceSessionId of pending.sourceSessionIds) {
+    usePanelStore.getState().rebindSession(sourceSessionId, pending.destinationSessionId);
+  }
+  sessionStore.setSessionRunning(pending.destinationSessionId, true);
+  pendingTerminalRebounds.delete(terminalId);
+  return true;
+}
+
+function cancelPendingTerminalReboundsForDestination(sessionId: string): void {
+  for (const [terminalId, pending] of pendingTerminalRebounds) {
+    if (pending.destinationSessionId !== sessionId) continue;
+    pendingTerminalRebounds.delete(terminalId);
+    for (const sourceSessionId of pending.sourceSessionIds) {
+      retireStoppedTerminalSessionSurface(sourceSessionId);
+    }
+  }
+}
+
+function isPendingTerminalReboundSource(sessionId: string): boolean {
+  return [...pendingTerminalRebounds.values()]
+    .some((pending) => pending.sourceSessionIds.has(sessionId));
+}
+
+function removePendingTerminalReboundSource(terminalId: string, sessionId: string): void {
+  const pending = pendingTerminalRebounds.get(terminalId);
+  if (!pending) return;
+  pending.sourceSessionIds.delete(sessionId);
+  if (pending.sourceSessionIds.size === 0) pendingTerminalRebounds.delete(terminalId);
 }
 
 function retireStoppedTerminalSessionSurface(sessionId: string): void {

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -299,11 +299,23 @@ export type AppServerMessage =
   | {
       type: 'terminal_session_runtime';
       sessionId: string;
+      terminalId: string;
       running: boolean;
+    }
+  | {
+      type: 'terminal_session_rebound';
+      previousSessionId: string;
+      sessionId: string;
+      terminalId: string;
     }
   | {
       type: 'terminal_session_runtime_snapshot';
       activeSessionIds: string[];
+      reboundSessions?: Array<{
+        previousSessionId: string;
+        sessionId: string;
+        terminalId: string;
+      }>;
     }
   | { type: 'error'; sessionId?: string; code: string; message: string; requestId?: string }
   | { type: 'terminal_prefill_written'; terminalId: string }

--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -18,15 +18,19 @@ import {
 } from '../terminal/terminal-handoff-lock';
 import { mintPaneToken } from '../terminal/pane-token-registry';
 import { buildProviderTerminalLaunch } from '../terminal/provider-launch';
+import { resolveTerminalProviderSessionReference } from '../terminal/provider-session-identity';
 import { detectTerminalProviders } from '../terminal/provider-detection';
 import { SettingsManager } from '../settings/manager';
 import { createCodexOverlay } from '../terminal/codex-overlay';
 import { buildClaudeHookSettingsJson } from '../terminal/claude-hook-settings';
 import { createOpenCodeOverlay } from '../terminal/opencode-overlay';
+import { createTerminalProviderSessionObserver } from '../terminal/provider-session-observer';
+import { getTerminalProviderSessionForTesseraSession } from '../db/terminal-provider-sessions';
+import { observeTerminalProviderSession } from '../terminal/provider-session-observation';
 import type { TerminalCreateOptions, TerminalLaunchSpec } from '../terminal/types';
 import { workspaceFileWatchManager } from '../workspace-files/workspace-file-watch-manager';
 import type { ClientMessage, ServerTransportMessage } from './message-types';
-import type { ProviderMeta } from '../cli/providers/types';
+import type { CliProvider, ProviderMeta } from '../cli/providers/types';
 import {
   clearUnreadFromWebSocket,
   closeSessionFromWebSocket,
@@ -146,6 +150,11 @@ export async function routeClientTransportMessage({
   const guardedSessionId = !unguardedSessionMessage && 'sessionId' in message
     ? message.sessionId
     : null;
+  let pendingTerminalReservation: {
+    manager: ReturnType<typeof bindTerminalSender>;
+    sessionId: string;
+    terminalId: string;
+  } | null = null;
   if (guardedSessionId && !beginTesseraSessionOperation(guardedSessionId)) {
     sendToUser(userId, {
       type: 'error',
@@ -497,7 +506,10 @@ export async function routeClientTransportMessage({
       // create/cwd allowlist용 sessionId(기존 동작 유지).
       const sessionId = structured?.sessionId ?? message.sessionId ?? null;
       const manager = bindTerminalSender(sendToConnection);
-      const terminalId = manager.resolveTerminalId(userId, message.terminalId, sessionId);
+      const terminalId = sessionId
+        ? manager.reserveTerminalId(userId, message.terminalId, sessionId)
+        : message.terminalId;
+      if (sessionId) pendingTerminalReservation = { manager, sessionId, terminalId };
       const terminalExists = manager.hasOrIsOpening(terminalId, userId, sessionId);
       let launchSpec: TerminalLaunchSpec | undefined;
       let providerId: string | undefined;
@@ -507,6 +519,7 @@ export async function routeClientTransportMessage({
       let resizeScrollbackPolicy: TerminalCreateOptions['resizeScrollbackPolicy'];
       let interruptInputPolicy: TerminalCreateOptions['interruptInputPolicy'];
       let canRestartForAppearance: TerminalCreateOptions['canRestartForAppearance'];
+      let terminalProvider: CliProvider | undefined;
       let acquiredHandoff = false;
 
       if (!terminalExists && isStructuredClaude && structured) {
@@ -516,11 +529,21 @@ export async function routeClientTransportMessage({
         // persist a resumable conversation until the first prompt is submitted.
         // Tessera records that prompt synchronously, so canonical history is the
         // resume boundary; a mere prior PTY launch is not.
-        const resume = await sessionHistory.historyExists(structured.sessionId);
+        const state = dbSessions.getSession(structured.sessionId)?.provider_state ?? null;
+        const providerSession = resolveTerminalProviderSessionReference(
+          structured.sessionId,
+          state,
+        );
+        const resume = providerSession.nativeFork
+          || await sessionHistory.historyExists(structured.sessionId);
         const built = buildProviderTerminalLaunch({
           providerId: 'claude-code',
-          sessionId: structured.sessionId,
+          sessionId: providerSession.providerSessionId,
           resume,
+          // Older persisted native forks predate activation metadata. Claude's
+          // native `/fork` artifact is a background daemon and must be attached.
+          providerSessionActivation: providerSession.activation
+            ?? (providerSession.nativeFork ? 'background' : undefined),
           settingsJson,
         });
         launchSpec = {
@@ -613,12 +636,13 @@ export async function routeClientTransportMessage({
       }
 
       if (!terminalExists && providerId) {
-        const terminalProvider = cliProviderRegistry.getProvider(providerId);
-        appearanceChangePolicy = terminalProvider.getTerminalAppearanceChangePolicy();
-        resizeScrollbackPolicy = terminalProvider.getTerminalResizeScrollbackPolicy();
-        interruptInputPolicy = terminalProvider.getTerminalInterruptInputPolicy();
+        const provider = cliProviderRegistry.getProvider(providerId);
+        terminalProvider = provider;
+        appearanceChangePolicy = provider.getTerminalAppearanceChangePolicy();
+        resizeScrollbackPolicy = provider.getTerminalResizeScrollbackPolicy();
+        interruptInputPolicy = provider.getTerminalInterruptInputPolicy();
         if (appearanceChangePolicy === 'restart' && structured) {
-          canRestartForAppearance = () => terminalProvider.canResumeTerminalAfterRestart?.(
+          canRestartForAppearance = () => provider.canResumeTerminalAfterRestart?.(
             dbSessions.getSession(structured.sessionId)?.provider_state ?? null,
           ) ?? false;
         } else if (appearanceChangePolicy === 'restart' && launchSpec?.handoffSessionId) {
@@ -635,8 +659,38 @@ export async function routeClientTransportMessage({
       const paneToken = !terminalExists && providerId
         ? mintPaneToken({ terminalId, userId, sessionId: tokenSessionId, providerId })
         : undefined;
+      if (!terminalExists && providerId && terminalProvider && paneToken && sessionId) {
+        const existingDisposer = launchObserverDisposer;
+        const providerSessionObserver = createTerminalProviderSessionObserver({
+          provider: terminalProvider,
+          currentProviderSessionId: () => {
+            const activeSessionId = manager.getSessionIdForTerminal(terminalId, userId)
+              ?? sessionId;
+            return getTerminalProviderSessionForTesseraSession(activeSessionId)
+              ?.provider_session_id;
+          },
+          onObservation: ({ activation, identity }) => {
+            try {
+              observeTerminalProviderSession({
+                pane: { terminalId, userId, sessionId, providerId },
+                identity,
+                activation,
+              });
+            } catch (error) {
+              logger.warn({ error, providerId, terminalId },
+                'Provider session observation could not be reconciled');
+            }
+          },
+        });
+        await providerSessionObserver.ready();
+        launchObserverDisposer = () => {
+          providerSessionObserver.dispose();
+          existingDisposer?.();
+        };
+      }
 
       try {
+        pendingTerminalReservation = null;
         await manager.create({
           userId,
           connectionId,
@@ -744,6 +798,13 @@ export async function routeClientTransportMessage({
         logUnknownClientTransportMessage(userId, message);
     }
   } finally {
+    if (pendingTerminalReservation) {
+      pendingTerminalReservation.manager.releaseTerminalReservation(
+        userId,
+        pendingTerminalReservation.sessionId,
+        pendingTerminalReservation.terminalId,
+      );
+    }
     if (guardedSessionId) {
       endTesseraSessionOperation(guardedSessionId);
     }

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -265,6 +265,7 @@ export class WebSocketServer {
     this.sendToConnection(ws, userId, {
       type: 'terminal_session_runtime_snapshot',
       activeSessionIds: [...terminalManager.getActiveSessionIds(userId)],
+      reboundSessions: terminalManager.getSessionReboundsForUser(userId),
     });
 
     // Hook state is process state, not a transient WebSocket event. Replay the

--- a/src/stores/panel-store.ts
+++ b/src/stores/panel-store.ts
@@ -534,6 +534,26 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
     }
   },
 
+  rebindSession: (previousSessionId, sessionId) => {
+    const state = get();
+    let changed = false;
+    const tabPanels = Object.fromEntries(Object.entries(state.tabPanels).map(([tabId, tabData]) => {
+      let tabChanged = false;
+      const panels = Object.fromEntries(Object.entries(tabData.panels).map(([panelId, panel]) => {
+        if (panel.sessionId !== previousSessionId) return [panelId, panel];
+        changed = true;
+        tabChanged = true;
+        return [panelId, { ...panel, sessionId }];
+      }));
+      return [tabId, tabChanged ? { ...tabData, panels } : tabData];
+    }));
+    if (!changed) return;
+    set({ tabPanels });
+    if (useSessionStore.getState().activeSessionId === previousSessionId) {
+      useSessionStore.getState().setActiveSession(sessionId);
+    }
+  },
+
   assignTerminal: (panelId, terminalId, terminalSessionId = null) => {
     const state = get();
     const tabData = state.tabPanels[state.activeTabId];

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -54,6 +54,7 @@ export interface PanelStoreActions {
   closePanelInTab(tabId: string, panelId: string): void;
   assignSession(panelId: string, sessionId: string | null): void;
   assignSessionInTab(tabId: string, panelId: string, sessionId: string | null): void;
+  rebindSession(previousSessionId: string, sessionId: string): void;
   assignTerminal(panelId: string, terminalId: string | null, terminalSessionId?: string | null): void;
   setActivePanelId(panelId: string): void;
   resizeSplit(leftAnchor: string, rightAnchor: string, ratio: number): void;

--- a/tests/codex-account-home.test.ts
+++ b/tests/codex-account-home.test.ts
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import {
   buildCodexAccountEnvironment,
   resolveCodexAccountHome,
+  writeCodexOverlayMarker,
 } from '../src/lib/codex-home';
 
 test('global Codex account lookup escapes a Tessera session overlay', () => {
@@ -16,6 +19,36 @@ test('global Codex account lookup escapes a Tessera session overlay', () => {
   });
 
   assert.equal(home, path.join(homeDir, '.codex'));
+});
+
+test('global Codex account lookup escapes a marked inherited overlay from another data root', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-inherited-codex-overlay-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const homeDir = path.join(root, 'home');
+  const overlayHome = path.join(root, 'other-data', 'codex-overlay', 'session-123');
+  const accountHome = path.join(homeDir, '.codex');
+  fs.mkdirSync(overlayHome, { recursive: true });
+  writeCodexOverlayMarker(overlayHome, accountHome);
+  const home = resolveCodexAccountHome({
+    env: {
+      CODEX_HOME: overlayHome,
+      TESSERA_DATA_DIR: path.join(root, 'isolated-tessera'),
+    },
+    homeDir,
+  });
+
+  assert.equal(home, accountHome);
+});
+
+test('an unmarked custom home below a codex-overlay directory is preserved', () => {
+  const homeDir = path.join(path.parse(process.cwd()).root, 'Users', 'test');
+  const customHome = path.join(path.parse(process.cwd()).root, 'accounts', 'codex-overlay', 'team');
+  const home = resolveCodexAccountHome({
+    env: { CODEX_HOME: customHome },
+    homeDir,
+  });
+
+  assert.equal(home, customHome);
 });
 
 test('global Codex account lookup preserves a real custom home', () => {

--- a/tests/opencode-hook-plugin.test.ts
+++ b/tests/opencode-hook-plugin.test.ts
@@ -185,6 +185,48 @@ test('resume targets the saved session and keeps processing after a failed POST'
   }
 });
 
+test('OpenCode native fork switches the invocation target and emits the child lifecycle', async () => {
+  const plugin = await loadPlugin({ resumeId: 'ses_parent' });
+  try {
+    await settlePosts(1, plugin.payloads);
+    await plugin.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'ses_fork', directory: '/workspace' } },
+      },
+    });
+    await settlePosts(2, plugin.payloads);
+    assert.deepEqual(plugin.payloads[1], {
+      hook_event_name: 'SessionStart',
+      session_id: 'ses_fork',
+    });
+    await plugin.event({
+      event: {
+        type: 'message.updated',
+        properties: { info: { id: 'fork-message', sessionID: 'ses_fork', role: 'user' } },
+      },
+    });
+    await plugin.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: { id: 'fork-part', messageID: 'fork-message', sessionID: 'ses_fork', type: 'text', text: 'fork prompt' } },
+      },
+    });
+    await plugin.event({
+      event: { type: 'session.idle', properties: { sessionID: 'ses_fork' } },
+    });
+
+    await settlePosts(4, plugin.payloads);
+    assert.deepEqual(plugin.payloads.slice(1), [
+      { hook_event_name: 'SessionStart', session_id: 'ses_fork' },
+      { hook_event_name: 'UserPromptSubmit', session_id: 'ses_fork', prompt: 'fork prompt' },
+      { hook_event_name: 'Stop', session_id: 'ses_fork' },
+    ]);
+  } finally {
+    plugin.restore();
+  }
+});
+
 test('OpenCode waits for all real text parts and ignores synthetic expansion text', async () => {
   const plugin = await loadPlugin();
   try {

--- a/tests/provider-terminal-launch.test.ts
+++ b/tests/provider-terminal-launch.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { buildProviderTerminalLaunch } from '@/lib/terminal/provider-launch';
+import {
+  buildTerminalProviderState,
+  resolveTerminalProviderSessionReference,
+} from '@/lib/terminal/provider-session-identity';
 
 test('Codex PTY starts with pre-trusted overlay hooks and no trust-bypass warning flag', () => {
   assert.deepEqual(
@@ -57,6 +61,33 @@ test('Claude PTY uses --resume only for a persisted Tessera conversation', () =>
     {
       command: 'claude',
       args: ['--resume', 'tessera-session', '--settings', '{"hooks":{}}'],
+    },
+  );
+});
+
+test('Claude background fork attaches to the provider child daemon', () => {
+  const providerState = buildTerminalProviderState({
+    providerId: 'claude-code',
+    providerSessionId: '772b268d-7979-4fe7-aecf-50985ccb652f',
+  }, 'background');
+  const reference = resolveTerminalProviderSessionReference('tessera-child', providerState);
+
+  assert.deepEqual(reference, {
+    providerSessionId: '772b268d-7979-4fe7-aecf-50985ccb652f',
+    nativeFork: true,
+    activation: 'background',
+  });
+  assert.deepEqual(
+    buildProviderTerminalLaunch({
+      providerId: 'claude-code',
+      sessionId: reference.providerSessionId,
+      resume: reference.nativeFork,
+      providerSessionActivation: reference.activation,
+      settingsJson: '{"hooks":{}}',
+    }),
+    {
+      command: 'claude',
+      args: ['attach', '772b268d'],
     },
   );
 });

--- a/tests/pty-ui-cleanup-contract.test.mjs
+++ b/tests/pty-ui-cleanup-contract.test.mjs
@@ -67,6 +67,6 @@ test('session PTY owns a workspace listener and lifecycle completion performs fi
   assert.match(watcher, /rootChangeListeners/);
   assert.match(
     hookReceiver,
-    /mapped\?\.status === 'completed'[\s\S]*refreshSessionDiffStateInBackground\(entry\.sessionId, entry\.userId, 'terminal lifecycle completion'\)/,
+    /mapped\?\.status === 'completed'[\s\S]*refreshSessionDiffStateInBackground\(sessionId, entry\.userId, 'terminal lifecycle completion'\)/,
   );
 });

--- a/tests/session-persistence-wiring-contract.test.mjs
+++ b/tests/session-persistence-wiring-contract.test.mjs
@@ -12,7 +12,7 @@ const restCreate = read('../src/app/api/sessions/route.ts');
 const wsActions = read('../src/lib/ws/server-session-actions.ts');
 
 test('schema declares model, reasoning effort, and service tier columns', () => {
-  assert.match(schema, /SCHEMA_VERSION = 28/);
+  assert.match(schema, /SCHEMA_VERSION = 29/);
   assert.match(schema, /model\s+TEXT/);
   assert.match(schema, /reasoning_effort TEXT/);
   assert.match(schema, /service_tier\s+TEXT/);

--- a/tests/terminal-contract.test.mjs
+++ b/tests/terminal-contract.test.mjs
@@ -85,10 +85,14 @@ test('plain and OSC 8 terminal links share the validated Electron external URL b
   );
 });
 
-test('Claude PTY resumes only after Tessera has persisted conversation history', () => {
+test('Claude PTY resumes persisted history and native fork provider sessions', () => {
   assert.match(
     routingSource,
-    /const resume = await sessionHistory\.historyExists\(structured\.sessionId\)/,
+    /resolveTerminalProviderSessionReference\(/,
+  );
+  assert.match(
+    routingSource,
+    /const resume = providerSession\.nativeFork[\s\S]*sessionHistory\.historyExists\(structured\.sessionId\)/,
   );
   assert.doesNotMatch(routingSource, /isTerminalLaunched/);
   assert.doesNotMatch(hookReceiverSource, /markTerminalLaunched/);
@@ -239,6 +243,7 @@ test('terminal websocket protocol covers process lifecycle', () => {
     'terminal_exit',
     'terminal_error',
     'terminal_session_runtime',
+    'terminal_session_rebound',
     'terminal_session_runtime_snapshot',
   ]) {
     assert.match(messageTypesSource, new RegExp(`type: '${type}'`));
@@ -356,6 +361,7 @@ test('websocket disconnect detaches surfaces without killing terminal processes'
 
 test('terminal runtime lifecycle is broadcast and replayed to session clients', () => {
   assert.match(sharedTerminalManagerSource, /type: 'terminal_session_runtime'/);
+  assert.match(sharedTerminalManagerSource, /type: 'terminal_session_rebound'/);
   assert.match(wsServerSource, /bindTerminalRuntimeSender/);
   assert.match(wsServerSource, /type: 'terminal_session_runtime_snapshot'/);
   assert.match(wsServerSource, /terminalManager\.getActiveSessionIds\(userId\)/);

--- a/tests/terminal-manager-lifecycle.test.ts
+++ b/tests/terminal-manager-lifecycle.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import test, { before } from 'node:test';
 import type { ServerTransportMessage } from '@/lib/ws/message-types';
 import type { TerminalCreateOptions, TerminalPtyFactory } from '@/lib/terminal/types';
+import { mintPaneToken, resolvePaneToken } from '@/lib/terminal/pane-token-registry';
 
 process.env.TESSERA_DATA_DIR = mkdtempSync(path.join(tmpdir(), 'tessera-terminal-test-'));
 process.env.NODE_ENV = 'test';
@@ -145,9 +146,81 @@ test('concurrent session opens spawn once and disconnect only detaches its surfa
   assert.deepEqual(manager.getRuntimeSummary(), { activeCount: 0, sessionCount: 0 });
 });
 
+test('terminal reservations isolate concurrent sessions before either PTY starts', async () => {
+  const delivered: ServerTransportMessage[] = [];
+  const spawned: FakePty[] = [];
+  const manager = new TerminalManager(
+    (_connectionId, message) => delivered.push(message),
+    async () => createFactory(spawned),
+  );
+  const firstTerminalId = manager.reserveTerminalId('user-a', 'shared-proposal', 'session-one');
+  const secondTerminalId = manager.reserveTerminalId('user-a', 'shared-proposal', 'session-two');
+  assert.notEqual(firstTerminalId, secondTerminalId);
+  const abandonedTerminalId = manager.reserveTerminalId(
+    'user-a',
+    'abandoned-proposal',
+    'abandoned-session',
+  );
+  manager.releaseTerminalReservation(
+    'user-a',
+    'abandoned-session',
+    abandonedTerminalId,
+  );
+  assert.equal(
+    manager.reserveTerminalId('user-a', 'abandoned-proposal', 'replacement-session'),
+    'abandoned-proposal',
+    'preparation failure cleanup must release both reservation directions',
+  );
+  manager.releaseTerminalReservation('user-a', 'replacement-session', 'abandoned-proposal');
+  const firstToken = mintPaneToken({
+    terminalId: firstTerminalId,
+    userId: 'user-a',
+    sessionId: 'session-one',
+    providerId: 'codex',
+  });
+  const secondToken = mintPaneToken({
+    terminalId: secondTerminalId,
+    userId: 'user-a',
+    sessionId: 'session-two',
+    providerId: 'codex',
+  });
+
+  await Promise.all([
+    manager.create(createOptions({
+      terminalId: 'shared-proposal',
+      sessionId: 'session-one',
+      paneToken: firstToken,
+    })),
+    manager.create(createOptions({
+      terminalId: 'shared-proposal',
+      sessionId: 'session-two',
+      connectionId: 'connection-b',
+      surfaceId: 'surface-b',
+      paneToken: secondToken,
+    })),
+  ]);
+
+  assert.equal(spawned.length, 2);
+  const startedTerminalIds = delivered
+    .filter((message) => message.type === 'terminal_started')
+    .map((message) => message.type === 'terminal_started' ? message.terminalId : '')
+    .sort();
+  assert.deepEqual(startedTerminalIds, [firstTerminalId, secondTerminalId].sort());
+  assert.equal(resolvePaneToken(firstToken)?.terminalId, firstTerminalId);
+  assert.equal(resolvePaneToken(secondToken)?.terminalId, secondTerminalId);
+  assert.deepEqual(manager.getRuntimeSummary(), { activeCount: 2, sessionCount: 2 });
+
+  await manager.shutdownAll();
+});
+
 test('session PTY lifecycle reports running until the process exits', async () => {
   const spawned: FakePty[] = [];
-  const runtimeStates: Array<{ sessionId: string; userId: string; running: boolean }> = [];
+  const runtimeStates: Array<{
+    sessionId: string;
+    terminalId: string;
+    userId: string;
+    running: boolean;
+  }> = [];
   const manager = new TerminalManager(
     () => {},
     async () => createFactory(spawned),
@@ -158,17 +231,27 @@ test('session PTY lifecycle reports running until the process exits', async () =
   );
 
   await manager.create(createOptions());
-  assert.deepEqual(runtimeStates, [{ sessionId: 'session-a', userId: 'user-a', running: true }]);
+  assert.deepEqual(runtimeStates, [{
+    sessionId: 'session-a',
+    terminalId: 'terminal-a',
+    userId: 'user-a',
+    running: true,
+  }]);
   assert.deepEqual([...manager.getActiveSessionIds('user-a')], ['session-a']);
 
   manager.detachConnection('connection-a');
-  assert.deepEqual(runtimeStates, [{ sessionId: 'session-a', userId: 'user-a', running: true }]);
+  assert.deepEqual(runtimeStates, [{
+    sessionId: 'session-a',
+    terminalId: 'terminal-a',
+    userId: 'user-a',
+    running: true,
+  }]);
   assert.deepEqual([...manager.getActiveSessionIds('user-a')], ['session-a']);
 
   spawned[0].emitExit(0);
   assert.deepEqual(runtimeStates, [
-    { sessionId: 'session-a', userId: 'user-a', running: true },
-    { sessionId: 'session-a', userId: 'user-a', running: false },
+    { sessionId: 'session-a', terminalId: 'terminal-a', userId: 'user-a', running: true },
+    { sessionId: 'session-a', terminalId: 'terminal-a', userId: 'user-a', running: false },
   ]);
   assert.deepEqual([...manager.getActiveSessionIds('user-a')], []);
 });
@@ -354,6 +437,140 @@ test('PTY Escape fallback rejects late tool activity but accepts the next prompt
   );
 });
 
+test('native CLI fork rebinds one live PTY from the parent session to the child', async () => {
+  const spawned: FakePty[] = [];
+  const delivered: ServerTransportMessage[] = [];
+  const runtimeStates: Array<{
+    sessionId: string;
+    terminalId: string;
+    userId: string;
+    running: boolean;
+  }> = [];
+  const runtimeRebounds: Array<{
+    previousSessionId: string;
+    sessionId: string;
+    terminalId: string;
+    userId: string;
+  }> = [];
+  const observed: string[] = [];
+  const disposed: string[] = [];
+  const manager = new TerminalManager(
+    (_connectionId, message) => delivered.push(message),
+    async () => createFactory(spawned),
+    ({ sessionId }) => {
+      observed.push(sessionId);
+      return () => disposed.push(sessionId);
+    },
+    {
+      onSessionRuntimeStateChange: (state) => runtimeStates.push(state),
+      onSessionRuntimeRebound: (state) => runtimeRebounds.push(state),
+    },
+  );
+
+  await manager.create(createOptions());
+  await nextImmediate();
+
+  assert.equal(
+    manager.markProviderSessionIdentityBackground(
+      'terminal-a',
+      'user-a',
+      'provider-child',
+    ),
+    true,
+  );
+  assert.equal(
+    manager.isProviderSessionIdentityBackground('terminal-a', 'user-a', 'provider-child'),
+    true,
+  );
+  assert.equal(manager.getSessionIdForTerminal('terminal-a', 'user-a'), 'session-a');
+
+  assert.equal(
+    manager.rebindSession('terminal-a', 'user-a', 'session-a', 'session-child'),
+    true,
+  );
+  await nextImmediate();
+
+  assert.deepEqual([...manager.getActiveSessionIds('user-a')], ['session-child']);
+  assert.equal(manager.getSessionIdForTerminal('terminal-a', 'user-a'), 'session-child');
+  assert.equal(manager.resolveTerminalId('user-a', 'child-proposal', 'session-child'), 'terminal-a');
+  assert.equal(manager.submitSessionInput('session-a', 'user-a', 'old session'), false);
+  assert.equal(manager.submitSessionInput('session-child', 'user-a', 'new session'), true);
+  assert.deepEqual(spawned[0].writes, ['new session\r']);
+  assert.equal(spawned[0].killCount, 0);
+  assert.equal(
+    manager.activateProviderSessionIdentity(
+      'terminal-a',
+      'user-a',
+      'provider-child',
+      'provider-parent',
+    ),
+    true,
+  );
+  assert.equal(
+    manager.isProviderSessionIdentityBackground('terminal-a', 'user-a', 'provider-child'),
+    false,
+  );
+  assert.equal(
+    manager.isProviderSessionIdentityRetired('terminal-a', 'user-a', 'provider-parent'),
+    true,
+  );
+  assert.equal(
+    manager.activateProviderSessionIdentity('terminal-a', 'user-a', 'provider-parent'),
+    false,
+  );
+  assert.equal(manager.getSessionIdForTerminal('terminal-a', 'user-a'), 'session-child');
+  assert.deepEqual(manager.getSessionReboundsForUser('user-a'), [{
+    previousSessionId: 'session-a',
+    sessionId: 'session-child',
+    terminalId: 'terminal-a',
+  }]);
+  assert.deepEqual(observed, ['session-a', 'session-child']);
+  assert.deepEqual(disposed, ['session-a']);
+  assert.deepEqual(runtimeStates, [
+    { sessionId: 'session-a', terminalId: 'terminal-a', userId: 'user-a', running: true },
+  ]);
+  assert.deepEqual(runtimeRebounds, [{
+    previousSessionId: 'session-a',
+    sessionId: 'session-child',
+    terminalId: 'terminal-a',
+    userId: 'user-a',
+  }]);
+
+  assert.equal(manager.hasOrIsOpening('terminal-a', 'user-a', 'session-a'), false);
+  const reservedParentTerminalId = manager.reserveTerminalId(
+    'user-a',
+    'terminal-a',
+    'session-a',
+  );
+  assert.notEqual(reservedParentTerminalId, 'terminal-a');
+  const parentPaneToken = mintPaneToken({
+    terminalId: reservedParentTerminalId,
+    userId: 'user-a',
+    sessionId: 'session-a',
+    providerId: 'codex',
+  });
+  delivered.length = 0;
+  await manager.create(createOptions({
+    connectionId: 'connection-b',
+    surfaceId: 'surface-b',
+    paneToken: parentPaneToken,
+  }));
+  assert.equal(spawned.length, 2, 'opening the parent must not attach to the child PTY');
+  const parentStart = delivered.find((message) => message.type === 'terminal_started');
+  assert.equal(parentStart?.type, 'terminal_started');
+  if (parentStart?.type === 'terminal_started') {
+    assert.equal(parentStart.terminalId, reservedParentTerminalId);
+    assert.equal(resolvePaneToken(parentPaneToken)?.terminalId, parentStart.terminalId);
+  }
+  assert.deepEqual(
+    manager.getSessionReboundsForUser('user-a'),
+    [],
+    'a reopened parent must not be rewritten to the child on reconnect',
+  );
+
+  await manager.shutdownAll();
+});
+
 test('cold attach receives one snapshot boundary followed by monotonic live output', async () => {
   const delivered: Array<{ connectionId: string; message: ServerTransportMessage }> = [];
   const spawned: FakePty[] = [];
@@ -477,7 +694,12 @@ test('resize redraw cannot erase scrollback even when ED3 is split across PTY ch
 test('a late exit from an older generation cannot erase its replacement runtime', async () => {
   const delivered: Array<{ connectionId: string; message: ServerTransportMessage }> = [];
   const spawned: FakePty[] = [];
-  const runtimeStates: Array<{ sessionId: string; userId: string; running: boolean }> = [];
+  const runtimeStates: Array<{
+    sessionId: string;
+    terminalId: string;
+    userId: string;
+    running: boolean;
+  }> = [];
   const manager = new TerminalManager(
     (connectionId, message) => delivered.push({ connectionId, message }),
     async () => createFactory(spawned),

--- a/tests/terminal-provider-session-observer.test.ts
+++ b/tests/terminal-provider-session-observer.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { createCodexTerminalSessionObserver } from '@/lib/cli/providers/codex/terminal-session-observer';
+import {
+  createClaudeTerminalSessionObserver,
+  isClaudeBackgroundTerminalSessionFork,
+} from '@/lib/cli/providers/claude-code/terminal-session-observer';
+
+test('Codex fork artifacts report the child identity before its first prompt', async (t) => {
+  const sessionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-codex-observer-'));
+  t.after(() => fs.rmSync(sessionsDir, { recursive: true, force: true }));
+  const observed: Array<Record<string, unknown>> = [];
+  const observer = createCodexTerminalSessionObserver({
+    sessionsDir,
+    currentProviderSessionId: () => 'thread-parent',
+    onObservation: (observation) => observed.push(observation),
+  });
+  t.after(observer.dispose);
+  await observer.ready();
+
+  const childPath = path.join(sessionsDir, 'rollout-child.jsonl');
+  fs.writeFileSync(childPath, `${JSON.stringify({
+    type: 'session_meta',
+    payload: {
+      id: 'thread-child',
+      session_id: 'thread-child',
+      forked_from_id: 'thread-parent',
+      cwd: '/workspace',
+    },
+  })}\n`);
+
+  for (let attempt = 0; attempt < 500 && observed.length === 0; attempt += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  assert.deepEqual(observed, [{
+    activation: 'active',
+    providerSessionId: 'thread-child',
+    transcriptPath: childPath,
+  }]);
+});
+
+test('Claude background fork jobs are discovered without activating the parent PTY', async (t) => {
+  const jobsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-claude-observer-'));
+  t.after(() => fs.rmSync(jobsDir, { recursive: true, force: true }));
+  const observed: Array<Record<string, unknown>> = [];
+  const observer = createClaudeTerminalSessionObserver({
+    jobsDir,
+    currentProviderSessionId: () => 'claude-parent',
+    onObservation: (observation) => observed.push(observation),
+  });
+  t.after(observer.dispose);
+  await observer.ready();
+
+  const jobDir = path.join(jobsDir, 'claude-c');
+  fs.mkdirSync(jobDir);
+  fs.writeFileSync(path.join(jobDir, 'state.json'), JSON.stringify({
+    forkSessionId: 'claude-child',
+    forkParentSessionId: 'claude-parent',
+    interactiveLineage: true,
+  }));
+
+  for (let attempt = 0; attempt < 500 && observed.length === 0; attempt += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  assert.deepEqual(observed, [{
+    activation: 'background',
+    providerSessionId: 'claude-child',
+  }]);
+  assert.equal(isClaudeBackgroundTerminalSessionFork({
+    currentProviderSessionId: 'claude-parent',
+    observedProviderSessionId: 'claude-child',
+    jobsDir,
+  }), true);
+});

--- a/tests/terminal-provider-session-reconciliation.test.ts
+++ b/tests/terminal-provider-session-reconciliation.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test, { before } from 'node:test';
+
+process.env.TESSERA_DATA_DIR = mkdtempSync(path.join(tmpdir(), 'tessera-provider-session-test-'));
+process.env.NODE_ENV = 'test';
+
+let dbSessions: typeof import('@/lib/db/sessions');
+let reconcileTerminalProviderSession: typeof import('@/lib/terminal/provider-session-reconciliation').reconcileTerminalProviderSession;
+let extractTerminalProviderSessionIdentity: typeof import('@/lib/terminal/provider-session-identity').extractTerminalProviderSessionIdentity;
+
+before(async () => {
+  const [{ initDatabase }, projects, sessions, reconciliation, identity] = await Promise.all([
+    import('@/lib/db/database'),
+    import('@/lib/db/projects'),
+    import('@/lib/db/sessions'),
+    import('@/lib/terminal/provider-session-reconciliation'),
+    import('@/lib/terminal/provider-session-identity'),
+  ]);
+  await initDatabase();
+  projects.registerProject('project-1', '/tmp/project-1', 'Project 1');
+  dbSessions = sessions;
+  reconcileTerminalProviderSession = reconciliation.reconcileTerminalProviderSession;
+  extractTerminalProviderSessionIdentity = identity.extractTerminalProviderSessionIdentity;
+});
+
+test('the common identity adapter normalizes provider hook payloads', () => {
+  assert.deepEqual(
+    extractTerminalProviderSessionIdentity('opencode', {
+      sessionID: ' opencode-child ',
+      transcriptPath: ' /tmp/opencode-child.jsonl ',
+    }),
+    {
+      providerId: 'opencode',
+      providerSessionId: 'opencode-child',
+      transcriptPath: '/tmp/opencode-child.jsonl',
+    },
+  );
+  assert.equal(
+    extractTerminalProviderSessionIdentity('codex', { session_id: 'bad\nidentifier' }),
+    null,
+  );
+});
+
+test('the first provider observation binds the existing PTY session without forking', () => {
+  dbSessions.createSession('unbound-parent', 'project-1', 'Unbound PTY', 'codex', {
+    providerState: JSON.stringify({ kind: 'terminal', launched: true }),
+  });
+
+  const result = reconcileTerminalProviderSession({
+    sourceSessionId: 'unbound-parent',
+    identity: { providerId: 'codex', providerSessionId: 'provider-initial' },
+  });
+
+  assert.deepEqual(result, {
+    kind: 'unchanged',
+    sessionId: 'unbound-parent',
+    previousSessionId: 'unbound-parent',
+  });
+});
+
+test('a new provider session creates one durable PTY child and preserves the parent', () => {
+  dbSessions.createSession('parent-session', 'project-1', 'Investigate login', 'codex', {
+    workDir: '/tmp/project-1',
+    worktreeManaged: true,
+    taskId: 'task-1',
+    collectionId: 'collection-1',
+    model: 'gpt-5.4',
+    reasoningEffort: 'high',
+    serviceTier: 'fast',
+    providerState: JSON.stringify({
+      kind: 'terminal',
+      launched: true,
+      codexSessionId: 'provider-parent',
+    }),
+  });
+  dbSessions.updateSession('parent-session', {
+    worktree_branch: 'feature/login',
+    worktree_managed: 1,
+  });
+
+  const result = reconcileTerminalProviderSession({
+    sourceSessionId: 'parent-session',
+    identity: {
+      providerId: 'codex',
+      providerSessionId: 'provider-child',
+      transcriptPath: '/tmp/provider-child.jsonl',
+    },
+  });
+
+  assert.equal(result.kind, 'created');
+  assert.equal(result.previousSessionId, 'parent-session');
+  assert.equal(result.previousProviderSessionId, 'provider-parent');
+  assert.notEqual(result.sessionId, 'parent-session');
+
+  const parent = dbSessions.getSession('parent-session');
+  const child = dbSessions.getSession(result.sessionId);
+  assert.equal(parent?.title, 'Investigate login');
+  assert.equal(child?.title, 'Investigate login (Fork)');
+  assert.equal(child?.provider, 'codex');
+  assert.equal(child?.project_id, 'project-1');
+  assert.equal(child?.work_dir, '/tmp/project-1');
+  assert.equal(child?.worktree_branch, 'feature/login');
+  assert.equal(child?.worktree_managed, 1);
+  assert.equal(child?.task_id, 'task-1');
+  assert.equal(child?.collection_id, 'collection-1');
+  assert.equal(child?.model, 'gpt-5.4');
+  assert.equal(child?.reasoning_effort, 'high');
+  assert.equal(child?.service_tier, 'fast');
+  assert.deepEqual(JSON.parse(child?.provider_state ?? '{}'), {
+    kind: 'terminal',
+    launched: true,
+    terminalProviderSessionId: 'provider-child',
+    codexSessionId: 'provider-child',
+  });
+  assert.equal(result.projectId, 'project-1');
+});
+
+test('duplicate and stale-pane observations resolve to the existing child', () => {
+  dbSessions.createSession('dedup-parent', 'project-1', 'Deduplicate fork', 'claude-code', {
+    workDir: '/tmp/project-1',
+    providerState: JSON.stringify({ kind: 'terminal', launched: true }),
+  });
+
+  const first = reconcileTerminalProviderSession({
+    sourceSessionId: 'dedup-parent',
+    identity: { providerId: 'claude-code', providerSessionId: 'claude-child' },
+    activation: 'background',
+  });
+  assert.equal(first.kind, 'created');
+  assert.deepEqual(JSON.parse(dbSessions.getSession(first.sessionId)?.provider_state ?? '{}'), {
+    kind: 'terminal',
+    launched: true,
+    terminalProviderSessionId: 'claude-child',
+    terminalProviderSessionActivation: 'background',
+  });
+
+  const duplicate = reconcileTerminalProviderSession({
+    sourceSessionId: first.sessionId,
+    identity: { providerId: 'claude-code', providerSessionId: 'claude-child' },
+  });
+  assert.deepEqual(duplicate, {
+    kind: 'unchanged',
+    sessionId: first.sessionId,
+    previousSessionId: first.sessionId,
+  });
+
+  const stalePane = reconcileTerminalProviderSession({
+    sourceSessionId: 'dedup-parent',
+    identity: { providerId: 'claude-code', providerSessionId: 'claude-child' },
+  });
+  assert.deepEqual(stalePane, {
+    kind: 'existing',
+    sessionId: first.sessionId,
+    previousSessionId: 'dedup-parent',
+    previousProviderSessionId: 'dedup-parent',
+  });
+});
+
+test('GUI sessions are ignored by the PTY provider-session reconciler', () => {
+  dbSessions.createSession('gui-session', 'project-1', 'GUI session', 'codex', {
+    providerState: JSON.stringify({ kind: 'chat', threadId: 'thread-gui' }),
+  });
+
+  const result = reconcileTerminalProviderSession({
+    sourceSessionId: 'gui-session',
+    identity: { providerId: 'codex', providerSessionId: 'provider-gui' },
+  });
+
+  assert.deepEqual(result, {
+    kind: 'ignored',
+    sessionId: 'gui-session',
+    previousSessionId: 'gui-session',
+  });
+});

--- a/tests/terminal-session-runtime-state.test.ts
+++ b/tests/terminal-session-runtime-state.test.ts
@@ -319,6 +319,403 @@ test('PTY runtime exit removes its panel without discarding unrelated panels', (
   assert.equal(useTabStore.getState().findSessionLocation(SESSION_ID), null);
 });
 
+test('PTY session rebound keeps the panel and transfers its session ownership atomically', () => {
+  const childSessionId = 'terminal-session-child';
+  const tabId = 'rebound-terminal-tab';
+  const panelId = 'rebound-terminal-panel';
+  useSessionStore.setState({
+    projects: [project(terminalSession(SESSION_ID, true), terminalSession(childSessionId))],
+  });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: SESSION_ID } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  receive({
+    type: 'terminal_session_rebound',
+    previousSessionId: SESSION_ID,
+    sessionId: childSessionId,
+    terminalId: `session-${SESSION_ID}`,
+  } as ServerTransportMessage);
+
+  assert.equal(useTabStore.getState().tabs.some((tab) => tab.id === tabId), true);
+  assert.equal(useTabStore.getState().findSessionLocation(SESSION_ID), null);
+  assert.deepEqual(
+    useTabStore.getState().findSessionLocation(childSessionId),
+    { tabId, panelId },
+  );
+  assert.equal(useSessionStore.getState().getSession(SESSION_ID)?.isRunning, false);
+  assert.equal(useSessionStore.getState().getSession(childSessionId)?.isRunning, true);
+});
+
+test('PTY session rebound waits for the child menu row before switching the visible panel', async (t) => {
+  const childSessionId = 'terminal-session-delayed-child';
+  const tabId = 'delayed-rebound-tab';
+  const panelId = 'delayed-rebound-panel';
+  let releaseLoad!: () => void;
+  const loadGate = new Promise<void>((resolve) => { releaseLoad = resolve; });
+  const originalLoadProjects = useSessionStore.getState().loadProjects;
+  t.after(() => useSessionStore.setState({ loadProjects: originalLoadProjects }));
+  useSessionStore.setState({
+    projects: [project(terminalSession(SESSION_ID, true))],
+    loadProjects: async () => {
+      await loadGate;
+      useSessionStore.setState({
+        projects: [project(terminalSession(SESSION_ID), terminalSession(childSessionId, true))],
+      });
+    },
+  });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: SESSION_ID } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  receive({
+    type: 'terminal_session_rebound',
+    previousSessionId: SESSION_ID,
+    sessionId: childSessionId,
+    terminalId: `session-${SESSION_ID}`,
+  });
+  assert.deepEqual(useTabStore.getState().findSessionLocation(SESSION_ID), { tabId, panelId });
+  assert.equal(useTabStore.getState().findSessionLocation(childSessionId), null);
+
+  releaseLoad();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(useTabStore.getState().findSessionLocation(SESSION_ID), null);
+  assert.deepEqual(useTabStore.getState().findSessionLocation(childSessionId), { tabId, panelId });
+});
+
+test('PTY runtime snapshot repairs a rebound missed while the client was disconnected', () => {
+  const childSessionId = 'terminal-session-reconnected-child';
+  const tabId = 'reconnected-rebound-tab';
+  const panelId = 'reconnected-rebound-panel';
+  useSessionStore.setState({
+    projects: [project(terminalSession(SESSION_ID, true), terminalSession(childSessionId))],
+  });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: SESSION_ID } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  receive({
+    type: 'terminal_session_runtime_snapshot',
+    activeSessionIds: [childSessionId],
+    reboundSessions: [{
+      previousSessionId: SESSION_ID,
+      sessionId: childSessionId,
+      terminalId: `session-${SESSION_ID}`,
+    }],
+  });
+
+  assert.equal(useTabStore.getState().tabs.some((tab) => tab.id === tabId), true);
+  assert.deepEqual(useTabStore.getState().findSessionLocation(childSessionId), { tabId, panelId });
+});
+
+test('delayed reconnect rebound keeps the source panel until the child row loads', async (t) => {
+  const childSessionId = 'snapshot-delayed-child';
+  const tabId = 'snapshot-delayed-tab';
+  const panelId = 'snapshot-delayed-panel';
+  let releaseLoad!: () => void;
+  const loadGate = new Promise<void>((resolve) => { releaseLoad = resolve; });
+  const originalLoadProjects = useSessionStore.getState().loadProjects;
+  t.after(() => useSessionStore.setState({ loadProjects: originalLoadProjects }));
+  useSessionStore.setState({
+    projects: [project(terminalSession(SESSION_ID, true))],
+    loadProjects: async () => {
+      await loadGate;
+      useSessionStore.setState({
+        projects: [project(terminalSession(SESSION_ID), terminalSession(childSessionId, true))],
+      });
+    },
+  });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: SESSION_ID } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  receive({
+    type: 'terminal_session_runtime_snapshot',
+    activeSessionIds: [childSessionId],
+    reboundSessions: [{
+      previousSessionId: SESSION_ID,
+      sessionId: childSessionId,
+      terminalId: `session-${SESSION_ID}`,
+    }],
+  });
+  assert.deepEqual(useTabStore.getState().findSessionLocation(SESSION_ID), { tabId, panelId });
+
+  releaseLoad();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.deepEqual(useTabStore.getState().findSessionLocation(childSessionId), { tabId, panelId });
+});
+
+test('rebound destination exit during menu load retires the source and ignores the late load', async (t) => {
+  const childSessionId = 'exited-delayed-child';
+  const tabId = 'exited-delayed-tab';
+  const panelId = 'exited-delayed-panel';
+  let releaseLoad!: () => void;
+  const loadGate = new Promise<void>((resolve) => { releaseLoad = resolve; });
+  const originalLoadProjects = useSessionStore.getState().loadProjects;
+  t.after(() => useSessionStore.setState({ loadProjects: originalLoadProjects }));
+  useSessionStore.setState({
+    projects: [project(terminalSession(SESSION_ID, true))],
+    loadProjects: async () => {
+      await loadGate;
+      useSessionStore.setState({
+        projects: [project(terminalSession(SESSION_ID), terminalSession(childSessionId))],
+      });
+    },
+  });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: SESSION_ID } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  receive({
+    type: 'terminal_session_rebound',
+    previousSessionId: SESSION_ID,
+    sessionId: childSessionId,
+    terminalId: `session-${SESSION_ID}`,
+  });
+  receive({ type: 'terminal_session_runtime', sessionId: childSessionId, running: false });
+  assert.equal(useTabStore.getState().tabs.some((tab) => tab.id === tabId), false);
+
+  releaseLoad();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(useTabStore.getState().tabs.some((tab) => tab.id === tabId), false);
+});
+
+test('rapid chained rebounds apply only the latest child when loads resolve in reverse', async (t) => {
+  const middleSessionId = 'rebound-middle';
+  const finalSessionId = 'rebound-final';
+  const tabId = 'rebound-chain-tab';
+  const panelId = 'rebound-chain-panel';
+  let releaseFirst!: () => void;
+  let releaseSecond!: () => void;
+  const firstGate = new Promise<void>((resolve) => { releaseFirst = resolve; });
+  const secondGate = new Promise<void>((resolve) => { releaseSecond = resolve; });
+  const originalLoadProjects = useSessionStore.getState().loadProjects;
+  t.after(() => useSessionStore.setState({ loadProjects: originalLoadProjects }));
+  let loadCount = 0;
+  useSessionStore.setState({
+    projects: [project(terminalSession(SESSION_ID, true))],
+    loadProjects: async () => {
+      loadCount += 1;
+      await (loadCount === 1 ? firstGate : secondGate);
+      useSessionStore.setState({
+        projects: [project(
+          terminalSession(SESSION_ID),
+          terminalSession(middleSessionId),
+          terminalSession(finalSessionId, true),
+        )],
+      });
+    },
+  });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: SESSION_ID } },
+        activePanelId: panelId,
+      },
+    },
+  });
+  const terminalId = `session-${SESSION_ID}`;
+
+  receive({
+    type: 'terminal_session_rebound',
+    previousSessionId: SESSION_ID,
+    sessionId: middleSessionId,
+    terminalId,
+  });
+  receive({
+    type: 'terminal_session_rebound',
+    previousSessionId: middleSessionId,
+    sessionId: finalSessionId,
+    terminalId,
+  });
+  releaseSecond();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.deepEqual(useTabStore.getState().findSessionLocation(finalSessionId), { tabId, panelId });
+
+  releaseFirst();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.deepEqual(useTabStore.getState().findSessionLocation(finalSessionId), { tabId, panelId });
+  assert.equal(useTabStore.getState().findSessionLocation(middleSessionId), null);
+});
+
+test('starting the fork parent in another terminal does not cancel the original terminal rebound', async (t) => {
+  const childSessionId = 'reopened-parent-child';
+  const tabId = 'reopened-parent-tab';
+  const panelId = 'reopened-parent-panel';
+  let releaseLoad!: () => void;
+  const loadGate = new Promise<void>((resolve) => { releaseLoad = resolve; });
+  const originalLoadProjects = useSessionStore.getState().loadProjects;
+  t.after(() => useSessionStore.setState({ loadProjects: originalLoadProjects }));
+  useSessionStore.setState({
+    projects: [project(terminalSession(SESSION_ID, true))],
+    loadProjects: async () => {
+      await loadGate;
+      useSessionStore.setState({
+        projects: [project(
+          terminalSession(SESSION_ID, true),
+          terminalSession(childSessionId, true),
+        )],
+      });
+    },
+  });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: SESSION_ID } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  receive({
+    type: 'terminal_session_rebound',
+    previousSessionId: SESSION_ID,
+    sessionId: childSessionId,
+    terminalId: `session-${SESSION_ID}`,
+  });
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    terminalId: 'separately-reopened-terminal',
+    running: true,
+  });
+  releaseLoad();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(useTabStore.getState().findSessionLocation(SESSION_ID), null);
+  assert.deepEqual(useTabStore.getState().findSessionLocation(childSessionId), { tabId, panelId });
+  assert.equal(useSessionStore.getState().getSession(SESSION_ID)?.isRunning, true);
+  assert.equal(useSessionStore.getState().getSession(childSessionId)?.isRunning, true);
+});
+
+test('reconnect snapshot cancels a stale pending rebound omitted by the server', async (t) => {
+  const childSessionId = 'reconnect-reopened-parent-child';
+  const tabId = 'reconnect-reopened-parent-tab';
+  const panelId = 'reconnect-reopened-parent-panel';
+  let releaseLoad!: () => void;
+  const loadGate = new Promise<void>((resolve) => { releaseLoad = resolve; });
+  const originalLoadProjects = useSessionStore.getState().loadProjects;
+  t.after(() => useSessionStore.setState({ loadProjects: originalLoadProjects }));
+  useSessionStore.setState({
+    projects: [project(terminalSession(SESSION_ID, true))],
+    loadProjects: async () => {
+      await loadGate;
+      useSessionStore.setState({
+        projects: [project(
+          terminalSession(SESSION_ID, true),
+          terminalSession(childSessionId, true),
+        )],
+      });
+    },
+  });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: SESSION_ID } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  receive({
+    type: 'terminal_session_rebound',
+    previousSessionId: SESSION_ID,
+    sessionId: childSessionId,
+    terminalId: `session-${SESSION_ID}`,
+  });
+  receive({
+    type: 'terminal_session_runtime_snapshot',
+    activeSessionIds: [SESSION_ID, childSessionId],
+    reboundSessions: [],
+  });
+  releaseLoad();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(useTabStore.getState().findSessionLocation(SESSION_ID), { tabId, panelId });
+  assert.equal(useTabStore.getState().findSessionLocation(childSessionId), null);
+});
+
 test('archiving a stopped PTY session retires its open surface after the request succeeds', async (t) => {
   const tabId = 'archived-terminal-tab';
   const panelId = 'archived-terminal-panel';

--- a/tests/terminal-title-contract.test.mjs
+++ b/tests/terminal-title-contract.test.mjs
@@ -50,7 +50,7 @@ test('automatic title fallback remains eligible for a later Stop retry', () => {
 test('terminal prompts apply the immediate local title before the Stop event', () => {
   assert.match(
     hookReceiverSource,
-    /event === 'UserPromptSubmit'[\s\S]*applyImmediateSessionTitle\(entry\.sessionId, prompt\)/,
+    /event === 'UserPromptSubmit'[\s\S]*applyImmediateSessionTitle\(sessionId, prompt\)/,
   );
   assert.match(hookReceiverSource, /type: 'session_title_updated'[\s\S]*silent: true/);
 });


### PR DESCRIPTION
## Summary

- observe provider-owned session artifacts through a shared terminal observer contract
- persist provider session identities independently from Tessera session IDs
- reconcile native Codex and Claude forks into durable PTY child sessions
- rebound the existing terminal panel to the discovered child without losing the parent session
- repair missed rebounds from runtime snapshots after reconnects

## Architecture

Provider adapters expose artifact observation and identity normalization. A common reconciliation layer owns persistence and panel rebound behavior for every PTY provider.

## Validation

- 109 of 110 focused assertions passed on the combined run
- the single filesystem-watcher timing failure passed immediately in isolation (2/2 observer tests)
- full ESLint run with no errors (two pre-existing warnings)
- `npx tsc --noEmit`
- `git diff --check origin/dev...HEAD`