### PR TITLE
fix(terminal): make desktop copy and paste reliable

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,7 +17,7 @@ import * as fs from 'fs';
 import { createTray, destroyTray, updateTrayCloseBehavior } from './tray';
 import { getTesseraDataPath } from '../src/lib/tessera-data-dir';
 import { normalizeExternalHttpUrl } from '../src/lib/external-http-url';
-import { getTerminalClipboardKind, readTerminalClipboard } from './terminal-clipboard';
+import { readTerminalClipboard } from './terminal-clipboard';
 
 type TitlebarMenuSection = 'file' | 'edit' | 'view' | 'window' | 'help';
 type TitlebarTheme = 'light' | 'dark';
@@ -1016,9 +1016,6 @@ function broadcastPopoutState(): void {
 
 // ── IPC ────────────────────────────────────────────────────────────────────
 ipcMain.handle('get-server-port', () => serverPort);
-ipcMain.on('get-terminal-clipboard-kind', (event) => {
-  event.returnValue = getTerminalClipboardKind(clipboard);
-});
 ipcMain.handle('read-terminal-clipboard', () => readTerminalClipboard(clipboard));
 ipcMain.on('ui-storage-get-item', (event, key: unknown) => {
   event.returnValue = getUiStorageItem(key);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,7 +17,7 @@ import * as fs from 'fs';
 import { createTray, destroyTray, updateTrayCloseBehavior } from './tray';
 import { getTesseraDataPath } from '../src/lib/tessera-data-dir';
 import { normalizeExternalHttpUrl } from '../src/lib/external-http-url';
-import { readTerminalClipboard } from './terminal-clipboard';
+import { readTerminalClipboard, writeTerminalClipboardText } from './terminal-clipboard';
 
 type TitlebarMenuSection = 'file' | 'edit' | 'view' | 'window' | 'help';
 type TitlebarTheme = 'light' | 'dark';
@@ -1017,6 +1017,9 @@ function broadcastPopoutState(): void {
 // ── IPC ────────────────────────────────────────────────────────────────────
 ipcMain.handle('get-server-port', () => serverPort);
 ipcMain.handle('read-terminal-clipboard', () => readTerminalClipboard(clipboard));
+ipcMain.handle('write-terminal-clipboard-text', (_event, text: unknown) => (
+  writeTerminalClipboardText(clipboard, text)
+));
 ipcMain.on('ui-storage-get-item', (event, key: unknown) => {
   event.returnValue = getUiStorageItem(key);
 });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,15 +1,10 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
-import type {
-  TerminalClipboardKind,
-  TerminalClipboardPayload,
-} from '../src/lib/terminal/terminal-clipboard-paste';
+import type { TerminalClipboardPayload } from '../src/lib/terminal/terminal-clipboard-paste';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
   isElectron: true,
   getServerPort: () => ipcRenderer.invoke('get-server-port'),
-  getTerminalClipboardKind: () =>
-    ipcRenderer.sendSync('get-terminal-clipboard-kind') as TerminalClipboardKind,
   readTerminalClipboard: () =>
     ipcRenderer.invoke('read-terminal-clipboard') as Promise<TerminalClipboardPayload>,
   uiStorageGetItem: (key: string) => ipcRenderer.sendSync('ui-storage-get-item', key) as string | null,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -7,6 +7,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getServerPort: () => ipcRenderer.invoke('get-server-port'),
   readTerminalClipboard: () =>
     ipcRenderer.invoke('read-terminal-clipboard') as Promise<TerminalClipboardPayload>,
+  writeTerminalClipboardText: (text: string) =>
+    ipcRenderer.invoke('write-terminal-clipboard-text', text) as Promise<void>,
   uiStorageGetItem: (key: string) => ipcRenderer.sendSync('ui-storage-get-item', key) as string | null,
   uiStorageSetItem: (key: string, value: string) =>
     ipcRenderer.sendSync('ui-storage-set-item', { key, value }),

--- a/electron/terminal-clipboard.ts
+++ b/electron/terminal-clipboard.ts
@@ -1,7 +1,4 @@
-import type {
-  TerminalClipboardKind,
-  TerminalClipboardPayload,
-} from '../src/lib/terminal/terminal-clipboard-paste';
+import type { TerminalClipboardPayload } from '../src/lib/terminal/terminal-clipboard-paste';
 
 const MAX_CLIPBOARD_IMAGE_DIMENSION = 16_384;
 const MAX_CLIPBOARD_IMAGE_PIXELS = 40_000_000;
@@ -16,11 +13,6 @@ interface ClipboardImageLike {
 interface ClipboardLike {
   readText(): string;
   readImage(): ClipboardImageLike;
-}
-
-export function getTerminalClipboardKind(clipboard: ClipboardLike): TerminalClipboardKind {
-  if (clipboard.readText().length > 0) return 'text';
-  return clipboard.readImage().isEmpty() ? 'empty' : 'image';
 }
 
 /** Read clipboard content for an explicit terminal paste gesture. */

--- a/electron/terminal-clipboard.ts
+++ b/electron/terminal-clipboard.ts
@@ -3,6 +3,7 @@ import type { TerminalClipboardPayload } from '../src/lib/terminal/terminal-clip
 const MAX_CLIPBOARD_IMAGE_DIMENSION = 16_384;
 const MAX_CLIPBOARD_IMAGE_PIXELS = 40_000_000;
 const MAX_CLIPBOARD_IMAGE_PNG_BYTES = 20 * 1024 * 1024;
+const MAX_CLIPBOARD_TEXT_BYTES = 4 * 1024 * 1024;
 
 interface ClipboardImageLike {
   isEmpty(): boolean;
@@ -13,6 +14,24 @@ interface ClipboardImageLike {
 interface ClipboardLike {
   readText(): string;
   readImage(): ClipboardImageLike;
+}
+
+interface ClipboardWriterLike {
+  writeText(text: string): void;
+}
+
+/** Write a validated terminal selection to the desktop clipboard. */
+export function writeTerminalClipboardText(
+  clipboard: ClipboardWriterLike,
+  text: unknown,
+): void {
+  if (typeof text !== 'string') {
+    throw new Error('Terminal clipboard text must be a string.');
+  }
+  if (Buffer.byteLength(text, 'utf8') > MAX_CLIPBOARD_TEXT_BYTES) {
+    throw new Error('Terminal selection is too large to copy.');
+  }
+  clipboard.writeText(text);
 }
 
 /** Read clipboard content for an explicit terminal paste gesture. */

--- a/src/app/dev-terminal-scroll-repro/terminal-scroll-repro-client.tsx
+++ b/src/app/dev-terminal-scroll-repro/terminal-scroll-repro-client.tsx
@@ -35,13 +35,16 @@ interface ReproWindow extends Window {
   __tesseraTerminalScrollRepro?: {
     bufferType(): 'normal' | 'alternate' | null;
     capturePtyInput(): boolean;
+    clearSelection(): void;
     firstVisibleRowTag(): string | null;
     isAtBottom(): boolean | null;
     metrics(): { baseY: number; viewportY: number; rows: number } | null;
     mouseReporting(): boolean | null;
+    selectText(text: string): string | null;
     takeCapturedPtyInput(): string[];
     visibleText(): string | null;
     viewportY(): number | null;
+    writeOutput(data: string): Promise<boolean>;
   };
 }
 
@@ -97,10 +100,37 @@ export function TerminalScrollReproClient() {
         });
         return true;
       },
+      clearSelection: () => {
+        const terminal = (surface as unknown as {
+          terminal: { clearSelection(): void } | null;
+        }).terminal;
+        terminal?.clearSelection();
+      },
       mouseReporting: () => (
         (surface as unknown as { terminal: { element?: HTMLElement } | null })
           .terminal?.element?.classList.contains('enable-mouse-events') ?? null
       ),
+      selectText: (text) => {
+        const terminal = (surface as unknown as {
+          terminal: {
+            buffer: { active: ReproTerminalBuffer };
+            cols: number;
+            getSelection(): string;
+            rows: number;
+            select(column: number, row: number, length: number): void;
+          } | null;
+        }).terminal;
+        if (!terminal) return null;
+        const lastBufferRow = terminal.buffer.active.baseY + terminal.rows;
+        for (let row = 0; row < lastBufferRow; row += 1) {
+          const line = terminal.buffer.active.getLine(row)?.translateToString() ?? '';
+          const column = line.indexOf(text);
+          if (column < 0) continue;
+          terminal.select(column, row, text.length);
+          return terminal.getSelection();
+        }
+        return null;
+      },
       takeCapturedPtyInput: () => capturedPtyInput.splice(0, capturedPtyInput.length),
       bufferType: () => (
         (surface as unknown as {
@@ -152,6 +182,16 @@ export function TerminalScrollReproClient() {
           terminal: { buffer: { active: ReproTerminalBuffer } } | null;
         }).terminal?.buffer.active.viewportY ?? null
       ),
+      writeOutput: (data) => new Promise((resolve) => {
+        const terminal = (surface as unknown as {
+          terminal: { write(value: string, callback: () => void): void } | null;
+        }).terminal;
+        if (!terminal) {
+          resolve(false);
+          return;
+        }
+        terminal.write(data, () => resolve(true));
+      }),
     };
     return () => {
       captureDisposable?.dispose();

--- a/src/lib/terminal/terminal-clipboard-paste.ts
+++ b/src/lib/terminal/terminal-clipboard-paste.ts
@@ -5,6 +5,7 @@ export interface TerminalClipboardImage {
 
 export interface ElectronTerminalClipboardApi {
   readTerminalClipboard(): Promise<TerminalClipboardPayload>;
+  writeTerminalClipboardText(text: string): Promise<void>;
 }
 
 export type TerminalClipboardPayload =

--- a/src/lib/terminal/terminal-clipboard-paste.ts
+++ b/src/lib/terminal/terminal-clipboard-paste.ts
@@ -4,7 +4,6 @@ export interface TerminalClipboardImage {
 }
 
 export interface ElectronTerminalClipboardApi {
-  getTerminalClipboardKind(): TerminalClipboardKind;
   readTerminalClipboard(): Promise<TerminalClipboardPayload>;
 }
 
@@ -12,8 +11,6 @@ export type TerminalClipboardPayload =
   | { kind: 'text'; text: string }
   | { kind: 'image'; image: TerminalClipboardImage }
   | { kind: 'empty' };
-
-export type TerminalClipboardKind = TerminalClipboardPayload['kind'];
 
 export type TerminalClipboardPasteResult = 'text' | 'image' | 'empty';
 

--- a/src/lib/terminal/terminal-key-input.ts
+++ b/src/lib/terminal/terminal-key-input.ts
@@ -31,16 +31,25 @@ export function isTerminalPasteShortcut(
   if (
     event.type !== 'keydown'
     || event.isComposing
-    || event.key.toLowerCase() !== 'v'
     || event.altKey
-    || event.shiftKey
   ) {
     return false;
   }
 
-  return platform === 'mac'
-    ? event.metaKey && !event.ctrlKey
-    : event.ctrlKey && !event.metaKey;
+  if (platform === 'mac') {
+    return event.key.toLowerCase() === 'v'
+      && event.metaKey
+      && !event.ctrlKey
+      && !event.shiftKey;
+  }
+
+  if (event.key === 'Insert') {
+    return event.shiftKey && !event.ctrlKey && !event.metaKey;
+  }
+
+  return event.key.toLowerCase() === 'v'
+    && event.ctrlKey
+    && !event.metaKey;
 }
 
 /**

--- a/src/lib/terminal/terminal-key-input.ts
+++ b/src/lib/terminal/terminal-key-input.ts
@@ -52,6 +52,31 @@ export function isTerminalPasteShortcut(
     && !event.metaKey;
 }
 
+export function isTerminalCopyShortcut(
+  event: TerminalKeyEvent,
+  platform: TerminalClientPlatform,
+  hasSelection: boolean,
+): boolean {
+  if (
+    event.type !== 'keydown'
+    || event.isComposing
+    || event.key.toLowerCase() !== 'c'
+    || event.altKey
+  ) {
+    return false;
+  }
+
+  if (platform === 'mac') {
+    return event.metaKey
+      && !event.ctrlKey
+      && (event.shiftKey || hasSelection);
+  }
+
+  return event.ctrlKey
+    && !event.metaKey
+    && (event.shiftKey || hasSelection);
+}
+
 /**
  * Returns input that must bypass xterm's default keyboard encoder.
  *

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -25,6 +25,7 @@ import type {
 } from './types';
 import {
   detectTerminalClientPlatform,
+  isTerminalCopyShortcut,
   isTerminalPasteShortcut,
   resolveTerminalInputAction,
 } from './terminal-key-input';
@@ -94,6 +95,8 @@ type XtermLike = TerminalScrollTarget & {
   loadAddon(addon: unknown): void;
   open(element: HTMLElement): void;
   focus(): void;
+  getSelection(): string;
+  hasSelection(): boolean;
   paste(data: string): void;
   write(data: string, callback?: () => void): void;
   reset(): void;
@@ -867,6 +870,27 @@ export class TerminalSurface {
         }
 
         if (
+          typeof electronClipboard?.writeTerminalClipboardText === 'function'
+          && isTerminalCopyShortcut(
+            event,
+            inputContext.platform,
+            terminal.hasSelection(),
+          )
+        ) {
+          // Bare Ctrl+C remains SIGINT unless xterm has a selection. Copy the
+          // selection explicitly so xterm cannot encode the chord as PTY input.
+          event.preventDefault();
+          event.stopPropagation();
+          const selection = terminal.getSelection();
+          if (selection) {
+            void electronClipboard.writeTerminalClipboardText(selection).catch((error: unknown) => {
+              this.reportClipboardCopyError(error);
+            });
+          }
+          return false;
+        }
+
+        if (
           typeof electronClipboard?.readTerminalClipboard === 'function'
           && isTerminalPasteShortcut(event, inputContext.platform)
         ) {
@@ -1016,6 +1040,13 @@ export class TerminalSurface {
     if (this.disposed) return;
     const message = error instanceof Error ? error.message : 'Failed to paste clipboard.';
     console.warn('[terminal] Clipboard paste failed', error);
+    useNotificationStore.getState().showToast(message, 'error');
+  }
+
+  private reportClipboardCopyError(error: unknown): void {
+    if (this.disposed) return;
+    const message = error instanceof Error ? error.message : 'Failed to copy terminal selection.';
+    console.warn('[terminal] Clipboard copy failed', error);
     useNotificationStore.getState().showToast(message, 'error');
   }
 

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -281,6 +281,8 @@ export class TerminalSurface {
   private readonly scrollSyncSettler = new LayoutSettleRunner();
   private pasteListener: ((event: ClipboardEvent) => void) | null = null;
   private compositionEndListener: ((event: CompositionEvent) => void) | null = null;
+  private suppressNextNativePaste = false;
+  private pasteSuppressionTimerId: number | null = null;
   private clipboardPasteQueue: Promise<void> = Promise.resolve();
   private root: HTMLDivElement | null = null;
   private intendedHost: HTMLElement | null = null;
@@ -721,6 +723,11 @@ export class TerminalSurface {
       this.root.removeEventListener('compositionend', this.compositionEndListener, true);
     }
     this.compositionEndListener = null;
+    this.suppressNextNativePaste = false;
+    if (this.pasteSuppressionTimerId !== null) {
+      window.clearTimeout(this.pasteSuppressionTimerId);
+      this.pasteSuppressionTimerId = null;
+    }
     if (this.terminal) discardForegroundRenderSettle(this.terminal);
     if (this.webglAddon) releaseXtermWebglContext(this.webglAddon);
     try {
@@ -860,13 +867,14 @@ export class TerminalSurface {
         }
 
         if (
-          typeof electronClipboard?.getTerminalClipboardKind === 'function'
-          && typeof electronClipboard.readTerminalClipboard === 'function'
+          typeof electronClipboard?.readTerminalClipboard === 'function'
           && isTerminalPasteShortcut(event, inputContext.platform)
-          && electronClipboard.getTerminalClipboardKind() === 'image'
         ) {
+          // xterm encodes bare Ctrl+V as \x16. Handle an explicit desktop paste
+          // before xterm so terminal TUIs receive clipboard text, not a control key.
           event.preventDefault();
           event.stopPropagation();
+          this.armNativePasteSuppression();
           this.notifyTerminalInput();
           this.enqueueClipboardPaste(() => (
             this.pasteDesktopClipboard(terminal, electronClipboard as ElectronTerminalClipboardApi)
@@ -907,6 +915,7 @@ export class TerminalSurface {
       });
       this.syncScrollStateFromController();
       this.pasteListener = (event) => {
+        if (this.consumeNativePasteSuppression(event)) return;
         if (event.clipboardData?.getData('text/plain')) {
           this.armTerminalInputOrigin();
           return;
@@ -968,6 +977,31 @@ export class TerminalSurface {
     this.onInput?.();
   }
 
+  private armNativePasteSuppression(): void {
+    // Chromium may dispatch a paste event after the keydown. The Electron IPC
+    // path already owns this gesture, so suppress that one follow-up event.
+    this.suppressNextNativePaste = true;
+    if (this.pasteSuppressionTimerId !== null) {
+      window.clearTimeout(this.pasteSuppressionTimerId);
+    }
+    this.pasteSuppressionTimerId = window.setTimeout(() => {
+      this.pasteSuppressionTimerId = null;
+      this.suppressNextNativePaste = false;
+    }, 0);
+  }
+
+  private consumeNativePasteSuppression(event: ClipboardEvent): boolean {
+    if (!this.suppressNextNativePaste) return false;
+    this.suppressNextNativePaste = false;
+    if (this.pasteSuppressionTimerId !== null) {
+      window.clearTimeout(this.pasteSuppressionTimerId);
+      this.pasteSuppressionTimerId = null;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    return true;
+  }
+
   private armTerminalInputOrigin(): void {
     this.terminalInputOriginArmed = true;
     const epoch = ++this.terminalInputOriginEpoch;
@@ -980,7 +1014,7 @@ export class TerminalSurface {
 
   private reportClipboardPasteError(error: unknown): void {
     if (this.disposed) return;
-    const message = error instanceof Error ? error.message : 'Failed to paste clipboard image.';
+    const message = error instanceof Error ? error.message : 'Failed to paste clipboard.';
     console.warn('[terminal] Clipboard paste failed', error);
     useNotificationStore.getState().showToast(message, 'error');
   }

--- a/tests/electron-terminal-clipboard.test.ts
+++ b/tests/electron-terminal-clipboard.test.ts
@@ -1,9 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import {
-  getTerminalClipboardKind,
-  readTerminalClipboard,
-} from '../electron/terminal-clipboard';
+import { readTerminalClipboard } from '../electron/terminal-clipboard';
 
 function clipboardStub(options: {
   text?: string;
@@ -29,17 +26,6 @@ test('desktop terminal clipboard gives text precedence over an available image',
   assert.deepEqual(
     readTerminalClipboard(clipboardStub({ text: 'copied text' })),
     { kind: 'text', text: 'copied text' },
-  );
-});
-
-test('desktop terminal clipboard kind lets ordinary text stay on the xterm paste path', () => {
-  assert.deepEqual(
-    [
-      getTerminalClipboardKind(clipboardStub({ text: 'copied text' })),
-      getTerminalClipboardKind(clipboardStub()),
-      getTerminalClipboardKind(clipboardStub({ emptyImage: true })),
-    ],
-    ['text', 'image', 'empty'],
   );
 });
 

--- a/tests/electron-terminal-clipboard.test.ts
+++ b/tests/electron-terminal-clipboard.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { readTerminalClipboard } from '../electron/terminal-clipboard';
+import {
+  readTerminalClipboard,
+  writeTerminalClipboardText,
+} from '../electron/terminal-clipboard';
 
 function clipboardStub(options: {
   text?: string;
@@ -52,6 +55,21 @@ test('desktop terminal clipboard reports empty content without fabricating input
 test('desktop terminal clipboard rejects images with unsafe dimensions', () => {
   assert.throws(
     () => readTerminalClipboard(clipboardStub({ width: 20_000, height: 20_000 })),
+    /too large/,
+  );
+});
+
+test('desktop terminal clipboard writes a validated selection as text', () => {
+  const writes: string[] = [];
+  writeTerminalClipboardText({ writeText: (text) => writes.push(text) }, 'selected output');
+  assert.deepEqual(writes, ['selected output']);
+});
+
+test('desktop terminal clipboard rejects invalid and oversized selection writes', () => {
+  const clipboard = { writeText: (_text: string) => {} };
+  assert.throws(() => writeTerminalClipboardText(clipboard, null), /must be a string/);
+  assert.throws(
+    () => writeTerminalClipboardText(clipboard, 'x'.repeat(4 * 1024 * 1024 + 1)),
     /too large/,
   );
 });

--- a/tests/terminal-clipboard.e2e.mjs
+++ b/tests/terminal-clipboard.e2e.mjs
@@ -141,6 +141,55 @@ try {
     true,
   );
 
+  const copyMarker = `TESSERA_COPY_SELECTION_${Date.now()}`;
+  assert.equal(
+    await page.evaluate((marker) => (
+      window.__tesseraTerminalScrollRepro?.writeOutput(`\r\n${marker}\r\n`)
+    ), copyMarker),
+    true,
+  );
+  const selectedText = await page.evaluate((marker) => (
+    window.__tesseraTerminalScrollRepro?.selectText(marker) ?? ''
+  ), copyMarker);
+  assert.equal(selectedText, copyMarker, 'the copy regression requires a visible terminal selection');
+  await electronApp.evaluate(({ clipboard }) => clipboard.writeText('stale clipboard text'));
+  await takePtyInput(page);
+  await page.keyboard.press('Control+C');
+  await page.waitForTimeout(250);
+  assert.equal(
+    await electronApp.evaluate(({ clipboard }) => clipboard.readText()),
+    selectedText,
+    'Ctrl+C with a terminal selection must copy the selected text',
+  );
+  assert.equal(
+    (await takePtyInput(page)).join('').includes('\x03'),
+    false,
+    'Ctrl+C with a terminal selection must not interrupt the PTY',
+  );
+
+  await electronApp.evaluate(({ clipboard }) => clipboard.writeText('stale explicit copy'));
+  await page.keyboard.press('Control+Shift+C');
+  await page.waitForTimeout(250);
+  assert.equal(
+    await electronApp.evaluate(({ clipboard }) => clipboard.readText()),
+    selectedText,
+    'Ctrl+Shift+C must explicitly copy the terminal selection',
+  );
+  assert.equal(
+    (await takePtyInput(page)).join(''),
+    '',
+    'Ctrl+Shift+C must not emit PTY input',
+  );
+  await page.evaluate(() => window.__tesseraTerminalScrollRepro?.clearSelection());
+  await takePtyInput(page);
+  await page.keyboard.press('Control+C');
+  const interruptInput = await waitForPtyInput(page, (input) => input.includes('\x03'));
+  assert.equal(
+    interruptInput.includes('\x03'),
+    true,
+    'Ctrl+C without a terminal selection must still interrupt the PTY',
+  );
+
   const marker = `TESSERA_CLIPBOARD_TEXT_${Date.now()}`;
   await electronApp.evaluate(({ clipboard }, text) => clipboard.writeText(text), marker);
   await takePtyInput(page);

--- a/tests/terminal-clipboard.e2e.mjs
+++ b/tests/terminal-clipboard.e2e.mjs
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { _electron as electron } from '@playwright/test';
+
+const port = Number(process.env.TESSERA_E2E_PORT ?? 3199);
+const appOrigin = `http://127.0.0.1:${port}`;
+const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tessera-clipboard-e2e-'));
+const serverOutput = [];
+let uploadedImagePath = null;
+let electronApp = null;
+
+const server = spawn('npm', ['run', 'dev'], {
+  cwd: process.cwd(),
+  detached: process.platform !== 'win32',
+  env: {
+    ...process.env,
+    NODE_ENV: 'development',
+    PORT: String(port),
+    TESSERA_DATA_DIR: dataDir,
+    TESSERA_ELECTRON_AUTH_BYPASS: '1',
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+for (const stream of [server.stdout, server.stderr]) {
+  stream.on('data', (chunk) => {
+    serverOutput.push(chunk.toString());
+    if (serverOutput.length > 200) serverOutput.shift();
+  });
+}
+
+async function waitForServer() {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null) {
+      throw new Error(`Tessera server exited early:\n${serverOutput.join('')}`);
+    }
+    try {
+      const response = await fetch(`${appOrigin}/dev-terminal-scroll-repro`);
+      if (response.ok) return;
+    } catch {
+      // The dev server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`Tessera server did not start:\n${serverOutput.join('')}`);
+}
+
+async function registerTestProject() {
+  const settingsResponse = await fetch(`${appOrigin}/api/settings`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ agentEnvironment: 'wsl' }),
+  });
+  assert.equal(
+    settingsResponse.ok,
+    true,
+    `failed to configure the E2E environment (${settingsResponse.status}): ${await settingsResponse.text()}`,
+  );
+  const response = await fetch(`${appOrigin}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ folderPath: process.cwd() }),
+  });
+  assert.equal(
+    response.ok,
+    true,
+    `failed to register the E2E project (${response.status}): ${await response.text()}`,
+  );
+}
+
+async function takePtyInput(page) {
+  return page.evaluate(() => (
+    window.__tesseraTerminalScrollRepro?.takeCapturedPtyInput() ?? []
+  ));
+}
+
+async function waitForPtyInput(page, predicate) {
+  const captured = [];
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    captured.push(...await takePtyInput(page));
+    if (predicate(captured.join(''))) return captured.join('');
+    await page.waitForTimeout(50);
+  }
+  return captured.join('');
+}
+
+async function stopServer() {
+  if (server.exitCode !== null || server.killed) return;
+  if (process.platform === 'win32') {
+    server.kill('SIGTERM');
+    return;
+  }
+  try {
+    process.kill(-server.pid, 'SIGTERM');
+  } catch {
+    server.kill('SIGTERM');
+  }
+}
+
+try {
+  await waitForServer();
+  await registerTestProject();
+  electronApp = await electron.launch({
+    args: ['dist-electron/electron/main.js'],
+    env: {
+      ...process.env,
+      NODE_ENV: 'development',
+      TESSERA_DATA_DIR: dataDir,
+      TESSERA_DEV_PORT: String(port),
+      TESSERA_ELECTRON_AUTH_BYPASS: '1',
+    },
+  });
+
+  const page = await electronApp.firstWindow();
+  page.on('console', (message) => serverOutput.push(`[renderer:${message.type()}] ${message.text()}\n`));
+  page.on('pageerror', (error) => serverOutput.push(`[renderer:error] ${error.stack ?? error.message}\n`));
+  await page.goto(`${appOrigin}/dev-terminal-scroll-repro`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+  try {
+    await page.getByTestId('terminal-repro-status').getByText('running').waitFor({
+      timeout: 30_000,
+    });
+  } catch (error) {
+    const body = await page.locator('body').innerText().catch(() => '<body unavailable>');
+    throw new Error(
+      `Terminal did not start. Page contents:\n${body}\nLogs:\n${serverOutput.join('')}`,
+      { cause: error },
+    );
+  }
+  const terminalInput = page.locator('.xterm-helper-textarea');
+  await terminalInput.focus();
+  assert.equal(
+    await page.evaluate(() => window.__tesseraTerminalScrollRepro?.capturePtyInput()),
+    true,
+  );
+
+  const marker = `TESSERA_CLIPBOARD_TEXT_${Date.now()}`;
+  await electronApp.evaluate(({ clipboard }, text) => clipboard.writeText(text), marker);
+  await takePtyInput(page);
+  await page.keyboard.press('Control+V');
+  const textInput = await waitForPtyInput(page, (input) => input.includes(marker));
+  assert.equal(textInput.split(marker).length - 1, 1, 'clipboard text must be pasted exactly once');
+  assert.equal(textInput.includes('\x16'), false, 'Ctrl+V must not reach the PTY as a control key');
+
+  await electronApp.evaluate(({ clipboard }) => clipboard.clear());
+  await takePtyInput(page);
+  await page.keyboard.press('Control+V');
+  await page.waitForTimeout(250);
+  assert.equal((await takePtyInput(page)).join(''), '', 'an empty clipboard must not emit PTY input');
+
+  await electronApp.evaluate(({ clipboard, nativeImage }) => {
+    const bitmap = Buffer.from([0x00, 0x00, 0xff, 0xff]);
+    clipboard.writeImage(nativeImage.createFromBitmap(bitmap, {
+      width: 1,
+      height: 1,
+      scaleFactor: 1,
+    }));
+  });
+  const imageClipboardState = await electronApp.evaluate(({ clipboard }) => {
+    const image = clipboard.readImage();
+    return {
+      isEmpty: image.isEmpty(),
+      pngBytes: image.toPNG().byteLength,
+      size: image.getSize(),
+      text: clipboard.readText(),
+    };
+  });
+  assert.equal(
+    imageClipboardState.isEmpty,
+    false,
+    `Electron did not retain the test image: ${JSON.stringify(imageClipboardState)}`,
+  );
+  await takePtyInput(page);
+  await page.keyboard.press('Control+V');
+  const imageInput = await waitForPtyInput(page, (input) => input.includes('clipboard-image.png'));
+  const imagePathMatch = imageInput.match(/(\/tmp\/tessera-uploads\/[^\x1b\r\n]+clipboard-image\.png)/);
+  assert.ok(
+    imagePathMatch,
+    `image paste must emit its uploaded path, received ${JSON.stringify(imageInput)}; `
+      + `clipboard=${JSON.stringify(imageClipboardState)}; page=${await page.locator('body').innerText()}; `
+      + `logs=${serverOutput.join('')}`,
+  );
+  uploadedImagePath = imagePathMatch[1];
+  assert.equal(imageInput.split('clipboard-image.png').length - 1, 1, 'image path must be pasted exactly once');
+  assert.equal(imageInput.includes('\x16'), false, 'image paste must not emit a Ctrl+V control key');
+} finally {
+  await electronApp?.close().catch(() => {});
+  await stopServer();
+  if (uploadedImagePath) await fs.rm(uploadedImagePath, { force: true });
+  await fs.rm(dataDir, { recursive: true, force: true });
+}

--- a/tests/terminal-contract.test.mjs
+++ b/tests/terminal-contract.test.mjs
@@ -232,6 +232,16 @@ test('terminal text and image paste cross the Electron clipboard boundary throug
   assert.doesNotMatch(terminalSurfaceSource, /getTerminalClipboardKind/);
 });
 
+test('terminal selection copy crosses Electron only when the copy shortcut owns the key event', () => {
+  assert.match(electronMainSource, /writeTerminalClipboardText\(clipboard, text\)/);
+  assert.match(electronPreloadSource, /writeTerminalClipboardText:/);
+  assert.match(electronPreloadSource, /ipcRenderer\.invoke\('write-terminal-clipboard-text', text\)/);
+  assert.match(terminalSurfaceSource, /isTerminalCopyShortcut\(/);
+  assert.match(terminalSurfaceSource, /terminal\.hasSelection\(\)/);
+  assert.match(terminalSurfaceSource, /terminal\.getSelection\(\)/);
+  assert.match(terminalSurfaceSource, /writeTerminalClipboardText\(selection\)/);
+});
+
 test('terminal websocket protocol covers process lifecycle', () => {
   for (const type of [
     'terminal_create',

--- a/tests/terminal-contract.test.mjs
+++ b/tests/terminal-contract.test.mjs
@@ -216,15 +216,20 @@ test('single-panel terminal sessions omit only the redundant session header', ()
   assert.match(chatAreaSource, /search=\{\{/);
 });
 
-test('terminal image paste crosses the Electron clipboard boundary through a narrow preload API', () => {
-  assert.match(electronMainSource, /getTerminalClipboardKind\(clipboard\)/);
+test('terminal text and image paste cross the Electron clipboard boundary through one explicit shortcut path', () => {
   assert.match(electronMainSource, /readTerminalClipboard\(clipboard\)/);
-  assert.match(electronPreloadSource, /ipcRenderer\.sendSync\('get-terminal-clipboard-kind'\)/);
   assert.match(electronPreloadSource, /readTerminalClipboard:/);
   assert.match(electronPreloadSource, /ipcRenderer\.invoke\('read-terminal-clipboard'\)/);
+  assert.match(
+    terminalSurfaceSource,
+    /if \(\s*typeof electronClipboard\?\.readTerminalClipboard === 'function'\s*&& isTerminalPasteShortcut\(event, inputContext\.platform\)/,
+  );
   assert.match(terminalSurfaceSource, /pasteTerminalClipboard\(payload/);
   assert.match(terminalSurfaceSource, /uploadTerminalClipboardImage/);
   assert.match(terminalSurfaceSource, /terminal\.paste\(data\)/);
+  assert.doesNotMatch(electronMainSource, /get-terminal-clipboard-kind|getTerminalClipboardKind/);
+  assert.doesNotMatch(electronPreloadSource, /get-terminal-clipboard-kind|getTerminalClipboardKind/);
+  assert.doesNotMatch(terminalSurfaceSource, /getTerminalClipboardKind/);
 });
 
 test('terminal websocket protocol covers process lifecycle', () => {

--- a/tests/terminal-key-input.test.ts
+++ b/tests/terminal-key-input.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   detectTerminalClientPlatform,
+  isTerminalCopyShortcut,
   isTerminalPasteShortcut,
   resolveTerminalInputAction,
   resolveTerminalKeyInput,
@@ -43,6 +44,21 @@ test('terminal paste shortcut follows the client platform without intercepting c
       isTerminalPasteShortcut(keyEvent({ type: 'keyup', key: 'v', metaKey: true }), 'mac'),
     ],
     [true, true, true, true, true, false, false, false],
+  );
+});
+
+test('terminal copy shortcut preserves Ctrl+C interrupt when there is no selection', () => {
+  assert.deepEqual(
+    [
+      isTerminalCopyShortcut(keyEvent({ key: 'c', ctrlKey: true }), 'linux', true),
+      isTerminalCopyShortcut(keyEvent({ key: 'c', ctrlKey: true }), 'linux', false),
+      isTerminalCopyShortcut(keyEvent({ key: 'C', ctrlKey: true, shiftKey: true }), 'windows', false),
+      isTerminalCopyShortcut(keyEvent({ key: 'c', metaKey: true }), 'mac', true),
+      isTerminalCopyShortcut(keyEvent({ key: 'C', metaKey: true, shiftKey: true }), 'mac', false),
+      isTerminalCopyShortcut(keyEvent({ key: 'c', ctrlKey: true }), 'mac', true),
+      isTerminalCopyShortcut(keyEvent({ key: 'c', ctrlKey: true, altKey: true }), 'linux', true),
+    ],
+    [true, false, true, true, true, false, false],
   );
 });
 

--- a/tests/terminal-key-input.test.ts
+++ b/tests/terminal-key-input.test.ts
@@ -36,11 +36,13 @@ test('terminal paste shortcut follows the client platform without intercepting c
       isTerminalPasteShortcut(keyEvent({ key: 'v', metaKey: true }), 'mac'),
       isTerminalPasteShortcut(keyEvent({ key: 'V', ctrlKey: true }), 'linux'),
       isTerminalPasteShortcut(keyEvent({ key: 'v', ctrlKey: true }), 'windows'),
+      isTerminalPasteShortcut(keyEvent({ key: 'v', ctrlKey: true, shiftKey: true }), 'linux'),
+      isTerminalPasteShortcut(keyEvent({ key: 'Insert', shiftKey: true }), 'windows'),
       isTerminalPasteShortcut(keyEvent({ key: 'v', ctrlKey: true }), 'mac'),
       isTerminalPasteShortcut(keyEvent({ key: 'v', metaKey: true, isComposing: true }), 'mac'),
       isTerminalPasteShortcut(keyEvent({ type: 'keyup', key: 'v', metaKey: true }), 'mac'),
     ],
-    [true, true, true, false, false, false],
+    [true, true, true, true, true, false, false, false],
   );
 });
 


### PR DESCRIPTION
## What changed

- Handle desktop text/image paste before xterm encodes the shortcut as PTY input.
- Copy selected terminal text explicitly while keeping bare Ctrl+C as SIGINT when no selection exists.
- Add Electron clipboard validation and end-to-end coverage.

## Why

Desktop terminal paste could send a control character instead of clipboard text, and Ctrl+C could reach the PTY before xterm copied a selection.

## Impact

Terminal copy/paste now behaves like a native desktop terminal without breaking interrupt semantics.

## Validation

- `npm run electron:compile`
- Clipboard end-to-end and terminal contract tests
- Electron clipboard and terminal key-input Node/tsx tests
- Targeted ESLint on changed Electron and terminal files
