### PR TITLE
fix(terminal): make peek and preview attaches read-only viewers

### DIFF
--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -106,6 +106,7 @@ export function TerminalPanel({
     sessionId: getSessionSelectionId(terminalSessionId),
     launch,
     previewOwned: runtimeOwnership === 'session-preview',
+    peekViewer: runtimeOwnership === 'session-peek',
   }), [
     isDark,
     launch,

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -808,7 +808,7 @@ export class TerminalManager {
     runtime: TerminalRuntime,
     options: Pick<
       TerminalCreateOptions,
-      'connectionId' | 'surfaceId' | 'cols' | 'rows' | 'appearance'
+      'connectionId' | 'surfaceId' | 'cols' | 'rows' | 'appearance' | 'previewOwnerToken' | 'viewer'
     >,
     reattached: boolean,
   ): Promise<void> {
@@ -824,8 +824,16 @@ export class TerminalManager {
     const snapshotSeq = runtime.sequence;
     const fallbackSnapshot = runtime.outputBuffer.join('');
     runtime.subscribers.set(subscriberKey, subscriber);
-    runtime.viewportOwner = subscriberKey;
-    if (options.cols && options.rows) {
+    // A preview attach (kanban peek) must not steal the viewport or resize
+    // the live PTY: resizing reflows the real session to the peek panel's
+    // grid, and the pane the user returns to renders displaced until it
+    // reclaims. A preview only takes over when nothing else owns the
+    // viewport (it created the runtime, or every owner detached).
+    const previewAttach = Boolean(options.previewOwnerToken) || options.viewer === true;
+    if (!previewAttach || runtime.viewportOwner === null) {
+      runtime.viewportOwner = subscriberKey;
+    }
+    if (options.cols && options.rows && runtime.viewportOwner === subscriberKey) {
       this.resizeRuntime(runtime, options.cols, options.rows);
     }
     this.sendStarted(runtime, subscriber, reattached);

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -78,6 +78,8 @@ export interface TerminalSurfaceOptions {
   sessionId?: string | null;
   launch?: { providerId: string; sessionId: string };
   previewOwned?: boolean;
+  /** Read-only peek surface: never claims the viewport or fits to its host. */
+  peekViewer?: boolean;
 }
 
 type XtermLike = TerminalScrollTarget & {
@@ -293,6 +295,7 @@ export class TerminalSurface {
   private serverGeneration: number | null = null;
   private lastSequence = 0;
   private replaying = false;
+  private previewViewer = false;
   private onInput: (() => void) | null = null;
   private terminalInputOriginArmed = false;
   private terminalInputOriginEpoch = 0;
@@ -466,6 +469,7 @@ export class TerminalSurface {
       prefillInput: pendingLaunch?.prefillInput,
       launch: pendingLaunch?.launch ?? this.options.launch,
       previewOwnerToken: this.options.previewOwned ? this.surfaceId : undefined,
+      viewer: this.options.peekViewer === true ? true : undefined,
     });
 
     if (!sent) {
@@ -1007,6 +1011,12 @@ export class TerminalSurface {
 
     if (message.type === 'terminal_started') {
       this.actualTerminalId = message.terminalId;
+      // A preview/peek surface attached to an already-running terminal is a
+      // read-only viewer: the server keeps the owner's grid, so local fits
+      // must not shrink this xterm to the peek panel or the view renders
+      // displaced against the PTY.
+      this.previewViewer = message.reattached
+        && (this.options.previewOwned === true || this.options.peekViewer === true);
       if (this.serverGeneration !== message.generation) {
         this.serverGeneration = message.generation;
         this.lastSequence = 0;
@@ -1298,6 +1308,10 @@ export class TerminalSurface {
   }
 
   private fitAndResize(claim: boolean, shouldFit = true): void {
+    // A preview viewer follows the owner's grid (set by the snapshot replay);
+    // fitting it to the peek panel would desync it from the PTY and the TUI
+    // would render displaced inside the preview.
+    if (this.previewViewer) return;
     if (!this.isMountedHostVisible() || !this.fitAddon || !this.terminal) return;
     let didFit = false;
     let restorePoint: TerminalScrollRestorePoint | null = null;

--- a/src/lib/terminal/types.ts
+++ b/src/lib/terminal/types.ts
@@ -40,6 +40,8 @@ export interface TerminalCreateOptions {
   surfaceId: string;
   /** Token that may conditionally release a runtime created by a transient preview. */
   previewOwnerToken?: string;
+  /** Read-only attach (kanban peek): never claims the viewport or resizes the PTY. */
+  viewer?: boolean;
   cwd?: string | null;
   sessionId?: string | null;
   shellKind?: TerminalShellKind;

--- a/src/lib/ws/client.ts
+++ b/src/lib/ws/client.ts
@@ -378,6 +378,7 @@ export class WebSocketClient {
     prefillInput?: string;
     launch?: { providerId: string; sessionId: string };
     previewOwnerToken?: string;
+    viewer?: boolean;
   }): boolean {
     // A deliberate restart supersedes a close queued during a disconnect.
     this.pendingTerminalCloses.delete(args.terminalId);

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -94,6 +94,8 @@ export type ClientMessage =
       terminalId: string;
       surfaceId: string;
       previewOwnerToken?: string;
+      /** Read-only attach (kanban peek): never claims the viewport or resizes the PTY. */
+      viewer?: boolean;
       cwd?: string | null;
       sessionId?: string | null;
       shellKind?: TerminalShellKind;

--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -696,6 +696,7 @@ export async function routeClientTransportMessage({
           connectionId,
           surfaceId: message.surfaceId,
           previewOwnerToken: message.previewOwnerToken,
+          viewer: message.viewer,
           terminalId,
           cwd: message.cwd,
           sessionId,


### PR DESCRIPTION
## Summary

- Server: an attach carrying `previewOwnerToken` or the new `viewer` flag (kanban peek, which is not preview-owned) no longer steals the PTY viewport or resizes the live runtime to the attaching panel's grid; it only takes ownership when nothing else owns the viewport (it created the runtime, or every owner detached).
- Client: a preview/peek surface attached to an already-running terminal becomes a read-only viewer — local fits are skipped and its xterm follows the owner's grid from the snapshot replay. Opening a session from the kanban peek or a list-view preview previously resized the real PTY to the panel's grid, and the TUI drew its input box displaced into the transcript both inside the peek and in the pane the user returned to.
- New optional `viewer` field on `terminal_create` plumbed through client/types/routing/manager.

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] `NODE_ENV=production npm run build`
- [x] Manual test: reproduced the displaced input box via kanban peek and list view before the change; terminal contract + render/scroll suites pass 79/79.
- [ ] Not tested:

## Screenshots or Recordings

N/A.

## Notes

Follow-up to #171/#172.
