### PR TITLE
fix(terminal): reclaim the PTY viewport when a visible pane finishes replay

### DIFF
--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -1089,7 +1089,15 @@ export class TerminalSurface {
           // composition stops garbling). An idle session never gets that
           // accidental recovery — schedule it deterministically after every
           // replay instead of waiting for the next output or focus cycle.
-          this.requestStableFit(false);
+          //
+          // The refit must CLAIM the viewport when this surface is the one on
+          // screen: the server drops non-claiming resizes while another
+          // subscriber owns the viewport (attach hands ownership to whoever
+          // attached last, e.g. a session preview), and a dropped refit leaves
+          // the PTY on a different grid than this view — the TUI then draws
+          // its input box displaced into the transcript. Previews and hidden
+          // LRU replays must not steal the viewport back.
+          this.requestStableFit(this.isMountedHostVisible() && !this.options.previewOwned);
           this.retryWebglAttachOnReveal();
           this.recoverRendererPresentation();
         },


### PR DESCRIPTION
## Summary

- Claim the PTY viewport on the post-replay refit when the surface is visible and not preview-owned. The server drops non-claiming resizes while another subscriber owns the viewport, and attach hands ownership to whoever attached last (e.g. a session preview) — a visible pane whose post-replay refit was dropped then runs on a different grid than the PTY, and the TUI draws its input box displaced into the transcript (typed echo lands between transcript rows, border rows mangle). Previews and hidden LRU replays keep sending non-claiming resizes so they cannot steal the viewport back.

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] `NODE_ENV=production npm run build`
- [x] Manual test: reproduced the displaced-input-box state on Windows before the fix; unit suites (render-pause-release, render-recovery, scroll-controller) pass 23/23.
- [ ] Not tested:

## Screenshots or Recordings

N/A.

## Notes

Follow-up to #171.
