### PR TITLE
fix: render one Kanban PR mismatch badge

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -978,14 +978,6 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                     surface="board"
                   />
                 )}
-                {prMismatch && (
-                  <span
-                    title={prMismatchReason ?? undefined}
-                    aria-label={prMismatchReason ?? undefined}
-                    className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-(--status-error-text) ring-1 ring-(--board-card-bg) cursor-help"
-                    data-testid="task-pr-mismatch-badge"
-                  />
-                )}
               </span>
             ) : null}
             {prMismatch && !task.worktreeBranch && (


### PR DESCRIPTION
## Summary

- remove a duplicate PR mismatch indicator from worktree Kanban cards
- keep the compact error dot in its original anchored position
- preserve the status indicator and no-worktree fallback badge

## Root cause

The execution-mode checkpoint and the later chat-card visual update both contributed the same mismatch badge block during conflict resolution.

## Validation

- focused Kanban and status-indicator contract tests
- ESLint on `kanban-card.tsx`
- `npx tsc --noEmit`
- exact file comparison against the original local integration tree