### PR TITLE
fix(terminal): never resize a live runtime from attach dims

### DIFF
--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -833,7 +833,14 @@ export class TerminalManager {
     if (!previewAttach || runtime.viewportOwner === null) {
       runtime.viewportOwner = subscriberKey;
     }
-    if (options.cols && options.rows && runtime.viewportOwner === subscriberKey) {
+    // Never resize a live runtime from attach dims (orca's daemon does the
+    // same): a reattaching client measures its pane only after mount, so its
+    // attach carries pre-fit defaults (80x24) — resizing the PTY to them and
+    // back again on the post-replay refit makes the TUI paint garbage frames
+    // at the wrong grid into scrollback, which is why reopened sessions came
+    // up broken at random. The claiming refit after the replay applies the
+    // one correct, measured resize.
+    if (options.cols && options.rows && runtime.viewportOwner === subscriberKey && !reattached) {
       this.resizeRuntime(runtime, options.cols, options.rows);
     }
     this.sendStarted(runtime, subscriber, reattached);


### PR DESCRIPTION
## Summary

- Stop resizing a live runtime from attach dims. A reattaching client measures its pane only after mount, so its attach carries pre-fit defaults (80x24); resizing the live PTY to them and back again on the post-replay claiming refit made the TUI paint garbage frames at the wrong grid into scrollback right before the snapshot — reopened sessions came up broken at random depending on how the double resize raced the replay. orca's daemon likewise never resizes on attach: sizing flows only from the foreground pane's measured fit.
- Fresh creates still size normally (spawn dims), and a preview/viewer attach still never resizes (see #173).

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] `NODE_ENV=production npm run build`
- [x] Manual test: terminal contract + render/resize suites pass 67/67.
- [ ] Not tested:

## Screenshots or Recordings

N/A.

## Notes

Follow-up to #172/#173; targets the remaining random broken-open on session reopen.
