### PR TITLE
fix(terminal): port the reveal/wake render-stability stack for Windows terminals

### DIFF
--- a/src/lib/terminal/terminal-foreground-render-settle.ts
+++ b/src/lib/terminal/terminal-foreground-render-settle.ts
@@ -1,0 +1,173 @@
+// Port of orca's pane-terminal-foreground-render-settle: repaint the viewport
+// as part of each foreground write, and once more after the scroll settles.
+// Chromium can paint a freshly scrolled row one frame later than xterm
+// finishes parsing, and the WebGL renderer's model diff can skip rows that
+// changed while a frame was dropped — both leave stale or missing rows until
+// something forces a repaint (classically a manual resize).
+
+import { runGuardedWriteCompletionStep } from './terminal-write-guard';
+
+export interface ForegroundTerminalOutputTarget {
+  buffer?: {
+    active?: {
+      cursorY?: number;
+      baseY?: number;
+      viewportY?: number;
+    };
+  };
+  rows?: number;
+  _core?: {
+    refresh?(start: number, end: number, sync?: boolean): void;
+  };
+  refresh?(start: number, end: number): void;
+  write(data: string, callback?: () => void): void;
+}
+
+interface ForegroundTerminalWriteOptions {
+  forceViewportRefresh?: boolean;
+  followupViewportRefresh?: boolean;
+  shouldRefreshViewportSynchronously?: () => boolean;
+  onParsed?: () => void;
+  onWriteFailure?: () => void;
+}
+
+const pendingViewportSettleRefreshByTerminal = new WeakMap<
+  ForegroundTerminalOutputTarget,
+  { kind: 'raf'; id: number } | { kind: 'timeout'; id: ReturnType<typeof setTimeout> }
+>();
+
+interface ViewportSnapshot {
+  baseY: number | null;
+  viewportY: number | null;
+}
+
+function refreshVisibleRows(
+  terminal: ForegroundTerminalOutputTarget,
+  synchronously: boolean,
+): void {
+  if (typeof terminal.rows !== 'number' || terminal.rows < 1) return;
+
+  const start = 0;
+  const end = Math.max(0, terminal.rows - 1);
+  try {
+    // DOM-rendered rewrites need an immediate repair, while WebGL can merge
+    // this full-grid request into xterm's already-queued frame.
+    if (synchronously && typeof terminal._core?.refresh === 'function') {
+      terminal._core.refresh(start, end, true);
+      return;
+    }
+    if (typeof terminal.refresh === 'function') {
+      terminal.refresh(start, end);
+      return;
+    }
+    terminal._core?.refresh?.(start, end, false);
+  } catch {
+    // Ignore disposed terminals; PTY output can race surface teardown.
+  }
+}
+
+function captureViewportSnapshot(terminal: ForegroundTerminalOutputTarget): ViewportSnapshot {
+  return {
+    baseY: typeof terminal.buffer?.active?.baseY === 'number' ? terminal.buffer.active.baseY : null,
+    viewportY:
+      typeof terminal.buffer?.active?.viewportY === 'number'
+        ? terminal.buffer.active.viewportY
+        : null,
+  };
+}
+
+function viewportChangedDuringWrite(
+  terminal: ForegroundTerminalOutputTarget,
+  beforeWrite: ViewportSnapshot,
+): boolean {
+  const afterWrite = captureViewportSnapshot(terminal);
+  return (
+    afterWrite.baseY !== null
+    && afterWrite.viewportY !== null
+    && (afterWrite.baseY !== beforeWrite.baseY || afterWrite.viewportY !== beforeWrite.viewportY)
+  );
+}
+
+function cancelScheduledViewportSettleRefresh(terminal: ForegroundTerminalOutputTarget): void {
+  const pending = pendingViewportSettleRefreshByTerminal.get(terminal);
+  if (!pending) return;
+  pendingViewportSettleRefreshByTerminal.delete(terminal);
+  if (pending.kind === 'raf') {
+    if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(pending.id);
+    return;
+  }
+  clearTimeout(pending.id);
+}
+
+function scheduleViewportSettleRefresh(
+  terminal: ForegroundTerminalOutputTarget,
+  shouldRefreshSynchronously?: () => boolean,
+): void {
+  cancelScheduledViewportSettleRefresh(terminal);
+  if (typeof requestAnimationFrame === 'function') {
+    const id = requestAnimationFrame(() => {
+      pendingViewportSettleRefreshByTerminal.delete(terminal);
+      refreshVisibleRows(terminal, shouldRefreshSynchronously?.() ?? true);
+    });
+    pendingViewportSettleRefreshByTerminal.set(terminal, { kind: 'raf', id });
+    return;
+  }
+
+  const id = setTimeout(() => {
+    pendingViewportSettleRefreshByTerminal.delete(terminal);
+    refreshVisibleRows(terminal, shouldRefreshSynchronously?.() ?? true);
+  }, 16);
+  pendingViewportSettleRefreshByTerminal.set(terminal, { kind: 'timeout', id });
+}
+
+function settleForegroundRender(
+  terminal: ForegroundTerminalOutputTarget,
+  beforeWriteViewport: ViewportSnapshot,
+  options: ForegroundTerminalWriteOptions,
+): void {
+  refreshVisibleRows(terminal, options.shouldRefreshViewportSynchronously?.() ?? true);
+  // When output advances the viewport, Chromium can paint the freshly scrolled
+  // top row one frame later than xterm finishes parsing. Repaint once more
+  // after the scroll settles so the user doesn't need to jiggle the window.
+  if (
+    options.followupViewportRefresh
+    || viewportChangedDuringWrite(terminal, beforeWriteViewport)
+  ) {
+    scheduleViewportSettleRefresh(terminal, options.shouldRefreshViewportSynchronously);
+  }
+}
+
+export function writeForegroundTerminalChunk(
+  terminal: ForegroundTerminalOutputTarget,
+  data: string,
+  options: ForegroundTerminalWriteOptions = {},
+): boolean {
+  const beforeWriteViewport = options.forceViewportRefresh
+    ? captureViewportSnapshot(terminal)
+    : null;
+  // Guarded steps: this callback runs inside xterm's WriteBuffer loop, where an
+  // escaping throw permanently wedges the terminal. Guard settle and onParsed
+  // separately so a renderer failure during settle can't starve the rest.
+  const runParsedSteps = (): void => {
+    if (beforeWriteViewport) {
+      runGuardedWriteCompletionStep('foreground-render-settle', () =>
+        settleForegroundRender(terminal, beforeWriteViewport, options));
+    }
+    if (options.onParsed) {
+      runGuardedWriteCompletionStep('foreground-on-parsed', options.onParsed);
+    }
+  };
+  try {
+    terminal.write(data, runParsedSteps);
+    return true;
+  } catch {
+    if (options.onWriteFailure) {
+      runGuardedWriteCompletionStep('foreground-on-write-failure', options.onWriteFailure);
+    }
+    return false;
+  }
+}
+
+export function discardForegroundRenderSettle(terminal: ForegroundTerminalOutputTarget): void {
+  cancelScheduledViewportSettleRefresh(terminal);
+}

--- a/src/lib/terminal/terminal-render-pause-release.ts
+++ b/src/lib/terminal/terminal-render-pause-release.ts
@@ -1,0 +1,67 @@
+/**
+ * Forces a full synchronous repaint through xterm's RenderService even when its
+ * IntersectionObserver still reports the screen element as not intersecting.
+ *
+ * On reveal (tab switch, parking-lot remount) the surface is DOM-visible but
+ * xterm's own observer callback can lag a frame, leaving
+ * `RenderService._isPaused === true`. While paused, `refreshRows` early-returns
+ * and only latches `_needsFullRefresh`, so a plain `terminal.refresh()` is
+ * swallowed: the cleared render model never repaints and the canvas keeps
+ * compositing stale rows. We cannot wait for the observer, so we clear the
+ * latch and drive one synchronous full render ourselves. The observer reasserts
+ * authority on its next callback.
+ *
+ * Every access is behind a typeof guard, so an xterm upgrade that renames these
+ * internals degrades to a no-op instead of throwing inside a render frame.
+ */
+
+interface MaybePausableRenderService {
+  _isPaused?: boolean;
+  _needsFullRefresh?: boolean;
+  refreshRows?: (start: number, end: number, sync?: boolean) => void;
+}
+
+type PausableRenderService = MaybePausableRenderService & {
+  refreshRows: (start: number, end: number, sync?: boolean) => void;
+};
+
+interface TerminalWithRenderService {
+  rows?: number;
+  _core?: {
+    _renderService?: MaybePausableRenderService;
+  };
+}
+
+function getRenderService(terminal: unknown): PausableRenderService | null {
+  const service = (terminal as TerminalWithRenderService | null)?._core?._renderService;
+  return service && typeof service.refreshRows === 'function'
+    ? (service as PausableRenderService)
+    : null;
+}
+
+/**
+ * Clears xterm's pause latch and forces a synchronous full-viewport repaint
+ * when the renderer is paused. Returns true when it drove the render, false
+ * when the terminal was left untouched (not paused, or internals unavailable)
+ * so the caller can fall back to its normal `terminal.refresh()`.
+ */
+export function forceRepaintThroughRenderPause(terminal: unknown): boolean {
+  const service = getRenderService(terminal);
+  if (!service || service._isPaused !== true) return false;
+
+  const rows = (terminal as TerminalWithRenderService).rows;
+  if (typeof rows !== 'number' || rows < 1) return false;
+
+  // Leave the latch as if the pending full refresh had been serviced — it is
+  // about to be — so the observer's next callback does not queue a redundant
+  // second full repaint.
+  service._isPaused = false;
+  service._needsFullRefresh = false;
+  try {
+    service.refreshRows(0, rows - 1, true);
+    return true;
+  } catch {
+    // The renderer can be torn down between the pause check and the render.
+    return false;
+  }
+}

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -47,6 +47,11 @@ import {
   TerminalBackgroundSgrDetector,
   resetAndRefreshTerminalRenderers,
 } from './terminal-render-recovery';
+import { forceRepaintThroughRenderPause } from './terminal-render-pause-release';
+import {
+  writeForegroundTerminalChunk,
+  discardForegroundRenderSettle,
+} from './terminal-foreground-render-settle';
 import {
   attachTerminalMouseWheelMultiplier,
   isTerminalTuiOwnedWheelEvent,
@@ -89,6 +94,7 @@ type XtermLike = TerminalScrollTarget & {
   paste(data: string): void;
   write(data: string, callback?: () => void): void;
   reset(): void;
+  resize(cols: number, rows: number): void;
   refresh(start: number, end: number): void;
   onData(callback: (data: string) => void): { dispose(): void };
   onScroll(callback: (viewportY: number) => void): { dispose(): void };
@@ -101,9 +107,90 @@ type FitAddonLike = {
   dispose?(): void;
 };
 
+type WebglAddonLike = {
+  clearTextureAtlas(): void;
+  dispose(): void;
+  onContextLoss(listener: () => void): void;
+};
+
+// While Chromium refuses WebGL context creation (GPU process crashed, or WebGL
+// blocked after repeated resets), every attach attempt burns a canvas and a
+// failed getContext. Latch the first failure and skip attempts until the next
+// wake/reveal recovery boundary clears it.
+let webglAttachFailedSinceRecovery = false;
+
+/**
+ * xterm clears the drawing buffer on dispose but Windows/ANGLE can keep the
+ * driver context alive, so rapid surface churn runs into Chromium's active
+ * WebGL context budget. Release the context and collapse the canvas so the
+ * slot frees immediately. All access is typeof-guarded: an xterm upgrade
+ * degrades this to a no-op.
+ */
+function releaseXtermWebglContext(addon: unknown): void {
+  try {
+    const renderer = (
+      addon as {
+        _renderer?: {
+          _gl?: { getExtension(name: string): { loseContext(): void } | null };
+          _canvas?: { width: number; height: number };
+        };
+      } | null
+    )?._renderer;
+    renderer?._gl?.getExtension('WEBGL_lose_context')?.loseContext();
+    if (renderer?._canvas) {
+      renderer._canvas.width = 0;
+      renderer._canvas.height = 0;
+    }
+  } catch {
+    // Best-effort; the context may already be lost.
+  }
+}
+
 const surfaces = new Map<string, TerminalSurface>();
 function recoverAllTerminalRenderers(): void {
   resetAndRefreshTerminalRenderers(surfaces.values());
+}
+
+// Wake recovery. Windows reclaims GPU contexts across sleep/display-off and
+// window occlusion far more aggressively than macOS, so a resume must retry
+// WebGL and repaint. Strength is tiered like orca's: plain refocus (alt-tab)
+// is frequent and often lands mid-stream — wiping the shared glyph atlas then
+// provokes xterm's page-merge race — so focus keeps the warm atlas and only a
+// genuine visibility resume clears it.
+let wakeRecoveryInstalled = false;
+let wakeRecoveryFrameId: number | null = null;
+let wakeRecoveryClearAtlases = false;
+
+function recoverTerminalsAfterWake(clearAtlases: boolean): void {
+  if (wakeRecoveryFrameId !== null) {
+    // A pending settled pass may only upgrade in strength — a plain focus
+    // landing after a genuine wake must not skip its atlas clear.
+    wakeRecoveryClearAtlases ||= clearAtlases;
+    return;
+  }
+  wakeRecoveryClearAtlases = clearAtlases;
+  for (const surface of surfaces.values()) surface.resumeRenderingAfterWake();
+  // The synchronous pass can run before revealed surfaces are laid out, where
+  // the WebGL renderer drops redraw requests. Follow with a settled frame.
+  wakeRecoveryFrameId = requestAnimationFrame(() => {
+    wakeRecoveryFrameId = null;
+    const clearAtlasesOnSettle = wakeRecoveryClearAtlases;
+    wakeRecoveryClearAtlases = false;
+    if (clearAtlasesOnSettle) {
+      recoverAllTerminalRenderers();
+      return;
+    }
+    for (const surface of surfaces.values()) surface.refreshTerminalViewport();
+  });
+}
+
+function installTerminalWakeRecovery(): void {
+  if (wakeRecoveryInstalled || typeof window === 'undefined') return;
+  wakeRecoveryInstalled = true;
+  window.addEventListener('focus', () => recoverTerminalsAfterWake(false));
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') recoverTerminalsAfterWake(true);
+  });
 }
 const sharedTerminalRenderRecovery = new QuietTerminalRenderRecovery(
   recoverAllTerminalRenderers,
@@ -177,7 +264,9 @@ export class TerminalSurface {
   private fontSize: number;
   private terminal: XtermLike | null = null;
   private fitAddon: FitAddonLike | null = null;
-  private webglAddon: { clearTextureAtlas(): void; dispose(): void } | null = null;
+  private webglAddon: WebglAddonLike | null = null;
+  private webglCtor: (new () => WebglAddonLike) | null = null;
+  private webglDisabledAfterContextLoss = false;
   private readonly backgroundSgrDetector = new TerminalBackgroundSgrDetector();
   private inputDisposable: { dispose(): void } | null = null;
   private scrollDisposable: { dispose(): void } | null = null;
@@ -308,9 +397,23 @@ export class TerminalSurface {
     });
     this.resizeObserver.observe(host);
 
+    // Two frames, not one: the frame right after a reveal can still be laying
+    // out the host, and the WebGL renderer silently drops redraw requests until
+    // the surface is attached and measured.
     requestAnimationFrame(() => {
-      if (this.mountedHost !== host) return;
-      this.requestStableFit(false);
+      requestAnimationFrame(() => {
+        if (this.mountedHost !== host) return;
+        this.requestStableFit(false);
+        this.retryWebglAttachOnReveal();
+        // While parked, output kept updating the renderer's per-cell model
+        // without ever presenting a frame, so on reveal the model diff reports
+        // those cells as unchanged and a plain repaint skips them. Rebuild from
+        // the buffer. This goes through the shared recovery rather than this
+        // surface's atlas alone: terminals with matching font settings share one
+        // glyph atlas, and clearing it for a single surface would invalidate the
+        // others' cached glyph coordinates without rebuilding their models.
+        recoverAllTerminalRenderers();
+      });
     });
   }
 
@@ -413,7 +516,90 @@ export class TerminalSurface {
 
   refreshTerminalViewport(): void {
     if (!this.terminal) return;
+    // A paused RenderService swallows refresh() — it latches the request instead
+    // of servicing it — so drive the render directly whenever that gate is up.
+    if (forceRepaintThroughRenderPause(this.terminal)) return;
     this.terminal.refresh(0, Math.max(0, this.terminal.rows - 1));
+  }
+
+  private attachWebglRenderer(): void {
+    if (!this.terminal || this.webglAddon || !this.webglCtor) return;
+    if (this.webglDisabledAfterContextLoss || webglAttachFailedSinceRecovery) return;
+    try {
+      const webglAddon = new this.webglCtor();
+      webglAddon.onContextLoss(() => {
+        try {
+          webglAddon.dispose();
+        } catch {
+          // already torn down
+        }
+        if (this.webglAddon === webglAddon) this.webglAddon = null;
+        // Chromium reclaims terminal contexts under pressure; recreating
+        // immediately can loop the loss and leave xterm blank. Stay on the DOM
+        // renderer until the next wake/reveal boundary retries the attach.
+        this.webglDisabledAfterContextLoss = true;
+
+        // DOM and WebGL renderers can calculate slightly different cell
+        // metrics. Wait until the DOM renderer owns the screen, then refit
+        // the stable grid so panel bounds and PTY dimensions stay aligned.
+        requestAnimationFrame(() => {
+          if (this.disposed || !this.terminal) return;
+          this.fitAndResize(false, true);
+          try {
+            this.terminal.refresh(0, Math.max(0, this.terminal.rows - 1));
+          } catch {
+            // The renderer may be torn down during the recovery frame.
+          }
+        });
+      });
+      this.terminal.loadAddon(webglAddon);
+      this.webglAddon = webglAddon;
+      // A newly attached WebGL canvas starts empty; repaint immediately so the
+      // surface does not look frozen until the next output arrives.
+      try {
+        this.terminal.refresh(0, Math.max(0, this.terminal.rows - 1));
+      } catch {
+        // The surface may be mid-teardown.
+      }
+    } catch (error) {
+      webglAttachFailedSinceRecovery = true;
+      console.warn('[terminal] WebGL unavailable — using DOM renderer', error);
+    }
+  }
+
+  /**
+   * Wake/reveal recovery boundary: clear the context-loss and attach-failure
+   * latches, retry the WebGL attach, and re-align the grid. Called for every
+   * surface on window focus and visibility resume — the only points where
+   * retrying WebGL is safe without looping a context-loss storm.
+   */
+  resumeRenderingAfterWake(): void {
+    if (this.disposed) return;
+    this.webglDisabledAfterContextLoss = false;
+    webglAttachFailedSinceRecovery = false;
+    if (!this.isMountedHostVisible()) return;
+    this.attachWebglRenderer();
+    this.requestStableFit(false);
+  }
+
+  /**
+   * Reveal is a WebGL recovery boundary, matching orca's reveal repaint chain
+   * (reattachWebglIfNeeded runs before the atlas reset). A context lost while
+   * the surface sat hidden — Windows reclaims hidden canvases first — or a
+   * transient attach failure otherwise strands the surface on the DOM
+   * renderer until the next window-level focus cycle: the two renderers
+   * compute subtly different cell metrics, so a revealed pane draws CJK
+   * slightly misaligned and IME composition anchors against the wrong grid.
+   * Users' reliable cure — unfocus the app, refocus, watch the pane visibly
+   * realign — is the wake path running this exact attach. Do it on reveal so
+   * the pane always comes back on the configured renderer.
+   */
+  private retryWebglAttachOnReveal(): void {
+    if (this.disposed || !this.webglCtor || this.webglAddon) return;
+    this.webglDisabledAfterContextLoss = false;
+    webglAttachFailedSinceRecovery = false;
+    this.attachWebglRenderer();
+    this.requestStableFit(false);
   }
 
   close(): void {
@@ -452,7 +638,9 @@ export class TerminalSurface {
     this.cancelColdPark();
     if (!this.terminal && this.mountedHost) void this.mount(this.mountedHost);
     requestAnimationFrame(() => {
-      if (!this.disposed && this.isMountedHostVisible()) recoverAllTerminalRenderers();
+      if (this.disposed || !this.isMountedHostVisible()) return;
+      this.retryWebglAttachOnReveal();
+      recoverAllTerminalRenderers();
     });
   }
 
@@ -525,6 +713,8 @@ export class TerminalSurface {
       this.root.removeEventListener('compositionend', this.compositionEndListener, true);
     }
     this.compositionEndListener = null;
+    if (this.terminal) discardForegroundRenderSettle(this.terminal);
+    if (this.webglAddon) releaseXtermWebglContext(this.webglAddon);
     try {
       this.webglAddon?.dispose();
     } catch {
@@ -580,6 +770,12 @@ export class TerminalSurface {
       getParkingLot().appendChild(root);
 
       const { webLinkHandler, oscLinkHandler } = createTerminalExternalLinkHandlers();
+      // No windowsPty hint: orca ships one for native Windows shells but
+      // explicitly excludes WSL sessions even though its daemon also spawns
+      // wsl.exe through ConPTY, and tessera's terminals are WSL sessions.
+      // Applying it here regressed Korean IME input (composition drawn at
+      // stale cursor positions) — if native cmd/powershell terminals need the
+      // hint later, gate it on the shell kind from terminal_created.
       const terminal = new Terminal({
         cursorBlink: true,
         convertEol: true,
@@ -606,34 +802,23 @@ export class TerminalSurface {
       terminal.unicode.activeVersion = '11';
       attachTerminalMouseWheelMultiplier(terminal);
 
+      // Renderer choice. WebGL everywhere by default — the postinstall patch
+      // (scripts/patch-xterm-webgl-atlas.mjs) fixes the addon's atlas-wipe
+      // no-op and propagates wipes to every renderer sharing the atlas, which
+      // were what garbled Windows/ANGLE. 'dom' stays available as an escape
+      // hatch and as a diagnostic (a report that survives on the DOM renderer
+      // is buffer corruption, not a renderer artifact):
+      //   localStorage.setItem('tessera.terminal.renderer', 'dom')
+      let rendererOverride: string | null = null;
       try {
-        const webglAddon = new WebglAddon();
-        webglAddon.onContextLoss(() => {
-          try {
-            webglAddon.dispose();
-          } catch {
-            // already torn down
-          }
-          if (this.webglAddon === webglAddon) this.webglAddon = null;
-
-          // DOM and WebGL renderers can calculate slightly different cell
-          // metrics. Wait until the DOM renderer owns the screen, then refit
-          // the stable grid so panel bounds and PTY dimensions stay aligned.
-          requestAnimationFrame(() => {
-            if (this.disposed || this.terminal !== terminal) return;
-            this.fitAndResize(false, true);
-            try {
-              terminal.refresh(0, Math.max(0, terminal.rows - 1));
-            } catch {
-              // The renderer may be torn down during the recovery frame.
-            }
-          });
-        });
-        terminal.loadAddon(webglAddon);
-        this.webglAddon = webglAddon;
-      } catch (error) {
-        console.warn('[terminal] WebGL unavailable — using DOM renderer', error);
+        rendererOverride = window.localStorage.getItem('tessera.terminal.renderer');
+      } catch {
+        // storage unavailable (private mode) — keep the default renderer
       }
+
+      this.webglCtor =
+        rendererOverride === 'dom' ? null : (WebglAddon as new () => WebglAddonLike);
+      this.attachWebglRenderer();
 
       this.root = root;
       this.terminal = terminal;
@@ -868,16 +1053,46 @@ export class TerminalSurface {
       this.lastSequence = message.seq;
       this.replaying = true;
       const restorePoint = this.scrollController?.captureRestorePoint();
-      const shouldRecoverRenderer = this.backgroundSgrDetector.consume(message.data);
+      // Recovery after a replay is unconditional (see onParsed below), but the
+      // detector still consumes the chunk to keep its cross-chunk scan state.
+      this.backgroundSgrDetector.consume(message.data);
       this.terminal?.reset();
-      this.terminal?.write(message.data, () => {
-        if (restorePoint) this.scrollController?.restore(restorePoint);
-        this.scheduleScrollRebuildSettle();
-        if (this.serverGeneration === message.generation) {
-          this.replaying = false;
-        }
-        this.scheduleSurfaceScrollStateSync();
-        if (shouldRecoverRenderer) this.recoverRendererPresentation();
+      // The snapshot serializes wrapped rows with cursor-motion sequences that
+      // only reproduce the original line layout at the grid width they were
+      // serialized on. Replaying at a different width plants misplaced
+      // fragments permanently into the scrollback, so match the snapshot's
+      // grid first and refit to the real pane size after the replay.
+      const snapshotResized =
+        this.terminal
+        && Number.isInteger(message.cols) && Number.isInteger(message.rows)
+        && message.cols >= 2 && message.rows >= 1
+        && (this.terminal.cols !== message.cols || this.terminal.rows !== message.rows);
+      if (snapshotResized) this.terminal?.resize(message.cols, message.rows);
+      if (!this.terminal) return;
+      writeForegroundTerminalChunk(this.terminal, message.data, {
+        forceViewportRefresh: true,
+        // A snapshot replay rewrites the whole grid; always follow up on the
+        // settled frame in case the immediate repaint raced layout.
+        followupViewportRefresh: true,
+        shouldRefreshViewportSynchronously: () => !this.webglAddon,
+        onParsed: () => {
+          if (restorePoint) this.scrollController?.restore(restorePoint);
+          this.scheduleScrollRebuildSettle();
+          if (this.serverGeneration === message.generation) {
+            this.replaying = false;
+          }
+          this.scheduleSurfaceScrollStateSync();
+          // Unconditional, not SGR-gated: a replay rasterizes CJK glyphs into
+          // whatever renderer state preceded the reveal, and that state stays
+          // subtly wrong (whole-pane Korean layout visibly shifts once a later
+          // atlas recovery re-rasterizes it, which is also the moment IME
+          // composition stops garbling). An idle session never gets that
+          // accidental recovery — schedule it deterministically after every
+          // replay instead of waiting for the next output or focus cycle.
+          this.requestStableFit(false);
+          this.retryWebglAttachOnReveal();
+          this.recoverRendererPresentation();
+        },
       });
       return;
     }
@@ -887,11 +1102,16 @@ export class TerminalSurface {
       this.lastSequence = message.seq;
       const restorePoint = this.scrollController?.captureRestorePoint();
       const shouldRecoverRenderer = this.backgroundSgrDetector.consume(message.data);
-      this.terminal?.write(message.data, () => {
-        if (restorePoint) this.scrollController?.restore(restorePoint);
-        this.scheduleScrollRebuildSettle();
-        this.scheduleSurfaceScrollStateSync();
-        if (shouldRecoverRenderer) this.recoverRendererPresentation();
+      if (!this.terminal) return;
+      writeForegroundTerminalChunk(this.terminal, message.data, {
+        forceViewportRefresh: true,
+        shouldRefreshViewportSynchronously: () => !this.webglAddon,
+        onParsed: () => {
+          if (restorePoint) this.scrollController?.restore(restorePoint);
+          this.scheduleScrollRebuildSettle();
+          this.scheduleSurfaceScrollStateSync();
+          if (shouldRecoverRenderer) this.recoverRendererPresentation();
+        },
       });
       return;
     }
@@ -1093,6 +1313,19 @@ export class TerminalSurface {
       // A zero-sized panel can briefly make FitAddon unable to calculate cells.
     } finally {
       if (restorePoint) this.scrollController?.restoreAfterLayout(restorePoint);
+      // Reflow plus the ConPTY resize repaint can strand the viewport in a
+      // blank region: the reflow scroll bumps the controller revision, which
+      // silently invalidates the queued restore. When the user was following
+      // the bottom before the resize, the bottom is an invariant, not a
+      // position — re-assert it once layout settles.
+      if (restorePoint?.intent === 'follow-output') {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            if (this.disposed || !this.scrollController) return;
+            this.scrollController.scrollToBottom();
+          });
+        });
+      }
       this.scheduleSurfaceScrollStateSync();
       // WebGL can finish a rapid resize with the correct xterm buffer but an
       // empty presentation model. Force the same full repaint and quiet atlas
@@ -1109,8 +1342,12 @@ export class TerminalSurface {
   }
 
   private getDimensions(): { cols: number; rows: number } | undefined {
-    return this.fitAddon?.proposeDimensions()
-      ?? (this.terminal ? { cols: this.terminal.cols, rows: this.terminal.rows } : undefined);
+    const proposed = this.fitAddon?.proposeDimensions();
+    // FitAddon clamps to 2x1 when measuring the 1px parking lot; sending that
+    // to the server would create the PTY and its headless model at a 2-column
+    // grid and permanently wrap early output into 1-2 character fragments.
+    if (proposed && proposed.cols > 2 && proposed.rows > 1) return proposed;
+    return this.terminal ? { cols: this.terminal.cols, rows: this.terminal.rows } : undefined;
   }
 
   private getProposedDimensions(): { cols: number; rows: number } | undefined {
@@ -1215,6 +1452,7 @@ export class TerminalSurface {
 }
 
 export function getTerminalSurface(options: TerminalSurfaceOptions): TerminalSurface {
+  installTerminalWakeRecovery();
   const existing = surfaces.get(options.registryKey);
   if (existing) return existing;
   const surface = new TerminalSurface(options);

--- a/src/lib/terminal/terminal-write-guard.ts
+++ b/src/lib/terminal/terminal-write-guard.ts
@@ -1,0 +1,21 @@
+// xterm's WriteBuffer._innerWrite invokes write-completion callbacks with no
+// try/catch; a synchronous throw skips the loop's tail re-schedule, and
+// write() only re-arms processing when the buffer is empty — which a stalled
+// buffer never is again. One escaping throw therefore permanently freezes the
+// surface: output stops rendering and the shell keeps eating keystrokes.
+// Guard each completion step individually so an earlier step's failure (e.g.
+// a WebGL refresh during viewport settle) cannot starve a later step.
+
+const MAX_REPORTS_PER_CONTEXT = 5;
+const reportCountsByContext = new Map<string, number>();
+
+export function runGuardedWriteCompletionStep(context: string, step: () => void): void {
+  try {
+    step();
+  } catch (error: unknown) {
+    const reported = reportCountsByContext.get(context) ?? 0;
+    if (reported >= MAX_REPORTS_PER_CONTEXT) return;
+    reportCountsByContext.set(context, reported + 1);
+    console.error(`[terminal] write-completion step "${context}" threw`, error);
+  }
+}

--- a/tests/terminal-render-pause-release.test.ts
+++ b/tests/terminal-render-pause-release.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { forceRepaintThroughRenderPause } from '@/lib/terminal/terminal-render-pause-release';
+
+interface RefreshCall {
+  start: number;
+  end: number;
+  sync: boolean | undefined;
+}
+
+function createTerminal(
+  options: { paused: boolean; rows?: number; onRefresh?: () => void } = { paused: true },
+): { terminal: unknown; calls: RefreshCall[]; service: Record<string, unknown> } {
+  const calls: RefreshCall[] = [];
+  const service = {
+    _isPaused: options.paused,
+    _needsFullRefresh: true,
+    refreshRows(start: number, end: number, sync?: boolean) {
+      calls.push({ start, end, sync });
+      options.onRefresh?.();
+    },
+  };
+  const terminal = { rows: options.rows ?? 24, _core: { _renderService: service } };
+  return { terminal, calls, service: service as unknown as Record<string, unknown> };
+}
+
+test('paused renderer is driven synchronously across the full viewport', () => {
+  const { terminal, calls } = createTerminal({ paused: true, rows: 24 });
+
+  assert.equal(forceRepaintThroughRenderPause(terminal), true);
+  assert.deepEqual(calls, [{ start: 0, end: 23, sync: true }]);
+});
+
+test('pause latches are cleared so the observer does not queue a second repaint', () => {
+  const { terminal, service } = createTerminal({ paused: true });
+
+  forceRepaintThroughRenderPause(terminal);
+
+  assert.equal(service._isPaused, false);
+  assert.equal(service._needsFullRefresh, false);
+});
+
+test('an unpaused renderer is left untouched so the caller falls back to refresh', () => {
+  const { terminal, calls } = createTerminal({ paused: false });
+
+  assert.equal(forceRepaintThroughRenderPause(terminal), false);
+  assert.deepEqual(calls, []);
+});
+
+test('missing xterm internals degrade to a no-op instead of throwing', () => {
+  assert.equal(forceRepaintThroughRenderPause(null), false);
+  assert.equal(forceRepaintThroughRenderPause(undefined), false);
+  assert.equal(forceRepaintThroughRenderPause({}), false);
+  assert.equal(forceRepaintThroughRenderPause({ rows: 24, _core: {} }), false);
+  // A renamed internal leaves refreshRows undefined — must not throw.
+  assert.equal(
+    forceRepaintThroughRenderPause({ rows: 24, _core: { _renderService: { _isPaused: true } } }),
+    false,
+  );
+});
+
+test('a terminal without usable rows is skipped', () => {
+  const { terminal: zeroRows, calls: zeroCalls } = createTerminal({ paused: true, rows: 0 });
+  assert.equal(forceRepaintThroughRenderPause(zeroRows), false);
+  assert.deepEqual(zeroCalls, []);
+
+  const { terminal: noRows } = createTerminal({ paused: true });
+  (noRows as { rows?: number }).rows = undefined;
+  assert.equal(forceRepaintThroughRenderPause(noRows), false);
+});
+
+test('a throwing render reports failure so the caller can still fall back', () => {
+  const { terminal } = createTerminal({
+    paused: true,
+    onRefresh: () => {
+      throw new Error('renderer disposed mid-frame');
+    },
+  });
+
+  assert.equal(forceRepaintThroughRenderPause(terminal), false);
+});


### PR DESCRIPTION
## Summary

Ports the render-stability stack orca runs on Windows into the terminal surface, fixing the remaining "garbles until you resize / refocus the window" class:

- **Pierce xterm's paused RenderService** (`terminal-render-pause-release.ts`): on reveal, xterm's own IntersectionObserver can lag a frame with `RenderService._isPaused` still set, and every `refresh()` is then latched instead of serviced — all recovery repaints were being silently swallowed. All internal access is typeof-guarded and degrades to a no-op across xterm upgrades.
- **Foreground write render-settle** (`terminal-foreground-render-settle.ts` + `terminal-write-guard.ts`): repaint the viewport with each output write and once more on the settled frame when the write scrolled it — Chromium paints a freshly scrolled row a frame later than xterm parses, and the WebGL model diff then skips it. Write-completion steps run individually guarded because a throw escaping xterm's WriteBuffer loop permanently wedges the terminal.
- **Wake recovery**: on window focus (atlas-preserving) and visibility resume (atlas-clearing; strength only upgrades between coalesced events), retry the WebGL attach, refit, and repaint every surface. Windows reclaims GPU contexts across sleep/occlusion far more aggressively than macOS.
- **WebGL reattach at reveal boundaries** (tab show, mount, replay completion): a context lost while a surface sat hidden — or one transient attach failure tripping the module-wide backoff latch — otherwise stranded surfaces on the DOM renderer until the next window-level focus cycle. The two renderers compute subtly different cell metrics, so stranded panes drew CJK slightly misaligned and Korean IME composition anchored against the wrong grid; users' reliable cure was literally unfocusing and refocusing the app. Also releases the GL context (`WEBGL_lose_context` + canvas collapse) on teardown so Windows/ANGLE frees the context-budget slot immediately.
- **Replay correctness**: replay snapshots at the grid they were serialized on (the serializer reproduces wrapped rows with cursor motion that only lines up at the original width; a mismatched replay plants 1–2-character fragments permanently into scrollback), then refit and run renderer recovery deterministically after every replay instead of waiting for the next output or focus event. `getDimensions()` no longer reports FitAddon's 2x1 parking-lot clamp to the server.
- **Resize bottom-follow invariant**: a resize while following the bottom could strand the viewport in a blank region (the reflow scroll bumps the scroll controller revision, invalidating the queued restore); re-assert the bottom on a settled frame.
- Escape hatch: `localStorage.setItem('tessera.terminal.renderer', 'dom')` forces the DOM renderer — also a diagnostic (a report that survives on DOM is buffer corruption, not a renderer artifact).

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] `NODE_ENV=production npm run build`
- [x] Manual test: verified on a Windows 10 machine (150% DPI, Korean IME, WSL2 sessions): reopened-session Korean IME composition no longer garbles or requires a focus cycle; resize no longer blanks the viewport; scrollback fragments no longer appear after tab switches. Unit tests: 23/23 across render-pause-release, render-recovery, and scroll-controller suites.
- [ ] Not tested:

## Screenshots or Recordings

Before/after screenshots of the Windows garble available from the debugging session on request.

## Notes

Part 3 of 3 of the Windows terminal stability work. Pairs with the xterm addon patch PR (the atlas-wipe recovery becomes a real wipe there) but does not depend on it to build or run.
