### PR TITLE
fix(terminal): queue keystrokes during snapshot replay instead of dropping them

### DIFF
--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -206,6 +206,8 @@ let parkingLot: HTMLElement | null = null;
  */
 const COLD_PARK_DELAY_MS = 30_000;
 const TERMINAL_RESIZE_SETTLE_DELAY_MS = 150;
+/** Upper bound for keystrokes queued while a snapshot replay parses. */
+const MAX_PENDING_REPLAY_INPUT_CHARS = 8_192;
 
 function getParkingLot(): HTMLElement {
   if (parkingLot?.isConnected) return parkingLot;
@@ -295,6 +297,7 @@ export class TerminalSurface {
   private serverGeneration: number | null = null;
   private lastSequence = 0;
   private replaying = false;
+  private pendingReplayInput = '';
   private previewViewer = false;
   private onInput: (() => void) | null = null;
   private terminalInputOriginArmed = false;
@@ -363,7 +366,7 @@ export class TerminalSurface {
     this.setThemeRestartRequired(false);
     this.themeRestartPending = true;
     this.autoConnect = true;
-    this.replaying = false;
+    this.discardReplayState();
     this.updateState('starting', 'Restarting terminal to apply theme...');
     wsClient.closeTerminal(this.actualTerminalId);
   }
@@ -487,8 +490,34 @@ export class TerminalSurface {
   }
 
   sendInput(data: string): boolean {
-    if (this.disposed || this.replaying || this.state.status === 'exited') return false;
+    if (this.disposed || this.state.status === 'exited') return false;
+    if (this.replaying) {
+      // Keystrokes during a snapshot replay used to be dropped silently, so a
+      // reopened session ignored typing for however long the replay took to
+      // parse (seconds on a deep scrollback — the random "input dead after
+      // opening" reports). Queue them and flush in order once the replay
+      // settles; restart/exit paths discard the queue instead.
+      if (this.pendingReplayInput.length + data.length <= MAX_PENDING_REPLAY_INPUT_CHARS) {
+        this.pendingReplayInput += data;
+      }
+      return true;
+    }
     return wsClient.sendTerminalInput(this.actualTerminalId, this.surfaceId, data);
+  }
+
+  /** Replay finished parsing: reopen the input path and flush queued keys. */
+  private finishReplayAndFlushInput(): void {
+    this.replaying = false;
+    const pending = this.pendingReplayInput;
+    this.pendingReplayInput = '';
+    if (!pending || this.disposed || this.state.status === 'exited') return;
+    wsClient.sendTerminalInput(this.actualTerminalId, this.surfaceId, pending);
+  }
+
+  /** Restart/exit paths: the queued keys no longer target a live view. */
+  private discardReplayState(): void {
+    this.replaying = false;
+    this.pendingReplayInput = '';
   }
 
   /** Ask the server to close only a runtime created by this preview token. */
@@ -620,7 +649,7 @@ export class TerminalSurface {
     this.autoConnect = true;
     this.serverGeneration = null;
     this.lastSequence = 0;
-    this.replaying = false;
+    this.discardReplayState();
     this.terminal?.reset();
     this.scrollController?.scrollToBottom();
     this.updateState('starting', 'Restarting terminal...');
@@ -1078,7 +1107,12 @@ export class TerminalSurface {
         && message.cols >= 2 && message.rows >= 1
         && (this.terminal.cols !== message.cols || this.terminal.rows !== message.rows);
       if (snapshotResized) this.terminal?.resize(message.cols, message.rows);
-      if (!this.terminal) return;
+      if (!this.terminal) {
+        // No terminal to replay into — never leave the replaying latch set or
+        // the input path stays closed forever.
+        this.discardReplayState();
+        return;
+      }
       writeForegroundTerminalChunk(this.terminal, message.data, {
         forceViewportRefresh: true,
         // A snapshot replay rewrites the whole grid; always follow up on the
@@ -1089,7 +1123,7 @@ export class TerminalSurface {
           if (restorePoint) this.scrollController?.restore(restorePoint);
           this.scheduleScrollRebuildSettle();
           if (this.serverGeneration === message.generation) {
-            this.replaying = false;
+            this.finishReplayAndFlushInput();
           }
           this.scheduleSurfaceScrollStateSync();
           // Unconditional, not SGR-gated: a replay rasterizes CJK glyphs into
@@ -1147,14 +1181,14 @@ export class TerminalSurface {
         }
         this.serverGeneration = null;
         this.lastSequence = 0;
-        this.replaying = false;
+        this.discardReplayState();
         this.terminal?.reset();
         this.scrollController?.scrollToBottom();
         void this.ensureConnected();
         return;
       }
       this.autoConnect = false;
-      this.replaying = false;
+      this.discardReplayState();
       clearClientTerminalHandoff(this.options.terminalId);
       this.updateState('exited', `Terminal exited with code ${message.exitCode}`);
       this.finishPendingLaunch('error', `Terminal exited with code ${message.exitCode}`);


### PR DESCRIPTION
## Summary

- `sendInput` silently discarded every keystroke while `replaying` was set; a reopened session keeps that latch up for as long as the snapshot takes to parse (seconds on a deep scrollback), so typing right after opening a session randomly went nowhere and had to be retyped.
- Queue up to 8KB of input during the replay and flush it in order when the replay finishes parsing. Restart/exit paths discard the queue (those keys no longer target a live view). The no-terminal early return now clears the latch so the input path can never wedge shut.

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] `NODE_ENV=production npm run build`
- [x] Manual test: terminal contract + render/scroll suites pass 72/72.
- [ ] Not tested:

## Screenshots or Recordings

N/A.

## Notes

Companion to #174 — together they cover the random broken-open and the random input-dead window on session reopen.
