### PR TITLE
fix(terminal): spawn Windows PTYs on bundled ConPTY and warm it at boot

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -21,6 +21,7 @@ import { ensureRemoteModelConfigLoaded } from './src/lib/model-config/remote-con
 import logger from './src/lib/logger';
 import { getServerPort } from './src/lib/server-port';
 import { handleHookRequest } from './src/lib/cli/hook-receiver';
+import { warmWindowsConptyOnce } from './src/lib/terminal/windows-conpty-warmup';
 
 const dev = process.env.NODE_ENV !== 'production';
 const hostname = process.env.TESSERA_HOST || process.env.HOST || '127.0.0.1';
@@ -86,6 +87,10 @@ async function startServer() {
   server.listen(port, hostname, () => {
     // Start WebSocket server on the same HTTP server
     wsServer.start(server);
+
+    // Pay the first ConPTY spawn cost (~seconds on Windows) before the user
+    // opens their first terminal.
+    warmWindowsConptyOnce();
 
     // Start rate limit poller
     rateLimitPoller.setBroadcast((msg) => wsServer.broadcast(msg));

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -581,14 +581,33 @@ export class TerminalManager {
       )) {
         throw new Error('The Codex terminal handoff was cancelled.');
       }
-      terminalProcess = ptyFactory.spawn(shell.command, shell.args, {
-        name: 'xterm-256color',
-        cols,
-        rows,
-        cwd: shell.cwd,
-        env: terminalEnv,
-        ...(getRuntimePlatform() === 'win32' ? { useConpty: false } : {}),
-      });
+      const spawnPtyProcess = (windowsPtyOptions: { useConptyDll?: boolean }) =>
+        ptyFactory.spawn(shell.command, shell.args, {
+          name: 'xterm-256color',
+          cols,
+          rows,
+          cwd: shell.cwd,
+          env: terminalEnv,
+          ...(getRuntimePlatform() === 'win32' ? windowsPtyOptions : {}),
+        });
+      try {
+        // node-pty's bundled ConPTY (conpty.dll + OpenConsole, shipped in
+        // prebuilds and asar-unpacked) has the modern wrap-marker behavior
+        // xterm expects; the OS ConPTY on older Windows builds corrupts
+        // full-width (CJK) TUI rows in scrollback and delta-repaints against
+        // a grid the client may not have converged on yet. The previous
+        // `useConpty: false` was a no-op — node-pty 1.2 removed winpty and
+        // ignores that flag entirely, so Windows was silently running on the
+        // legacy system ConPTY.
+        terminalProcess = spawnPtyProcess({ useConptyDll: true });
+      } catch (error) {
+        if (getRuntimePlatform() !== 'win32') throw error;
+        logger.warn(
+          { error, terminalId: options.terminalId },
+          'Bundled ConPTY spawn failed; retrying with the system ConPTY',
+        );
+        terminalProcess = spawnPtyProcess({});
+      }
       const processHandle = terminalProcess;
       traceTerminalStage('spawn:after', { terminalId: options.terminalId });
       logger.debug({ terminalId: options.terminalId }, 'Terminal PTY spawned');

--- a/src/lib/terminal/windows-conpty-warmup.ts
+++ b/src/lib/terminal/windows-conpty-warmup.ts
@@ -1,0 +1,51 @@
+import os from 'os';
+import logger from '@/lib/logger';
+
+const WARMUP_KILL_TIMEOUT_MS = 10_000;
+
+let warmed = false;
+
+/**
+ * Pays the one-time cost of the first ConPTY spawn (conpty native module
+ * load, bundled conpty.dll + OpenConsole.exe first launch, Defender scans of
+ * those binaries) at server boot instead of on the user's first terminal.
+ * orca measured ~2.7s for the first spawn vs ~70ms after on a Windows dev
+ * profile.
+ */
+export function warmWindowsConptyOnce(): void {
+  if (process.platform !== 'win32' || warmed) return;
+  warmed = true;
+  // setImmediate keeps server startup ahead of the warm-up; a real terminal
+  // spawn arriving first simply does the warming itself.
+  setImmediate(() => {
+    void (async () => {
+      try {
+        const ptyFactory = await import('node-pty');
+        const proc = ptyFactory.spawn(process.env.COMSPEC || 'cmd.exe', ['/c', 'exit'], {
+          name: 'xterm-256color',
+          cols: 2,
+          rows: 1,
+          cwd: os.homedir(),
+          env: process.env as Record<string, string>,
+          // Match real terminal spawns so the bundled ConPTY binaries are the
+          // ones warmed, not the legacy system ConPTY.
+          useConptyDll: true,
+        });
+        const killTimer = setTimeout(() => {
+          try {
+            proc.kill();
+          } catch {
+            // best-effort cleanup of a stuck warm-up shell
+          }
+        }, WARMUP_KILL_TIMEOUT_MS);
+        killTimer.unref?.();
+        proc.onExit(() => {
+          clearTimeout(killTimer);
+        });
+      } catch (error) {
+        // Warm-up is best-effort; real spawns surface their own errors.
+        logger.debug({ error }, 'Windows ConPTY warm-up skipped');
+      }
+    })();
+  });
+}


### PR DESCRIPTION
## Summary

- Spawn Windows PTYs on node-pty's bundled modern ConPTY (`useConptyDll: true`) instead of the legacy system ConPTY, with a fallback to the system ConPTY if the bundled one fails to start.
  - The previous `useConpty: false` was a no-op: node-pty 1.2 removed winpty and silently ignores that flag, so every Windows terminal was running on the OS ConPTY of whatever Windows build the machine has. Legacy ConPTY corrupts full-width (CJK) TUI rows in scrollback and delta-repaints against its own grid while the client is still converging — the fragment/merged-row garble reported on Windows and absent on macOS (kernel PTY, no ConPTY in the path).
  - The required `conpty.dll` + `OpenConsole.exe` already ship with node-pty's prebuilds and are asar-unpacked in packaged builds; no packaging changes needed.
- Warm ConPTY once at server boot (`windows-conpty-warmup.ts`, ported from orca's daemon warm-up): a throwaway `cmd /c exit` spawn at 2x1 pays the multi-second first-spawn cost (native module load, first `OpenConsole.exe` launch, Defender scans) before the user opens their first terminal. Measured ~2.7s first vs ~70ms after on a Windows dev profile.

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] `NODE_ENV=production npm run build`
- [x] Manual test: verified on a Windows 10 machine (Korean locale, WSL2 sessions) — the long-session fragment/merged-row scrollback garble that previously required a manual resize to clear no longer reproduces with the bundled ConPTY; first-terminal spawn latency drops to near-instant with the warm-up.
- [ ] Not tested:

## Screenshots or Recordings

N/A (terminal byte-stream behavior; before/after garble screenshots available in the debugging session if needed).

## Notes

Part 1 of 3 of the Windows terminal stability work. Independent of the other two PRs.
