### PR TITLE
feat(terminal): fork sessions when provider conversations reset

### DIFF
--- a/docs/research/orca-native-cli-fork.md
+++ b/docs/research/orca-native-cli-fork.md
@@ -115,6 +115,45 @@ Orca terminal context menu의 fork는 위 native fork와 다르다. xterm scroll
 [new worktree + tab](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.ts#L215-L302),
 [bounded prompt](https://github.com/stablyai/orca/blob/b19dccd9b74328daa39bf20955a57fdfc7279c3e/src/renderer/src/lib/agent-session-fork-context.ts#L1-L20)
 
+## 6. 대화 리셋(`/clear`·`/new`)은 fork와 신호 타이밍이 다르다 — 2026-07-22 실측
+
+같은 "새 provider 세션"이라도 리셋은 fork와 달리 **CLI가 즉시 알려주지 않는다.**
+codex-cli 0.144.5와 opencode 1.14.48을 PTY로 띄워 훅/플러그인 이벤트를 직접 캡처한 결과:
+
+| CLI | 리셋 직후 | 다음 프롬프트 제출 시 |
+| --- | --- | --- |
+| claude | `SessionStart(source=clear)` 새 session_id 즉시 (대화가 없어도 발화) | — |
+| codex | 이벤트 없음 (rollout 파일도 안 생김) | `SessionStart(source=clear)` + 새 rollout |
+| opencode | 이벤트 없음 (`session.created` 안 옴) | `session.created` → 플러그인 `SessionStart` |
+
+codex/opencode는 새 대화를 lazy하게 만든다 — 리셋 시점엔 provider session id 자체가
+존재하지 않는다. 그래서 hook만으로는 "다음 프롬프트까지 이전 Tessera 세션에 묶여 있는"
+공백이 생긴다(수정 전 실측: `/clear` 후 사이드바 무변화, 다음 프롬프트에서야 fork 생성).
+
+### 왜 hook·artifact로는 못 잡는가
+
+- codex 훅 이벤트는 바이너리 기준 7종뿐이다: `session_start`, `user_prompt_submit`,
+  `pre_tool_use`, `post_tool_use`, `permission_request`, `stop`, `compact`.
+  세션 종료/전환 계열 이벤트가 아예 없어 `/clear` 시점에 발화시킬 훅이 없다.
+- codex `remote-control`은 app-server 데몬 전용이라 PTY의 TUI 프로세스와 별개다.
+- opencode 플러그인 훅은 `event`(서버 이벤트 버스)·`tool`·`auth`·`permission.ask`뿐이고,
+  `/new`는 TUI 클라이언트의 로컬 상태 전환이라 서버 이벤트가 발생하지 않는다.
+
+### 그래서 화면을 읽는다
+
+리셋 순간 두 CLI가 확실히 하는 일은 화면 repaint뿐이다. 입력 방식(타이핑/탭 완성/
+팝업 선택)과 무관하므로 Tessera는 여기서 신호를 얻는다
+(`terminal-conversation-reset-screen.ts`, provider adapter의 `detectTerminalConversationReset`):
+
+- codex: 방금 닫은 세션의 `To continue this session, run codex resume <uuid>`.
+  uuid를 Tessera가 보유한 provider session id와 대조하므로 오탐이 사실상 없다.
+- opencode: 빈 컴포저 홈 화면의 `Ask anything...` 문구(대화가 생기면 사라진다).
+
+감지되면 provider 식별자 없이 세션을 먼저 분기해 두고(`terminalProviderSessionPending`),
+뒤늦게 도착한 첫 식별자를 그 세션이 흡수한다. 감지가 틀렸다면 이전 식별자가 다시
+관찰되므로 빈 대기 세션을 버리고 원래 세션으로 PTY를 되돌린다. 화면 문구가 바뀌어
+감지에 실패해도 동작은 수정 전(다음 프롬프트에 fork)으로 degrade될 뿐이다.
+
 ## Tessera 적용 시사점
 
 1. 공통 `ProviderSessionIdentity { provider, id, transcriptPath? }`를 PTY session/tab ID와

--- a/src/lib/cli/hook-receiver.ts
+++ b/src/lib/cli/hook-receiver.ts
@@ -212,6 +212,11 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
         pane: entry,
         identity: providerIdentity,
         activation: discoveredInBackground ? 'background' : 'active',
+        // SessionStart(source=clear) is a conversation reset, not a branch of the
+        // current one: the child starts empty and must be titled like a new session.
+        ...(event === 'SessionStart' && readString(payload.source) === 'clear'
+          ? { origin: 'reset' as const }
+          : {}),
       });
       if (observation.ignored) return send(204);
       sessionId = observation.sessionId;

--- a/src/lib/cli/providers/codex/adapter.ts
+++ b/src/lib/cli/providers/codex/adapter.ts
@@ -66,6 +66,7 @@ import { getRuntimePlatform } from '@/lib/system/runtime-platform';
 import logger from '@/lib/logger';
 import { getTesseraDataPath } from '@/lib/tessera-data-dir';
 import { fetchCodexRateLimitSnapshot } from './rate-limit-client';
+import { codexScreenShowsConversationReset } from '@/lib/terminal/terminal-conversation-reset-screen';
 
 const CLI_TIMEOUT_MS = 120_000;
 const STATUS_CHECK_TIMEOUT_MS = 5_000;
@@ -275,6 +276,8 @@ export class CodexAdapter implements CliProvider {
   }
 
   createTerminalSessionObserver = createCodexTerminalSessionObserver;
+
+  detectTerminalConversationReset = codexScreenShowsConversationReset;
 
   canResumeTerminalAfterRestart(providerState: string | null): boolean {
     if (!providerState) return false;

--- a/src/lib/cli/providers/opencode/adapter.ts
+++ b/src/lib/cli/providers/opencode/adapter.ts
@@ -27,6 +27,7 @@ import { updateProviderStateWithRetry } from '../../process-manager-side-effects
 import { getRuntimePlatform } from '@/lib/system/runtime-platform';
 import logger from '@/lib/logger';
 import { opencodeProtocolParser } from './protocol-parser';
+import { openCodeScreenShowsConversationReset } from '@/lib/terminal/terminal-conversation-reset-screen';
 import {
   buildOpenCodePermissionEnv,
   composeOpenCodeModelId,
@@ -121,6 +122,8 @@ export class OpenCodeAdapter implements CliProvider {
   getTerminalInterruptInputPolicy(): 'none' {
     return 'none';
   }
+
+  detectTerminalConversationReset = openCodeScreenShowsConversationReset;
 
   async isAvailable(environment?: 'native' | 'wsl'): Promise<boolean> {
     if (environment) {

--- a/src/lib/cli/providers/provider-contract.ts
+++ b/src/lib/cli/providers/provider-contract.ts
@@ -158,6 +158,18 @@ export interface CliProvider {
   }): boolean;
 
   /**
+   * Recognizes, from what the PTY currently shows, that the running conversation
+   * was reset in place (`/clear`, `/new`). Codex and OpenCode mint the next
+   * session id lazily — nothing is reported until the next prompt — so the
+   * screen is the only signal available at the moment it happens, and it is
+   * independent of how the command was issued (typed, completed, or picked).
+   */
+  detectTerminalConversationReset?(options: {
+    visibleText: string;
+    currentProviderSessionId: string;
+  }): boolean;
+
+  /**
    * Checks whether this CLI binary is available in the requested environment
    * ("native" host vs. "wsl"). When omitted, implementations fall back to a
    * same-host binary probe.

--- a/src/lib/db/sessions.ts
+++ b/src/lib/db/sessions.ts
@@ -314,6 +314,17 @@ export function getArchivedChatSessions(
   `).all(...params) as SessionRow[];
 }
 
+/** Sessions a project currently shows, used to number a new placeholder title. */
+export function countActiveSessionsInProject(projectId: string): number {
+  const row = getDb().prepare(`
+    SELECT COUNT(*) as cnt
+    FROM sessions s
+    LEFT JOIN tasks t ON t.id = s.task_id
+    WHERE s.project_id = ? AND ${ACTIVE_SESSION_SCOPE_SQL}
+  `).get(projectId) as { cnt: number } | undefined;
+  return row?.cnt ?? 0;
+}
+
 export function countArchivedChatSessions(projectId?: string, query?: string): number {
   const where = archivedChatWhere(projectId, query);
   const row = getDb().prepare(`

--- a/src/lib/terminal/provider-session-identity.ts
+++ b/src/lib/terminal/provider-session-identity.ts
@@ -95,6 +95,33 @@ export function resolveTerminalProviderSessionReference(
     : { providerSessionId: tesseraSessionId, nativeFork: false };
 }
 
+/**
+ * State for a PTY session forked before its provider identity exists — the
+ * Codex/OpenCode reset case, where the CLI only mints the new session id once
+ * the next prompt is submitted. The marker tells reconciliation that the first
+ * identity this session observes is its own (and that an identity already owned
+ * by another session means the reset never happened).
+ */
+export function buildPendingTerminalProviderState(): string {
+  return JSON.stringify({
+    kind: 'terminal',
+    launched: true,
+    terminalProviderSessionPending: true,
+  });
+}
+
+export function isPendingTerminalProviderSessionState(
+  providerState: string | null | undefined,
+): boolean {
+  if (!providerState) return false;
+  try {
+    return (JSON.parse(providerState) as Record<string, unknown>)
+      .terminalProviderSessionPending === true;
+  } catch {
+    return false;
+  }
+}
+
 export function buildTerminalProviderState(
   identity: TerminalProviderSessionIdentity,
   activation?: TerminalProviderSessionActivation,

--- a/src/lib/terminal/provider-session-observation.ts
+++ b/src/lib/terminal/provider-session-observation.ts
@@ -2,7 +2,10 @@ import logger from '@/lib/logger';
 import { broadcastSessionMutation } from '@/lib/ws/mutation-broadcast';
 import type { PaneTokenEntry } from './pane-token-registry';
 import type { TerminalProviderSessionIdentity } from './provider-session-identity';
-import { reconcileTerminalProviderSession } from './provider-session-reconciliation';
+import {
+  reconcileTerminalProviderSession,
+  type TerminalProviderSessionOrigin,
+} from './provider-session-reconciliation';
 import { terminalManager } from './shared-terminal-manager';
 
 /** Applies one provider identity observation to the common PTY session model. */
@@ -10,8 +13,9 @@ export function observeTerminalProviderSession(options: {
   pane: PaneTokenEntry;
   identity: TerminalProviderSessionIdentity;
   activation: 'active' | 'background';
+  origin?: TerminalProviderSessionOrigin;
 }): { ignored: boolean; sessionId: string | null } {
-  const { pane, identity, activation } = options;
+  const { pane, identity, activation, origin } = options;
   const activeSessionId = pane.sessionId
     ? terminalManager.getSessionIdForTerminal(pane.terminalId, pane.userId)
     : null;
@@ -47,6 +51,7 @@ export function observeTerminalProviderSession(options: {
     sourceSessionId: activeSessionId,
     identity,
     activation,
+    ...(origin ? { origin } : {}),
   });
   if (reconciliation.kind === 'created') {
     broadcastSessionMutation(pane.userId, {

--- a/src/lib/terminal/provider-session-reconciliation.ts
+++ b/src/lib/terminal/provider-session-reconciliation.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { generateDefaultTitle } from '@/lib/session/title-generator';
 import * as dbSessions from '@/lib/db/sessions';
 import { getDb } from '@/lib/db/database';
 import {
@@ -7,11 +8,16 @@ import {
   getTerminalProviderSessionForTesseraSession,
 } from '@/lib/db/terminal-provider-sessions';
 import {
+  buildPendingTerminalProviderState,
   buildTerminalProviderState,
+  isPendingTerminalProviderSessionState,
   readPersistedTerminalProviderSessionId,
   type TerminalProviderSessionActivation,
   type TerminalProviderSessionIdentity,
 } from './provider-session-identity';
+
+/** How the provider's new session came to exist. */
+export type TerminalProviderSessionOrigin = 'fork' | 'reset';
 
 export type TerminalProviderSessionReconciliationResult = {
   kind: 'ignored' | 'unchanged' | 'existing' | 'created';
@@ -21,9 +27,17 @@ export type TerminalProviderSessionReconciliationResult = {
   projectId?: string;
 };
 
-function forkTitle(sourceTitle: string): string {
+/**
+ * A fork continues the parent conversation, so it inherits the parent's title.
+ * A reset (`/clear`, `/new`) starts an empty one and must look like any other
+ * new session — a placeholder the first prompt then replaces with a real title.
+ */
+function childTitle(source: dbSessions.SessionRow, origin: TerminalProviderSessionOrigin): string {
+  if (origin === 'reset') {
+    return generateDefaultTitle(dbSessions.countActiveSessionsInProject(source.project_id));
+  }
   const suffix = ' (Fork)';
-  return `${sourceTitle.slice(0, Math.max(1, 100 - suffix.length))}${suffix}`;
+  return `${source.title.slice(0, Math.max(1, 100 - suffix.length))}${suffix}`;
 }
 
 function registerIdentity(
@@ -38,14 +52,16 @@ function registerIdentity(
   });
 }
 
-function createForkSession(
+function createChildSession(
   source: dbSessions.SessionRow,
-  identity: TerminalProviderSessionIdentity,
-  activation?: TerminalProviderSessionActivation,
+  origin: TerminalProviderSessionOrigin,
+  providerState: string,
+  onCreated?: (sessionId: string) => void,
 ): string {
   const sessionId = randomUUID();
+  const title = childTitle(source, origin);
   getDb().transaction(() => {
-    dbSessions.createSession(sessionId, source.project_id, forkTitle(source.title), source.provider, {
+    dbSessions.createSession(sessionId, source.project_id, title, source.provider, {
       workDir: source.work_dir ?? undefined,
       worktreeManaged: source.worktree_managed === 1,
       taskId: source.task_id ?? undefined,
@@ -53,24 +69,87 @@ function createForkSession(
       model: source.model ?? undefined,
       reasoningEffort: source.reasoning_effort,
       serviceTier: source.service_tier,
-      providerState: buildTerminalProviderState(identity, activation),
+      providerState,
     });
     dbSessions.updateSession(sessionId, {
       worktree_branch: source.worktree_branch,
       worktree_managed: source.worktree_managed ?? 0,
       chat_workflow_status: source.chat_workflow_status,
     });
-    registerIdentity(sessionId, identity);
+    onCreated?.(sessionId);
   })();
   return sessionId;
+}
+
+/**
+ * Forks a PTY session before the provider has minted the identity for it — the
+ * Codex/OpenCode reset case. The child carries no provider session id yet; the
+ * first one it observes becomes its own (see reconcilePendingTerminalProviderSession).
+ * Returns null when the source has no provider conversation to leave behind.
+ */
+export function createPendingTerminalProviderSessionFork(
+  sourceSessionId: string,
+): { sessionId: string; projectId: string } | null {
+  const source = dbSessions.getSession(sourceSessionId);
+  if (
+    !source
+    || source.deleted === 1
+    || dbSessions.extractSessionKind(source.provider_state) !== 'terminal'
+    || isPendingTerminalProviderSessionState(source.provider_state)
+  ) return null;
+  // Nothing has been said in this PTY yet (no rollout, no hook): resetting an
+  // empty conversation must not leave an empty session behind.
+  if (
+    !getTerminalProviderSessionForTesseraSession(sourceSessionId)
+    && !readPersistedTerminalProviderSessionId(source)
+  ) return null;
+
+  return {
+    sessionId: createChildSession(source, 'reset', buildPendingTerminalProviderState()),
+    projectId: source.project_id,
+  };
+}
+
+/**
+ * Resolves the first identity observed by a session that was forked ahead of the
+ * provider (see buildPendingTerminalProviderState). Two outcomes only:
+ *  - the identity is unowned → this session was waiting for exactly that, adopt it;
+ *  - the identity already belongs to another session → the reset the input tracker
+ *    predicted never happened, so drop the empty placeholder and hand the PTY back.
+ */
+function reconcilePendingTerminalProviderSession(
+  source: dbSessions.SessionRow,
+  identity: TerminalProviderSessionIdentity,
+  activation?: TerminalProviderSessionActivation,
+): TerminalProviderSessionReconciliationResult {
+  const existing = getTerminalProviderSession(identity.providerId, identity.providerSessionId);
+  const existingSession = existing ? dbSessions.getSession(existing.tessera_session_id) : undefined;
+  if (existingSession && existingSession.deleted === 0 && existingSession.id !== source.id) {
+    dbSessions.deleteSession(source.id);
+    return {
+      kind: 'existing',
+      sessionId: existingSession.id,
+      previousSessionId: source.id,
+    };
+  }
+
+  getDb().transaction(() => {
+    dbSessions.updateSession(source.id, {
+      provider_state: buildTerminalProviderState(identity, activation),
+    });
+    registerIdentity(source.id, identity);
+  })();
+  return { kind: 'unchanged', sessionId: source.id, previousSessionId: source.id };
 }
 
 export function reconcileTerminalProviderSession(options: {
   sourceSessionId: string;
   identity: TerminalProviderSessionIdentity;
   activation?: TerminalProviderSessionActivation;
+  /** Whether the CLI branched the current conversation or started an empty one. */
+  origin?: TerminalProviderSessionOrigin;
 }): TerminalProviderSessionReconciliationResult {
-  const { activation, identity, sourceSessionId } = options;
+  const { activation, identity, origin = 'fork', sourceSessionId } = options;
   const source = dbSessions.getSession(sourceSessionId);
   if (
     !source
@@ -82,6 +161,9 @@ export function reconcileTerminalProviderSession(options: {
   }
 
   let sourceBinding = getTerminalProviderSessionForTesseraSession(sourceSessionId);
+  if (!sourceBinding && isPendingTerminalProviderSessionState(source.provider_state)) {
+    return reconcilePendingTerminalProviderSession(source, identity, activation);
+  }
   if (!sourceBinding) {
     const persistedProviderSessionId = readPersistedTerminalProviderSessionId(source);
     const sourceProviderSessionId = persistedProviderSessionId ?? identity.providerSessionId;
@@ -112,7 +194,12 @@ export function reconcileTerminalProviderSession(options: {
     };
   }
 
-  const sessionId = createForkSession(source, identity, activation);
+  const sessionId = createChildSession(
+    source,
+    origin,
+    buildTerminalProviderState(identity, activation),
+    (created) => registerIdentity(created, identity),
+  );
   return {
     kind: 'created',
     sessionId,

--- a/src/lib/terminal/provider-session-reset.ts
+++ b/src/lib/terminal/provider-session-reset.ts
@@ -1,0 +1,43 @@
+import logger from '@/lib/logger';
+import * as dbSessions from '@/lib/db/sessions';
+import { broadcastSessionMutation } from '@/lib/ws/mutation-broadcast';
+import type { TerminalManager } from './terminal-manager';
+import { createPendingTerminalProviderSessionFork } from './provider-session-reconciliation';
+
+/**
+ * Moves a PTY to a fresh Tessera session the moment its agent is told to reset
+ * the conversation, without waiting for a provider session id that Codex and
+ * OpenCode only mint on the next prompt.
+ *
+ * The rebind is the whole point: the live PTY keeps running while its ownership
+ * moves, so the sidebar shows the new conversation immediately and the old one
+ * keeps the transcript it already has.
+ */
+export function forkTerminalSessionForProviderReset(options: {
+  manager: TerminalManager;
+  terminalId: string;
+  userId: string;
+}): string | null {
+  const { manager, terminalId, userId } = options;
+  const sourceSessionId = manager.getSessionIdForTerminal(terminalId, userId);
+  if (!sourceSessionId) return null;
+
+  const fork = createPendingTerminalProviderSessionFork(sourceSessionId);
+  if (!fork) return null;
+
+  if (!manager.rebindSession(terminalId, userId, sourceSessionId, fork.sessionId)) {
+    // The PTY moved (or died) between the keystroke and here — the placeholder
+    // would never be adopted by anything, so it must not survive.
+    dbSessions.deleteSession(fork.sessionId);
+    return null;
+  }
+
+  manager.clearProviderSessionIdentity(terminalId, userId);
+  broadcastSessionMutation(userId, { kind: 'created', projectId: fork.projectId });
+  logger.info({
+    previousSessionId: sourceSessionId,
+    sessionId: fork.sessionId,
+    terminalId,
+  }, 'Terminal provider session reset forked ahead of the provider');
+  return fork.sessionId;
+}

--- a/src/lib/terminal/shared-terminal-manager.ts
+++ b/src/lib/terminal/shared-terminal-manager.ts
@@ -1,5 +1,7 @@
 import type { ServerTransportMessage } from '@/lib/ws/message-types';
+import logger from '@/lib/logger';
 import { getManagedSessionWorkDir } from '@/lib/git/session-diff-refresh';
+import { forkTerminalSessionForProviderReset } from './provider-session-reset';
 import { scheduleRecompute } from '@/lib/git/worktree-diff-stats-cache';
 import { workspaceFileWatchManager } from '@/lib/workspace-files/workspace-file-watch-manager';
 import { TerminalManager } from './terminal-manager';
@@ -52,6 +54,15 @@ function createSharedState(): SharedTerminalManagerState {
       },
       onSessionStateChange: ({ message, userId }) => {
         state.sendToUser?.(userId, message);
+      },
+      onTerminalConversationReset: ({ terminalId, userId }) => {
+        try {
+          forkTerminalSessionForProviderReset({ manager: state.manager, terminalId, userId });
+        } catch (error) {
+          // A reset that cannot be forked must never disturb the PTY: the agent
+          // has already reset, and the fork still lands on the next prompt.
+          logger.warn({ error, terminalId }, 'Terminal conversation reset fork skipped');
+        }
       },
       onSessionRuntimeRebound: ({ previousSessionId, sessionId, terminalId, userId }) => {
         state.sendToUser?.(userId, {

--- a/src/lib/terminal/terminal-conversation-reset-screen.ts
+++ b/src/lib/terminal/terminal-conversation-reset-screen.ts
@@ -1,0 +1,41 @@
+/**
+ * Screen signatures that mean "the conversation running in this PTY was reset".
+ *
+ * Claude Code announces `/clear` through a SessionStart hook, so it needs none
+ * of this. Codex and OpenCode announce nothing: both create the new session
+ * lazily on the next prompt (measured 2026-07-22), leaving the PTY bound to the
+ * previous Tessera session until then. What they *do* do, immediately and
+ * regardless of how the command was issued, is repaint the screen — so that is
+ * what these matchers read.
+ *
+ * Both patterns are anchored on something that cannot appear mid-conversation:
+ *  - Codex prints the resume hint for the session it just closed, naming that
+ *    session's id — matched against the id Tessera currently holds, which makes
+ *    a false positive essentially impossible.
+ *  - OpenCode returns to its empty-composer home screen, whose placeholder is
+ *    replaced by the transcript as soon as anything is said.
+ */
+
+/** Codex: `To continue this session, run codex resume <uuid>` after a reset. */
+export function codexScreenShowsConversationReset(options: {
+  visibleText: string;
+  currentProviderSessionId: string;
+}): boolean {
+  const { currentProviderSessionId, visibleText } = options;
+  if (!currentProviderSessionId) return false;
+  const escaped = currentProviderSessionId.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  return new RegExp(`codex\\s+resume\\s+${escaped}\\b`, 'iu').test(visibleText);
+}
+
+/**
+ * OpenCode: the home screen's composer placeholder. It is only rendered while
+ * the session has no messages, so seeing it again after a bound conversation
+ * means that conversation is gone.
+ */
+export function openCodeScreenShowsConversationReset(options: {
+  visibleText: string;
+  currentProviderSessionId: string;
+}): boolean {
+  if (!options.currentProviderSessionId) return false;
+  return /Ask anything\.\.\./u.test(options.visibleText);
+}

--- a/src/lib/terminal/terminal-headless-model.ts
+++ b/src/lib/terminal/terminal-headless-model.ts
@@ -2,6 +2,8 @@ import { Terminal } from '@xterm/headless';
 import { SerializeAddon } from '@xterm/addon-serialize';
 
 const DEFAULT_SCROLLBACK_ROWS = 5_000;
+/** Rows readVisibleText() scans by default — one screen plus a little history. */
+const VISIBLE_TEXT_ROWS = 120;
 
 /**
  * DEC private modes SerializeAddon omits from snapshots. It serializes the
@@ -128,6 +130,28 @@ export class TerminalHeadlessModel {
       cols: this.terminal.cols,
       rows: this.terminal.rows,
     };
+  }
+
+  /**
+   * Plain text of what the user can currently see, newest rows last. Provider
+   * adapters read it to recognize screens a CLI only paints on a conversation
+   * reset — the one reset signal Codex/OpenCode give at the moment it happens.
+   * Wrapped rows are rejoined so a match is not lost to the terminal width.
+   */
+  readVisibleText(maxRows = VISIBLE_TEXT_ROWS): string {
+    if (this.disposed) return '';
+    const buffer = this.terminal.buffer.active;
+    const end = buffer.baseY + this.terminal.rows;
+    const start = Math.max(0, end - Math.max(1, maxRows));
+    const rows: string[] = [];
+    for (let index = start; index < end; index += 1) {
+      const line = buffer.getLine(index);
+      if (!line) continue;
+      const text = line.translateToString(true);
+      if (line.isWrapped && rows.length > 0) rows[rows.length - 1] += text;
+      else rows.push(text);
+    }
+    return rows.join('\n');
   }
 
   dispose(): void {

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -191,6 +191,9 @@ interface TerminalRuntime {
   cancelPrefill?: () => void;
   disposeSessionObservers: Array<() => void>;
   lastSessionState?: TerminalSessionStateMessage;
+  detectConversationReset?: TerminalCreateOptions['detectConversationReset'];
+  conversationResetScanTimer?: ReturnType<typeof setTimeout>;
+  conversationResetHandledProviderSessionIds: Set<string>;
   providerSessionId?: string;
   retiredProviderSessionIds: Set<string>;
   backgroundProviderSessionIds: Set<string>;
@@ -201,7 +204,7 @@ interface TerminalRuntime {
 /** The runtime only needs these members; tests can inject a stub model. */
 export type TerminalHeadlessModelLike = Pick<
   TerminalHeadlessModel,
-  'write' | 'resize' | 'snapshot' | 'dispose'
+  'write' | 'resize' | 'snapshot' | 'readVisibleText' | 'dispose'
 >;
 
 export interface TerminalManagerOptions {
@@ -227,6 +230,11 @@ export interface TerminalManagerOptions {
     userId: string;
   }) => void;
   interruptSettleMs?: number;
+  /** The agent running in this PTY reset its conversation in place. */
+  onTerminalConversationReset?: (state: {
+    terminalId: string;
+    userId: string;
+  }) => void;
   onSessionRuntimeRebound?: (state: {
     previousSessionId: string;
     sessionId: string;
@@ -247,6 +255,12 @@ function normalizeTerminalDimension(value: number | undefined, fallback: number,
  * stale screen with all live output trapped in pendingFrames.
  */
 const DEFAULT_SNAPSHOT_TIMEOUT_MS = 3_000;
+
+/**
+ * Idle gap before re-reading the screen for a conversation reset. Long enough
+ * that a repaint has settled into one scan, short enough to feel immediate.
+ */
+const CONVERSATION_RESET_SCAN_MS = 250;
 
 async function resolveSnapshotWithTimeout(
   model: TerminalHeadlessModelLike,
@@ -660,6 +674,8 @@ export class TerminalManager {
         disposeSessionObservers: options.launchObserverDisposer
           ? [options.launchObserverDisposer]
           : [],
+        detectConversationReset: options.detectConversationReset,
+        conversationResetHandledProviderSessionIds: new Set(),
         retiredProviderSessionIds: new Set(),
         backgroundProviderSessionIds: new Set(),
         reboundFromSessionIds: new Set(),
@@ -755,6 +771,7 @@ export class TerminalManager {
         // replay 버퍼: 원본 청크 순서/내용 그대로 즉시 누적 — coalescing과 독립.
         this.appendBufferedOutput(runtime, data);
         runtime.model.write(data);
+        this.scheduleConversationResetScan(runtime);
 
         // prefill 감지: 원본 청크 타이밍에 의존하므로 즉시 처리(WS 전송만 뒤에서 모은다).
         if (prefillInput && !prefillSent) {
@@ -955,6 +972,60 @@ export class TerminalManager {
     }
     runtime.process.write(data);
     this.observeAgentInterruptInput(runtime, data);
+  }
+
+  /**
+   * Codex/OpenCode do not announce a conversation reset — they mint the next
+   * session id only when the next prompt is submitted. What they do repaint,
+   * immediately and however the command was issued, is the screen, so the
+   * provider adapter reads that instead. Scans are throttled and only run while
+   * a provider session is actually bound to this PTY.
+   */
+  private scheduleConversationResetScan(runtime: TerminalRuntime): void {
+    if (!runtime.detectConversationReset || runtime.conversationResetScanTimer) return;
+    runtime.conversationResetScanTimer = setTimeout(() => {
+      runtime.conversationResetScanTimer = undefined;
+      this.scanForConversationReset(runtime);
+    }, CONVERSATION_RESET_SCAN_MS);
+    runtime.conversationResetScanTimer.unref?.();
+  }
+
+  private scanForConversationReset(runtime: TerminalRuntime): void {
+    const providerSessionId = runtime.providerSessionId;
+    if (
+      runtime.ended
+      || !runtime.sessionId
+      || !providerSessionId
+      || !runtime.detectConversationReset
+      || runtime.conversationResetHandledProviderSessionIds.has(providerSessionId)
+    ) return;
+
+    let reset = false;
+    try {
+      reset = runtime.detectConversationReset({
+        visibleText: runtime.model.readVisibleText(),
+        currentProviderSessionId: providerSessionId,
+      });
+    } catch (error) {
+      logger.debug({ error, terminalId: runtime.terminalId },
+        'Conversation reset detection skipped');
+      return;
+    }
+    if (!reset) return;
+
+    runtime.conversationResetHandledProviderSessionIds.add(providerSessionId);
+    this.managerOptions.onTerminalConversationReset?.({
+      terminalId: runtime.terminalId,
+      userId: runtime.userId,
+    });
+  }
+
+  /** Detaches the runtime from its provider identity without retiring it, so a
+   *  reset that never happened can hand the same identity straight back. */
+  clearProviderSessionIdentity(terminalId: string, userId: string): void {
+    const runtime = this.getOwnedTerminal(terminalId, userId);
+    if (!runtime || runtime.ended) return;
+    runtime.providerSessionId = undefined;
   }
 
   private observeAgentInterruptInput(runtime: TerminalRuntime, data: string): void {

--- a/src/lib/terminal/types.ts
+++ b/src/lib/terminal/types.ts
@@ -50,6 +50,14 @@ export interface TerminalCreateOptions {
   paneToken?: string;
   /** Native agent provider launched inside this PTY. */
   providerId?: string;
+  /**
+   * Provider-owned reader that recognizes a conversation reset from what the
+   * PTY currently shows (Codex/OpenCode report nothing when it happens).
+   */
+  detectConversationReset?: (options: {
+    visibleText: string;
+    currentProviderSessionId: string;
+  }) => boolean;
   /** Provider-declared behavior for light/dark changes in an already-running TUI. */
   appearanceChangePolicy?: TerminalAppearanceChangePolicy;
   /** Provider-declared handling for ED3 emitted by a resize redraw. */

--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -757,6 +757,11 @@ export async function routeClientTransportMessage({
           launchSpec,
           paneToken,
           providerId,
+          detectConversationReset: terminalProvider?.detectTerminalConversationReset
+            ? (options) => Boolean(
+              terminalProvider.detectTerminalConversationReset?.(options),
+            )
+            : undefined,
           appearanceChangePolicy,
           resizeScrollbackPolicy,
           interruptInputPolicy,

--- a/tests/terminal-conversation-reset-screen.test.ts
+++ b/tests/terminal-conversation-reset-screen.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  codexScreenShowsConversationReset,
+  openCodeScreenShowsConversationReset,
+} from '@/lib/terminal/terminal-conversation-reset-screen';
+
+const CODEX_SESSION_ID = '019f89be-ddfb-70f2-b21b-474c42bab15d';
+
+// Captured from codex-cli 0.144.5 right after /clear.
+const CODEX_AFTER_RESET = [
+  '╭──────────────────────────────────────────────────────╮',
+  '│ >_ OpenAI Codex (v0.144.5)                           │',
+  '│ model:     gpt-5.6-sol low   fast   /model to change │',
+  '╰──────────────────────────────────────────────────────╯',
+  '  Tip: See the Codex keymap documentation for supported actions and examples.',
+  'Token usage: total=7,016 input=7,011 (+ 9,984 cached) output=5',
+  `To continue this session, run codex resume ${CODEX_SESSION_ID}`,
+  '› Summarize recent commits',
+].join('\n');
+
+const CODEX_MID_CONVERSATION = [
+  '› reply with exactly: ok',
+  '• ok',
+  '  gpt-5.6-sol low fast · Context 2% used · Fast on',
+].join('\n');
+
+// Captured from opencode 1.14.48 right after /new.
+const OPENCODE_AFTER_RESET = [
+  '                     ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▄ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀',
+  '  ┃  Ask anything... "Fix a TODO in the codebase"',
+  '  ┃  Build · GPT-5.3 Codex Spark OpenAI',
+  '                          tab agents  ctrl+p commands',
+].join('\n');
+
+const OPENCODE_MID_CONVERSATION = [
+  '  > reply with exactly: ok',
+  '  ok',
+  '  ~/Source/tessera-dev:dev                              1.14.48',
+].join('\n');
+
+test('codex resume hint for the bound session marks that conversation closed', () => {
+  assert.equal(codexScreenShowsConversationReset({
+    visibleText: CODEX_AFTER_RESET,
+    currentProviderSessionId: CODEX_SESSION_ID,
+  }), true);
+});
+
+test('codex mid-conversation screens and other sessions never match', () => {
+  assert.equal(codexScreenShowsConversationReset({
+    visibleText: CODEX_MID_CONVERSATION,
+    currentProviderSessionId: CODEX_SESSION_ID,
+  }), false);
+  // The hint names some other rollout — this PTY's conversation is untouched.
+  assert.equal(codexScreenShowsConversationReset({
+    visibleText: CODEX_AFTER_RESET,
+    currentProviderSessionId: '019f8998-575d-7e73-8764-eda3aaccd380',
+  }), false);
+  assert.equal(codexScreenShowsConversationReset({
+    visibleText: CODEX_AFTER_RESET,
+    currentProviderSessionId: '',
+  }), false);
+});
+
+test('opencode home screen after a bound conversation marks it reset', () => {
+  assert.equal(openCodeScreenShowsConversationReset({
+    visibleText: OPENCODE_AFTER_RESET,
+    currentProviderSessionId: 'ses_07676a371ffebpi3WHDsyiiNJc',
+  }), true);
+  assert.equal(openCodeScreenShowsConversationReset({
+    visibleText: OPENCODE_MID_CONVERSATION,
+    currentProviderSessionId: 'ses_07676a371ffebpi3WHDsyiiNJc',
+  }), false);
+});
+
+test('no bound provider session means there is nothing to fork away from', () => {
+  assert.equal(openCodeScreenShowsConversationReset({
+    visibleText: OPENCODE_AFTER_RESET,
+    currentProviderSessionId: '',
+  }), false);
+});

--- a/tests/terminal-manager-lifecycle.test.ts
+++ b/tests/terminal-manager-lifecycle.test.ts
@@ -1152,3 +1152,50 @@ test('a wedged headless model cannot freeze reattach: fallback snapshot then liv
     .join('');
   assert.match(liveForB, /live-after-reattach/, 'live output must resume after the fallback snapshot');
 });
+
+test('a provider-detected conversation reset is reported once per bound session', async () => {
+  const spawned: FakePty[] = [];
+  const resets: Array<{ terminalId: string; userId: string }> = [];
+  const manager = new TerminalManager(
+    () => {},
+    async () => createFactory(spawned),
+    undefined,
+    {
+      onTerminalConversationReset: (state) => resets.push(state),
+      createHeadlessModel: () => {
+        let text = '';
+        return {
+          write: (data: string) => { text += data; },
+          resize: () => {},
+          snapshot: async () => ({ data: '', cols: 100, rows: 30, alternateScreen: false }),
+          readVisibleText: () => text,
+          dispose: () => {},
+        };
+      },
+    },
+  );
+
+  await manager.create(createOptions({
+    terminalId: 'terminal-reset',
+    sessionId: 'session-reset',
+    providerId: 'codex',
+    detectConversationReset: ({ visibleText, currentProviderSessionId }) =>
+      visibleText.includes(`codex resume ${currentProviderSessionId}`),
+  }));
+  const settle = () => new Promise((resolve) => setTimeout(resolve, 400));
+
+  // Nothing is bound yet: an empty PTY has no conversation to fork away from.
+  spawned[0].emitData('To continue this session, run codex resume rollout-1\r\n');
+  await settle();
+  assert.deepEqual(resets, []);
+
+  manager.activateProviderSessionIdentity('terminal-reset', 'user-a', 'rollout-1');
+  spawned[0].emitData('To continue this session, run codex resume rollout-1\r\n');
+  await settle();
+  assert.deepEqual(resets, [{ terminalId: 'terminal-reset', userId: 'user-a' }]);
+
+  // The same screen must not fork again while it stays on screen.
+  spawned[0].emitData('more output\r\n');
+  await settle();
+  assert.equal(resets.length, 1);
+});

--- a/tests/terminal-provider-session-reconciliation.test.ts
+++ b/tests/terminal-provider-session-reconciliation.test.ts
@@ -9,6 +9,7 @@ process.env.NODE_ENV = 'test';
 
 let dbSessions: typeof import('@/lib/db/sessions');
 let reconcileTerminalProviderSession: typeof import('@/lib/terminal/provider-session-reconciliation').reconcileTerminalProviderSession;
+let createPendingTerminalProviderSessionFork: typeof import('@/lib/terminal/provider-session-reconciliation').createPendingTerminalProviderSessionFork;
 let extractTerminalProviderSessionIdentity: typeof import('@/lib/terminal/provider-session-identity').extractTerminalProviderSessionIdentity;
 
 before(async () => {
@@ -23,6 +24,7 @@ before(async () => {
   projects.registerProject('project-1', '/tmp/project-1', 'Project 1');
   dbSessions = sessions;
   reconcileTerminalProviderSession = reconciliation.reconcileTerminalProviderSession;
+  createPendingTerminalProviderSessionFork = reconciliation.createPendingTerminalProviderSessionFork;
   extractTerminalProviderSessionIdentity = identity.extractTerminalProviderSessionIdentity;
 });
 
@@ -157,6 +159,120 @@ test('duplicate and stale-pane observations resolve to the existing child', () =
     previousSessionId: 'dedup-parent',
     previousProviderSessionId: 'dedup-parent',
   });
+});
+
+test('a reset fork waits for its provider identity and then adopts it', () => {
+  dbSessions.createSession('reset-parent', 'project-1', 'Investigate login', 'codex', {
+    workDir: '/tmp/project-1',
+    providerState: JSON.stringify({
+      kind: 'terminal',
+      launched: true,
+      codexSessionId: 'rollout-before-clear',
+    }),
+  });
+
+  const fork = createPendingTerminalProviderSessionFork('reset-parent');
+  assert.ok(fork);
+  assert.equal(fork.projectId, 'project-1');
+  const forked = dbSessions.getSession(fork.sessionId);
+  // A reset starts an empty conversation, so it is titled like any new session
+  // and the first prompt replaces the placeholder.
+  assert.match(forked?.title ?? '', /^Session \d+$/u);
+  assert.equal(forked?.provider, 'codex');
+  assert.deepEqual(JSON.parse(forked?.provider_state ?? '{}'), {
+    kind: 'terminal',
+    launched: true,
+    terminalProviderSessionPending: true,
+  });
+
+  // The rollout Codex mints on the next prompt belongs to the waiting session,
+  // and no second fork is created for it.
+  const adopted = reconcileTerminalProviderSession({
+    sourceSessionId: fork.sessionId,
+    identity: {
+      providerId: 'codex',
+      providerSessionId: 'rollout-after-clear',
+      transcriptPath: '/tmp/rollout-after-clear.jsonl',
+    },
+  });
+  assert.deepEqual(adopted, {
+    kind: 'unchanged',
+    sessionId: fork.sessionId,
+    previousSessionId: fork.sessionId,
+  });
+  assert.deepEqual(JSON.parse(dbSessions.getSession(fork.sessionId)?.provider_state ?? '{}'), {
+    kind: 'terminal',
+    launched: true,
+    terminalProviderSessionId: 'rollout-after-clear',
+    codexSessionId: 'rollout-after-clear',
+  });
+  assert.equal(dbSessions.getSession('reset-parent')?.deleted, 0);
+});
+
+test('a reset that never happened hands the PTY back and drops the empty fork', () => {
+  dbSessions.createSession('mispredicted-parent', 'project-1', 'Keep talking', 'codex', {
+    providerState: JSON.stringify({
+      kind: 'terminal',
+      launched: true,
+      codexSessionId: 'rollout-kept',
+    }),
+  });
+  reconcileTerminalProviderSession({
+    sourceSessionId: 'mispredicted-parent',
+    identity: { providerId: 'codex', providerSessionId: 'rollout-kept' },
+  });
+
+  const fork = createPendingTerminalProviderSessionFork('mispredicted-parent');
+  assert.ok(fork);
+
+  const recovered = reconcileTerminalProviderSession({
+    sourceSessionId: fork.sessionId,
+    identity: { providerId: 'codex', providerSessionId: 'rollout-kept' },
+  });
+  assert.deepEqual(recovered, {
+    kind: 'existing',
+    sessionId: 'mispredicted-parent',
+    previousSessionId: fork.sessionId,
+  });
+  assert.equal(dbSessions.getSession(fork.sessionId), undefined);
+});
+
+test('a PTY with no provider conversation yet is never pre-forked', () => {
+  dbSessions.createSession('untouched-pty', 'project-1', 'Fresh PTY', 'codex', {
+    providerState: JSON.stringify({ kind: 'terminal', launched: true }),
+  });
+  assert.equal(createPendingTerminalProviderSessionFork('untouched-pty'), null);
+
+  dbSessions.createSession('gui-reset', 'project-1', 'GUI session', 'codex', {
+    providerState: JSON.stringify({ kind: 'chat', threadId: 'thread-gui-reset' }),
+  });
+  assert.equal(createPendingTerminalProviderSessionFork('gui-reset'), null);
+  assert.equal(createPendingTerminalProviderSessionFork('missing-session'), null);
+});
+
+test('a hook-reported reset is titled as a new session, a fork keeps the parent title', () => {
+  dbSessions.createSession('origin-parent', 'project-1', 'Investigate login', 'claude-code', {
+    providerState: JSON.stringify({ kind: 'terminal', launched: true }),
+  });
+  reconcileTerminalProviderSession({
+    sourceSessionId: 'origin-parent',
+    identity: { providerId: 'claude-code', providerSessionId: 'origin-parent-provider' },
+  });
+
+  const reset = reconcileTerminalProviderSession({
+    sourceSessionId: 'origin-parent',
+    identity: { providerId: 'claude-code', providerSessionId: 'cleared-child' },
+    origin: 'reset',
+  });
+  assert.equal(reset.kind, 'created');
+  assert.match(dbSessions.getSession(reset.sessionId)?.title ?? '', /^Session \d+$/u);
+
+  const forked = reconcileTerminalProviderSession({
+    sourceSessionId: 'origin-parent',
+    identity: { providerId: 'claude-code', providerSessionId: 'branched-child' },
+  });
+  assert.equal(forked.kind, 'created');
+  assert.equal(dbSessions.getSession(forked.sessionId)?.title, 'Investigate login (Fork)');
 });
 
 test('GUI sessions are ignored by the PTY provider-session reconciler', () => {


### PR DESCRIPTION
## What changed

- Detect Codex/OpenCode conversation resets from provider state and terminal screens.
- Fork the live PTY into a new durable Tessera session without losing the parent history.
- Reconcile delayed provider identities and roll back false-positive resets safely.

## Why

Starting a new native CLI conversation inside an existing PTY previously kept writing into the original Tessera session, mixing two separate conversation histories.

## Impact

Native conversation resets now create a distinct session while preserving the running terminal and the original conversation.

## Validation

- `npm run server:compile`
- Targeted Node/tsx tests for reset-screen detection, terminal lifecycle, and provider-session reconciliation
- `node --test tests/terminal-contract.test.mjs`
- Targeted ESLint on changed runtime and test files
