### PR TITLE
feat: add Kanban session peek

### DIFF
--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -87,6 +87,14 @@ export const KanbanBoard = memo(function KanbanBoard() {
   const selectedProjectDir = useBoardStore((s) => s.selectedProjectDir);
   const activeCollectionFilter = useBoardStore((s) => s.activeCollectionFilter);
   const setCollectionFilter = useBoardStore((s) => s.setCollectionFilter);
+  const peekSessionId = useBoardStore((s) => s.peekSessionId);
+  const peekFileRef = useBoardStore((s) => s.peekFileRef);
+  const selectedBoardSessionId = useBoardStore((s) => s.selectedBoardSessionId);
+  const openSessionPeek = useBoardStore((s) => s.openSessionPeek);
+  const closeSessionPeek = useBoardStore((s) => s.closeSessionPeek);
+  const kanbanSessionOpenMode = useSettingsStore(
+    (state) => state.settings.kanbanSessionOpenMode,
+  );
 
   // Collection store
   const collectionsByProject = useCollectionStore((s) => s.collectionsByProject);
@@ -96,7 +104,9 @@ export const KanbanBoard = memo(function KanbanBoard() {
   const tasksByProject = useTaskStore((s) => s.tasksByProject);
   // Session store
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
-  const selectionSessionId = getSessionSelectionId(activeSessionId);
+  const selectionSessionId = getSessionSelectionId(
+    kanbanSessionOpenMode === 'peek' ? selectedBoardSessionId : activeSessionId,
+  );
   const projects = useSessionStore((s) => s.projects);
   const scrollPositionKey = getKanbanScrollPositionKey(selectedProjectDir, activeCollectionFilter);
   const [portfolioProjectFilter, setPortfolioProjectFilter] = useState<string | null>(null);
@@ -521,7 +531,19 @@ export const KanbanBoard = memo(function KanbanBoard() {
   }, [filteredChats, isAllProjects, mergedTasksByStatus, visibleProjects, workflowChatsByStatus]);
 
   // Click handlers
-  const { handleSessionClick, handleSessionDoubleClick } = useSessionClickHandlers({ orderedIds });
+  const handleOpenSessionPeek = useCallback((session: UnifiedSession) => {
+    openSessionPeek(session.id);
+  }, [openSessionPeek]);
+  const { handleSessionClick, handleSessionDoubleClick } = useSessionClickHandlers({
+    orderedIds,
+    onOpenSession: kanbanSessionOpenMode === 'peek' ? handleOpenSessionPeek : undefined,
+  });
+
+  useEffect(() => {
+    if (kanbanSessionOpenMode !== 'peek' && (peekSessionId || peekFileRef)) {
+      closeSessionPeek();
+    }
+  }, [closeSessionPeek, kanbanSessionOpenMode, peekFileRef, peekSessionId]);
 
   const handleChatDragStart = useCallback((sessionId: string, e: React.DragEvent) => {
     const selectionStore = useSelectionStore.getState();
@@ -786,8 +808,9 @@ export const KanbanBoard = memo(function KanbanBoard() {
   }, [handleSessionClick]);
 
   const handleChatDoubleClick = useCallback((session: UnifiedSession) => {
+    if (kanbanSessionOpenMode === 'peek') return;
     handleSessionDoubleClick(session);
-  }, [handleSessionDoubleClick]);
+  }, [handleSessionDoubleClick, kanbanSessionOpenMode]);
 
   // ── Add session to existing task (matching list view's addSessionToTask) ──
 
@@ -971,7 +994,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
 
   return (
     <div
-      className="flex flex-col h-full w-full bg-(--board-bg) overflow-hidden"
+      className="relative flex h-full w-full flex-col overflow-hidden bg-(--board-bg)"
       data-testid="kanban-board"
     >
       {isAllProjects ? (
@@ -1081,7 +1104,6 @@ export const KanbanBoard = memo(function KanbanBoard() {
           />
         </div>
       </div>
-
       <KanbanScrollControls scrollAreaId={scrollAreaId} scrollAreaRef={scrollAreaRef} />
 
       {/* Task context menu -- rendered in portal via TaskContextMenu */}
@@ -1128,6 +1150,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
         onConfirm={handleMoveConfirm}
         onCancel={() => setMoveSessionTarget(null)}
       />
+
     </div>
   );
 });

--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -963,7 +963,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                   <span
                     title={prMismatchReason ?? undefined}
                     aria-label={prMismatchReason ?? undefined}
-                    className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-(--status-warning-text) ring-1 ring-(--board-card-bg) cursor-help"
+                    className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-(--status-error-text) ring-1 ring-(--board-card-bg) cursor-help"
                     data-testid="task-pr-mismatch-badge"
                   />
                 )}

--- a/src/components/board/session-peek.tsx
+++ b/src/components/board/session-peek.tsx
@@ -1,0 +1,379 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { MessageSquare, Terminal, X } from 'lucide-react';
+import { ChatArea } from '@/components/chat/chat-area';
+import { MemoryFileTab } from '@/components/memory/memory-file-tab';
+import { WorkspaceFileTab } from '@/components/workspace/workspace-file-tab';
+import { TabIdContext } from '@/stores/panel-store';
+import { useSessionStore } from '@/stores/session-store';
+import {
+  DEFAULT_PEEK_FILE_SIDECAR_WIDTH,
+  MIN_PEEK_FILE_SIDECAR_WIDTH,
+  useBoardStore,
+} from '@/stores/board-store';
+import { useI18n } from '@/lib/i18n';
+
+interface SessionPeekProps {
+  sessionId: string;
+  showSessionContent?: boolean;
+  onClose: () => void;
+}
+
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  'a[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+const PEEK_TAB_ID = 'kanban-session-peek';
+const PEEK_PANEL_ID = 'kanban-session-peek-panel';
+const PEEK_FILE_TAB_ID = 'kanban-file-peek';
+const PEEK_FILE_PANEL_ID = 'kanban-file-peek-panel';
+const MIN_SESSION_PANE_WIDTH = 420;
+const RESIZE_HANDLE_WIDTH = 7;
+const RESIZE_KEYBOARD_STEP = 24;
+
+function isTextEditingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.matches('input, textarea, select, [contenteditable="true"]');
+}
+
+export function SessionPeek({
+  sessionId,
+  showSessionContent = true,
+  onClose,
+}: SessionPeekProps) {
+  const { t } = useI18n();
+  const session = useSessionStore((state) => state.getSession(sessionId));
+  const peekFileRef = useBoardStore((state) => state.peekFileRef);
+  const persistedFileWidth = useBoardStore((state) => state.peekFileSidecarWidth);
+  const closePeekFile = useBoardStore((state) => state.closePeekFile);
+  const openPeekFile = useBoardStore((state) => state.openPeekFile);
+  const setPeekFileDirty = useBoardStore((state) => state.setPeekFileDirty);
+  const setPersistedFileWidth = useBoardStore((state) => state.setPeekFileSidecarWidth);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const splitContainerRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const backdropPointerStartedRef = useRef(false);
+  const resizeDragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startWidth: number;
+    previousCursor: string;
+    previousUserSelect: string;
+  } | null>(null);
+  const resizeWidthRef = useRef(persistedFileWidth);
+  const [fileSidecarWidth, setFileSidecarWidth] = useState(persistedFileWidth);
+  const [splitContainerWidth, setSplitContainerWidth] = useState(0);
+  const isTerminal = session?.kind === 'terminal';
+  const isFileOnly = !showSessionContent && Boolean(peekFileRef);
+  const isSplit = showSessionContent && Boolean(peekFileRef);
+  const titleId = `session-peek-title-${sessionId}`;
+
+  useEffect(() => {
+    const container = splitContainerRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') return;
+    const updateWidth = () => setSplitContainerWidth(container.clientWidth);
+    updateWidth();
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [isSplit]);
+
+  const clampFileWidth = useCallback((width: number, containerWidth = splitContainerWidth) => {
+    const maxWidth = Math.max(
+      MIN_PEEK_FILE_SIDECAR_WIDTH,
+      containerWidth - MIN_SESSION_PANE_WIDTH - RESIZE_HANDLE_WIDTH,
+    );
+    return Math.min(maxWidth, Math.max(MIN_PEEK_FILE_SIDECAR_WIDTH, width));
+  }, [splitContainerWidth]);
+
+  const applyFileWidth = useCallback((width: number, persist: boolean) => {
+    const nextWidth = clampFileWidth(width);
+    resizeWidthRef.current = nextWidth;
+    setFileSidecarWidth(nextWidth);
+    if (persist) setPersistedFileWidth(nextWidth);
+  }, [clampFileWidth, setPersistedFileWidth]);
+
+  const finishResize = useCallback(() => {
+    const drag = resizeDragRef.current;
+    if (!drag) return;
+    document.body.style.cursor = drag.previousCursor;
+    document.body.style.userSelect = drag.previousUserSelect;
+    resizeDragRef.current = null;
+    setPersistedFileWidth(resizeWidthRef.current);
+  }, [setPersistedFileWidth]);
+
+  useEffect(() => () => {
+    const drag = resizeDragRef.current;
+    if (!drag) return;
+    document.body.style.cursor = drag.previousCursor;
+    document.body.style.userSelect = drag.previousUserSelect;
+  }, []);
+
+  useEffect(() => {
+    returnFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    (closeButtonRef.current ?? dialogRef.current)?.focus({ preventScroll: true });
+
+    return () => {
+      const returnTarget = returnFocusRef.current;
+      requestAnimationFrame(() => {
+        if (returnTarget?.isConnected) returnTarget.focus({ preventScroll: true });
+      });
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!session) onClose();
+  }, [onClose, session]);
+
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      // Escape is application input in PTY programs, and GUI composers use it
+      // for cancelling generation and closing their own transient controls.
+      if (isTextEditingTarget(event.target)) return;
+      if (peekFileRef) {
+        event.preventDefault();
+        closePeekFile();
+        return;
+      }
+      if (isTerminal) return;
+      event.preventDefault();
+      onClose();
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [closePeekFile, isTerminal, onClose, peekFileRef]);
+
+  const handleDialogKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') return;
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+      .filter((element) => !element.hasAttribute('disabled') && element.offsetParent !== null);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }, []);
+
+  const handleBackdropPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    backdropPointerStartedRef.current = event.target === event.currentTarget;
+  }, []);
+
+  const handleBackdropPointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const shouldClose = backdropPointerStartedRef.current && event.target === event.currentTarget;
+    backdropPointerStartedRef.current = false;
+    if (shouldClose) onClose();
+  }, [onClose]);
+
+  const handleResizePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    resizeDragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: resizeWidthRef.current,
+      previousCursor: document.body.style.cursor,
+      previousUserSelect: document.body.style.userSelect,
+    };
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, []);
+
+  const handleResizePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = resizeDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const containerWidth = splitContainerRef.current?.clientWidth ?? splitContainerWidth;
+    const nextWidth = clampFileWidth(
+      drag.startWidth - (event.clientX - drag.startX),
+      containerWidth,
+    );
+    resizeWidthRef.current = nextWidth;
+    setFileSidecarWidth(nextWidth);
+  }, [clampFileWidth, splitContainerWidth]);
+
+  const handleResizePointerEnd = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = resizeDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    finishResize();
+  }, [finishResize]);
+
+  const handleResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    let nextWidth: number | null = null;
+    if (event.key === 'ArrowLeft') {
+      nextWidth = fileSidecarWidth + RESIZE_KEYBOARD_STEP;
+    } else if (event.key === 'ArrowRight') {
+      nextWidth = fileSidecarWidth - RESIZE_KEYBOARD_STEP;
+    } else if (event.key === 'Home') {
+      nextWidth = MIN_PEEK_FILE_SIDECAR_WIDTH;
+    } else if (event.key === 'End') {
+      nextWidth = splitContainerWidth - MIN_SESSION_PANE_WIDTH - RESIZE_HANDLE_WIDTH;
+    }
+    if (nextWidth === null) return;
+    event.preventDefault();
+    applyFileWidth(nextWidth, true);
+  }, [applyFileWidth, fileSidecarWidth, splitContainerWidth]);
+
+  if (!session) return null;
+
+  const SessionIcon = isTerminal ? Terminal : MessageSquare;
+  const effectiveFileWidth = clampFileWidth(fileSidecarWidth);
+  const surfaceBadge = isTerminal ? 'PTY' : 'GUI';
+  const peekFileLabel = peekFileRef?.type === 'workspace-file'
+    ? peekFileRef.path
+    : peekFileRef?.fileName;
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/40 p-3 backdrop-blur-[2px] sm:p-5"
+      data-testid="kanban-session-peek-backdrop"
+      onPointerDown={handleBackdropPointerDown}
+      onPointerUp={handleBackdropPointerUp}
+      onPointerCancel={() => { backdropPointerStartedRef.current = false; }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={showSessionContent ? titleId : undefined}
+        aria-label={isFileOnly ? peekFileLabel : undefined}
+        tabIndex={-1}
+        onKeyDown={handleDialogKeyDown}
+        className="flex min-h-0 overflow-hidden rounded-xl border border-(--divider) bg-(--chat-bg) shadow-[0_28px_90px_rgba(0,0,0,0.42)]"
+        style={{
+          width: peekFileRef ? 'min(96%, 88rem)' : 'min(92%, 72rem)',
+          height: '92%',
+        }}
+        data-testid="kanban-session-peek"
+        data-session-kind={isTerminal ? 'terminal' : 'chat'}
+      >
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          {showSessionContent ? (
+            <header className="flex h-11 shrink-0 items-center gap-2 border-b border-(--chat-header-border) bg-(--chat-header-bg) px-3">
+              <SessionIcon className="h-4 w-4 shrink-0 text-(--accent)" aria-hidden="true" />
+              <h2
+                id={titleId}
+                className="min-w-0 flex-1 truncate text-sm font-semibold text-(--text-primary)"
+              >
+                {session.title}
+              </h2>
+              <span className="rounded-full border border-(--divider) px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-(--text-muted)">
+                {surfaceBadge}
+              </span>
+              <button
+                ref={closeButtonRef}
+                type="button"
+                onClick={onClose}
+                className="rounded-md p-1.5 text-(--text-muted) transition-colors hover:bg-(--sidebar-hover) hover:text-(--text-primary) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                aria-label={t('common.close')}
+                title={t('common.close')}
+                data-testid="kanban-session-peek-close"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </header>
+          ) : null}
+          <div
+            ref={splitContainerRef}
+            className="flex min-h-0 flex-1 overflow-hidden"
+            data-testid="kanban-peek-split-container"
+          >
+            {showSessionContent ? (
+              <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+                <TabIdContext.Provider value={PEEK_TAB_ID}>
+                  <ChatArea
+                    key={sessionId}
+                    sessionId={sessionId}
+                    panelId={PEEK_PANEL_ID}
+                    presentation="peek"
+                  />
+                </TabIdContext.Provider>
+              </div>
+            ) : null}
+
+            {isSplit ? (
+              <div
+                role="separator"
+                aria-label="Resize file preview"
+                aria-orientation="vertical"
+                aria-valuemin={MIN_PEEK_FILE_SIDECAR_WIDTH}
+                aria-valuemax={Math.max(
+                  MIN_PEEK_FILE_SIDECAR_WIDTH,
+                  splitContainerWidth - MIN_SESSION_PANE_WIDTH - RESIZE_HANDLE_WIDTH,
+                )}
+                aria-valuenow={Math.round(effectiveFileWidth)}
+                tabIndex={0}
+                onDoubleClick={() => applyFileWidth(DEFAULT_PEEK_FILE_SIDECAR_WIDTH, true)}
+                onKeyDown={handleResizeKeyDown}
+                onPointerDown={handleResizePointerDown}
+                onPointerMove={handleResizePointerMove}
+                onPointerUp={handleResizePointerEnd}
+                onPointerCancel={handleResizePointerEnd}
+                className="group relative z-10 w-[7px] shrink-0 cursor-col-resize bg-(--divider) outline-none transition-colors hover:bg-(--accent) focus-visible:bg-(--accent)"
+                style={{ touchAction: 'none' }}
+                data-testid="kanban-peek-file-resize-handle"
+              >
+                <span className="pointer-events-none absolute inset-y-0 -left-1 -right-1" />
+              </div>
+            ) : null}
+
+            {peekFileRef ? (
+              <aside
+                className="min-h-0 min-w-0 shrink-0 overflow-hidden bg-(--chat-bg)"
+                style={isSplit ? { width: effectiveFileWidth } : { flex: '1 1 0%' }}
+                data-testid="kanban-peek-file-sidecar"
+                data-file-type={peekFileRef.type}
+              >
+                <TabIdContext.Provider value={PEEK_FILE_TAB_ID}>
+                  {peekFileRef.type === 'memory-file' ? (
+                    <MemoryFileTab
+                      key={`${peekFileRef.sourceSessionId}:${peekFileRef.memoryKind}:${peekFileRef.fileName}`}
+                      memoryRef={peekFileRef}
+                      panelId={PEEK_FILE_PANEL_ID}
+                      onClose={closePeekFile}
+                      onDirtyChange={setPeekFileDirty}
+                    />
+                  ) : (
+                    <WorkspaceFileTab
+                      key={`${peekFileRef.sourceSessionId}:${peekFileRef.kind}:${peekFileRef.path}`}
+                      fileRef={peekFileRef}
+                      panelId={PEEK_FILE_PANEL_ID}
+                      surfaceActive
+                      onClose={closePeekFile}
+                      onFileRefChange={openPeekFile}
+                    />
+                  )}
+                </TabIdContext.Provider>
+              </aside>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useContext, useEffect, useMemo, useRef } from "react";
+import { memo, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { selectIsTurnInFlight, useChatStore } from "@/stores/chat-store";
 import { useSessionStore } from "@/stores/session-store";
 import { useSessionNavigation } from "@/hooks/use-session-navigation";
@@ -13,7 +13,7 @@ import { MessageInput } from "./message-input";
 import { WorkflowStatusBar } from "./workflow/workflow-status-bar";
 import { TodoStatusBar } from "./todo/todo-status-bar";
 import { InteractivePromptOverlay } from "./interactive-prompt-overlay";
-import { MessageSquare, AlertCircle, X as XIcon } from "lucide-react";
+import { MessageSquare, AlertCircle, LoaderCircle, X as XIcon } from "lucide-react";
 import { ChatAreaSkeleton } from "./chat-area-skeleton";
 import { Button } from "@/components/ui/button";
 import { usePanelStore, selectActiveTab, EMPTY_PANELS, TabIdContext } from "@/stores/panel-store";
@@ -26,22 +26,40 @@ import { shouldShowSessionHeader } from "@/lib/terminal/session-header-visibilit
 interface ChatAreaProps {
   sessionId: string;
   panelId: string;
+  presentation?: 'panel' | 'peek';
 }
 
-export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaProps) {
+const PEEK_LOADING_DELAY_MS = 300;
+
+export const ChatArea = memo(function ChatArea({
+  sessionId,
+  panelId,
+  presentation = 'panel',
+}: ChatAreaProps) {
   const { t } = useI18n();
   const tabId = useContext(TabIdContext);
+  const isPeek = presentation === 'peek';
+  const [peekLoadingReadySessionId, setPeekLoadingReadySessionId] = useState<string | null>(null);
+  useEffect(() => {
+    if (!isPeek) return;
+    const timer = setTimeout(() => {
+      setPeekLoadingReadySessionId(sessionId);
+    }, PEEK_LOADING_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [isPeek, sessionId]);
+  const shouldShowPeekLoading = isPeek && peekLoadingReadySessionId === sessionId;
   // Side-by-side panels in the active tab are all on-screen even though only
   // one is the panel-store's "active" panel; gating autoscroll on isPanelActive
   // froze the unfocused panel's viewport during streaming (issue #16).
-  const isViewActive = useTabStore((state) => state.activeTabId === tabId);
+  const isViewActive = useTabStore((state) => isPeek || state.activeTabId === tabId);
   const isPreviewTab = useTabStore(
-    (state) => state.tabs.find((tab) => tab.id === tabId)?.isPreview ?? false,
+    (state) => !isPeek && (state.tabs.find((tab) => tab.id === tabId)?.isPreview ?? false),
   );
   const { windowedMessages, hasMore, loadMore, isLoadingMore } =
     useWindowedMessages(sessionId);
   const isSinglePanel = usePanelStore(
-    (state) => Object.keys(selectActiveTab(state)?.panels ?? EMPTY_PANELS).length <= 1,
+    (state) => isPeek
+      || Object.keys(selectActiveTab(state)?.panels ?? EMPTY_PANELS).length <= 1,
   );
 
   const session = useSessionStore((state) => state.getSession(sessionId));
@@ -71,8 +89,8 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
       return;
     }
     autoLoadedSessionIdRef.current = session.id;
-    void viewSession(session);
-  }, [session, historyLoaded, viewSession]);
+    void viewSession(session, { activate: !isPeek });
+  }, [session, historyLoaded, isPeek, viewSession]);
   const groupedMessagesForSearch = useMemo(
     () => groupMessages(windowedMessages),
     [windowedMessages],
@@ -121,7 +139,7 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
           <Button
             onClick={() => {
               clearError(sessionId);
-              viewSession(session);
+              viewSession(session, { activate: !isPeek });
             }}
           >
             {t("chat.retry")}
@@ -132,7 +150,8 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
   }
 
   if (messages === undefined) {
-    return <ChatAreaSkeleton isSinglePanel={isSinglePanel} />;
+    if (!isPeek) return <ChatAreaSkeleton isSinglePanel={isSinglePanel} />;
+    return shouldShowPeekLoading ? <SessionPeekLoading /> : null;
   }
 
   const isUnifiedSession = "isRunning" in session;
@@ -151,7 +170,7 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
 
   return (
     <div className="flex-1 flex flex-col h-full bg-(--chat-bg)">
-      {shouldShowSessionHeader({ isTerminalSession, isSinglePanel }) && (
+      {!isPeek && shouldShowSessionHeader({ isTerminalSession, isSinglePanel }) && (
         <Header
           sessionId={sessionId}
           panelId={panelId}
@@ -179,7 +198,13 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
               panelId={panelId}
               terminalId={terminalId}
               terminalSessionId={sessionId}
-              runtimeOwnership={isPreviewTab ? 'session-preview' : 'session-retained'}
+              runtimeOwnership={isPeek
+                ? 'session-peek'
+                : isPreviewTab
+                  ? 'session-preview'
+                  : 'session-retained'}
+              surfaceActive={isPeek}
+              startupOverlay={shouldShowPeekLoading ? <SessionPeekLoading /> : undefined}
               launch={{ providerId: sessionProvider, sessionId }}
             />
           ) : null
@@ -218,12 +243,35 @@ export const ChatArea = memo(function ChatArea({ sessionId, panelId }: ChatAreaP
             isReadOnly={isReadOnly}
             isStopped={isStopped}
             isSinglePanel={isSinglePanel}
+            surfaceActive={isPeek}
           />
         </>
       )}
     </div>
   );
 });
+
+function SessionPeekLoading() {
+  const { t } = useI18n();
+
+  return (
+    <div
+      className="flex h-full flex-1 items-center justify-center bg-(--chat-bg)"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      data-testid="kanban-session-peek-loading"
+    >
+      <div className="flex flex-col items-center gap-3 text-center">
+        <LoaderCircle
+          className="h-7 w-7 animate-spin text-(--accent) motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+        <p className="text-sm text-(--text-muted)">{t("chat.loadingSession")}</p>
+      </div>
+    </div>
+  );
+}
 
 function SessionNotFound({ sessionId }: { sessionId: string }) {
   const { t } = useI18n();

--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -97,20 +97,27 @@ function getKanbanScrollArea(): HTMLDivElement | null {
 export function ChatLayout() {
   const { t } = useI18n();
   const activeSessionId = useSessionStore((state) => state.activeSessionId);
+  const viewMode = useBoardStore((state) => state.viewMode);
+  const selectedBoardSessionId = useBoardStore((state) => state.selectedBoardSessionId);
+  const kanbanSessionOpenMode = useSettingsStore(
+    (state) => state.settings.kanbanSessionOpenMode,
+  );
   const activePanelSessionId = usePanelStore((state) => {
     const activeTabData = selectActiveTab(state);
     return activeTabData?.panels[activeTabData.activePanelId]?.sessionId ?? null;
   });
-  const activeGitSessionId = resolveActiveWorkspaceSessionId({
-    activePanelSessionId,
-    activeSessionId,
-  });
+  const isKanbanPeekMode = viewMode === 'board' && kanbanSessionOpenMode === 'peek';
+  const activeGitSessionId = isKanbanPeekMode && selectedBoardSessionId
+    ? selectedBoardSessionId
+    : resolveActiveWorkspaceSessionId({
+        activePanelSessionId,
+        activeSessionId,
+      });
 
   const markSessionAsRead = useNotificationStore(
     (state) => state.markSessionAsRead,
   );
   const sidebarCollapsed = useSettingsStore((state) => state.sidebarCollapsed);
-  const viewMode = useBoardStore((state) => state.viewMode);
   const selectedProjectDir = useBoardStore((state) => state.selectedProjectDir);
   const sidebarWidth = useSettingsStore(
     (state) => state.getSidebarWidth(viewMode, selectedProjectDir),
@@ -136,6 +143,7 @@ export function ChatLayout() {
   const projectsLoadedRef = useRef(initiallyHasProjects);
   const [projectsLoaded, setProjectsLoaded] = useState(initiallyHasProjects);
   const isCompactViewport = viewportWidth < COMPACT_VIEWPORT_BREAKPOINT;
+  const isKanbanPeekLayout = isKanbanPeekMode && !sidebarCollapsed;
 
   const sidebarBaseMinWidth =
     viewMode === "board" ? BOARD_SIDEBAR_MIN_WIDTH : LIST_SIDEBAR_MIN_WIDTH;
@@ -459,6 +467,10 @@ export function ChatLayout() {
     if (!electronApi?.isElectron || !electronApi.onPopoutOpenSession) return;
     const cleanup = electronApi.onPopoutOpenSession(({ sessionId, action }) => {
       if (!sessionId) return;
+      if (action === 'preview' && isKanbanPeekMode) {
+        useBoardStore.getState().openSessionPeek(sessionId);
+        return;
+      }
       const tabStore = useTabStore.getState();
       const location = tabStore.findSessionLocation(sessionId);
       const session = useSessionStore.getState().getSession(sessionId);
@@ -481,7 +493,7 @@ export function ChatLayout() {
     return () => {
       if (typeof cleanup === 'function') cleanup();
     };
-  }, []);
+  }, [isKanbanPeekMode]);
 
   // BR-TOGGLE-005: 반응형 강제 collapsed (<1024px)
   useEffect(() => {
@@ -514,13 +526,14 @@ export function ChatLayout() {
                 ? "100vw"
                 : effectiveSidebarWidth}
             collapsed={sidebarCollapsed}
+            fillAvailable={isKanbanPeekLayout}
             className={cn(
               !sidebarCollapsed && isCompactViewport
                 && "fixed inset-0 z-50 h-[100dvh] border-r-0 shadow-2xl",
             )}
           />
           {/* Resize handle */}
-          {!sidebarCollapsed && !isCompactViewport && (
+          {!isKanbanPeekLayout && !sidebarCollapsed && !isCompactViewport && (
                 <div
                   className={cn(
                     "relative z-10 shrink-0 w-px h-full bg-transparent cursor-col-resize transition-all duration-150",
@@ -538,13 +551,16 @@ export function ChatLayout() {
                 </div>
           )}
 
-          {/* Right area — TabBar + TabPanelHost (always visible) */}
-          <div className="flex-1 flex flex-col overflow-hidden min-w-0">
-            <TabBar />
-            <TabPanelHost />
-            {/* Portal target for the Git diff drawer (rendered by GitPanel) */}
-            <div id="git-diff-drawer-portal" />
-          </div>
+          {/* Split mode keeps the existing tab workspace beside the board. */}
+          {!isKanbanPeekLayout && (
+            <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+              <TabBar />
+              <TabPanelHost />
+            </div>
+          )}
+
+          {/* Portal target for the Git diff drawer (rendered by GitPanel). */}
+          <div id="git-diff-drawer-portal" />
 
           {/* Git Panel + Resize Handle */}
           {gitPanelOpen && (

--- a/src/components/chat/composer-session-controls.tsx
+++ b/src/components/chat/composer-session-controls.tsx
@@ -380,6 +380,7 @@ interface ComposerSessionControlsProps {
     data: ProviderSessionOptions | null;
     isLoading: boolean;
   };
+  surfaceActive?: boolean;
 }
 
 interface ComposerSessionControlsInnerProps {
@@ -394,6 +395,7 @@ interface ComposerSessionControlsInnerProps {
   initialAccessMode: ProviderSessionAccessMode;
   initialModel: string;
   initialReasoningEffort: string | null;
+  surfaceActive: boolean;
 }
 
 function resolveReasoningEffort(
@@ -524,6 +526,7 @@ function ComposerSessionControlsInner({
   initialAccessMode,
   initialModel,
   initialReasoningEffort,
+  surfaceActive,
 }: ComposerSessionControlsInnerProps) {
   const { t } = useI18n();
   const [sessionMode, setSessionMode] = useState<ProviderSessionMode>(initialSessionMode);
@@ -807,6 +810,7 @@ function ComposerSessionControlsInner({
     if (!modelShortcut && !reasoningShortcut && !planShortcut && !fastModeShortcut) return;
 
     const isActivePanelSession = () => {
+      if (surfaceActive) return true;
       const panelState = usePanelStore.getState();
       const tabData = selectActiveTab(panelState);
       const panelActiveSessionId = tabData?.panels[tabData.activePanelId]?.sessionId ?? null;
@@ -854,6 +858,7 @@ function ComposerSessionControlsInner({
     planShortcut,
     reasoningShortcut,
     sessionId,
+    surfaceActive,
   ]);
 
   return (
@@ -1002,6 +1007,7 @@ export function ComposerSessionControls({
   sessionId,
   variant = 'block',
   providerSessionOptions,
+  surfaceActive = false,
 }: ComposerSessionControlsProps) {
   const session = useSessionStore((state) => state.getSession(sessionId));
   const settings = useSettingsStore((state) => state.settings);
@@ -1054,6 +1060,7 @@ export function ComposerSessionControls({
       initialAccessMode={initialAccessMode}
       initialModel={initialModel}
       initialReasoningEffort={initialReasoningEffort}
+      surfaceActive={surfaceActive}
     />
   );
 }

--- a/src/components/chat/left-panel.tsx
+++ b/src/components/chat/left-panel.tsx
@@ -12,6 +12,7 @@ const KanbanBoard = dynamic(
 import { FolderBrowserDialog } from './folder-browser-dialog';
 import { DeleteProjectDialog } from './delete-project-dialog';
 import { useBoardStore } from '@/stores/board-store';
+import { useSettingsStore } from '@/stores/settings-store';
 import { useSessionStore } from '@/stores/session-store';
 import { useTabStore } from '@/stores/tab-store';
 import { useFolderBrowserStore } from '@/stores/folder-browser-store';
@@ -19,11 +20,13 @@ import { useSessionCrud } from '@/hooks/use-session-crud';
 import { usePopoutActive } from '@/hooks/use-popout-active';
 import { ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { SessionPeek } from '@/components/board/session-peek';
 
 interface LeftPanelProps {
   width: number | string;
   className?: string;
   collapsed?: boolean;
+  fillAvailable?: boolean;
 }
 
 interface ProjectImportError extends Error {
@@ -31,12 +34,23 @@ interface ProjectImportError extends Error {
   status?: number;
 }
 
-export function LeftPanel({ width, className, collapsed = false }: LeftPanelProps) {
+export function LeftPanel({
+  width,
+  className,
+  collapsed = false,
+  fillAvailable = false,
+}: LeftPanelProps) {
   const isFolderBrowserOpen = useFolderBrowserStore((state) => state.isOpen);
   const openFolderBrowser = useFolderBrowserStore((state) => state.open);
   const closeFolderBrowser = useFolderBrowserStore((state) => state.close);
   const [removeTarget, setRemoveTarget] = useState<string | null>(null);
   const viewMode = useBoardStore((state) => state.viewMode);
+  const peekSessionId = useBoardStore((state) => state.peekSessionId);
+  const peekFileRef = useBoardStore((state) => state.peekFileRef);
+  const closeSessionPeek = useBoardStore((state) => state.closeSessionPeek);
+  const kanbanSessionOpenMode = useSettingsStore(
+    (state) => state.settings.kanbanSessionOpenMode,
+  );
   const projects = useSessionStore((state) => state.projects);
   const { deleteProject } = useSessionCrud();
   const { isActive: isPopoutActive, closePopouts } = usePopoutActive();
@@ -65,12 +79,18 @@ export function LeftPanel({ width, className, collapsed = false }: LeftPanelProp
 
   return (
     <div
-      className={cn("shrink-0 flex border-r border-(--divider) overflow-hidden", className)}
-      style={{ width: typeof width === 'number' ? `${width}px` : width }}
+      className={cn(
+        'flex overflow-hidden border-r border-(--divider)',
+        fillAvailable ? 'min-w-0 flex-1' : 'shrink-0',
+        className,
+      )}
+      style={fillAvailable
+        ? { width: 0 }
+        : { width: typeof width === 'number' ? `${width}px` : width }}
       data-testid="left-panel-container"
     >
       <ProjectStrip onAddProject={handleAddProject} onRemoveProject={setRemoveTarget} />
-      {!collapsed && <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+      {!collapsed && <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
         <AppHeader />
         <div className="min-h-0 flex-1 overflow-hidden relative">
           {viewMode === 'board' ? <KanbanBoard /> : <Sidebar />}
@@ -99,6 +119,13 @@ export function LeftPanel({ width, className, collapsed = false }: LeftPanelProp
             </div>
           )}
         </div>
+        {viewMode === 'board' && kanbanSessionOpenMode === 'peek' && (peekSessionId || peekFileRef) ? (
+          <SessionPeek
+            sessionId={peekSessionId ?? peekFileRef!.sourceSessionId}
+            showSessionContent={Boolean(peekSessionId)}
+            onClose={closeSessionPeek}
+          />
+        ) : null}
       </div>}
       <FolderBrowserDialog
         isOpen={isFolderBrowserOpen}

--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -126,11 +126,19 @@ interface MessageInputProps {
   isReadOnly?: boolean;
   isStopped?: boolean;
   isSinglePanel?: boolean;
+  surfaceActive?: boolean;
 }
 
 const EMPTY_COLLECTIONS: Collection[] = [];
 
-export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isSinglePanel = false }: MessageInputProps) {
+export function MessageInput({
+  sessionId,
+  isDisabled,
+  isReadOnly,
+  isStopped,
+  isSinglePanel = false,
+  surfaceActive = false,
+}: MessageInputProps) {
   const { t } = useI18n();
   const setDraftInput = useChatStore((state) => state.setDraftInput);
   const [inputValue, setInputValue] = useState(() => useChatStore.getState().getDraftInput(sessionId));
@@ -463,6 +471,10 @@ export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isS
 
   // 마운트 시 활성 패널이면 자동 포커스 (스켈레톤 → ChatArea 전환 후 첫 렌더)
   useEffect(() => {
+    if (surfaceActive) {
+      requestAnimationFrame(() => textareaRef.current?.focus());
+      return;
+    }
     const ps = usePanelStore.getState();
     const tabData = selectActiveTab(ps);
     const activePanelId = tabData?.activePanelId ?? '';
@@ -470,7 +482,7 @@ export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isS
     if (panels[activePanelId]?.sessionId === sessionId) {
       requestAnimationFrame(() => textareaRef.current?.focus());
     }
-  }, [sessionId]);
+  }, [sessionId, surfaceActive]);
 
   // 프롬프트 해제 후 textarea 자동 재포커스
   const prevActivePromptRef = useRef(activePrompt);
@@ -496,10 +508,12 @@ export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isS
 
     const handleGlobalKey = (e: globalThis.KeyboardEvent) => {
       if (e.key !== 'Escape' && e.key !== 'Enter') return;
-      const panelState = usePanelStore.getState();
-      const tabData = selectActiveTab(panelState);
-      const panelActiveSessionId = tabData?.panels[tabData.activePanelId]?.sessionId ?? null;
-      if (sessionId !== panelActiveSessionId) return;
+      if (!surfaceActive) {
+        const panelState = usePanelStore.getState();
+        const tabData = selectActiveTab(panelState);
+        const panelActiveSessionId = tabData?.panels[tabData.activePanelId]?.sessionId ?? null;
+        if (sessionId !== panelActiveSessionId) return;
+      }
 
       e.preventDefault();
       stopVoiceRecording();
@@ -507,7 +521,7 @@ export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isS
 
     window.addEventListener('keydown', handleGlobalKey);
     return () => window.removeEventListener('keydown', handleGlobalKey);
-  }, [voiceState, stopVoiceRecording, sessionId]);
+  }, [voiceState, stopVoiceRecording, sessionId, surfaceActive]);
 
   // Voice input keyboard shortcut: Ctrl+Alt+V (Win/Linux) / Cmd+Option+V (macOS)
   useEffect(() => {
@@ -517,15 +531,17 @@ export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isS
       [voiceKey]: (e) => {
         e.preventDefault();
         // 멀티패널: 활성 패널 세션만 반응
-        const panelState = usePanelStore.getState();
-        const tabData = selectActiveTab(panelState);
-        const panelActiveSessionId = tabData?.panels[tabData.activePanelId]?.sessionId ?? null;
-        if (sessionId !== panelActiveSessionId) return;
+        if (!surfaceActive) {
+          const panelState = usePanelStore.getState();
+          const tabData = selectActiveTab(panelState);
+          const panelActiveSessionId = tabData?.panels[tabData.activePanelId]?.sessionId ?? null;
+          if (sessionId !== panelActiveSessionId) return;
+        }
         toggleVoiceRecording();
       },
     });
     return unsubscribe;
-  }, [canUseVoice, voiceKey, sessionId, toggleVoiceRecording]);
+  }, [canUseVoice, voiceKey, sessionId, surfaceActive, toggleVoiceRecording]);
   const handleInputChange = useCallback(
     (value: string) => {
       recordTerminalDraftEdit(sessionId);
@@ -1492,6 +1508,7 @@ export function MessageInput({ sessionId, isDisabled, isReadOnly, isStopped, isS
                     sessionId={sessionId}
                     variant="inline"
                     providerSessionOptions={providerSessionOptions}
+                    surfaceActive={surfaceActive}
                   />
                   <div ref={quickCreateTriggerRef} className="relative shrink-0">
                     <button

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { memo } from 'react';
-import { PanelLeftClose } from 'lucide-react';
+import { PanelLeftClose, PanelRightClose, PanelRightOpen } from 'lucide-react';
 import { useI18n } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import { useElectronPlatform } from '@/hooks/use-electron-platform';
 import { useSettingsStore } from '@/stores/settings-store';
 import { useBoardStore } from '@/stores/board-store';
 import { useSessionStore } from '@/stores/session-store';
+import { useGitStore } from '@/stores/git-store';
 import { ALL_PROJECTS_SENTINEL, getProjectColor } from '@/lib/constants/project-strip';
 import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
 import { ProjectViewModeToggle } from '@/components/tab/project-view-mode-toggle';
@@ -27,7 +28,14 @@ export const AppHeader = memo(function AppHeader() {
 
   // Sidebar collapse
   const toggleSidebar = useSettingsStore((state) => state.toggleSidebar);
+  const kanbanSessionOpenMode = useSettingsStore(
+    (state) => state.settings.kanbanSessionOpenMode,
+  );
+  const gitPanelOpen = useGitStore((state) => state.isOpen);
+  const toggleGitPanel = useGitStore((state) => state.toggle);
   const selectedProjectDir = useBoardStore((state) => state.selectedProjectDir);
+  const viewMode = useBoardStore((state) => state.viewMode);
+  const isKanbanPeekMode = viewMode === 'board' && kanbanSessionOpenMode === 'peek';
   const projects = useSessionStore((state) => state.projects);
   const selectedProject = projects.find((project) => project.encodedDir === selectedProjectDir) ?? null;
   const isAllProjects = selectedProjectDir === ALL_PROJECTS_SENTINEL;
@@ -84,25 +92,45 @@ export const AppHeader = memo(function AppHeader() {
                 className={isElectronTitlebar ? 'electron-no-drag' : undefined}
                 labelMode="short"
               />
+              {isKanbanPeekMode ? (
+                <button
+                  type="button"
+                  onClick={toggleGitPanel}
+                  className={cn(
+                    'electron-no-drag flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-(--divider) transition-colors',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35',
+                    gitPanelOpen
+                      ? 'bg-(--accent)/14 text-(--accent)'
+                      : 'bg-(--chat-bg) text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--text-primary)',
+                  )}
+                  aria-label={gitPanelOpen ? t('chat.closeGitPanel') : t('chat.openGitPanel')}
+                  aria-pressed={gitPanelOpen}
+                  title={gitPanelOpen ? t('chat.closeGitPanel') : t('chat.openGitPanel')}
+                  data-testid="kanban-git-panel-toggle"
+                >
+                  {gitPanelOpen ? <PanelRightClose size={16} /> : <PanelRightOpen size={16} />}
+                </button>
+              ) : null}
             </>
           ) : (
             <div className="flex-1" />
           )}
 
-          {/* Sidebar collapse button */}
-          <ShortcutTooltip id="toggle-sidebar" label={t('shortcut.toggleSidebar')}>
-            <button
-              onClick={toggleSidebar}
-              className={cn(
-                'shrink-0 rounded p-1 text-(--text-muted) transition-colors hover:bg-(--sidebar-hover) hover:text-(--text-primary)',
-                isElectronTitlebar && 'electron-no-drag',
-              )}
-              aria-label={t('sidebar.collapse')}
-              data-testid="sidebar-collapse-btn"
-            >
-              <PanelLeftClose size={16} />
-            </button>
-          </ShortcutTooltip>
+          {!isKanbanPeekMode ? (
+            <ShortcutTooltip id="toggle-sidebar" label={t('shortcut.toggleSidebar')}>
+              <button
+                onClick={toggleSidebar}
+                className={cn(
+                  'shrink-0 rounded p-1 text-(--text-muted) transition-colors hover:bg-(--sidebar-hover) hover:text-(--text-primary)',
+                  isElectronTitlebar && 'electron-no-drag',
+                )}
+                aria-label={t('sidebar.collapse')}
+                data-testid="sidebar-collapse-btn"
+              >
+                <PanelLeftClose size={16} />
+              </button>
+            </ShortcutTooltip>
+          ) : null}
         </div>
       </header>
     </>

--- a/src/components/memory/memory-file-tab.tsx
+++ b/src/components/memory/memory-file-tab.tsx
@@ -123,9 +123,13 @@ function MemoryViewModeToggle({
 export function MemoryFileTab({
   memoryRef,
   panelId,
+  onClose,
+  onDirtyChange,
 }: {
   memoryRef: MemoryFileSessionRef;
   panelId: string;
+  onClose?: () => void;
+  onDirtyChange?: (dirty: boolean) => void;
 }) {
   const { t } = useI18n();
   const { fileName, sourceSessionId, memoryKind } = memoryRef;
@@ -158,6 +162,11 @@ export function MemoryFileTab({
   const readOnly = state.data?.readOnly ?? false;
   const visibleFileName = state.data?.fileName ?? displayFileName(fileName);
   dirtyRef.current = dirty;
+
+  useEffect(() => {
+    onDirtyChange?.(dirty);
+    return () => onDirtyChange?.(false);
+  }, [dirty, onDirtyChange]);
 
   useEffect(() => {
     if (readOnly && viewMode === "edit") setViewMode("preview");
@@ -339,12 +348,16 @@ export function MemoryFileTab({
   }, [saveFile, viewMode]);
 
   const handleClose = useCallback(() => {
+    if (onClose) {
+      onClose();
+      return;
+    }
     if (panelCount >= 2) {
       closePanel(panelId);
     } else {
       assignSession(panelId, null);
     }
-  }, [assignSession, closePanel, panelCount, panelId]);
+  }, [assignSession, closePanel, onClose, panelCount, panelId]);
 
   async function copyContent() {
     try {
@@ -422,6 +435,7 @@ export function MemoryFileTab({
             className="h-8 w-8 shrink-0"
             onClick={handleClose}
             aria-label={t("memoryPanel.fileTab.closeMemoryPanel")}
+            data-testid="memory-file-close"
           >
             <X className="h-4 w-4" />
           </Button>

--- a/src/components/memory/memory-panel.tsx
+++ b/src/components/memory/memory-panel.tsx
@@ -417,8 +417,9 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
 
   const openRow = useCallback((row: MemoryRowItem, pin: boolean) => {
     if (!sessionId) return;
-    if (pin) openMemoryFileTab(sessionId, row.kind, row.relativePath);
-    else previewMemoryFileTab(sessionId, row.kind, row.relativePath);
+    const options = { preferKanbanPeek: true };
+    if (pin) openMemoryFileTab(sessionId, row.kind, row.relativePath, options);
+    else previewMemoryFileTab(sessionId, row.kind, row.relativePath, options);
   }, [sessionId]);
 
   const handleCreate = useCallback(async () => {
@@ -453,7 +454,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
 
       setCreateOpen(false);
       setCreateName("");
-      openMemoryFileTab(sessionId, "memory", fileName);
+      openMemoryFileTab(sessionId, "memory", fileName, { preferKanbanPeek: true });
       void loadMemories();
       toast.success(t("memoryPanel.toast.created", { fileName }));
     } catch (error) {

--- a/src/components/settings/appearance-settings.tsx
+++ b/src/components/settings/appearance-settings.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { Check } from 'lucide-react';
+import { useId } from 'react';
 import { useSettingsStore } from '@/stores/settings-store';
 import { useI18n } from '@/lib/i18n';
+import type { KanbanSessionOpenMode } from '@/lib/settings/types';
+import { cn } from '@/lib/utils';
 import {
   DEFAULT_FONT_SCALE,
   FONT_SCALE_OPTIONS,
@@ -15,6 +18,72 @@ import {
 } from '@/lib/terminal/terminal-theme';
 
 const PRESET_LABEL_KEYS = ['small', 'medium', 'large', 'xlarge'] as const;
+const KANBAN_SESSION_OPEN_MODES: KanbanSessionOpenMode[] = ['split', 'peek'];
+
+function KanbanSessionOpenModePicker({
+  value,
+  onChange,
+}: {
+  value: KanbanSessionOpenMode;
+  onChange: (mode: KanbanSessionOpenMode) => void;
+}) {
+  const { t } = useI18n();
+  const groupId = useId();
+
+  return (
+    <fieldset className="space-y-3 border-t border-(--divider) pt-4">
+      <legend className="text-sm font-medium text-(--text-secondary)">
+        {t('settings.kanbanSessionOpenMode.title')}
+      </legend>
+      <p className="-mt-2 text-xs leading-5 text-(--text-muted)">
+        {t('settings.kanbanSessionOpenMode.description')}
+      </p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {KANBAN_SESSION_OPEN_MODES.map((mode) => {
+          const selected = value === mode;
+          const inputId = `${groupId}-${mode}`;
+          return (
+            <label
+              key={mode}
+              htmlFor={inputId}
+              className={cn(
+                'relative flex cursor-pointer gap-3 rounded-xl border px-3 py-3 text-left transition-colors',
+                'has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-(--accent)',
+                selected
+                  ? 'border-[color-mix(in_srgb,var(--accent)_35%,transparent)] bg-[color-mix(in_srgb,var(--accent)_10%,transparent)]'
+                  : 'border-(--divider) bg-(--sidebar-bg) hover:border-(--accent)/25',
+              )}
+            >
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-medium text-(--text-primary)">
+                  {t(`settings.kanbanSessionOpenMode.${mode}.label`)}
+                </span>
+                <span className="mt-1.5 block text-xs leading-5 text-(--text-muted)">
+                  {t(`settings.kanbanSessionOpenMode.${mode}.description`)}
+                </span>
+              </span>
+              <span className="relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
+                <input
+                  type="radio"
+                  id={inputId}
+                  name={groupId}
+                  value={mode}
+                  data-testid={`kanban-session-open-mode-${mode}`}
+                  checked={selected}
+                  onChange={() => onChange(mode)}
+                  className="h-4 w-4 appearance-none rounded-full border border-(--input-border) bg-(--input-bg) checked:border-(--accent) checked:bg-(--accent)"
+                />
+                {selected ? (
+                  <Check className="pointer-events-none absolute h-3 w-3 text-white" aria-hidden="true" />
+                ) : null}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
 
 function TerminalThemePresetPicker({
   mode,
@@ -94,6 +163,9 @@ export default function AppearanceSettings() {
   const inactivePanelDimming = useSettingsStore((state) => state.settings.inactivePanelDimming);
   const showProviderIcons = useSettingsStore((state) => state.settings.showProviderIcons);
   const showRecentWork = useSettingsStore((state) => state.settings.showRecentWork);
+  const kanbanSessionOpenMode = useSettingsStore(
+    (state) => state.settings.kanbanSessionOpenMode,
+  );
   const updateSettings = useSettingsStore((state) => state.updateSettings);
 
   // Theme and font scale are applied globally by ThemeInitializer.
@@ -122,6 +194,11 @@ export default function AppearanceSettings() {
           <option value="auto">{t('settings.theme.auto')}</option>
         </select>
       </div>
+
+      <KanbanSessionOpenModePicker
+        value={kanbanSessionOpenMode}
+        onChange={(mode) => void updateSettings({ kanbanSessionOpenMode: mode })}
+      />
 
       <div className="space-y-3 border-t border-(--divider) pt-4">
         <div>

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useSyncExternalStore,
   type DragEvent,
+  type ReactNode,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { GripVertical, RotateCcw, Terminal as TerminalIcon, X } from 'lucide-react';
@@ -34,7 +35,11 @@ interface TerminalPanelProps {
   terminalId: string;
   terminalSessionId: string | null;
   /** Determines whether unmount detaches, or may close a preview-created PTY. */
-  runtimeOwnership?: 'standalone' | 'session-preview' | 'session-retained';
+  runtimeOwnership?: 'standalone' | 'session-preview' | 'session-retained' | 'session-peek';
+  /** Treat a transient surface as visible/focused without borrowing panel-store state. */
+  surfaceActive?: boolean;
+  /** Optional overlay shown until the terminal surface reports that it is running. */
+  startupOverlay?: ReactNode;
   launch?: { providerId: string; sessionId: string };
 }
 
@@ -63,6 +68,8 @@ export function TerminalPanel({
   terminalId,
   terminalSessionId,
   runtimeOwnership = 'standalone',
+  surfaceActive = false,
+  startupOverlay,
   launch,
 }: TerminalPanelProps) {
   const tabId = useContext(TabIdContext);
@@ -74,18 +81,20 @@ export function TerminalPanel({
   const selectedThemePreset = isDark ? darkThemePreset : lightThemePreset;
   const terminalFontSize = getTerminalFontSize(fontScale);
   const containerRef = useRef<HTMLDivElement>(null);
+  const pendingSurfaceCleanupRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const assignTerminal = usePanelStore((state) => state.assignTerminal);
   const connectionStatus = useChatStore((state) => state.connectionStatus);
   const sessionOwned = runtimeOwnership !== 'standalone';
   const previewOwnsRuntimeRef = useRef(runtimeOwnership === 'session-preview');
   const handleTerminalInput = useCallback(() => {
-    if (runtimeOwnership === 'standalone') return;
+    if (runtimeOwnership === 'standalone' || runtimeOwnership === 'session-peek') return;
     previewOwnsRuntimeRef.current = false;
     useTabStore.getState().pinTab(tabId);
   }, [runtimeOwnership, tabId]);
-  const isTabActive = useTabStore((state) => state.activeTabId === tabId);
+  const isTabActive = useTabStore((state) => surfaceActive || state.activeTabId === tabId);
   const isPanelActive = usePanelStore((state) => (
-    state.activeTabId === tabId && state.tabPanels[tabId]?.activePanelId === panelId
+    surfaceActive
+    || (state.activeTabId === tabId && state.tabPanels[tabId]?.activePanelId === panelId)
   ));
   const surface = useMemo(() => getTerminalSurface({
     registryKey: `${tabId}:${panelId}:${terminalId}`,
@@ -179,6 +188,10 @@ export function TerminalPanel({
   useEffect(() => {
     const host = containerRef.current;
     if (!host) return;
+    if (pendingSurfaceCleanupRef.current !== null) {
+      clearTimeout(pendingSurfaceCleanupRef.current);
+      pendingSurfaceCleanupRef.current = null;
+    }
 
     void surface.mount(host);
     return () => {
@@ -186,7 +199,8 @@ export function TerminalPanel({
       // Moving a panel can transiently unmount it. Check ownership after the
       // store update settles. A moved surface detaches; an actually removed
       // standalone terminal is the only case that kills the PTY.
-      setTimeout(() => {
+      pendingSurfaceCleanupRef.current = setTimeout(() => {
+        pendingSurfaceCleanupRef.current = null;
         const remainsInSamePanel = isTerminalAssignedToPanel(
           tabId,
           panelId,
@@ -276,6 +290,9 @@ export function TerminalPanel({
       )}
       <div className="relative min-h-0 flex-1 overflow-hidden p-2">
         <div ref={containerRef} className="h-full min-w-0 overflow-hidden" />
+        {status === 'starting' && startupOverlay ? (
+          <div className="absolute inset-0 z-10">{startupOverlay}</div>
+        ) : null}
         {!isAtBottom && (
           <ScrollToBottomButton
             onClick={() => surface.scrollToBottom()}

--- a/src/components/workspace/workspace-code-view.tsx
+++ b/src/components/workspace/workspace-code-view.tsx
@@ -305,11 +305,25 @@ export function WorkspaceCodeView({
   }
 
   if (!data) {
-    return <EmptyState title="No file loaded" body="Select a file to preview it." />;
+    return (
+      <div className="flex h-full min-h-0 flex-col bg-(--chat-bg)">
+        <PendingStateHeader mode={mode} path={path} onClose={onClose} />
+        <div className="min-h-0 flex-1">
+          <EmptyState title="No file loaded" body="Select a file to preview it." />
+        </div>
+      </div>
+    );
   }
 
   if (fileData?.binary) {
-    return <EmptyState title="Binary file" body="Preview is unavailable for binary content." icon="binary" />;
+    return (
+      <div className="flex h-full min-h-0 flex-col bg-(--chat-bg)">
+        <PendingStateHeader mode={mode} path={path} onClose={onClose} />
+        <div className="min-h-0 flex-1">
+          <EmptyState title="Binary file" body="Preview is unavailable for binary content." icon="binary" />
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -275,12 +275,16 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
           onClick={() => {
             if (!sessionId) return;
             setSelectedPath(node.path);
-            previewWorkspaceFileTab(sessionId, "file", node.path);
+            previewWorkspaceFileTab(sessionId, "file", node.path, {
+              preferKanbanPeek: true,
+            });
           }}
           onDoubleClick={() => {
             if (!sessionId) return;
             setSelectedPath(node.path);
-            openWorkspaceFileTab(sessionId, "file", node.path);
+            openWorkspaceFileTab(sessionId, "file", node.path, {
+              preferKanbanPeek: true,
+            });
           }}
           onDragStart={(event) => {
             if (!sessionId) return;

--- a/src/components/workspace/workspace-file-tab.tsx
+++ b/src/components/workspace/workspace-file-tab.tsx
@@ -94,13 +94,19 @@ function shouldRefreshForSession(
 export function WorkspaceFileTab({
   fileRef,
   panelId,
+  surfaceActive = false,
+  onClose,
+  onFileRefChange,
 }: {
   fileRef: WorkspaceFileSessionRef;
   panelId: string;
+  surfaceActive?: boolean;
+  onClose?: () => void;
+  onFileRefChange?: (fileRef: WorkspaceFileSessionRef) => void;
 }) {
   const { kind, path, sourceSessionId } = fileRef;
   const tabId = useContext(TabIdContext);
-  const isTabActive = useTabStore((state) => state.activeTabId === tabId);
+  const isTabActive = useTabStore((state) => surfaceActive || state.activeTabId === tabId);
   const isDocumentVisible = useDocumentVisibility();
   const subscriberId = useStableWorkspaceFilesSubscriberId("workspace-file-tab");
   const panelCount = usePanelStore(
@@ -186,6 +192,15 @@ export function WorkspaceFileTab({
 
     const renameTarget = findRenameTarget(msg, path);
     if (renameTarget) {
+      if (onFileRefChange) {
+        onFileRefChange({
+          type: "workspace-file",
+          sourceSessionId,
+          kind,
+          path: renameTarget,
+        });
+        return;
+      }
       assignSession(
         panelId,
         buildWorkspaceFileSessionId(sourceSessionId, kind, renameTarget),
@@ -201,7 +216,7 @@ export function WorkspaceFileTab({
     if (msg.hasMoreChangedPaths || msg.changedPaths.includes(path)) {
       refreshFile();
     }
-  }, [assignSession, kind, loadFile, panelId, path, refreshFile, sourceSessionId]);
+  }, [assignSession, kind, loadFile, onFileRefChange, panelId, path, refreshFile, sourceSessionId]);
 
   useWorkspaceFilesLiveSync({
     enabled: isTabActive && isDocumentVisible,
@@ -272,6 +287,10 @@ export function WorkspaceFileTab({
       loading={state.loading}
       mode={fileRef.kind}
       onClose={() => {
+        if (onClose) {
+          onClose();
+          return;
+        }
         if (panelCount >= 2) {
           closePanel(panelId);
         } else {

--- a/src/hooks/use-session-click-handlers.ts
+++ b/src/hooks/use-session-click-handlers.ts
@@ -40,10 +40,14 @@ export function tryForwardClickToMainWindow(
 export function useSessionClickHandlers(options?: {
   /** Ordered list of session IDs in the current view (for Shift+Click range select) */
   orderedIds?: string[];
+  /** Optional normal-click destination used by surfaces such as Kanban Peek. */
+  onOpenSession?: (session: UnifiedSession) => void | Promise<void>;
 }): {
   handleSessionClick: (session: UnifiedSession, event?: React.MouseEvent) => Promise<void>;
   handleSessionDoubleClick: (session: UnifiedSession) => Promise<void>;
 } {
+  const orderedIds = options?.orderedIds;
+  const onOpenSession = options?.onOpenSession;
   // Reactive subscriptions
   const clearUnreadCount = useSessionStore((state) => state.clearUnreadCount);
   const notifications = useNotificationStore((state) => state.notifications);
@@ -75,7 +79,7 @@ export function useSessionClickHandlers(options?: {
       // BRANCH A2 — Shift+click: range select from active session
       if (event && event.shiftKey) {
         const selStore = useSelectionStore.getState();
-        const oids = options?.orderedIds ?? [];
+        const oids = orderedIds ?? [];
         // Use active session as anchor when no prior Ctrl+Click anchor exists
         if (!selStore.lastClickedId) {
           const activeId = getSessionSelectionId(useSessionStore.getState().activeSessionId);
@@ -107,6 +111,11 @@ export function useSessionClickHandlers(options?: {
         return;
       }
 
+      if (onOpenSession) {
+        await onOpenSession(session);
+        return;
+      }
+
       // 2. Cross-tab location search (BR-SIDEBAR-004: replaces isInAnotherPanel)
       const location = useTabStore.getState().findSessionLocation(session.id);
       const openMode = resolveSessionTabOpenMode(session);
@@ -129,7 +138,7 @@ export function useSessionClickHandlers(options?: {
       }
       await viewSession(session);
     },
-    [unreadSessionIds, clearUnreadCount, viewSession, options?.orderedIds]
+    [unreadSessionIds, clearUnreadCount, viewSession, orderedIds, onOpenSession]
   );
 
   // Handle session double-click — always opens as pinned tab

--- a/src/hooks/use-session-navigation.ts
+++ b/src/hooks/use-session-navigation.ts
@@ -40,9 +40,13 @@ export function useSessionNavigation() {
    * where WebSocket streaming messages arrive before JSONL history is fetched.
    */
   const viewSession = useCallback(
-    async (session: UnifiedSession, options?: { forceReload?: boolean }) => {
+    async (
+      session: UnifiedSession,
+      options?: { forceReload?: boolean; activate?: boolean },
+    ) => {
+      const shouldActivate = options?.activate !== false;
       if (!options?.forceReload && chatStore.isHistoryLoaded(session.id)) {
-        sessionStore.setActiveSession(session.id);
+        if (shouldActivate) sessionStore.setActiveSession(session.id);
         return;
       }
 
@@ -59,7 +63,7 @@ export function useSessionNavigation() {
           if (response.status === 404) {
             if (session.isRunning) {
               restoreSessionReplay(session.id, { messages: [] });
-              sessionStore.setActiveSession(session.id);
+              if (shouldActivate) sessionStore.setActiveSession(session.id);
               return;
             }
             toast.error(i18n.t('errors.sessionFileNotFound'));
@@ -81,7 +85,7 @@ export function useSessionNavigation() {
           });
         }
 
-        sessionStore.setActiveSession(session.id);
+        if (shouldActivate) sessionStore.setActiveSession(session.id);
       } catch (err) {
         toast.error(i18n.t('errors.sessionLoadFailed'));
         console.error('View session error:', err);

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -109,6 +109,18 @@ export const en: I18nMessages = {
     showProviderIconsDesc: 'Show the CLI provider mark in list and kanban items.',
     showRecentWork: 'Show Recent Work section',
     showRecentWorkDesc: 'Show a "Recent Work" section at the top of the sidebar.',
+    kanbanSessionOpenMode: {
+      title: 'Open sessions from Kanban',
+      description: 'Choose how session cards open while the Kanban board is active.',
+      split: {
+        label: 'Split view',
+        description: 'Show the board and session side by side.',
+      },
+      peek: {
+        label: 'Peek',
+        description: 'Open GUI chats and PTY terminals in a large overlay above the board.',
+      },
+    },
     enterKey: {
       label: 'Enter Key Behavior',
       send: 'Enter = Send',
@@ -400,6 +412,7 @@ export const en: I18nMessages = {
     reconnecting: 'Reconnecting...',
     disconnected: 'Disconnected',
     reconnect: 'Reconnect',
+    loadingSession: 'Loading session...',
     loadingHistory: 'Loading chat history...',
     thinking: 'Thinking...',
     send: 'Send',
@@ -976,6 +989,7 @@ export const en: I18nMessages = {
       globalScope: 'Global',
       projectScope: 'Project',
       unsavedChanges: 'Unsaved changes',
+      discardChangesConfirm: 'Discard unsaved Context changes?',
       save: 'Save',
       saveShortcut: 'Save (⌘S)',
       noUnsavedChanges: 'No unsaved changes',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -109,6 +109,18 @@ export const ja: I18nMessages = {
     showProviderIconsDesc: 'リストとカンバンの項目に CLI プロバイダーのマークを表示します。',
     showRecentWork: '「最近の作業」セクションを表示',
     showRecentWorkDesc: 'サイドバー上部に「最近の作業」セクションを表示します。',
+    kanbanSessionOpenMode: {
+      title: 'カンバンからセッションを開く方法',
+      description: 'カンバンでセッションカードを選択したときの開き方を選びます。',
+      split: {
+        label: '分割表示',
+        description: 'カンバンとセッションを並べて表示します。',
+      },
+      peek: {
+        label: 'Peek',
+        description: 'カンバン上の大きなウィンドウで GUI チャットと PTY ターミナルを使用します。',
+      },
+    },
     enterKey: {
       label: 'Enter キーの動作',
       send: 'Enter = 送信',
@@ -400,6 +412,7 @@ export const ja: I18nMessages = {
     reconnecting: '再接続中...',
     disconnected: '切断済み',
     reconnect: '再接続',
+    loadingSession: 'セッションを読み込み中...',
     loadingHistory: 'チャット履歴を読み込み中...',
     thinking: '考え中...',
     send: '送信',
@@ -976,6 +989,7 @@ export const ja: I18nMessages = {
       globalScope: 'グローバル',
       projectScope: 'プロジェクト',
       unsavedChanges: '未保存の変更',
+      discardChangesConfirm: '未保存の Context の変更を破棄しますか？',
       save: '保存',
       saveShortcut: '保存 (⌘S)',
       noUnsavedChanges: '未保存の変更はありません',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -109,6 +109,18 @@ export const ko: I18nMessages = {
     showProviderIconsDesc: '리스트와 칸반 항목에 CLI 프로바이더 마크를 표시합니다.',
     showRecentWork: '최근 작업 섹션 표시',
     showRecentWorkDesc: '사이드바 상단에 "최근 작업" 섹션을 표시합니다.',
+    kanbanSessionOpenMode: {
+      title: '칸반 카드 열기 방식',
+      description: '칸반 보드에서 세션 카드를 눌렀을 때 열리는 방식을 선택합니다.',
+      split: {
+        label: '분할 보기',
+        description: '칸반과 세션을 나란히 표시합니다.',
+      },
+      peek: {
+        label: 'Peek',
+        description: '칸반 위의 큰 창에서 GUI 채팅과 PTY 터미널을 사용합니다.',
+      },
+    },
     enterKey: {
       label: 'Enter 키 동작',
       send: 'Enter = 전송',
@@ -402,6 +414,7 @@ export const ko: I18nMessages = {
     reconnecting: '재연결 중...',
     disconnected: '연결 끊김',
     reconnect: '재연결',
+    loadingSession: '세션을 불러오는 중...',
     loadingHistory: '대화 내역 불러오는 중...',
     thinking: '생각 중...',
     send: '전송',
@@ -983,6 +996,7 @@ export const ko: I18nMessages = {
       globalScope: '전역',
       projectScope: '프로젝트',
       unsavedChanges: '저장되지 않은 변경',
+      discardChangesConfirm: '저장하지 않은 Context 변경 사항을 버릴까요?',
       save: '저장',
       saveShortcut: '저장 (⌘S)',
       noUnsavedChanges: '저장할 변경 사항 없음',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -101,6 +101,12 @@ export interface I18nMessages {
     showProviderIconsDesc: string;
     showRecentWork: string;
     showRecentWorkDesc: string;
+    kanbanSessionOpenMode: {
+      title: string;
+      description: string;
+      split: { label: string; description: string };
+      peek: { label: string; description: string };
+    };
     enterKey: {
       label: string;
       send: string;
@@ -394,6 +400,7 @@ export interface I18nMessages {
     reconnecting: string;
     disconnected: string;
     reconnect: string;
+    loadingSession: string;
     loadingHistory: string;
     thinking: string;
     send: string;
@@ -975,6 +982,7 @@ export interface I18nMessages {
       globalScope: string;
       projectScope: string;
       unsavedChanges: string;
+      discardChangesConfirm: string;
       save: string;
       saveShortcut: string;
       noUnsavedChanges: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -109,6 +109,18 @@ export const zh: I18nMessages = {
     showProviderIconsDesc: '在列表和看板项目中显示 CLI 提供者标记。',
     showRecentWork: '显示"最近工作"区域',
     showRecentWorkDesc: '在侧边栏顶部显示"最近工作"区域。',
+    kanbanSessionOpenMode: {
+      title: '从看板打开会话',
+      description: '选择在看板中点击会话卡片时的打开方式。',
+      split: {
+        label: '分屏视图',
+        description: '并排显示看板和会话。',
+      },
+      peek: {
+        label: 'Peek',
+        description: '在看板上方的大窗口中使用 GUI 聊天和 PTY 终端。',
+      },
+    },
     enterKey: {
       label: 'Enter 键行为',
       send: 'Enter = 发送',
@@ -400,6 +412,7 @@ export const zh: I18nMessages = {
     reconnecting: '重新连接中...',
     disconnected: '已断开',
     reconnect: '重新连接',
+    loadingSession: '正在加载会话...',
     loadingHistory: '加载聊天记录...',
     thinking: '思考中...',
     send: '发送',
@@ -976,6 +989,7 @@ export const zh: I18nMessages = {
       globalScope: '全局',
       projectScope: '项目',
       unsavedChanges: '未保存的更改',
+      discardChangesConfirm: '要放弃未保存的 Context 更改吗？',
       save: '保存',
       saveShortcut: '保存 (⌘S)',
       noUnsavedChanges: '没有未保存的更改',

--- a/src/lib/settings/provider-defaults.ts
+++ b/src/lib/settings/provider-defaults.ts
@@ -355,6 +355,12 @@ function normalizeWindowsCloseBehavior(value: unknown): UserSettings['windowsClo
   return value === 'tray' || value === 'quit' ? value : 'ask';
 }
 
+function normalizeKanbanSessionOpenMode(
+  value: unknown,
+): UserSettings['kanbanSessionOpenMode'] {
+  return value === 'peek' ? 'peek' : 'split';
+}
+
 function normalizeProviderSessionMode(
   providerId: string,
   value: unknown,
@@ -553,6 +559,7 @@ export function normalizeUserSettings(raw: Partial<UserSettings> | null | undefi
     inactivePanelDimming: 30,
     showProviderIcons: true,
     showRecentWork: true,
+    kanbanSessionOpenMode: 'split',
     sttEngine: 'webSpeech',
     geminiApiKey: '',
     favoriteSkills: [],
@@ -638,6 +645,7 @@ export function normalizeUserSettings(raw: Partial<UserSettings> | null | undefi
     fontSize: normalizeFontScale(raw?.fontSize),
     showProviderIcons: raw?.showProviderIcons ?? defaults.showProviderIcons,
     showRecentWork: raw?.showRecentWork ?? defaults.showRecentWork,
+    kanbanSessionOpenMode: normalizeKanbanSessionOpenMode(raw?.kanbanSessionOpenMode),
     cliCommandOverrides: normalizeCliCommandOverrides(raw?.cliCommandOverrides),
     archivedWorktreeRetentionDays: retentionDays ?? defaults.archivedWorktreeRetentionDays,
     managedWorktreePathTemplate: normalizeManagedWorktreePathTemplate(raw?.managedWorktreePathTemplate),

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -14,6 +14,7 @@ export type EnterKeyBehavior = 'send' | 'newline';
 export type SttEngine = 'webSpeech' | 'gemini';
 export type AgentEnvironment = 'native' | 'wsl';
 export type WindowsCloseBehavior = 'ask' | 'tray' | 'quit';
+export type KanbanSessionOpenMode = 'split' | 'peek';
 export type CliCommandOverrides = Record<string, Partial<Record<AgentEnvironment, string>>>;
 
 export interface SetupState {
@@ -82,6 +83,8 @@ export interface UserSettings {
   inactivePanelDimming: number;
   showProviderIcons: boolean;
   showRecentWork: boolean;
+  /** How selecting a session card behaves while the Kanban board is active. */
+  kanbanSessionOpenMode: KanbanSessionOpenMode;
   sttEngine: SttEngine;
   geminiApiKey: string;
   favoriteSkills: string[];

--- a/src/lib/workspace-tabs/open-workspace-tab.ts
+++ b/src/lib/workspace-tabs/open-workspace-tab.ts
@@ -2,12 +2,58 @@
 
 import { usePanelStore } from "@/stores/panel-store";
 import { useTabStore } from "@/stores/tab-store";
+import { useBoardStore } from "@/stores/board-store";
+import { useSettingsStore } from "@/stores/settings-store";
 import {
   buildMemoryFileSessionId,
   buildWorkspaceFileSessionId,
   type WorkspaceFileTabKind,
 } from "./special-session";
 import type { MemoryTargetKind } from "@/types/memory";
+
+interface FileOpenOptions {
+  preferKanbanPeek?: boolean;
+}
+
+function canOpenFileInKanbanPeek(): boolean {
+  const settingsState = useSettingsStore.getState();
+  const boardState = useBoardStore.getState();
+  return settingsState.settings.kanbanSessionOpenMode === "peek"
+    && !settingsState.sidebarCollapsed
+    && boardState.viewMode === "board";
+}
+
+function tryOpenWorkspaceFileInKanbanPeek(
+  sourceSessionId: string,
+  kind: WorkspaceFileTabKind,
+  filePath: string,
+): boolean {
+  if (!canOpenFileInKanbanPeek()) return false;
+
+  useBoardStore.getState().openPeekFile({
+    type: "workspace-file",
+    sourceSessionId,
+    kind,
+    path: filePath,
+  });
+  return true;
+}
+
+function tryOpenMemoryFileInKanbanPeek(
+  sourceSessionId: string,
+  memoryKind: MemoryTargetKind,
+  fileName: string,
+): boolean {
+  if (!canOpenFileInKanbanPeek()) return false;
+
+  useBoardStore.getState().openPeekFile({
+    type: "memory-file",
+    sourceSessionId,
+    memoryKind,
+    fileName,
+  });
+  return true;
+}
 
 function focusOrCreateSpecialTab(
   specialSessionId: string,
@@ -30,7 +76,12 @@ export function openWorkspaceFileTab(
   sourceSessionId: string,
   kind: WorkspaceFileTabKind,
   filePath: string,
+  options: FileOpenOptions = {},
 ): void {
+  if (
+    options.preferKanbanPeek
+    && tryOpenWorkspaceFileInKanbanPeek(sourceSessionId, kind, filePath)
+  ) return;
   focusOrCreateSpecialTab(
     buildWorkspaceFileSessionId(sourceSessionId, kind, filePath),
     {
@@ -44,7 +95,12 @@ export function previewWorkspaceFileTab(
   sourceSessionId: string,
   kind: WorkspaceFileTabKind,
   filePath: string,
+  options: FileOpenOptions = {},
 ): void {
+  if (
+    options.preferKanbanPeek
+    && tryOpenWorkspaceFileInKanbanPeek(sourceSessionId, kind, filePath)
+  ) return;
   previewSpecialFileTab(buildWorkspaceFileSessionId(sourceSessionId, kind, filePath));
 }
 
@@ -52,7 +108,12 @@ export function openMemoryFileTab(
   sourceSessionId: string,
   memoryKind: MemoryTargetKind,
   fileName: string,
+  options: FileOpenOptions = {},
 ): void {
+  if (
+    options.preferKanbanPeek
+    && tryOpenMemoryFileInKanbanPeek(sourceSessionId, memoryKind, fileName)
+  ) return;
   focusOrCreateSpecialTab(
     buildMemoryFileSessionId(sourceSessionId, memoryKind, fileName),
     {
@@ -66,7 +127,12 @@ export function previewMemoryFileTab(
   sourceSessionId: string,
   memoryKind: MemoryTargetKind,
   fileName: string,
+  options: FileOpenOptions = {},
 ): void {
+  if (
+    options.preferKanbanPeek
+    && tryOpenMemoryFileInKanbanPeek(sourceSessionId, memoryKind, fileName)
+  ) return;
   previewSpecialFileTab(buildMemoryFileSessionId(sourceSessionId, memoryKind, fileName));
 }
 

--- a/src/stores/board-store.ts
+++ b/src/stores/board-store.ts
@@ -1,18 +1,61 @@
 import { create } from 'zustand';
 import { captureTelemetryEvent } from '@/lib/telemetry/client';
+import { i18n } from '@/lib/i18n';
 import {
   readUiStorageItem,
   removeUiStorageItem,
   writeUiStorageItem,
 } from '@/lib/persistence/ui-storage';
+import type {
+  MemoryFileSessionRef,
+  WorkspaceFileSessionRef,
+} from '@/lib/workspace-tabs/special-session';
+
+type PeekFileRef = WorkspaceFileSessionRef | MemoryFileSessionRef;
+
+function isSamePeekFile(left: PeekFileRef | null, right: PeekFileRef): boolean {
+  if (!left || left.type !== right.type || left.sourceSessionId !== right.sourceSessionId) {
+    return false;
+  }
+  if (left.type === 'workspace-file' && right.type === 'workspace-file') {
+    return left.kind === right.kind && left.path === right.path;
+  }
+  return left.type === 'memory-file'
+    && right.type === 'memory-file'
+    && left.memoryKind === right.memoryKind
+    && left.fileName === right.fileName;
+}
+
+function confirmDiscardPeekFileChanges(state: Pick<BoardState, 'peekFileDirty'>): boolean {
+  if (!state.peekFileDirty || typeof window === 'undefined') return true;
+  return window.confirm(i18n.t('memoryPanel.fileTab.discardChangesConfirm'));
+}
 
 export type ViewMode = 'list' | 'board';
+export const DEFAULT_PEEK_FILE_SIDECAR_WIDTH = 460;
+export const MIN_PEEK_FILE_SIDECAR_WIDTH = 300;
+export const MAX_PEEK_FILE_SIDECAR_WIDTH = 900;
 
 interface BoardState {
   // View mode for the selected project. Persisted per project below.
   viewMode: ViewMode;
   projectViewModes: Record<string, ViewMode>;
   setViewMode: (mode: ViewMode) => void;
+
+  // Transient Kanban Peek state. Selection survives light-dismiss so the
+  // utility panel can keep showing the last inspected session.
+  peekSessionId: string | null;
+  selectedBoardSessionId: string | null;
+  peekFileRef: PeekFileRef | null;
+  peekFileDirty: boolean;
+  peekFileSidecarWidth: number;
+  openSessionPeek: (sessionId: string) => void;
+  openPeekFile: (fileRef: PeekFileRef) => void;
+  closePeekFile: () => void;
+  setPeekFileDirty: (dirty: boolean) => void;
+  setPeekFileSidecarWidth: (width: number) => void;
+  closeSessionPeek: () => boolean;
+  clearSessionPeek: () => boolean;
 
   // Kanban drag-and-drop state
   draggingTaskId: string | null;
@@ -94,6 +137,7 @@ const SELECTED_PROJECT_DIR_KEY = 'ccw:selectedProjectDir';
 const ALL_PROJECTS_EXPANDED_SECTIONS_KEY = 'ccw:allProjectsExpandedSections';
 const LIST_RUNNING_FILTER_KEY = 'ccw:listRunningFilterActive';
 const ACTIVE_COLLECTION_FILTER_KEY = 'ccw:activeCollectionFilter';
+const PEEK_FILE_SIDECAR_WIDTH_KEY = 'ccw:peekFileSidecarWidth';
 
 function isViewMode(value: unknown): value is ViewMode {
   return value === 'list' || value === 'board';
@@ -232,6 +276,20 @@ function saveBooleanFlag(key: string, value: boolean): void {
   }
 }
 
+function loadPeekFileSidecarWidth(): number {
+  if (typeof window === 'undefined') return DEFAULT_PEEK_FILE_SIDECAR_WIDTH;
+  try {
+    const value = Number(readUiStorageItem(PEEK_FILE_SIDECAR_WIDTH_KEY));
+    return Number.isFinite(value)
+      && value >= MIN_PEEK_FILE_SIDECAR_WIDTH
+      && value <= MAX_PEEK_FILE_SIDECAR_WIDTH
+      ? value
+      : DEFAULT_PEEK_FILE_SIDECAR_WIDTH;
+  } catch {
+    return DEFAULT_PEEK_FILE_SIDECAR_WIDTH;
+  }
+}
+
 function resolveProjectViewMode(
   projectDir: string | null,
   projectViewModes: Record<string, ViewMode>,
@@ -246,6 +304,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
   projectViewModes: loadProjectViewModes(),
   setViewMode: (mode) => {
     if (get().viewMode === mode) return;
+    if (mode !== 'board' && !confirmDiscardPeekFileChanges(get())) return;
     set((state) => {
       const nextProjectViewModes =
         state.selectedProjectDir
@@ -263,11 +322,70 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       return {
         viewMode: mode,
         projectViewModes: nextProjectViewModes,
+        ...(mode !== 'board' && {
+          peekSessionId: null,
+          peekFileRef: null,
+          peekFileDirty: false,
+        }),
       };
     });
     void captureTelemetryEvent('workspace_view_changed', {
       view: mode === 'board' ? 'kanban' : 'list',
     });
+  },
+
+  peekSessionId: null,
+  selectedBoardSessionId: null,
+  peekFileRef: null,
+  peekFileDirty: false,
+  peekFileSidecarWidth: loadPeekFileSidecarWidth(),
+  openSessionPeek: (sessionId) => set((state) => {
+    const keepFile = state.peekFileRef?.sourceSessionId === sessionId;
+    if (!keepFile && !confirmDiscardPeekFileChanges(state)) return state;
+    return {
+      peekSessionId: sessionId,
+      selectedBoardSessionId: sessionId,
+      peekFileRef: keepFile ? state.peekFileRef : null,
+      peekFileDirty: keepFile ? state.peekFileDirty : false,
+    };
+  }),
+  openPeekFile: (fileRef) => set((state) => {
+    if (!isSamePeekFile(state.peekFileRef, fileRef) && !confirmDiscardPeekFileChanges(state)) {
+      return state;
+    }
+    return {
+      peekFileRef: fileRef,
+      peekFileDirty: isSamePeekFile(state.peekFileRef, fileRef) && state.peekFileDirty,
+      selectedBoardSessionId: state.peekSessionId ?? fileRef.sourceSessionId,
+    };
+  }),
+  closePeekFile: () => set((state) => {
+    if (!confirmDiscardPeekFileChanges(state)) return state;
+    return { peekFileRef: null, peekFileDirty: false };
+  }),
+  setPeekFileDirty: (dirty) => set({ peekFileDirty: dirty }),
+  setPeekFileSidecarWidth: (width) => {
+    const normalized = Math.round(Math.min(
+      MAX_PEEK_FILE_SIDECAR_WIDTH,
+      Math.max(MIN_PEEK_FILE_SIDECAR_WIDTH, width),
+    ));
+    try { writeUiStorageItem(PEEK_FILE_SIDECAR_WIDTH_KEY, String(normalized)); } catch { /* ignore */ }
+    set({ peekFileSidecarWidth: normalized });
+  },
+  closeSessionPeek: () => {
+    if (!confirmDiscardPeekFileChanges(get())) return false;
+    set({ peekSessionId: null, peekFileRef: null, peekFileDirty: false });
+    return true;
+  },
+  clearSessionPeek: () => {
+    if (!confirmDiscardPeekFileChanges(get())) return false;
+    set({
+      peekSessionId: null,
+      peekFileRef: null,
+      peekFileDirty: false,
+      selectedBoardSessionId: null,
+    });
+    return true;
   },
 
   draggingTaskId: null,
@@ -359,6 +477,8 @@ export const useBoardStore = create<BoardState>((set, get) => ({
 
   selectedProjectDir: loadNullableString(SELECTED_PROJECT_DIR_KEY),
   setSelectedProjectDir: (dir) => {
+    if (get().selectedProjectDir === dir) return;
+    if (!confirmDiscardPeekFileChanges(get())) return;
     set((state) => {
       const nextProjectViewModes =
         state.selectedProjectDir
@@ -372,6 +492,10 @@ export const useBoardStore = create<BoardState>((set, get) => ({
         selectedProjectDir: dir,
         projectViewModes: nextProjectViewModes,
         viewMode: resolveProjectViewMode(dir, nextProjectViewModes, state.viewMode),
+        peekSessionId: null,
+        peekFileRef: null,
+        peekFileDirty: false,
+        selectedBoardSessionId: null,
       };
     });
     const { projectViewModes, viewMode } = get();

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -5,7 +5,7 @@ import type { ServerHostInfo } from '@/lib/system/types';
 import { DEFAULT_SETTINGS } from '@/lib/settings/defaults';
 import { normalizeUserSettings } from '@/lib/settings/provider-defaults';
 import { i18n } from '@/lib/i18n';
-import type { ViewMode } from '@/stores/board-store';
+import { useBoardStore, type ViewMode } from '@/stores/board-store';
 
 export const SETTINGS_STORAGE_KEY = 'tessera:settings';
 export const SETTINGS_SYNC_CHANNEL = 'tessera:settings-sync';
@@ -194,8 +194,15 @@ export const useSettingsStore = create<SettingsState>()(
       },
 
       // REQ-007: Sidebar toggle
-      toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
-      setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+      toggleSidebar: () => {
+        const collapsed = !get().sidebarCollapsed;
+        if (collapsed && !useBoardStore.getState().closeSessionPeek()) return;
+        set({ sidebarCollapsed: collapsed });
+      },
+      setSidebarCollapsed: (collapsed) => {
+        if (collapsed && !useBoardStore.getState().closeSessionPeek()) return;
+        set({ sidebarCollapsed: collapsed });
+      },
 
       // REQ-002: Sidebar resize
       getSidebarWidth: (mode, projectDir) => {
@@ -234,6 +241,12 @@ export const useSettingsStore = create<SettingsState>()(
 
       updateSettings: async (partial, options) => {
         const prior = get().settings;
+        if (
+          partial.kanbanSessionOpenMode
+          && partial.kanbanSessionOpenMode !== prior.kanbanSessionOpenMode
+          && partial.kanbanSessionOpenMode !== 'peek'
+          && !useBoardStore.getState().closeSessionPeek()
+        ) return;
         const updated = normalizeUserSettings({
           ...prior,
           ...partial,

--- a/tests/kanban-peek-context-sidecar-contract.test.mjs
+++ b/tests/kanban-peek-context-sidecar-contract.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const openWorkspaceTabSource = fs.readFileSync(
+  new URL('../src/lib/workspace-tabs/open-workspace-tab.ts', import.meta.url),
+  'utf8',
+);
+const memoryPanelSource = fs.readFileSync(
+  new URL('../src/components/memory/memory-panel.tsx', import.meta.url),
+  'utf8',
+);
+const memoryFileTabSource = fs.readFileSync(
+  new URL('../src/components/memory/memory-file-tab.tsx', import.meta.url),
+  'utf8',
+);
+const sessionPeekSource = fs.readFileSync(
+  new URL('../src/components/board/session-peek.tsx', import.meta.url),
+  'utf8',
+);
+const boardStoreSource = fs.readFileSync(
+  new URL('../src/stores/board-store.ts', import.meta.url),
+  'utf8',
+);
+const settingsStoreSource = fs.readFileSync(
+  new URL('../src/stores/settings-store.ts', import.meta.url),
+  'utf8',
+);
+
+test('Context rows explicitly route memory files into Kanban Peek', () => {
+  assert.match(openWorkspaceTabSource, /tryOpenMemoryFileInKanbanPeek/);
+  assert.match(openWorkspaceTabSource, /type: "memory-file"/);
+  assert.match(openWorkspaceTabSource, /options\.preferKanbanPeek/);
+  assert.match(memoryPanelSource, /preferKanbanPeek: true/);
+});
+
+test('Peek state accepts both workspace and editable Context file references', () => {
+  assert.match(boardStoreSource, /WorkspaceFileSessionRef \| MemoryFileSessionRef/);
+  assert.match(sessionPeekSource, /<MemoryFileTab/);
+  assert.match(sessionPeekSource, /peekFileRef\.type === 'memory-file'/);
+});
+
+test('the reused Context file editor closes through Peek and retains editing controls', () => {
+  assert.match(memoryFileTabSource, /onClose\?: \(\) => void/);
+  assert.match(memoryFileTabSource, /onDirtyChange\?: \(dirty: boolean\) => void/);
+  assert.match(memoryFileTabSource, /data-testid="memory-mode-edit"/);
+  assert.match(memoryFileTabSource, /data-testid="memory-save-btn"/);
+  assert.match(memoryFileTabSource, /data-testid="memory-file-close"/);
+  assert.match(memoryFileTabSource, /onChange=\{setDraft\}/);
+});
+
+test('unsaved Context edits are guarded before Peek replacement or close', () => {
+  assert.match(boardStoreSource, /peekFileDirty: boolean/);
+  assert.match(boardStoreSource, /confirmDiscardPeekFileChanges/);
+  assert.match(boardStoreSource, /discardChangesConfirm/);
+  assert.match(sessionPeekSource, /onDirtyChange=\{setPeekFileDirty\}/);
+  assert.match(settingsStoreSource, /collapsed && !useBoardStore\.getState\(\)\.closeSessionPeek\(\)/);
+  assert.match(settingsStoreSource, /partial\.kanbanSessionOpenMode/);
+});

--- a/tests/kanban-peek-file-sidecar-contract.test.mjs
+++ b/tests/kanban-peek-file-sidecar-contract.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const openWorkspaceTabSource = fs.readFileSync(
+  new URL('../src/lib/workspace-tabs/open-workspace-tab.ts', import.meta.url),
+  'utf8',
+);
+const boardStoreSource = fs.readFileSync(
+  new URL('../src/stores/board-store.ts', import.meta.url),
+  'utf8',
+);
+const sessionPeekSource = fs.readFileSync(
+  new URL('../src/components/board/session-peek.tsx', import.meta.url),
+  'utf8',
+);
+const workspaceFileTabSource = fs.readFileSync(
+  new URL('../src/components/workspace/workspace-file-tab.tsx', import.meta.url),
+  'utf8',
+);
+const workspaceFilePanelSource = fs.readFileSync(
+  new URL('../src/components/workspace/workspace-file-panel.tsx', import.meta.url),
+  'utf8',
+);
+
+test('workspace file clicks route into the visible Kanban Peek workspace', () => {
+  assert.match(openWorkspaceTabSource, /tryOpenWorkspaceFileInKanbanPeek/);
+  assert.match(openWorkspaceTabSource, /openPeekFile/);
+  assert.match(openWorkspaceTabSource, /options\.preferKanbanPeek/);
+  assert.match(workspaceFilePanelSource, /preferKanbanPeek: true/);
+});
+
+test('board state owns the transient file sidecar without creating a hidden tab', () => {
+  assert.match(boardStoreSource, /peekFileRef:/);
+  assert.match(boardStoreSource, /openPeekFile:/);
+  assert.match(boardStoreSource, /closePeekFile:/);
+  assert.match(boardStoreSource, /peekFileSidecarWidth:/);
+  assert.match(
+    boardStoreSource,
+    /selectedBoardSessionId: state\.peekSessionId \?\? fileRef\.sourceSessionId/,
+  );
+});
+
+test('Session Peek renders the shared file viewer behind an accessible resizer', () => {
+  assert.match(sessionPeekSource, /<WorkspaceFileTab/);
+  assert.match(sessionPeekSource, /data-testid="kanban-peek-file-sidecar"/);
+  assert.match(sessionPeekSource, /data-testid="kanban-peek-file-resize-handle"/);
+  assert.match(sessionPeekSource, /role="separator"/);
+  assert.match(sessionPeekSource, /onPointerMove/);
+  assert.match(sessionPeekSource, /onKeyDown/);
+});
+
+test('file-only Peek delegates its title bar to the file viewer', () => {
+  assert.match(sessionPeekSource, /aria-labelledby=\{showSessionContent \? titleId : undefined\}/);
+  assert.match(sessionPeekSource, /\{showSessionContent \? \(\s*<header/);
+  assert.match(sessionPeekSource, /aria-label=\{isFileOnly \? peekFileLabel : undefined\}/);
+});
+
+test('the reused workspace file view can be active and close inside a transient surface', () => {
+  assert.match(workspaceFileTabSource, /surfaceActive\?: boolean/);
+  assert.match(workspaceFileTabSource, /onClose\?: \(\) => void/);
+  assert.match(workspaceFileTabSource, /surfaceActive \|\| state\.activeTabId === tabId/);
+});

--- a/tests/kanban-session-open-mode.test.ts
+++ b/tests/kanban-session-open-mode.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeUserSettings } from '@/lib/settings/provider-defaults';
+
+test('existing users keep the split Kanban session layout by default', () => {
+  assert.equal(normalizeUserSettings({}).kanbanSessionOpenMode, 'split');
+});
+
+test('Peek is preserved as a valid Kanban session open mode', () => {
+  assert.equal(
+    normalizeUserSettings({ kanbanSessionOpenMode: 'peek' }).kanbanSessionOpenMode,
+    'peek',
+  );
+});
+
+test('unknown Kanban session open modes fall back to split view', () => {
+  assert.equal(
+    normalizeUserSettings({ kanbanSessionOpenMode: 'drawer' as never }).kanbanSessionOpenMode,
+    'split',
+  );
+});

--- a/tests/kanban-session-peek-contract.test.mjs
+++ b/tests/kanban-session-peek-contract.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const chatLayoutSource = fs.readFileSync(
+  new URL('../src/components/chat/chat-layout.tsx', import.meta.url),
+  'utf8',
+);
+const boardSource = fs.readFileSync(
+  new URL('../src/components/board/kanban-board.tsx', import.meta.url),
+  'utf8',
+);
+const leftPanelSource = fs.readFileSync(
+  new URL('../src/components/chat/left-panel.tsx', import.meta.url),
+  'utf8',
+);
+const peekSource = fs.readFileSync(
+  new URL('../src/components/board/session-peek.tsx', import.meta.url),
+  'utf8',
+);
+const chatAreaSource = fs.readFileSync(
+  new URL('../src/components/chat/chat-area.tsx', import.meta.url),
+  'utf8',
+);
+const terminalPanelSource = fs.readFileSync(
+  new URL('../src/components/terminal/terminal-panel.tsx', import.meta.url),
+  'utf8',
+);
+const navigationSource = fs.readFileSync(
+  new URL('../src/hooks/use-session-navigation.ts', import.meta.url),
+  'utf8',
+);
+const appHeaderSource = fs.readFileSync(
+  new URL('../src/components/layout/app-header.tsx', import.meta.url),
+  'utf8',
+);
+
+test('Peek mode gives the Kanban panel the workspace instead of mounting the tab area beside it', () => {
+  assert.match(chatLayoutSource, /const isKanbanPeekLayout = isKanbanPeekMode && !sidebarCollapsed/);
+  assert.match(chatLayoutSource, /fillAvailable=\{isKanbanPeekLayout\}/);
+  assert.match(chatLayoutSource, /\{!isKanbanPeekLayout && \(\s*<div[^>]*>[\s\S]*<TabBar \/>[\s\S]*<TabPanelHost \/>/);
+  assert.match(appHeaderSource, /data-testid="kanban-git-panel-toggle"/);
+  assert.match(appHeaderSource, /toggleGitPanel/);
+});
+
+test('Board Peek keeps the board chrome focused while preserving the right workspace panel toggle', () => {
+  assert.match(appHeaderSource, /const isKanbanPeekMode = viewMode === 'board' && kanbanSessionOpenMode === 'peek'/);
+  assert.match(appHeaderSource, /\{!isKanbanPeekMode \? \([\s\S]*data-testid="sidebar-collapse-btn"[\s\S]*\) : null\}/);
+  assert.match(appHeaderSource, /\{isKanbanPeekMode \? \([\s\S]*data-testid="kanban-git-panel-toggle"[\s\S]*\) : null\}/);
+});
+
+test('normal Kanban clicks open Peek without replacing the active tab session', () => {
+  assert.match(boardSource, /onOpenSession:\s*kanbanSessionOpenMode === 'peek'/);
+  assert.match(boardSource, /openSessionPeek\(session\.id\)/);
+  assert.match(leftPanelSource, /<SessionPeek[\s\S]*sessionId=\{peekSessionId \?\? peekFileRef!\.sourceSessionId\}/);
+});
+
+test('Session Peek light-dismisses safely and hosts the shared GUI or PTY session surface', () => {
+  assert.match(peekSource, /role="dialog"/);
+  assert.match(peekSource, /aria-modal="true"/);
+  assert.match(peekSource, /backdropPointerStartedRef/);
+  assert.match(peekSource, /presentation="peek"/);
+  assert.match(peekSource, /isTerminal \? 'PTY' : 'GUI'/);
+  assert.match(peekSource, /value=\{PEEK_TAB_ID\}/);
+  assert.match(peekSource, /panelId=\{PEEK_PANEL_ID\}/);
+});
+
+test('Session Peek uses a compact, accessible loading indicator instead of the full chat skeleton', () => {
+  assert.match(chatAreaSource, /const PEEK_LOADING_DELAY_MS = 300/);
+  assert.match(chatAreaSource, /setTimeout\([\s\S]*setPeekLoadingReadySessionId\(sessionId\)[\s\S]*PEEK_LOADING_DELAY_MS/);
+  assert.match(chatAreaSource, /const shouldShowPeekLoading = isPeek && peekLoadingReadySessionId === sessionId/);
+  assert.match(chatAreaSource, /messages === undefined[\s\S]*shouldShowPeekLoading \? <SessionPeekLoading \/> : null/);
+  assert.match(chatAreaSource, /data-testid="kanban-session-peek-loading"/);
+  assert.match(chatAreaSource, /role="status"/);
+  assert.match(chatAreaSource, /t\("chat\.loadingSession"\)/);
+  assert.match(chatAreaSource, /motion-reduce:animate-none/);
+  assert.match(chatAreaSource, /startupOverlay=\{shouldShowPeekLoading \? <SessionPeekLoading \/> : undefined\}/);
+  assert.match(terminalPanelSource, /status === 'starting' && startupOverlay/);
+});
+
+test('PTY sessions use retained Peek ownership without pinning or killing a tab runtime', () => {
+  assert.match(chatAreaSource, /isPeek\s*\? 'session-peek'/);
+  assert.match(chatAreaSource, /surfaceActive=\{isPeek\}/);
+  assert.match(terminalPanelSource, /runtimeOwnership === 'standalone' \|\| runtimeOwnership === 'session-peek'/);
+  assert.match(terminalPanelSource, /clearTimeout\(pendingSurfaceCleanupRef\.current\)/);
+});
+
+test('Peek loads history without mutating the hidden active tab session', () => {
+  assert.match(chatAreaSource, /viewSession\(session, \{ activate: !isPeek \}\)/);
+  assert.match(navigationSource, /const shouldActivate = options\?\.activate !== false/);
+  assert.match(navigationSource, /if \(shouldActivate\) sessionStore\.setActiveSession\(session\.id\)/);
+});


### PR DESCRIPTION
## Summary

- open GUI and PTY sessions in a transient Kanban Peek surface
- preserve the active tab while loading Peek history and runtime state
- open workspace and Context files beside the Peek session
- guard unsaved Context edits before replacing or closing the sidecar
- retain preview-owned PTY runtimes without pinning or killing tab-owned sessions
- show a compact delayed loading indicator for Peek content

## Impact

Users can inspect and edit session context from the board without leaving Kanban or replacing their active workspace tab.

## Validation

- 24 focused Kanban Peek, file sidecar, and PTY preview tests
- full ESLint run with no errors (two pre-existing warnings)
- `npx tsc --noEmit`
- `git diff --check origin/dev...HEAD`