### PR TITLE
fix(terminal): stabilize PTY snapshot replay and device queries

### DIFF
--- a/src/lib/terminal/terminal-device-query-controller.ts
+++ b/src/lib/terminal/terminal-device-query-controller.ts
@@ -1,0 +1,176 @@
+/**
+ * Answers the device queries a TUI emits at startup (CPR, DSR, primary DA)
+ * from the server, mirroring how the appearance controller answers OSC colors.
+ *
+ * Why this exists: these queries are answered by the terminal emulator, and
+ * tessera's emulator is the browser's xterm instance — a WebSocket round trip
+ * away, and absent entirely until a surface attaches. A reply that arrives
+ * after the querying program stopped reading lands on the tty with ECHO still
+ * enabled, which paints it as literal `^[[1;1R` on screen (codex emits
+ * `CSI 6n` the moment it starts). Consuming the query here means the browser
+ * never sees it, never synthesizes a late reply, and the program gets its
+ * answer immediately without leaving the machine.
+ *
+ * Scope is deliberately limited to queries whose answer is fully determined by
+ * state the server already owns. Kitty keyboard flags (`CSI ? u`) are left
+ * alone on purpose: the honest answer depends on what the browser emulator
+ * supports, so faking one here could tell a TUI to use an encoding the real
+ * emulator cannot produce.
+ */
+
+const CSI = '\x1b[';
+// Long enough to hold any CSI sequence split across PTY chunks; a fragment
+// past this is flushed as ordinary output rather than buffered forever.
+const MAX_PENDING_QUERY_CHARS = 64;
+
+export type TerminalDeviceQueryKind =
+  | 'cursor-position'
+  | 'extended-cursor-position'
+  | 'device-status'
+  | 'primary-device-attributes';
+
+export type TerminalDeviceQueryCursor = {
+  /** 1-based row, as CPR reports it. */
+  row: number;
+  /** 1-based column, as CPR reports it. */
+  column: number;
+};
+
+type CsiParseResult =
+  | { kind: 'match'; sequence: string }
+  | { kind: 'partial' }
+  | { kind: 'none' };
+
+/**
+ * A chunk split at its query boundaries. `output` is everything that preceded
+ * `query` in the chunk, so a caller can apply that output before reading the
+ * state a cursor report has to describe.
+ */
+export type TerminalDeviceQuerySegment = {
+  output: string;
+  query: TerminalDeviceQueryKind | null;
+};
+
+const QUERY_BY_SEQUENCE = new Map<string, TerminalDeviceQueryKind>([
+  [`${CSI}6n`, 'cursor-position'],
+  [`${CSI}?6n`, 'extended-cursor-position'],
+  [`${CSI}5n`, 'device-status'],
+  [`${CSI}c`, 'primary-device-attributes'],
+  [`${CSI}0c`, 'primary-device-attributes'],
+]);
+
+/**
+ * Formats the reply for a consumed query. The device-attributes answer matches
+ * what xterm.js reports (`VT100 with Advanced Video Option`) so a program sees
+ * the same terminal identity whether the server or the browser answered.
+ */
+export function formatTerminalDeviceQueryReply(
+  kind: TerminalDeviceQueryKind,
+  cursor: TerminalDeviceQueryCursor,
+): string {
+  const row = Math.max(1, Math.trunc(cursor.row));
+  const column = Math.max(1, Math.trunc(cursor.column));
+
+  switch (kind) {
+    case 'cursor-position':
+      return `${CSI}${row};${column}R`;
+    case 'extended-cursor-position':
+      return `${CSI}?${row};${column};1R`;
+    case 'device-status':
+      return `${CSI}0n`;
+    case 'primary-device-attributes':
+      return `${CSI}?1;2c`;
+  }
+}
+
+export function createTerminalDeviceQueryController() {
+  let pendingQuery = '';
+
+  return {
+    /**
+     * Strips answerable queries from a PTY chunk, split at each query boundary.
+     * Concatenating every `output` gives what the rest of the pipeline (model,
+     * replay buffer, browser) should see; each non-null `query` still needs a
+     * reply written back to the PTY, after its own segment has been applied.
+     */
+    consumeOutput(data: string): TerminalDeviceQuerySegment[] {
+      const input = pendingQuery + data;
+      pendingQuery = '';
+      const segments: TerminalDeviceQuerySegment[] = [];
+      let output = '';
+      let offset = 0;
+
+      while (offset < input.length) {
+        const candidate = input.indexOf('\x1b', offset);
+        if (candidate === -1) {
+          output += input.slice(offset);
+          break;
+        }
+        output += input.slice(offset, candidate);
+
+        const parsed = parseCsiSequence(input, candidate);
+        if (parsed.kind === 'partial') {
+          const fragment = input.slice(candidate);
+          // Only hold a fragment that can still become a query we answer.
+          // Buffering every split CSI would move chunk boundaries for the rest
+          // of the pipeline, and the resize transaction reassembles its own
+          // split sequences (ED3) off those boundaries.
+          if (fragment.length <= MAX_PENDING_QUERY_CHARS && isQueryPrefix(fragment)) {
+            pendingQuery = fragment;
+          } else {
+            output += fragment;
+          }
+          break;
+        }
+        if (parsed.kind === 'none') {
+          output += input[candidate];
+          offset = candidate + 1;
+          continue;
+        }
+
+        const query = QUERY_BY_SEQUENCE.get(parsed.sequence);
+        if (query) {
+          segments.push({ output, query });
+          output = '';
+        } else {
+          output += parsed.sequence;
+        }
+        offset = candidate + parsed.sequence.length;
+      }
+
+      segments.push({ output, query: null });
+      return segments;
+    },
+
+    /** Releases a half-received sequence so an exiting PTY loses no output. */
+    drain(): string {
+      const output = pendingQuery;
+      pendingQuery = '';
+      return output;
+    },
+  };
+}
+
+function isQueryPrefix(fragment: string): boolean {
+  for (const sequence of QUERY_BY_SEQUENCE.keys()) {
+    if (sequence.startsWith(fragment)) return true;
+  }
+  return false;
+}
+
+function parseCsiSequence(data: string, offset: number): CsiParseResult {
+  if (offset + 1 >= data.length) return { kind: 'partial' };
+  if (data[offset + 1] !== '[') return { kind: 'none' };
+
+  for (let index = offset + 2; index < data.length; index += 1) {
+    const code = data.charCodeAt(index);
+    // Final byte terminates the sequence.
+    if (code >= 0x40 && code <= 0x7e) {
+      return { kind: 'match', sequence: data.slice(offset, index + 1) };
+    }
+    // Anything outside parameter/intermediate range means this was never a CSI.
+    if (code < 0x20 || code > 0x3f) return { kind: 'none' };
+  }
+
+  return { kind: 'partial' };
+}

--- a/src/lib/terminal/terminal-headless-model.ts
+++ b/src/lib/terminal/terminal-headless-model.ts
@@ -106,6 +106,57 @@ export class TerminalHeadlessModel {
       .join('');
   }
 
+  /**
+   * SerializeAddon walks `IBufferLine.length` for every non-final row. After
+   * an alternate-screen terminal shrinks, xterm deliberately retains removed
+   * columns in its backing lines even though `terminal.cols` already reports
+   * the smaller PTY width. OpenTUI paints those hidden columns, so the emitted
+   * ANSI can still contain (for example) 166 cells per row while the snapshot
+   * claims 134. Replaying that stream at 134 columns wraps every row and
+   * scrolls the beginning of the frame away.
+   *
+   * Present capped, non-mutating line views only while SerializeAddon runs.
+   * Keeping the backing lines intact matches xterm's resize semantics: hidden
+   * cells can become visible again if the same surface later grows.
+   */
+  private serializeAtCurrentAlternateWidth(
+    savedCursor: ReturnType<typeof readSavedCursorRegister>,
+  ): string {
+    const alternate = this.terminal.buffer.alternate;
+    const originalGetLine = alternate.getLine.bind(alternate);
+    const ownGetLineDescriptor = Object.getOwnPropertyDescriptor(alternate, 'getLine');
+
+    Object.defineProperty(alternate, 'getLine', {
+      configurable: true,
+      value: (index: number) => {
+        const line = originalGetLine(index);
+        if (!line || line.length <= this.terminal.cols) return line;
+        return Object.create(line, {
+          length: {
+            configurable: true,
+            enumerable: true,
+            value: this.terminal.cols,
+          },
+        });
+      },
+    });
+
+    try {
+      return serializeWithAbsoluteCursor(
+        this.serializer,
+        this.terminal,
+        { scrollback: DEFAULT_SCROLLBACK_ROWS },
+        savedCursor,
+      );
+    } finally {
+      if (ownGetLineDescriptor) {
+        Object.defineProperty(alternate, 'getLine', ownGetLineDescriptor);
+      } else {
+        Reflect.deleteProperty(alternate, 'getLine');
+      }
+    }
+  }
+
   write(data: string): void {
     if (this.disposed || data.length === 0) return;
 
@@ -149,12 +200,16 @@ export class TerminalHeadlessModel {
     }
 
     const alternateScreen = this.terminal.buffer.active.type === 'alternate';
-    const combinedData = serializeWithAbsoluteCursor(
-      this.serializer,
-      this.terminal,
-      { scrollback: DEFAULT_SCROLLBACK_ROWS },
-      readSavedCursorRegister(this.terminal),
-    ) + this.serializeSnapshotOnlyDecModes();
+    const savedCursor = readSavedCursorRegister(this.terminal);
+    const serialized = alternateScreen
+      ? this.serializeAtCurrentAlternateWidth(savedCursor)
+      : serializeWithAbsoluteCursor(
+        this.serializer,
+        this.terminal,
+        { scrollback: DEFAULT_SCROLLBACK_ROWS },
+        savedCursor,
+      );
+    const combinedData = serialized + this.serializeSnapshotOnlyDecModes();
     const split = splitTerminalSnapshotAnsi(combinedData, alternateScreen);
     return {
       data: split.data,

--- a/src/lib/terminal/terminal-headless-model.ts
+++ b/src/lib/terminal/terminal-headless-model.ts
@@ -1,5 +1,12 @@
 import { Terminal } from '@xterm/headless';
 import { SerializeAddon } from '@xterm/addon-serialize';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
+import {
+  readSavedCursorRegister,
+  serializeWithAbsoluteCursor,
+} from './terminal-serialize-absolute-cursor';
+import { advancePartialEscapeTail } from './terminal-partial-escape-tail';
+import { activateTesseraTerminalUnicodeProvider } from './terminal-unicode-provider';
 
 const DEFAULT_SCROLLBACK_ROWS = 5_000;
 /** Rows readVisibleText() scans by default — one screen plus a little history. */
@@ -14,6 +21,18 @@ const VISIBLE_TEXT_ROWS = 120;
  * re-assert its modes on the next keypress-triggered redraw.
  */
 const SNAPSHOT_ONLY_TRACKED_DEC_MODES: readonly number[] = [1005, 1006, 1007, 1015, 1016];
+const ALTERNATE_SCREEN_MARKER = '\x1b[?1049h';
+
+export interface TerminalHeadlessSnapshot {
+  data: string;
+  cols: number;
+  rows: number;
+  alternateScreen: boolean;
+  /** Normal-buffer scrollback captured separately while an alt frame is active. */
+  scrollbackAnsi?: string;
+  /** Parser state that SerializeAddon cannot represent. Must replay last. */
+  pendingEscapeTailAnsi?: string;
+}
 
 /**
  * Server-side xterm model used only for cold surface reattachment.
@@ -28,6 +47,7 @@ export class TerminalHeadlessModel {
   private writeTail: Promise<void> = Promise.resolve();
   private readonly pendingWriteCompletions = new Set<() => void>();
   private readonly activeSnapshotOnlyDecModes = new Set<number>();
+  private pendingEscapeTail = '';
   private disposed = false;
 
   constructor(cols: number, rows: number) {
@@ -42,6 +62,8 @@ export class TerminalHeadlessModel {
     });
     this.serializer = new SerializeAddon();
     this.terminal.loadAddon(this.serializer);
+    this.terminal.loadAddon(new Unicode11Addon());
+    activateTesseraTerminalUnicodeProvider(this.terminal);
     this.trackSnapshotOnlyDecModes();
   }
 
@@ -97,6 +119,7 @@ export class TerminalHeadlessModel {
         const complete = () => {
           if (completed) return;
           completed = true;
+          this.pendingEscapeTail = advancePartialEscapeTail(this.pendingEscapeTail, data);
           this.pendingWriteCompletions.delete(complete);
           resolve();
         };
@@ -118,17 +141,28 @@ export class TerminalHeadlessModel {
     this.terminal.resize(normalizeDimension(cols), normalizeDimension(rows));
   }
 
-  async snapshot(): Promise<{ data: string; cols: number; rows: number }> {
+  async snapshot(): Promise<TerminalHeadlessSnapshot> {
     const boundary = this.writeTail;
     await boundary;
     if (this.disposed) {
       throw new Error('Terminal model is disposed');
     }
+
+    const alternateScreen = this.terminal.buffer.active.type === 'alternate';
+    const combinedData = serializeWithAbsoluteCursor(
+      this.serializer,
+      this.terminal,
+      { scrollback: DEFAULT_SCROLLBACK_ROWS },
+      readSavedCursorRegister(this.terminal),
+    ) + this.serializeSnapshotOnlyDecModes();
+    const split = splitTerminalSnapshotAnsi(combinedData, alternateScreen);
     return {
-      data: this.serializer.serialize({ scrollback: DEFAULT_SCROLLBACK_ROWS })
-        + this.serializeSnapshotOnlyDecModes(),
+      data: split.data,
       cols: this.terminal.cols,
       rows: this.terminal.rows,
+      alternateScreen,
+      ...(split.scrollbackAnsi !== undefined && { scrollbackAnsi: split.scrollbackAnsi }),
+      ...(this.pendingEscapeTail && { pendingEscapeTailAnsi: this.pendingEscapeTail }),
     };
   }
 
@@ -164,4 +198,18 @@ export class TerminalHeadlessModel {
 
 function normalizeDimension(value: number): number {
   return Math.max(1, Math.floor(value));
+}
+
+function splitTerminalSnapshotAnsi(
+  snapshotAnsi: string,
+  alternateScreen: boolean,
+): { data: string; scrollbackAnsi?: string } {
+  if (!alternateScreen) return { data: snapshotAnsi };
+  const start = snapshotAnsi.lastIndexOf(ALTERNATE_SCREEN_MARKER);
+  if (start === -1) return { data: snapshotAnsi };
+
+  return {
+    scrollbackAnsi: snapshotAnsi.slice(0, start),
+    data: snapshotAnsi.slice(start + ALTERNATE_SCREEN_MARKER.length),
+  };
 }

--- a/src/lib/terminal/terminal-headless-model.ts
+++ b/src/lib/terminal/terminal-headless-model.ts
@@ -7,6 +7,7 @@ import {
 } from './terminal-serialize-absolute-cursor';
 import { advancePartialEscapeTail } from './terminal-partial-escape-tail';
 import { activateTesseraTerminalUnicodeProvider } from './terminal-unicode-provider';
+import type { TerminalDeviceQueryCursor } from './terminal-device-query-controller';
 
 const DEFAULT_SCROLLBACK_ROWS = 5_000;
 /** Rows readVisibleText() scans by default — one screen plus a little history. */
@@ -185,6 +186,20 @@ export class TerminalHeadlessModel {
         // Keep later writes/snapshots usable after one parser failure. The
         // caller retains a bounded raw replay buffer as a fallback.
       });
+  }
+
+  /**
+   * Resolves once every write queued so far has been parsed, so a caller can
+   * read cursor state at a completed parser boundary rather than mid-chunk.
+   */
+  whenSettled(): Promise<void> {
+    return this.writeTail;
+  }
+
+  /** 1-based cursor position of the active buffer, as CPR reports it. */
+  cursorPosition(): TerminalDeviceQueryCursor {
+    const buffer = this.terminal.buffer.active;
+    return { row: buffer.cursorY + 1, column: buffer.cursorX + 1 };
   }
 
   resize(cols: number, rows: number): void {

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -15,7 +15,10 @@ import { getServerPort } from '@/lib/server-port';
 import { revokePaneTokensForTerminal } from './pane-token-registry';
 import { cleanupCodexOverlayForTerminal } from './codex-overlay';
 import { cleanupCodexOverlayInWsl } from './codex-overlay-wsl';
-import { TerminalHeadlessModel } from './terminal-headless-model';
+import {
+  TerminalHeadlessModel,
+  type TerminalHeadlessSnapshot,
+} from './terminal-headless-model';
 import { normalizeTerminalColorEnv } from './terminal-color-env';
 import { createTerminalAppearanceController } from './terminal-appearance-controller';
 import {
@@ -265,7 +268,7 @@ const CONVERSATION_RESET_SCAN_MS = 250;
 async function resolveSnapshotWithTimeout(
   model: TerminalHeadlessModelLike,
   timeoutMs: number,
-): Promise<{ data: string; cols: number; rows: number }> {
+): Promise<TerminalHeadlessSnapshot> {
   const snapshot = model.snapshot();
   // If the timeout wins, a late rejection from the losing promise must not
   // surface as an unhandled rejection.
@@ -857,9 +860,6 @@ export class TerminalManager {
     const fallbackSnapshot = runtime.outputBuffer.join('');
     runtime.subscribers.set(subscriberKey, subscriber);
     runtime.viewportOwner = subscriberKey;
-    if (options.cols && options.rows) {
-      this.resizeRuntime(runtime, options.cols, options.rows);
-    }
     this.sendStarted(runtime, subscriber, reattached);
     const runtimeAppearance = runtime.appearanceController?.getAppearance();
     if (
@@ -896,6 +896,13 @@ export class TerminalManager {
         data: snapshot.data,
         cols: snapshot.cols,
         rows: snapshot.rows,
+        alternateScreen: snapshot.alternateScreen,
+        ...(snapshot.scrollbackAnsi !== undefined && {
+          scrollbackAnsi: snapshot.scrollbackAnsi,
+        }),
+        ...(snapshot.pendingEscapeTailAnsi && {
+          pendingEscapeTailAnsi: snapshot.pendingEscapeTailAnsi,
+        }),
       });
     } catch (error) {
       if (runtime.subscribers.get(subscriberKey) !== subscriber) return;
@@ -907,8 +914,10 @@ export class TerminalManager {
         generation: runtime.generation,
         seq: snapshotSeq,
         data: fallbackSnapshot,
-        cols: normalizeTerminalDimension(options.cols, 80, MAX_TERMINAL_COLS),
-        rows: normalizeTerminalDimension(options.rows, 24, MAX_TERMINAL_ROWS),
+        // Raw replay was produced at the live PTY's current grid, not at the
+        // destination panel's requested dimensions.
+        cols: runtime.cols,
+        rows: runtime.rows,
         fallback: true,
       });
     }
@@ -1158,6 +1167,7 @@ export class TerminalManager {
     cols: number,
     rows: number,
     claim = false,
+    replayRefresh = false,
   ): void {
     const runtime = this.getOwnedTerminal(terminalId, userId);
     if (!runtime || runtime.ended) return;
@@ -1167,7 +1177,7 @@ export class TerminalManager {
       runtime.viewportOwner = subscriberKey;
     }
     if (runtime.viewportOwner !== subscriberKey) return;
-    this.resizeRuntime(runtime, cols, rows);
+    this.resizeRuntime(runtime, cols, rows, replayRefresh);
   }
 
   detach(terminalId: string, userId: string, connectionId: string, surfaceId: string): void {
@@ -1774,17 +1784,37 @@ export class TerminalManager {
     });
   }
 
-  private resizeRuntime(runtime: TerminalRuntime, cols: number, rows: number): void {
+  private resizeRuntime(
+    runtime: TerminalRuntime,
+    cols: number,
+    rows: number,
+    forceRefresh = false,
+  ): void {
     const normalizedCols = normalizeTerminalDimension(cols, 80, MAX_TERMINAL_COLS);
     const normalizedRows = normalizeTerminalDimension(rows, 24, MAX_TERMINAL_ROWS);
-    if (runtime.cols === normalizedCols && runtime.rows === normalizedRows) return;
+    const dimensionsChanged = runtime.cols !== normalizedCols || runtime.rows !== normalizedRows;
+    if (!dimensionsChanged && !forceRefresh) return;
     if (runtime.resizeScrollbackPolicy === 'preserve-on-ed3') {
       runtime.resizeOutputTransaction?.begin();
     }
     runtime.process.resize(normalizedCols, normalizedRows);
-    runtime.model.resize(normalizedCols, normalizedRows);
-    runtime.cols = normalizedCols;
-    runtime.rows = normalizedRows;
+    if (dimensionsChanged) {
+      runtime.model.resize(normalizedCols, normalizedRows);
+      runtime.cols = normalizedCols;
+      runtime.rows = normalizedRows;
+    }
+
+    if (forceRefresh && getRuntimePlatform() !== 'win32') {
+      // POSIX node-pty only emits SIGWINCH when dimensions change. Snapshot
+      // replay also needs a repaint at the same grid, so mirror Orca's
+      // explicit post-replay signal. ConPTY gets the same-size native resize
+      // above; node-pty does not support signals on Windows.
+      try {
+        runtime.process.kill('SIGWINCH');
+      } catch {
+        // The process may have exited between replay and refresh.
+      }
+    }
   }
 
   private inferInterrupt(

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -22,6 +22,11 @@ import {
 import { normalizeTerminalColorEnv } from './terminal-color-env';
 import { createTerminalAppearanceController } from './terminal-appearance-controller';
 import {
+  createTerminalDeviceQueryController,
+  formatTerminalDeviceQueryReply,
+  type TerminalDeviceQueryKind,
+} from './terminal-device-query-controller';
+import {
   ownsTerminalHandoffLock,
   releaseTerminalHandoffByTerminal,
 } from './terminal-handoff-lock';
@@ -169,6 +174,7 @@ interface TerminalRuntime {
   appearanceRestartPending: boolean;
   process: TerminalProcessHandle;
   appearanceController?: ReturnType<typeof createTerminalAppearanceController>;
+  deviceQueryController: ReturnType<typeof createTerminalDeviceQueryController>;
   model: TerminalHeadlessModelLike;
   cols: number;
   rows: number;
@@ -208,7 +214,7 @@ interface TerminalRuntime {
 export type TerminalHeadlessModelLike = Pick<
   TerminalHeadlessModel,
   'write' | 'resize' | 'snapshot' | 'readVisibleText' | 'dispose'
->;
+> & Partial<Pick<TerminalHeadlessModel, 'whenSettled' | 'cursorPosition'>>;
 
 export interface TerminalManagerOptions {
   closeExitGraceMs?: number;
@@ -663,6 +669,7 @@ export class TerminalManager {
         appearanceRestartIntent: options.appearanceRestartIntent,
         appearanceRestartPending: false,
         process: processHandle,
+        deviceQueryController: createTerminalDeviceQueryController(),
         model,
         cols,
         rows,
@@ -769,7 +776,7 @@ export class TerminalManager {
         prefillHardTimer = setTimeout(sendPrefill, PREFILL_HARD_TIMEOUT_MS);
       }
 
-      const deliverOutput = (data: string) => {
+      const emitOutput = (data: string) => {
         if (data.length === 0) return;
         // replay 버퍼: 원본 청크 순서/내용 그대로 즉시 누적 — coalescing과 독립.
         this.appendBufferedOutput(runtime, data);
@@ -794,6 +801,20 @@ export class TerminalManager {
         // WS 전송만 한 tick 모아 1회 전송(flood 완화).
         this.queueOutput(runtime, data);
       };
+
+      // CPR/DSR/DA는 여기서 소비한다 — 브라우저 xterm까지 왕복시키면 응답이 늦어
+      // tty ECHO에 `^[[1;1R`로 찍힌다(codex는 기동 즉시 CSI 6n을 보낸다).
+      // resize 트랜잭션 뒤에 두는 이유: 트랜잭션은 원본 청크 경계로 분할 ED3를
+      // 재조립하므로, 그 앞에서 조각을 붙잡으면 경계 신호가 사라진다.
+      const deliverOutput = (raw: string) => {
+        if (raw.length === 0) return;
+        // 세그먼트 순서대로 처리해야 커서 보고가 질의 시점의 위치를 답한다.
+        for (const segment of runtime.deviceQueryController.consumeOutput(raw)) {
+          emitOutput(segment.output);
+          if (segment.query) this.answerDeviceQueries(runtime, segment.query);
+        }
+      };
+
       runtime.resizeOutputTransaction = new TerminalResizeOutputTransaction({
         emit: deliverOutput,
       });
@@ -808,6 +829,9 @@ export class TerminalManager {
         if (pendingColorQueryData) {
           runtime.resizeOutputTransaction?.accept(pendingColorQueryData);
         }
+        // 트랜잭션을 다시 태우면 같은 조각이 컨트롤러에 재보관되어 유실되므로
+        // 하위로 직접 흘린다.
+        emitOutput(runtime.deviceQueryController.drain());
         clearPrefillTimers();
         this.finalizeRuntimeExit(runtime, key, event);
       });
@@ -1035,6 +1059,26 @@ export class TerminalManager {
     const runtime = this.getOwnedTerminal(terminalId, userId);
     if (!runtime || runtime.ended) return;
     runtime.providerSessionId = undefined;
+  }
+
+  /**
+   * Writes the reply for a query consumed from the PTY output. It waits for the
+   * model to finish parsing the output that preceded the query, so a cursor
+   * report describes the position the querying program actually left behind
+   * rather than a mid-chunk guess. A model without those members (test stubs)
+   * degrades to the home position, which is what a fresh grid would report.
+   */
+  private answerDeviceQueries(runtime: TerminalRuntime, query: TerminalDeviceQueryKind): void {
+    const settled = runtime.model.whenSettled?.() ?? Promise.resolve();
+    void settled.then(() => {
+      if (runtime.ended) return;
+      const cursor = runtime.model.cursorPosition?.() ?? { row: 1, column: 1 };
+      try {
+        runtime.process.write(formatTerminalDeviceQueryReply(query, cursor));
+      } catch {
+        // The PTY can exit between emitting the query and receiving its reply.
+      }
+    });
   }
 
   private observeAgentInterruptInput(runtime: TerminalRuntime, data: string): void {

--- a/src/lib/terminal/terminal-partial-escape-tail.ts
+++ b/src/lib/terminal/terminal-partial-escape-tail.ts
@@ -1,0 +1,121 @@
+/**
+ * A PTY chunk can end in the middle of an escape sequence. Those bytes live
+ * only in xterm's parser state and are absent from SerializeAddon output. Keep
+ * the incomplete tail so replay can re-arm the parser before live bytes resume.
+ */
+
+type ScanState =
+  | 'ground'
+  | 'esc'
+  | 'escIntermediate'
+  | 'csi'
+  | 'osc'
+  | 'oscEsc'
+  | 'string'
+  | 'stringEsc';
+
+const ESC = 0x1b;
+const CAN = 0x18;
+const SUB = 0x1a;
+const BEL = 0x07;
+
+export const MAX_PARTIAL_ESCAPE_TAIL_LENGTH = 4_096;
+
+function stateAfterEscByte(code: number): ScanState {
+  if (code === 0x5b) return 'csi';
+  if (code === 0x5d) return 'osc';
+  // DCS, SOS, PM and APC are all terminated by ST.
+  if (code === 0x50 || code === 0x58 || code === 0x5e || code === 0x5f) {
+    return 'string';
+  }
+  if (code >= 0x20 && code <= 0x2f) return 'escIntermediate';
+  if (code < 0x20 || code === 0x7f) return 'esc';
+  return 'ground';
+}
+
+export function extractPartialEscapeTail(stream: string): string {
+  let state: ScanState = 'ground';
+  let start = 0;
+
+  for (let index = 0; index < stream.length; index += 1) {
+    const code = stream.charCodeAt(index);
+    if (state === 'ground') {
+      if (code === ESC) {
+        start = index;
+        state = 'esc';
+      }
+      continue;
+    }
+
+    if (
+      code === ESC
+      && state !== 'osc'
+      && state !== 'string'
+      && state !== 'oscEsc'
+      && state !== 'stringEsc'
+    ) {
+      start = index;
+      state = 'esc';
+      continue;
+    }
+
+    if (
+      (code === CAN || code === SUB)
+      && (state === 'esc' || state === 'escIntermediate')
+    ) {
+      state = 'ground';
+      continue;
+    }
+
+    switch (state) {
+      case 'esc':
+        state = stateAfterEscByte(code);
+        break;
+      case 'escIntermediate':
+        if (code >= 0x30 && code <= 0x7e) state = 'ground';
+        break;
+      case 'csi':
+        if (code === CAN || code === SUB || (code >= 0x40 && code <= 0x7e)) {
+          state = 'ground';
+        }
+        break;
+      case 'osc':
+        if (code === BEL || code === CAN || code === SUB) {
+          state = 'ground';
+        } else if (code === ESC) {
+          state = 'oscEsc';
+        }
+        break;
+      case 'oscEsc':
+        if (code === 0x5c) {
+          state = 'ground';
+        } else {
+          start = index - 1;
+          state = code === ESC ? 'esc' : stateAfterEscByte(code);
+        }
+        break;
+      case 'string':
+        if (code === CAN || code === SUB) {
+          state = 'ground';
+        } else if (code === ESC) {
+          state = 'stringEsc';
+        }
+        break;
+      case 'stringEsc':
+        if (code === 0x5c) {
+          state = 'ground';
+        } else {
+          start = index - 1;
+          state = code === ESC ? 'esc' : stateAfterEscByte(code);
+        }
+        break;
+    }
+  }
+
+  return state === 'ground' ? '' : stream.slice(start);
+}
+
+export function advancePartialEscapeTail(pendingTail: string, chunk: string): string {
+  const tail = extractPartialEscapeTail(pendingTail + chunk);
+  return tail.length > MAX_PARTIAL_ESCAPE_TAIL_LENGTH ? '' : tail;
+}

--- a/src/lib/terminal/terminal-serialize-absolute-cursor.ts
+++ b/src/lib/terminal/terminal-serialize-absolute-cursor.ts
@@ -1,0 +1,79 @@
+/**
+ * SerializeAddon restores its final cursor with relative movements. When the
+ * last serialized row exactly fills the right margin, replay leaves xterm in
+ * wrap-pending state and that relative movement can land one column early.
+ * Always finish a non-empty snapshot with the source terminal's authoritative
+ * absolute cursor position.
+ */
+
+interface SerializeCursorTerminal {
+  cols: number;
+  rows: number;
+  buffer: { active: { cursorX: number; cursorY: number } };
+}
+
+interface BufferSerializer<TOptions> {
+  serialize(options?: TOptions): string;
+}
+
+export interface SavedCursorRegister {
+  x: number;
+  y: number;
+}
+
+interface TerminalWithSavedCursorCore extends SerializeCursorTerminal {
+  _core?: {
+    buffer?: {
+      savedX?: number;
+      savedY?: number;
+      ybase?: number;
+    };
+  };
+}
+
+/** Read xterm's active-buffer DECSC register in viewport-relative coordinates. */
+export function readSavedCursorRegister(
+  terminal: SerializeCursorTerminal,
+): SavedCursorRegister | null {
+  const buffer = (terminal as TerminalWithSavedCursorCore)._core?.buffer;
+  if (
+    typeof buffer?.savedX !== 'number'
+    || typeof buffer.savedY !== 'number'
+    || typeof buffer.ybase !== 'number'
+  ) {
+    return null;
+  }
+
+  const y = Math.min(Math.max(buffer.savedY - buffer.ybase, 0), terminal.rows - 1);
+  const x = Math.min(Math.max(buffer.savedX, 0), terminal.cols - 1);
+  // Home is also xterm's never-saved default. Avoid replacing the fresh
+  // terminal's default saved SGR/charset when no explicit save was observed.
+  return x === 0 && y === 0 ? null : { x, y };
+}
+
+export function serializeWithAbsoluteCursor<TOptions>(
+  serializer: BufferSerializer<TOptions>,
+  terminal: SerializeCursorTerminal,
+  options?: TOptions,
+  savedCursor: SavedCursorRegister | null = null,
+): string {
+  const serialized = serializer.serialize(options);
+  if (serialized.length === 0) return serialized;
+
+  const { cursorX, cursorY } = terminal.buffer.active;
+  // CUP cannot recreate xterm's wrap-pending cursor (cursorX === cols). Plain
+  // replay already preserves that state, so leave those snapshots untouched.
+  if (
+    cursorX < 0
+    || cursorX >= terminal.cols
+    || cursorY < 0
+    || cursorY >= terminal.rows
+  ) {
+    return serialized;
+  }
+
+  const savedCursorSequence = savedCursor
+    ? `\x1b[${savedCursor.y + 1};${savedCursor.x + 1}H\x1b7`
+    : '';
+  return `${serialized}${savedCursorSequence}\x1b[${cursorY + 1};${cursorX + 1}H`;
+}

--- a/src/lib/terminal/terminal-snapshot-replay.ts
+++ b/src/lib/terminal/terminal-snapshot-replay.ts
@@ -1,0 +1,26 @@
+export interface TerminalSnapshotReplayPayload {
+  data: string;
+  alternateScreen?: boolean;
+  scrollbackAnsi?: string;
+  pendingEscapeTailAnsi?: string;
+}
+
+/** Build one ordered replay stream. A partial escape tail must be last. */
+export function buildTerminalSnapshotReplay(
+  snapshot: TerminalSnapshotReplayPayload,
+): string {
+  let preamble: string;
+  if (!snapshot.alternateScreen) {
+    preamble = '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H';
+  } else if (snapshot.scrollbackAnsi !== undefined) {
+    preamble = [
+      '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      snapshot.scrollbackAnsi,
+      '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
+    ].join('');
+  } else {
+    preamble = '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H';
+  }
+
+  return `${preamble}${snapshot.data}${snapshot.pendingEscapeTailAnsi ?? ''}`;
+}

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ITheme } from '@xterm/xterm';
+import type { ITheme, IUnicodeHandling } from '@xterm/xterm';
 import { v4 as uuidv4 } from 'uuid';
 import { wsClient } from '@/lib/ws/client';
 import type { ServerTransportMessage } from '@/lib/ws/message-types';
@@ -56,6 +56,8 @@ import {
   attachTerminalMouseWheelMultiplier,
   isTerminalTuiOwnedWheelEvent,
 } from './terminal-mouse-wheel';
+import { activateTesseraTerminalUnicodeProvider } from './terminal-unicode-provider';
+import { buildTerminalSnapshotReplay } from './terminal-snapshot-replay';
 
 export type TerminalSurfaceStatus = 'starting' | 'running' | 'exited' | 'error';
 
@@ -84,7 +86,8 @@ type XtermLike = TerminalScrollTarget & {
   cols: number;
   rows: number;
   options: { theme?: ITheme; fontSize?: number };
-  unicode: { activeVersion: string };
+  unicode: IUnicodeHandling;
+  modes: { sendFocusMode: boolean };
   attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void;
   attachCustomWheelEventHandler(handler: (event: WheelEvent) => boolean): void;
   element?: HTMLElement;
@@ -293,6 +296,9 @@ export class TerminalSurface {
   private serverGeneration: number | null = null;
   private lastSequence = 0;
   private replaying = false;
+  private replayEpoch = 0;
+  private pendingReplayFitEpoch: number | null = null;
+  private pendingReplayOutput: Array<{ data: string; generation: number; seq: number }> = [];
   private onInput: (() => void) | null = null;
   private terminalInputOriginArmed = false;
   private terminalInputOriginEpoch = 0;
@@ -360,7 +366,7 @@ export class TerminalSurface {
     this.setThemeRestartRequired(false);
     this.themeRestartPending = true;
     this.autoConnect = true;
-    this.replaying = false;
+    this.cancelSnapshotReplay();
     this.updateState('starting', 'Restarting terminal to apply theme...');
     wsClient.closeTerminal(this.actualTerminalId);
   }
@@ -605,6 +611,7 @@ export class TerminalSurface {
   close(): void {
     if (this.disposed) return;
     this.autoConnect = false;
+    this.cancelSnapshotReplay();
     clearClientTerminalHandoff(this.options.terminalId);
     wsClient.closeTerminal(this.actualTerminalId);
     this.attachedConnectionGeneration = 0;
@@ -616,7 +623,7 @@ export class TerminalSurface {
     this.autoConnect = true;
     this.serverGeneration = null;
     this.lastSequence = 0;
-    this.replaying = false;
+    this.cancelSnapshotReplay();
     this.terminal?.reset();
     this.scrollController?.scrollToBottom();
     this.updateState('starting', 'Restarting terminal...');
@@ -686,6 +693,7 @@ export class TerminalSurface {
   }
 
   private releaseRenderResources(): void {
+    this.cancelSnapshotReplay();
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
     this.cancelPendingFit();
@@ -799,7 +807,7 @@ export class TerminalSurface {
       terminal.loadAddon(new SerializeAddon());
       terminal.loadAddon(new Unicode11Addon());
       terminal.loadAddon(new WebLinksAddon(webLinkHandler));
-      terminal.unicode.activeVersion = '11';
+      activateTesseraTerminalUnicodeProvider(terminal);
       attachTerminalMouseWheelMultiplier(terminal);
 
       // Renderer choice. WebGL everywhere by default — the postinstall patch
@@ -997,6 +1005,7 @@ export class TerminalSurface {
       if (!surfaceMatches) return;
       this.autoConnect = false;
       this.attachedConnectionGeneration = 0;
+      this.cancelSnapshotReplay();
       clearClientTerminalHandoff(this.options.terminalId);
       this.updateState('error', message.message);
       this.finishPendingLaunch('error', message.message);
@@ -1008,6 +1017,7 @@ export class TerminalSurface {
     if (message.type === 'terminal_started') {
       this.actualTerminalId = message.terminalId;
       if (this.serverGeneration !== message.generation) {
+        this.cancelSnapshotReplay();
         this.serverGeneration = message.generation;
         this.lastSequence = 0;
       }
@@ -1051,7 +1061,10 @@ export class TerminalSurface {
       ) return;
       this.serverGeneration = message.generation;
       this.lastSequence = message.seq;
+      const replayEpoch = ++this.replayEpoch;
       this.replaying = true;
+      this.pendingReplayFitEpoch = null;
+      this.pendingReplayOutput = [];
       const restorePoint = this.scrollController?.captureRestorePoint();
       // Recovery after a replay is unconditional (see onParsed below), but the
       // detector still consumes the chunk to keep its cross-chunk scan state.
@@ -1068,19 +1081,27 @@ export class TerminalSurface {
         && message.cols >= 2 && message.rows >= 1
         && (this.terminal.cols !== message.cols || this.terminal.rows !== message.rows);
       if (snapshotResized) this.terminal?.resize(message.cols, message.rows);
-      if (!this.terminal) return;
-      writeForegroundTerminalChunk(this.terminal, message.data, {
+      if (!this.terminal) {
+        this.cancelSnapshotReplay();
+        return;
+      }
+      const replayData = buildTerminalSnapshotReplay(message);
+      writeForegroundTerminalChunk(this.terminal, replayData, {
         forceViewportRefresh: true,
         // A snapshot replay rewrites the whole grid; always follow up on the
         // settled frame in case the immediate repaint raced layout.
         followupViewportRefresh: true,
         shouldRefreshViewportSynchronously: () => !this.webglAddon,
         onParsed: () => {
+          if (
+            this.replayEpoch !== replayEpoch
+            || this.serverGeneration !== message.generation
+          ) return;
           if (restorePoint) this.scrollController?.restore(restorePoint);
           this.scheduleScrollRebuildSettle();
-          if (this.serverGeneration === message.generation) {
-            this.replaying = false;
-          }
+          // Keep live output and user input behind the replay barrier until the
+          // destination grid is fitted and the PTY receives its repaint resize.
+          this.pendingReplayFitEpoch = replayEpoch;
           this.scheduleSurfaceScrollStateSync();
           // Unconditional, not SGR-gated: a replay rasterizes CJK glyphs into
           // whatever renderer state preceded the reveal, and that state stays
@@ -1100,19 +1121,15 @@ export class TerminalSurface {
     if (message.type === 'terminal_output') {
       if (message.generation !== this.serverGeneration || message.seq <= this.lastSequence) return;
       this.lastSequence = message.seq;
-      const restorePoint = this.scrollController?.captureRestorePoint();
-      const shouldRecoverRenderer = this.backgroundSgrDetector.consume(message.data);
-      if (!this.terminal) return;
-      writeForegroundTerminalChunk(this.terminal, message.data, {
-        forceViewportRefresh: true,
-        shouldRefreshViewportSynchronously: () => !this.webglAddon,
-        onParsed: () => {
-          if (restorePoint) this.scrollController?.restore(restorePoint);
-          this.scheduleScrollRebuildSettle();
-          this.scheduleSurfaceScrollStateSync();
-          if (shouldRecoverRenderer) this.recoverRendererPresentation();
-        },
-      });
+      if (this.replaying) {
+        this.pendingReplayOutput.push({
+          data: message.data,
+          generation: message.generation,
+          seq: message.seq,
+        });
+        return;
+      }
+      this.applyTerminalOutput(message.data);
       return;
     }
 
@@ -1129,17 +1146,65 @@ export class TerminalSurface {
         }
         this.serverGeneration = null;
         this.lastSequence = 0;
-        this.replaying = false;
+        this.cancelSnapshotReplay();
         this.terminal?.reset();
         this.scrollController?.scrollToBottom();
         void this.ensureConnected();
         return;
       }
       this.autoConnect = false;
-      this.replaying = false;
+      this.cancelSnapshotReplay();
       clearClientTerminalHandoff(this.options.terminalId);
       this.updateState('exited', `Terminal exited with code ${message.exitCode}`);
       this.finishPendingLaunch('error', `Terminal exited with code ${message.exitCode}`);
+    }
+  }
+
+  private applyTerminalOutput(data: string): void {
+    const restorePoint = this.scrollController?.captureRestorePoint();
+    const shouldRecoverRenderer = this.backgroundSgrDetector.consume(data);
+    if (!this.terminal) return;
+    writeForegroundTerminalChunk(this.terminal, data, {
+      forceViewportRefresh: true,
+      shouldRefreshViewportSynchronously: () => !this.webglAddon,
+      onParsed: () => {
+        if (restorePoint) this.scrollController?.restore(restorePoint);
+        this.scheduleScrollRebuildSettle();
+        this.scheduleSurfaceScrollStateSync();
+        if (shouldRecoverRenderer) this.recoverRendererPresentation();
+      },
+    });
+  }
+
+  private cancelSnapshotReplay(): void {
+    this.replayEpoch += 1;
+    this.replaying = false;
+    this.pendingReplayFitEpoch = null;
+    this.pendingReplayOutput = [];
+  }
+
+  private finishSnapshotReplay(replayEpoch: number): void {
+    if (this.replayEpoch !== replayEpoch || this.pendingReplayFitEpoch !== replayEpoch) return;
+
+    const pendingOutput = this.pendingReplayOutput;
+    this.pendingReplayOutput = [];
+    this.pendingReplayFitEpoch = null;
+    this.replaying = false;
+    for (const frame of pendingOutput) {
+      if (frame.generation === this.serverGeneration) this.applyTerminalOutput(frame.data);
+    }
+
+    const terminal = this.terminal;
+    const activeElement = document.activeElement;
+    if (
+      terminal?.modes.sendFocusMode
+      && activeElement
+      && terminal.element?.contains(activeElement)
+    ) {
+      // Focus may have happened before replay restored ?1004h. Re-send the
+      // event once after the snapshot barrier so fullscreen TUIs always learn
+      // that this newly attached surface is active.
+      wsClient.sendTerminalInput(this.actualTerminalId, this.surfaceId, '\x1b[I');
     }
   }
 
@@ -1291,13 +1356,19 @@ export class TerminalSurface {
 
   private fitAndResize(claim: boolean, shouldFit = true): void {
     if (!this.isMountedHostVisible() || !this.fitAddon || !this.terminal) return;
+    const replayFitEpoch = this.pendingReplayFitEpoch;
+    // A ResizeObserver/activation fit can race snapshot parsing. Preserve the
+    // exact source grid until the replay write callback establishes a barrier.
+    if (this.replaying && replayFitEpoch === null) return;
     let didFit = false;
+    let fitCompleted = !shouldFit;
     let restorePoint: TerminalScrollRestorePoint | null = null;
     try {
       if (shouldFit) {
         restorePoint = this.scrollController?.captureRestorePoint() ?? null;
         this.fitAddon.fit();
         didFit = true;
+        fitCompleted = true;
       }
       const dimensions = this.getDimensions();
       if (dimensions && this.attachedConnectionGeneration > 0) {
@@ -1307,10 +1378,26 @@ export class TerminalSurface {
           dimensions.cols,
           dimensions.rows,
           claim,
+          replayFitEpoch !== null,
         );
       }
     } catch {
       // A zero-sized panel can briefly make FitAddon unable to calculate cells.
+      // Do not strand a parsed snapshot behind the replay barrier: repaint at
+      // its exact source grid now and let the next ResizeObserver fit retry.
+      if (replayFitEpoch !== null) {
+        if (this.attachedConnectionGeneration > 0) {
+          wsClient.resizeTerminal(
+            this.actualTerminalId,
+            this.surfaceId,
+            this.terminal.cols,
+            this.terminal.rows,
+            claim,
+            true,
+          );
+        }
+        fitCompleted = true;
+      }
     } finally {
       if (restorePoint) this.scrollController?.restoreAfterLayout(restorePoint);
       // Reflow plus the ConPTY resize repaint can strand the viewport in a
@@ -1331,6 +1418,9 @@ export class TerminalSurface {
       // empty presentation model. Force the same full repaint and quiet atlas
       // recovery Orca uses for stale terminal presentation.
       if (didFit) this.recoverRendererPresentation();
+      if (replayFitEpoch !== null && fitCompleted) {
+        this.finishSnapshotReplay(replayFitEpoch);
+      }
     }
   }
 

--- a/src/lib/terminal/terminal-unicode-provider.ts
+++ b/src/lib/terminal/terminal-unicode-provider.ts
@@ -1,0 +1,73 @@
+import type { IUnicodeHandling, IUnicodeVersionProvider } from '@xterm/xterm';
+
+interface XtermTerminalWithUnicodeCore {
+  unicode: IUnicodeHandling;
+  _core?: {
+    unicodeService?: {
+      _providers?: Record<string, IUnicodeVersionProvider>;
+    };
+  };
+}
+
+const TESSERA_UNICODE_VERSION = 'tessera-11-zwj';
+const UNICODE11_VERSION = '11';
+const ZERO_WIDTH_JOINER = 0x200d;
+
+function extractWidth(properties: number): 0 | 1 | 2 {
+  return ((properties >> 1) & 3) as 0 | 1 | 2;
+}
+
+function extractCharKind(properties: number): number {
+  return properties >> 3;
+}
+
+function createProperties(charKind: number, width: 0 | 1 | 2, shouldJoin: boolean): number {
+  return ((charKind & 0xffffff) << 3) | ((width & 3) << 1) | (shouldJoin ? 1 : 0);
+}
+
+class TesseraUnicodeProvider implements IUnicodeVersionProvider {
+  readonly version = TESSERA_UNICODE_VERSION;
+
+  constructor(private readonly baseProvider: IUnicodeVersionProvider) {}
+
+  wcwidth(codepoint: number): 0 | 1 | 2 {
+    return this.baseProvider.wcwidth(codepoint);
+  }
+
+  charProperties(codepoint: number, preceding: number): number {
+    const precedingWidth = extractWidth(preceding);
+    const precedingKind = extractCharKind(preceding);
+
+    if (codepoint === ZERO_WIDTH_JOINER && precedingWidth > 0) {
+      return createProperties(ZERO_WIDTH_JOINER, precedingWidth, true);
+    }
+
+    if (
+      precedingKind === ZERO_WIDTH_JOINER
+      && precedingWidth > 0
+      && this.wcwidth(codepoint) > 0
+    ) {
+      return createProperties(codepoint, precedingWidth, true);
+    }
+
+    return this.baseProvider.charProperties(codepoint, preceding);
+  }
+}
+
+export function activateTesseraTerminalUnicodeProvider(
+  terminal: XtermTerminalWithUnicodeCore,
+): void {
+  const { unicode } = terminal;
+  if (unicode.activeVersion === TESSERA_UNICODE_VERSION) return;
+
+  const baseProvider = terminal._core?.unicodeService?._providers?.[UNICODE11_VERSION];
+  if (!baseProvider) {
+    unicode.activeVersion = UNICODE11_VERSION;
+    return;
+  }
+
+  if (!unicode.versions.includes(TESSERA_UNICODE_VERSION)) {
+    unicode.register(new TesseraUnicodeProvider(baseProvider));
+  }
+  unicode.activeVersion = TESSERA_UNICODE_VERSION;
+}

--- a/src/lib/ws/client.ts
+++ b/src/lib/ws/client.ts
@@ -416,8 +416,16 @@ export class WebSocketClient {
     cols: number,
     rows: number,
     claim = false,
-  ) {
-    this.sendRequest('terminal_resize', { terminalId, surfaceId, cols, rows, claim });
+    replayRefresh = false,
+  ): boolean {
+    return this.sendRequest('terminal_resize', {
+      terminalId,
+      surfaceId,
+      cols,
+      rows,
+      claim,
+      replayRefresh,
+    });
   }
 
   closeTerminal(terminalId: string): boolean {

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -128,6 +128,8 @@ export type ClientMessage =
       cols: number;
       rows: number;
       claim?: boolean;
+      /** Repaint a live TUI after an authoritative snapshot replay. */
+      replayRefresh?: boolean;
     }
   | { type: 'terminal_close'; requestId: string; terminalId: string }
   | { type: 'subscribe_workspace_files'; requestId: string; sessionId: string; subscriberId: string }
@@ -349,6 +351,9 @@ export type AppServerMessage =
       cols: number;
       rows: number;
       fallback?: boolean;
+      alternateScreen?: boolean;
+      scrollbackAnsi?: string;
+      pendingEscapeTailAnsi?: string;
     }
   | {
       type: 'terminal_output';

--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -827,6 +827,7 @@ export async function routeClientTransportMessage({
         message.cols,
         message.rows,
         message.claim,
+        message.replayRefresh,
       );
       return;
 

--- a/tests/terminal-device-query-controller.test.ts
+++ b/tests/terminal-device-query-controller.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  createTerminalDeviceQueryController,
+  formatTerminalDeviceQueryReply,
+  type TerminalDeviceQuerySegment,
+} from '@/lib/terminal/terminal-device-query-controller';
+
+function flatten(segments: readonly TerminalDeviceQuerySegment[]) {
+  return {
+    output: segments.map((segment) => segment.output).join(''),
+    queries: segments.map((segment) => segment.query).filter((query) => query !== null),
+  };
+}
+
+test('device query controller consumes the queries codex emits at startup', () => {
+  const controller = createTerminalDeviceQueryController();
+
+  // The exact opening burst codex writes before drawing anything.
+  const result = flatten(controller.consumeOutput(
+    '\x1b[?2004h\x1b[>4;0m\x1b[>7u\x1b[?1004h\x1b[6n\x1b[?u\x1b[c\x1b[?2026h',
+  ));
+
+  // CPR and primary DA are answered here; every other sequence must survive
+  // untouched, including the kitty flags query we deliberately do not answer.
+  assert.equal(
+    result.output,
+    '\x1b[?2004h\x1b[>4;0m\x1b[>7u\x1b[?1004h\x1b[?u\x1b[?2026h',
+  );
+  assert.deepEqual(result.queries, ['cursor-position', 'primary-device-attributes']);
+});
+
+test('device query controller splits a chunk at each query boundary', () => {
+  const controller = createTerminalDeviceQueryController();
+
+  // The split lets the caller apply `before` to its model, read the cursor for
+  // the reply, and only then apply `after` — a cursor report must not describe
+  // output that had not been written when the program asked.
+  assert.deepEqual(controller.consumeOutput('before\x1b[6nafter'), [
+    { output: 'before', query: 'cursor-position' },
+    { output: 'after', query: null },
+  ]);
+});
+
+test('device query controller always returns a trailing segment', () => {
+  const controller = createTerminalDeviceQueryController();
+
+  assert.deepEqual(controller.consumeOutput('plain'), [{ output: 'plain', query: null }]);
+  assert.deepEqual(controller.consumeOutput('\x1b[6n'), [
+    { output: '', query: 'cursor-position' },
+    { output: '', query: null },
+  ]);
+});
+
+test('device query controller answers a cursor report from the live cursor', () => {
+  assert.equal(
+    formatTerminalDeviceQueryReply('cursor-position', { row: 12, column: 34 }),
+    '\x1b[12;34R',
+  );
+  assert.equal(
+    formatTerminalDeviceQueryReply('extended-cursor-position', { row: 3, column: 7 }),
+    '\x1b[?3;7;1R',
+  );
+  assert.equal(
+    formatTerminalDeviceQueryReply('device-status', { row: 1, column: 1 }),
+    '\x1b[0n',
+  );
+  // Matches what xterm.js reports, so the terminal identity is the same
+  // whether the server or the browser answered.
+  assert.equal(
+    formatTerminalDeviceQueryReply('primary-device-attributes', { row: 1, column: 1 }),
+    '\x1b[?1;2c',
+  );
+});
+
+test('device query controller clamps a degenerate cursor to the home position', () => {
+  assert.equal(
+    formatTerminalDeviceQueryReply('cursor-position', { row: 0, column: -4 }),
+    '\x1b[1;1R',
+  );
+});
+
+test('device query controller reassembles a query split across PTY chunks', () => {
+  const controller = createTerminalDeviceQueryController();
+
+  const first = flatten(controller.consumeOutput('before\x1b[6'));
+  assert.equal(first.output, 'before');
+  assert.deepEqual(first.queries, []);
+
+  const second = flatten(controller.consumeOutput('nafter'));
+  assert.equal(second.output, 'after');
+  assert.deepEqual(second.queries, ['cursor-position']);
+});
+
+test('device query controller leaves ordinary output and lookalike CSI intact', () => {
+  const controller = createTerminalDeviceQueryController();
+
+  // `6m` is SGR, `?6h` is DECOM, `16n` is not a query we answer, and a bare
+  // ESC that never becomes a CSI must still reach the screen.
+  const result = flatten(controller.consumeOutput('\x1b[6m\x1b[?6h\x1b[16n\x1bXtext'));
+
+  assert.equal(result.output, '\x1b[6m\x1b[?6h\x1b[16n\x1bXtext');
+  assert.deepEqual(result.queries, []);
+});
+
+test('device query controller does not hold a split CSI that cannot become a query', () => {
+  const controller = createTerminalDeviceQueryController();
+
+  // ED3 arriving as `\x1b[3` + `J` must keep its original chunk boundaries:
+  // the resize transaction reassembles that sequence itself, and buffering it
+  // here would hide the split half from it.
+  const first = flatten(controller.consumeOutput('rows\x1b[3'));
+  assert.equal(first.output, 'rows\x1b[3');
+  assert.deepEqual(first.queries, []);
+
+  const second = flatten(controller.consumeOutput('J'));
+  assert.equal(second.output, 'J');
+  assert.deepEqual(second.queries, []);
+});
+
+test('device query controller drains a half-received sequence on exit', () => {
+  const controller = createTerminalDeviceQueryController();
+
+  assert.equal(flatten(controller.consumeOutput('tail\x1b[')).output, 'tail');
+  assert.equal(controller.drain(), '\x1b[');
+  assert.equal(controller.drain(), '');
+});
+
+test('device query controller flushes an oversized fragment instead of buffering it', () => {
+  const controller = createTerminalDeviceQueryController();
+  const oversized = `\x1b[${'1;'.repeat(80)}`;
+
+  assert.equal(flatten(controller.consumeOutput(oversized)).output, oversized);
+  assert.equal(controller.drain(), '');
+});

--- a/tests/terminal-headless-model.test.ts
+++ b/tests/terminal-headless-model.test.ts
@@ -89,6 +89,60 @@ test('alternate-screen snapshot separates normal scrollback and restores its cur
   model.dispose();
 });
 
+test('alternate-screen snapshot preserves OpenTUI rows after a width shrink', async () => {
+  const cols = 20;
+  const rows = 6;
+  const initialCols = 24;
+  const initialRows = 8;
+  const model = new TerminalHeadlessModel(initialCols, initialRows);
+  const labels = Array.from({ length: initialRows }, (_, index) => `ROW-${index}`);
+  model.write([
+    '\x1b[?1049h\x1b[2J',
+    ...labels.map((label, index) => (
+      `\x1b[${index + 1};1H\x1b[38;2;255;255;255;48;2;245;245;245m${label.padEnd(initialCols, ' ')}`
+    )),
+  ].join(''));
+  // Finish parsing at the old PTY size before simulating a cold reopen at a
+  // smaller surface. Otherwise resize could win the intentionally async write.
+  await model.snapshot();
+  model.resize(cols, rows);
+  const snapshot = await model.snapshot();
+
+  const restored = new Terminal({
+    cols: snapshot.cols,
+    rows: snapshot.rows,
+    allowProposedApi: true,
+  });
+  await writeTerminal(restored, buildTerminalSnapshotReplay(snapshot));
+  restored.resize(cols, rows);
+
+  assert.deepEqual(
+    Array.from({ length: rows }, (_, index) => (
+      restored.buffer.active.getLine(index)?.translateToString().trimEnd()
+    )),
+    labels.slice(-rows),
+  );
+  restored.dispose();
+  model.dispose();
+});
+
+test('alternate-screen snapshot does not discard columns hidden by a shrink', async () => {
+  const model = new TerminalHeadlessModel(24, 4);
+  model.write('\x1b[?1049h\x1b[1;24HX');
+  await model.snapshot();
+
+  model.resize(20, 4);
+  await model.snapshot();
+  model.resize(24, 4);
+  const expanded = await model.snapshot();
+
+  const restored = new Terminal({ cols: 24, rows: 4, allowProposedApi: true });
+  await writeTerminal(restored, buildTerminalSnapshotReplay(expanded));
+  assert.equal(restored.buffer.active.getLine(0)?.translateToString(), ' '.repeat(23) + 'X');
+  restored.dispose();
+  model.dispose();
+});
+
 test('snapshot carries a PTY escape sequence that ended between chunks', async () => {
   const model = new TerminalHeadlessModel(20, 4);
   model.write('\x1b[38;2;120');

--- a/tests/terminal-headless-model.test.ts
+++ b/tests/terminal-headless-model.test.ts
@@ -1,6 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { Terminal } from '@xterm/headless';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { TerminalHeadlessModel } from '../src/lib/terminal/terminal-headless-model';
+import { buildTerminalSnapshotReplay } from '../src/lib/terminal/terminal-snapshot-replay';
+import { activateTesseraTerminalUnicodeProvider } from '../src/lib/terminal/terminal-unicode-provider';
+
+function writeTerminal(terminal: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve));
+}
 
 test('disposing during a pending xterm write releases the snapshot boundary', async () => {
   const model = new TerminalHeadlessModel(80, 24);
@@ -47,4 +55,60 @@ test('snapshot drops encoding modes the TUI disabled or reset', async () => {
   softReset.write('\x1b[?1006h\x1b[!p');
   assert.doesNotMatch((await softReset.snapshot()).data, /\[\?1006h/);
   softReset.dispose();
+});
+
+test('snapshot replay restores an exact absolute cursor after a margin-filled row', async () => {
+  const model = new TerminalHeadlessModel(10, 4);
+  model.write('0123456789\x1b[3;5H');
+  const snapshot = await model.snapshot();
+
+  const restored = new Terminal({ cols: 10, rows: 4, allowProposedApi: true });
+  await writeTerminal(restored, buildTerminalSnapshotReplay(snapshot));
+
+  assert.equal(restored.buffer.active.cursorX, 4);
+  assert.equal(restored.buffer.active.cursorY, 2);
+  restored.dispose();
+  model.dispose();
+});
+
+test('alternate-screen snapshot separates normal scrollback and restores its cursor', async () => {
+  const model = new TerminalHeadlessModel(10, 4);
+  model.write('normal-buffer\r\n\x1b[?1049halt-frame\x1b[3;5H');
+  const snapshot = await model.snapshot();
+
+  assert.equal(snapshot.alternateScreen, true);
+  assert.match(snapshot.scrollbackAnsi ?? '', /normal-buffer/);
+  assert.doesNotMatch(snapshot.data, /\[\?1049h/);
+
+  const restored = new Terminal({ cols: 10, rows: 4, allowProposedApi: true });
+  await writeTerminal(restored, buildTerminalSnapshotReplay(snapshot));
+  assert.equal(restored.buffer.active.type, 'alternate');
+  assert.equal(restored.buffer.active.cursorX, 4);
+  assert.equal(restored.buffer.active.cursorY, 2);
+  restored.dispose();
+  model.dispose();
+});
+
+test('snapshot carries a PTY escape sequence that ended between chunks', async () => {
+  const model = new TerminalHeadlessModel(20, 4);
+  model.write('\x1b[38;2;120');
+  const partial = await model.snapshot();
+  assert.equal(partial.pendingEscapeTailAnsi, '\x1b[38;2;120');
+
+  model.write(';80;40mcolored');
+  const complete = await model.snapshot();
+  assert.equal(complete.pendingEscapeTailAnsi, undefined);
+  assert.match(complete.data, /colored/);
+  model.dispose();
+});
+
+test('headless and renderer Unicode provider budgets a ZWJ emoji as one wide glyph', async () => {
+  const terminal = new Terminal({ cols: 20, rows: 4, allowProposedApi: true });
+  terminal.loadAddon(new Unicode11Addon());
+  activateTesseraTerminalUnicodeProvider(terminal);
+  await writeTerminal(terminal, '👩‍💻');
+
+  assert.equal(terminal.unicode.activeVersion, 'tessera-11-zwj');
+  assert.equal(terminal.buffer.active.cursorX, 2);
+  terminal.dispose();
 });

--- a/tests/terminal-manager-lifecycle.test.ts
+++ b/tests/terminal-manager-lifecycle.test.ts
@@ -1251,3 +1251,49 @@ test('a provider-detected conversation reset is reported once per bound session'
   await settle();
   assert.equal(resets.length, 1);
 });
+
+test('startup device queries are answered by the server and never reach the browser', async () => {
+  const delivered: Array<{ connectionId: string; message: ServerTransportMessage }> = [];
+  const spawned: FakePty[] = [];
+  const manager = new TerminalManager(
+    (connectionId, message) => delivered.push({ connectionId, message }),
+    async () => createFactory(spawned),
+  );
+
+  await manager.create(createOptions({ terminalId: 'terminal-query', sessionId: 'session-query' }));
+  delivered.length = 0;
+
+  // The opening burst codex writes before it draws anything.
+  spawned[0].emitData('\x1b[?2004h\x1b[6n\x1b[?u\x1b[c\x1b[?2026hframe');
+  // The cursor report waits for the model to finish parsing what came before it.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  // Answered locally, so the querying program never waits on a WS round trip.
+  assert.deepEqual(spawned[0].writes, ['\x1b[1;1R', '\x1b[?1;2c']);
+
+  const output = delivered
+    .filter(({ message }) => message.type === 'terminal_output')
+    .map(({ message }) => (message.type === 'terminal_output' ? message.data : ''))
+    .join('');
+  // The browser must not see the queries it would otherwise answer late, but
+  // everything else — including the kitty query we leave alone — passes through.
+  assert.doesNotMatch(output, /\x1b\[6n/);
+  assert.doesNotMatch(output, /\x1b\[c/);
+  assert.equal(output, '\x1b[?2004h\x1b[?u\x1b[?2026hframe');
+});
+
+test('a cursor report reflects where the program actually left the cursor', async () => {
+  const spawned: FakePty[] = [];
+  const manager = new TerminalManager(
+    () => undefined,
+    async () => createFactory(spawned),
+  );
+
+  await manager.create(createOptions({ terminalId: 'terminal-cursor', sessionId: 'session-cursor' }));
+
+  spawned[0].emitData('\x1b[5;9Hplaced\x1b[6n');
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  // Row 5, column 9 plus the six characters written there.
+  assert.deepEqual(spawned[0].writes, ['\x1b[5;15R']);
+});

--- a/tests/terminal-manager-lifecycle.test.ts
+++ b/tests/terminal-manager-lifecycle.test.ts
@@ -28,6 +28,7 @@ before(async () => {
 class FakePty {
   readonly writes: string[] = [];
   readonly resizes: Array<{ cols: number; rows: number }> = [];
+  readonly killSignals: Array<string | undefined> = [];
   killCount = 0;
   private dataListeners: Array<(data: string) => void> = [];
   private exitListeners: Array<(event: { exitCode: number; signal?: number }) => void> = [];
@@ -48,7 +49,8 @@ class FakePty {
     this.resizes.push({ cols, rows });
   }
 
-  kill(): void {
+  kill(signal?: string): void {
+    this.killSignals.push(signal);
     this.killCount += 1;
   }
 
@@ -882,6 +884,46 @@ test('claiming an already-sized viewport does not send a redundant PTY resize', 
   await manager.shutdownAll();
 });
 
+test('cold attach snapshots the source grid before the destination fit and forces a repaint', async () => {
+  const delivered: Array<{ connectionId: string; message: ServerTransportMessage }> = [];
+  const spawned: FakePty[] = [];
+  const manager = new TerminalManager(
+    (connectionId, message) => delivered.push({ connectionId, message }),
+    async () => createFactory(spawned),
+  );
+
+  await manager.create(createOptions({ cols: 100, rows: 30 }));
+  delivered.length = 0;
+  await manager.create(createOptions({
+    terminalId: 'reattach-proposal',
+    connectionId: 'connection-b',
+    surfaceId: 'surface-b',
+    cols: 140,
+    rows: 45,
+  }));
+
+  assert.deepEqual(spawned[0].resizes, [], 'attach must not reflow the source before snapshot');
+  const snapshot = delivered.find(({ connectionId, message }) => (
+    connectionId === 'connection-b' && message.type === 'terminal_snapshot'
+  ))?.message;
+  assert.equal(snapshot?.type, 'terminal_snapshot');
+  if (snapshot?.type === 'terminal_snapshot') {
+    assert.deepEqual({ cols: snapshot.cols, rows: snapshot.rows }, { cols: 100, rows: 30 });
+  }
+
+  manager.resize('terminal-a', 'user-a', 'connection-b', 'surface-b', 140, 45, false, true);
+  manager.resize('terminal-a', 'user-a', 'connection-b', 'surface-b', 140, 45, false, true);
+  assert.deepEqual(spawned[0].resizes, [
+    { cols: 140, rows: 45 },
+    { cols: 140, rows: 45 },
+  ]);
+  assert.equal(
+    spawned[0].killSignals.filter((signal) => signal === 'SIGWINCH').length,
+    process.platform === 'win32' ? 0 : 2,
+  );
+  await manager.shutdownAll();
+});
+
 test('PTY spawn normalizes inherited color opt-outs at the manager boundary', async () => {
   let spawnEnv: NodeJS.ProcessEnv | null = null;
   const factory: TerminalPtyFactory = {
@@ -1128,7 +1170,12 @@ test('a wedged headless model cannot freeze reattach: fallback snapshot then liv
 
   delivered.length = 0;
   await Promise.race([
-    manager.create(createOptions({ connectionId: 'connection-b', surfaceId: 'surface-b' })),
+    manager.create(createOptions({
+      connectionId: 'connection-b',
+      surfaceId: 'surface-b',
+      cols: 140,
+      rows: 45,
+    })),
     deadline('reattach froze waiting for the wedged model snapshot'),
   ]);
 
@@ -1139,6 +1186,11 @@ test('a wedged headless model cannot freeze reattach: fallback snapshot then liv
   if (snapshot?.type === 'terminal_snapshot') {
     assert.equal(snapshot.fallback, true, 'wedged model must degrade to the raw fallback snapshot');
     assert.match(snapshot.data, /history-before-park/);
+    assert.deepEqual(
+      { cols: snapshot.cols, rows: snapshot.rows },
+      { cols: 100, rows: 30 },
+      'fallback bytes must replay at the grid that produced them',
+    );
   }
 
   delivered.length = 0;

--- a/tests/terminal-snapshot-replay.test.ts
+++ b/tests/terminal-snapshot-replay.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  advancePartialEscapeTail,
+  extractPartialEscapeTail,
+} from '../src/lib/terminal/terminal-partial-escape-tail';
+import { buildTerminalSnapshotReplay } from '../src/lib/terminal/terminal-snapshot-replay';
+
+test('partial escape tracking folds safely across PTY chunk boundaries', () => {
+  assert.equal(extractPartialEscapeTail('plain\x1b[31'), '\x1b[31');
+  assert.equal(advancePartialEscapeTail('\x1b[31', 'mred'), '');
+  assert.equal(advancePartialEscapeTail('', '\x1b]8;;https://example.com'), '\x1b]8;;https://example.com');
+  assert.equal(advancePartialEscapeTail('\x1b]8;;https://example.com', '\x1b\\link'), '');
+});
+
+test('normal snapshot replay exits alt screen and clears the old grid first', () => {
+  const replay = buildTerminalSnapshotReplay({ data: 'snapshot' });
+  assert.equal(replay, '\x1b[?1049l\x1b[2J\x1b[3J\x1b[Hsnapshot');
+});
+
+test('alternate snapshot replay rebuilds normal scrollback before the active frame', () => {
+  const replay = buildTerminalSnapshotReplay({
+    data: 'alt-frame',
+    alternateScreen: true,
+    scrollbackAnsi: 'normal-scrollback',
+    pendingEscapeTailAnsi: '\x1b[38;2',
+  });
+
+  assert.ok(replay.indexOf('normal-scrollback') < replay.indexOf('\x1b[?1049h'));
+  assert.ok(replay.indexOf('\x1b[?1049h') < replay.indexOf('alt-frame'));
+  assert.ok(replay.endsWith('\x1b[38;2'), 'the incomplete parser tail must be the final bytes');
+});


### PR DESCRIPTION
## What changed

- Replay PTY snapshots with stable cursor, Unicode, alternate-screen, and partial escape-sequence state.
- Serialize alternate-screen contents at the source width before fitting the destination surface.
- Answer startup terminal device queries on the server so they never leak into browser rendering.

## Why

Cold attaches and terminal resizes could drift cells, lose hidden columns, or expose device-query bytes as visible output.

## Impact

Reattached terminal sessions preserve their grid and cursor more reliably across resize, Unicode, and full-screen TUI scenarios.

## Validation

- `npm run server:compile`
- Targeted Node/tsx tests for headless snapshots, manager lifecycle, replay, and device-query handling
- `node --test tests/terminal-contract.test.mjs`
- Targeted ESLint on changed terminal/runtime files
