### PR TITLE
feat(workspace): sync WSL files and folder browsing in real time

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -418,6 +418,13 @@ if (process.env.TESSERA_DISABLE_GPU === '1') {
   app.commandLine.appendSwitch('max-active-webgl-contexts', '128');
 }
 
+// The embedded server listens on 127.0.0.1 only, but windows load http://localhost.
+// On hosts where connecting to ::1 stalls (observed ~210ms per connect with WSL /
+// VPN network stacks), every fresh renderer connection pays that penalty. Pin
+// localhost to IPv4 in Chromium's resolver; keeping the literal "localhost" URL
+// preserves the renderer origin (localStorage, IndexedDB).
+app.commandLine.appendSwitch('host-resolver-rules', 'MAP localhost 127.0.0.1');
+
 let mainWindow: BrowserWindow | null = null;
 const popoutWindows = new Set<BrowserWindow>();
 let serverProcess: ChildProcess | null = null;

--- a/src/app/api/sessions/[id]/files/route.ts
+++ b/src/app/api/sessions/[id]/files/route.ts
@@ -90,7 +90,7 @@ export async function GET(
   }
 
   try {
-    const result = await workspaceFileWatchManager.getIndexedSnapshotForRoot(root)
+    const result = await workspaceFileWatchManager.ensureSnapshotForRoot(root)
       ?? await walkWorkspaceFiles(root);
     return NextResponse.json({
       files: result.files,

--- a/src/app/api/sessions/[id]/messages/route.ts
+++ b/src/app/api/sessions/[id]/messages/route.ts
@@ -4,6 +4,7 @@ import * as dbSessions from '@/lib/db/sessions';
 import { jsonError } from '@/lib/http/json-error';
 import logger from '@/lib/logger';
 import { sessionHistory } from '@/lib/session-history';
+import { workspaceFileWatchManager } from '@/lib/workspace-files/workspace-file-watch-manager';
 
 function buildEmptyHistoryResponse(sessionId: string): NextResponse {
   return NextResponse.json({
@@ -44,6 +45,11 @@ export async function GET(
     if (!dbSession) {
       return jsonError('not_found', 'Session not found', 404);
     }
+
+    // Opening a session is the earliest signal that its Files tab may be used.
+    // Network-share workspaces (WSL paths served from Windows) take hundreds of
+    // ms per walk, so start building the index before the tab is clicked.
+    workspaceFileWatchManager.warmSessionWorkspace(id);
 
     const hasHistory = await sessionHistory.historyExists(id);
     if (!hasHistory) {

--- a/src/components/chat/folder-browser-dialog.tsx
+++ b/src/components/chat/folder-browser-dialog.tsx
@@ -25,7 +25,8 @@ import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 import { useElectronPlatform } from '@/hooks/use-electron-platform';
 import { useSettingsStore } from '@/stores/settings-store';
-import type { AgentEnvironment } from '@/lib/settings/types';
+import type { AgentEnvironment, UserSettings } from '@/lib/settings/types';
+import type { ServerHostInfo } from '@/lib/system/types';
 import { FeedbackDialog } from '@/components/feedback/feedback-dialog';
 import { captureTelemetryEvent } from '@/lib/telemetry/client';
 
@@ -44,6 +45,11 @@ interface BrowseResponse {
   isGitRepo: boolean;
 }
 
+interface SettingsResponse {
+  settings: UserSettings;
+  serverHostInfo?: ServerHostInfo;
+}
+
 interface FolderBrowserDialogProps {
   isOpen: boolean;
   onClose: () => void;
@@ -58,6 +64,7 @@ export function FolderBrowserDialog({
   const { t } = useI18n();
   const electronPlatform = useElectronPlatform();
   const agentEnvironment = useSettingsStore((state) => state.settings.agentEnvironment);
+  const applyExternalSettings = useSettingsStore((state) => state.applyExternalSettings);
   const serverIsWindowsEcosystem = useSettingsStore(
     (state) => state.serverHostInfo?.isWindowsEcosystem ?? false,
   );
@@ -73,17 +80,20 @@ export function FolderBrowserDialog({
   const [showHidden, setShowHidden] = useState(false);
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
   const [browseEnvironment, setBrowseEnvironment] = useState<AgentEnvironment>('native');
+  const [isSettingsReady, setIsSettingsReady] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const requestGenerationRef = useRef(0);
+  const settingsReadyRef = useRef(false);
+  const settingsAbortControllerRef = useRef<AbortController | null>(null);
+  const browseAbortControllerRef = useRef<AbortController | null>(null);
   const canBrowseWsl = serverIsWindowsEcosystem || electronPlatform === 'win32';
   const isEnvironmentAllowed = useCallback(
-    (environment: AgentEnvironment) => environment === agentEnvironment,
-    [agentEnvironment],
+    (environment: AgentEnvironment) => (
+      isSettingsReady && environment === agentEnvironment
+    ),
+    [agentEnvironment, isSettingsReady],
   );
-
-  const getInitialBrowseEnvironment = useCallback((): AgentEnvironment => {
-    return canBrowseWsl && agentEnvironment === 'wsl' ? 'wsl' : 'native';
-  }, [agentEnvironment, canBrowseWsl]);
 
   const resetDirectoryState = useCallback(() => {
     setCurrentPath('');
@@ -98,8 +108,23 @@ export function FolderBrowserDialog({
   const fetchDirectory = useCallback(async (
     path?: string,
     hidden?: boolean,
-    environment: AgentEnvironment = agentEnvironment,
+    environment: AgentEnvironment = 'native',
+    existingGeneration?: number,
   ) => {
+    if (!settingsReadyRef.current && existingGeneration === undefined) return;
+
+    const requestGeneration = existingGeneration ?? requestGenerationRef.current + 1;
+    if (existingGeneration === undefined) {
+      requestGenerationRef.current = requestGeneration;
+      settingsAbortControllerRef.current?.abort();
+      settingsAbortControllerRef.current = null;
+    } else if (requestGenerationRef.current !== existingGeneration) {
+      return;
+    }
+
+    browseAbortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    browseAbortControllerRef.current = abortController;
     setIsLoading(true);
     setError(null);
 
@@ -109,7 +134,9 @@ export function FolderBrowserDialog({
       if (hidden) query.set('showHidden', 'true');
       query.set('environment', environment);
       const qs = query.toString();
-      const response = await fetch(`/api/filesystem/browse${qs ? `?${qs}` : ''}`);
+      const response = await fetch(`/api/filesystem/browse${qs ? `?${qs}` : ''}`, {
+        signal: abortController.signal,
+      });
 
       if (!response.ok) {
         const data = await response.json();
@@ -117,6 +144,10 @@ export function FolderBrowserDialog({
       }
 
       const data: BrowseResponse = await response.json();
+      if (
+        abortController.signal.aborted
+        || requestGenerationRef.current !== requestGeneration
+      ) return;
       setCurrentPath(data.currentPath);
       setCurrentFilesystemPath(data.filesystemPath);
       setParentPath(data.parentPath);
@@ -126,22 +157,116 @@ export function FolderBrowserDialog({
       // Scroll list to top when navigating
       if (listRef.current) listRef.current.scrollTop = 0;
     } catch (err) {
+      if (
+        abortController.signal.aborted
+        || requestGenerationRef.current !== requestGeneration
+      ) return;
       setError(err instanceof Error ? err.message : 'Failed to browse');
     } finally {
-      setIsLoading(false);
+      if (
+        !abortController.signal.aborted
+        && requestGenerationRef.current === requestGeneration
+      ) {
+        setIsLoading(false);
+      }
+      if (browseAbortControllerRef.current === abortController) {
+        browseAbortControllerRef.current = null;
+      }
     }
-  }, [agentEnvironment]);
+  }, []);
 
-  // Load home directory on open (reset showHidden)
-  useEffect(() => {
-    if (isOpen) {
-      const initialEnvironment = getInitialBrowseEnvironment();
+  // The persisted renderer snapshot can briefly disagree with a fresh or
+  // restarted server. Resolve the authoritative settings before choosing the
+  // filesystem so the initial browse request cannot cross environments.
+  useEffect(function initializeFolderBrowser() {
+    if (!isOpen) return;
+
+    const requestGeneration = requestGenerationRef.current + 1;
+    requestGenerationRef.current = requestGeneration;
+    settingsReadyRef.current = false;
+    settingsAbortControllerRef.current?.abort();
+    browseAbortControllerRef.current?.abort();
+    const settingsAbortController = new AbortController();
+    settingsAbortControllerRef.current = settingsAbortController;
+    setIsSettingsReady(false);
+    resetDirectoryState();
+    setShowHidden(false);
+    setIsLoading(true);
+
+    void fetchAuthoritativeSettings(settingsAbortController.signal).then((data) => {
+      if (
+        settingsAbortController.signal.aborted
+        || requestGenerationRef.current !== requestGeneration
+      ) return;
+
+      applyExternalSettings(data.settings);
+      useSettingsStore.setState({ serverHostInfo: data.serverHostInfo ?? null });
+      const latest = useSettingsStore.getState();
+      const latestAgentEnvironment = latest.settings.agentEnvironment;
+      const latestCanBrowseWsl = (
+        data.serverHostInfo?.isWindowsEcosystem === true
+        || electronPlatform === 'win32'
+      );
+      const initialEnvironment = (
+        latestCanBrowseWsl && latestAgentEnvironment === 'wsl'
+          ? 'wsl'
+          : 'native'
+      );
+      settingsReadyRef.current = true;
+      setIsSettingsReady(true);
       setBrowseEnvironment(initialEnvironment);
-      resetDirectoryState();
-      setShowHidden(false);
-      fetchDirectory(undefined, false, initialEnvironment);
-    }
-  }, [fetchDirectory, getInitialBrowseEnvironment, isOpen, resetDirectoryState]);
+      void fetchDirectory(undefined, false, initialEnvironment, requestGeneration);
+    }).catch((error: unknown) => {
+      if (
+        isAbortError(error)
+        || settingsAbortController.signal.aborted
+        || requestGenerationRef.current !== requestGeneration
+      ) return;
+      settingsReadyRef.current = false;
+      setIsSettingsReady(false);
+      setError('Failed to load settings');
+      setIsLoading(false);
+    }).finally(() => {
+      if (settingsAbortControllerRef.current === settingsAbortController) {
+        settingsAbortControllerRef.current = null;
+      }
+    });
+
+    return function cancelFolderBrowserRequests() {
+      settingsReadyRef.current = false;
+      requestGenerationRef.current += 1;
+      settingsAbortController.abort();
+      if (settingsAbortControllerRef.current === settingsAbortController) {
+        settingsAbortControllerRef.current = null;
+      }
+      browseAbortControllerRef.current?.abort();
+      browseAbortControllerRef.current = null;
+    };
+  }, [applyExternalSettings, electronPlatform, fetchDirectory, isOpen, resetDirectoryState]);
+
+  useEffect(function synchronizeOpenBrowserEnvironment() {
+    if (!isOpen || !isSettingsReady || !settingsReadyRef.current) return;
+
+    const nextEnvironment = (
+      canBrowseWsl && agentEnvironment === 'wsl'
+        ? 'wsl'
+        : 'native'
+    );
+    if (nextEnvironment === browseEnvironment) return;
+
+    setBrowseEnvironment(nextEnvironment);
+    resetDirectoryState();
+    setShowHidden(false);
+    void fetchDirectory(undefined, false, nextEnvironment);
+  }, [
+    agentEnvironment,
+    browseEnvironment,
+    canBrowseWsl,
+    fetchDirectory,
+    isOpen,
+    isSettingsReady,
+    resetDirectoryState,
+  ]);
 
   const handleNavigate = (path: string) => {
     fetchDirectory(path, showHidden, browseEnvironment);
@@ -286,7 +411,7 @@ export function FolderBrowserDialog({
               size="sm"
               className="shrink-0 h-[38px]"
               onClick={() => fetchDirectory(pathInput.trim(), showHidden, browseEnvironment)}
-              disabled={isLoading}
+              disabled={isLoading || !isSettingsReady}
               title={t('dialog.folderBrowser.go')}
             >
               {t('dialog.folderBrowser.go')}
@@ -358,14 +483,16 @@ export function FolderBrowserDialog({
           ) : error ? (
             <div className="flex flex-col items-center justify-center h-full text-(--text-muted) px-4">
               <p className="text-sm text-(--error)">{error}</p>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="mt-2"
-                onClick={() => fetchDirectory(undefined, false, browseEnvironment)}
-              >
-                {t('dialog.folderBrowser.goHome')}
-              </Button>
+              {isSettingsReady && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-2"
+                  onClick={() => fetchDirectory(undefined, false, browseEnvironment)}
+                >
+                  {t('dialog.folderBrowser.goHome')}
+                </Button>
+              )}
             </div>
           ) : (
             <div className="py-1">
@@ -465,6 +592,26 @@ export function FolderBrowserDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+async function fetchAuthoritativeSettings(signal: AbortSignal): Promise<SettingsResponse> {
+  const response = await fetch('/api/settings', { signal });
+  if (!response.ok) {
+    throw new Error(`Settings load failed with status ${response.status}`);
+  }
+
+  const data = await response.json() as Partial<SettingsResponse>;
+  if (
+    !data.settings
+    || (data.settings.agentEnvironment !== 'native' && data.settings.agentEnvironment !== 'wsl')
+  ) {
+    throw new Error('Settings response is missing a valid Agent Environment');
+  }
+  return data as SettingsResponse;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
 }
 
 function normalizeProjectImportErrorCode(error: unknown): string {

--- a/src/components/workspace/workspace-explorer-tab.tsx
+++ b/src/components/workspace/workspace-explorer-tab.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { AlertCircle, FileText, FolderTree, LoaderCircle, Search } from "lucide-react";
+import { AlertCircle, Eye, EyeOff, FileText, FolderTree, LoaderCircle, Search } from "lucide-react";
 import { useContext, useMemo, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tooltip } from "@/components/ui/tooltip";
 import {
   useDocumentVisibility,
   useStableWorkspaceFilesSubscriberId,
   useWorkspaceFilesLiveSync,
 } from "@/hooks/use-workspace-files-live-sync";
 import { useWorkspaceFileList } from "@/hooks/use-workspace-file-list";
+import { isHiddenWorkspaceRelativePath } from "@/lib/workspace-files/hidden-workspace-path";
+import { useWorkspaceFileViewStore } from "@/stores/workspace-file-view-store";
 import { openWorkspaceFileTab } from "@/lib/workspace-tabs/open-workspace-tab";
 import type { WorkspaceExplorerSessionRef } from "@/lib/workspace-tabs/special-session";
 import { TabIdContext } from "@/stores/panel-store";
@@ -58,6 +61,8 @@ export function WorkspaceExplorerTab({
   const isDocumentVisible = useDocumentVisibility();
   const subscriberId = useStableWorkspaceFilesSubscriberId("workspace-explorer-tab");
   const [query, setQuery] = useState("");
+  const showHiddenFiles = useWorkspaceFileViewStore((state) => state.showHiddenFiles);
+  const toggleShowHiddenFiles = useWorkspaceFileViewStore((state) => state.toggleShowHiddenFiles);
   const {
     error,
     files,
@@ -73,13 +78,19 @@ export function WorkspaceExplorerTab({
     subscriberId,
   });
 
+  const baseFiles = useMemo(
+    () => (showHiddenFiles
+      ? files
+      : files.filter((filePath) => !isHiddenWorkspaceRelativePath(filePath))),
+    [files, showHiddenFiles],
+  );
   const visibleFiles = useMemo(() => {
     const trimmed = query.trim().toLowerCase();
-    if (!trimmed) return files.slice(0, 500);
-    return files
+    if (!trimmed) return baseFiles.slice(0, 500);
+    return baseFiles
       .filter((filePath) => filePath.toLowerCase().includes(trimmed))
       .slice(0, 500);
-  }, [files, query]);
+  }, [baseFiles, query]);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-(--chat-bg)">
@@ -91,19 +102,37 @@ export function WorkspaceExplorerTab({
               <h2 className="text-sm font-semibold text-(--text-primary)">Files</h2>
             </div>
             <p className="mt-1 text-xs text-(--text-muted)">
-              {files.length.toLocaleString()} files
+              {baseFiles.length.toLocaleString()} files
               {truncated ? " · truncated" : ""}
             </p>
           </div>
-          <label className="flex h-9 w-[min(24rem,45vw)] items-center gap-2 rounded-md border border-(--input-border) bg-(--sidebar-bg) px-3 focus-within:border-(--accent)">
-            <Search className="h-4 w-4 shrink-0 text-(--text-muted)" />
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search files"
-              className="min-w-0 flex-1 bg-transparent text-sm text-(--text-primary) outline-none placeholder:text-(--text-muted)"
-            />
-          </label>
+          <div className="flex items-center gap-2">
+            <label className="flex h-9 w-[min(24rem,45vw)] items-center gap-2 rounded-md border border-(--input-border) bg-(--sidebar-bg) px-3 focus-within:border-(--accent)">
+              <Search className="h-4 w-4 shrink-0 text-(--text-muted)" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search files"
+                className="min-w-0 flex-1 bg-transparent text-sm text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+              />
+            </label>
+            <Tooltip content={showHiddenFiles ? "Hide hidden files" : "Show hidden files"}>
+              <button
+                type="button"
+                onClick={toggleShowHiddenFiles}
+                className={cn(
+                  "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border transition-colors",
+                  showHiddenFiles
+                    ? "border-(--accent) bg-(--accent)/10 text-(--text-primary)"
+                    : "border-(--input-border) text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--text-primary)",
+                )}
+                aria-label={showHiddenFiles ? "Hide hidden files" : "Show hidden files"}
+                aria-pressed={showHiddenFiles}
+              >
+                {showHiddenFiles ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+              </button>
+            </Tooltip>
+          </div>
         </div>
       </div>
 

--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -4,6 +4,8 @@ import {
   AlertCircle,
   ChevronRight,
   Copy,
+  Eye,
+  EyeOff,
   FileText,
   Folder,
   FolderOpen,
@@ -20,6 +22,8 @@ import {
   useWorkspaceFilesLiveSync,
 } from "@/hooks/use-workspace-files-live-sync";
 import { useWorkspaceFileList } from "@/hooks/use-workspace-file-list";
+import { isHiddenWorkspaceRelativePath } from "@/lib/workspace-files/hidden-workspace-path";
+import { useWorkspaceFileViewStore } from "@/stores/workspace-file-view-store";
 import {
   openWorkspaceFileTab,
   previewWorkspaceFileTab,
@@ -157,6 +161,8 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
   const [contextMenu, setContextMenu] = useState<PathContextMenuState | null>(null);
+  const showHiddenFiles = useWorkspaceFileViewStore((state) => state.showHiddenFiles);
+  const toggleShowHiddenFiles = useWorkspaceFileViewStore((state) => state.toggleShowHiddenFiles);
   const {
     error,
     files,
@@ -173,12 +179,18 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
     subscriberId,
   });
 
+  const baseFiles = useMemo(
+    () => (showHiddenFiles
+      ? files
+      : files.filter((filePath) => !isHiddenWorkspaceRelativePath(filePath))),
+    [files, showHiddenFiles],
+  );
   const visibleFiles = useMemo(() => {
     const trimmed = query.trim().toLowerCase();
-    if (!trimmed) return files;
-    return files
+    if (!trimmed) return baseFiles;
+    return baseFiles
       .filter((filePath) => filePath.toLowerCase().includes(trimmed));
-  }, [files, query]);
+  }, [baseFiles, query]);
   const fileTree = useMemo(() => buildFileTree(visibleFiles), [visibleFiles]);
   const isSearching = query.trim().length > 0;
 
@@ -342,11 +354,27 @@ export function WorkspaceFilePanel({ sessionId }: { sessionId: string | null }) 
                 Files
               </p>
               <p className="truncate text-[11px] text-(--text-muted)">
-                {files.length.toLocaleString()} files
+                {baseFiles.length.toLocaleString()} files
                 {truncated ? " · truncated" : ""}
               </p>
             </div>
           </div>
+          <Tooltip content={showHiddenFiles ? "Hide hidden files" : "Show hidden files"}>
+            <button
+              type="button"
+              onClick={toggleShowHiddenFiles}
+              className={cn(
+                "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border transition-colors",
+                showHiddenFiles
+                  ? "border-(--accent) bg-(--accent)/10 text-(--text-primary)"
+                  : "border-(--input-border) text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--text-primary)",
+              )}
+              aria-label={showHiddenFiles ? "Hide hidden files" : "Show hidden files"}
+              aria-pressed={showHiddenFiles}
+            >
+              {showHiddenFiles ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+            </button>
+          </Tooltip>
         </div>
         <label className="mt-3 flex h-8 items-center gap-2 rounded-md border border-(--input-border) bg-(--chat-bg) px-2.5 focus-within:border-(--accent)">
           <Search className="h-3.5 w-3.5 shrink-0 text-(--text-muted)" />

--- a/src/lib/workspace-files/hidden-workspace-path.ts
+++ b/src/lib/workspace-files/hidden-workspace-path.ts
@@ -1,0 +1,24 @@
+/**
+ * Dotfiles that stay visible even when "show hidden files" is off. `.env.example`
+ * is a committed template meant to be read, unlike `.env` and other dotfiles.
+ */
+const ALWAYS_VISIBLE_DOTFILE_BASENAMES = new Set([".env.example"]);
+
+/**
+ * A workspace-relative path is "hidden" when its basename or any ancestor
+ * directory starts with a dot. Mirrors the default dotfile filtering that
+ * `isIgnoredWorkspacePath` applies server-side, but kept dependency-free (no
+ * node builtins) so the client bundle can reuse it for the show-hidden toggle.
+ *
+ * Build/VCS/cache output dirs (node_modules, .git, …) are excluded earlier by
+ * the server scan and never reach this check.
+ */
+export function isHiddenWorkspaceRelativePath(relativePath: string): boolean {
+  const parts = relativePath.split(/[/\\]+/).filter((part) => part && part !== ".");
+  if (parts.length === 0) return false;
+
+  const basename = parts[parts.length - 1];
+  const ancestors = parts.slice(0, -1);
+  if (ancestors.some((part) => part.startsWith("."))) return true;
+  return basename.startsWith(".") && !ALWAYS_VISIBLE_DOTFILE_BASENAMES.has(basename);
+}

--- a/src/lib/workspace-files/workspace-file-scan.ts
+++ b/src/lib/workspace-files/workspace-file-scan.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 import { getFilesystemPathModule } from "@/lib/filesystem/host-path";
+import { isHiddenWorkspaceRelativePath } from "./hidden-workspace-path";
 
 export const MAX_WORKSPACE_FILES = 20000;
 
@@ -34,21 +35,31 @@ export function normalizeWorkspaceRelativePath(filePath: string): string {
     .join("/");
 }
 
-export function isIgnoredWorkspacePath(filePath: string, stats?: { isDirectory(): boolean }): boolean {
+export function isIgnoredWorkspacePath(
+  filePath: string,
+  stats?: { isDirectory(): boolean },
+  options?: { includeHidden?: boolean },
+): boolean {
   const normalized = normalizeWorkspaceRelativePath(filePath);
   if (!normalized) return false;
 
   const parts = normalized.split("/");
-  const basename = parts[parts.length - 1] ?? "";
-  if (basename.startsWith(".") && basename !== ".env.example") {
+  const directoryParts = stats?.isDirectory() ? parts : parts.slice(0, -1);
+
+  // Build/VCS/cache output dirs are always excluded: they hold thousands of
+  // files (blowing past MAX_WORKSPACE_FILES) and the WSL inotify bridge relies
+  // on this set to skip watching them. The show-hidden toggle never surfaces them.
+  if (directoryParts.some((part) => IGNORED_WORKSPACE_DIR_NAMES.has(part))) {
     return true;
   }
 
-  const directoryParts = stats?.isDirectory() ? parts : parts.slice(0, -1);
-  if (directoryParts.some((part) => part.startsWith("."))) {
+  // Other dotfiles (.github, .env, .claude, …) are hidden by default, but the
+  // caller can opt in to stream the full list so a client-side toggle can reveal
+  // them without a re-scan.
+  if (!options?.includeHidden && isHiddenWorkspaceRelativePath(normalized)) {
     return true;
   }
-  return directoryParts.some((part) => IGNORED_WORKSPACE_DIR_NAMES.has(part));
+  return false;
 }
 
 export async function walkWorkspaceFiles(root: string): Promise<WorkspaceFileWalkResult> {
@@ -68,7 +79,9 @@ export async function walkWorkspaceFiles(root: string): Promise<WorkspaceFileWal
     for (const ent of entries) {
       if (truncated) return;
       const childRel = relDir ? `${relDir}/${ent.name}` : ent.name;
-      if (isIgnoredWorkspacePath(childRel, ent)) continue;
+      // Collect dotfiles too — the client filters them via the show-hidden
+      // toggle. Only the always-ignored build/VCS dirs are pruned here.
+      if (isIgnoredWorkspacePath(childRel, ent, { includeHidden: true })) continue;
 
       if (ent.isDirectory()) {
         await recurse(pathModule.join(absDir, ent.name), childRel);

--- a/src/lib/workspace-files/workspace-file-watch-manager.ts
+++ b/src/lib/workspace-files/workspace-file-watch-manager.ts
@@ -11,10 +11,18 @@ import {
   type WorkspaceFileWalkResult,
   walkWorkspaceFiles,
 } from "./workspace-file-scan";
+import {
+  type BridgeEvent,
+  isWslDistroRunning,
+  parseWslUncRoot,
+  WslInotifyBridge,
+  type WslUncRoot,
+} from "./wsl-inotify-bridge";
 
 type WsSendToUser = (userId: string, message: ServerTransportMessage) => void;
 
 type WatchStatus = "starting" | "active" | "fallback";
+type WatchMode = "watch" | "poll";
 type WatchEventName = "add" | "addDir" | "change" | "unlink" | "unlinkDir";
 
 interface WorkspaceFileSubscriber {
@@ -41,28 +49,50 @@ interface WatchEventStats {
 }
 
 interface WorkspaceWatchEntry {
+  bridge: WslInotifyBridge | null;
+  bridgeActive: boolean;
+  closeTimer: NodeJS.Timeout | null;
   debounceTimer: NodeJS.Timeout | null;
   files: Set<string>;
+  lastIndexedAt: number;
   pendingAddedPaths: Set<string>;
   pendingChangedPaths: Set<string>;
   pendingDeletedPaths: Set<string>;
   pendingEventsBeforeReady: PendingWatchEvent[];
   pendingHasMoreChangedPaths: boolean;
   pendingTreeChanged: boolean;
+  pollTimer: NodeJS.Timeout | null;
   ready: boolean;
   readyPromise: Promise<void>;
+  refreshing: boolean;
   root: string;
   rootChangeListeners: Map<string, WorkspaceRootChangeListener>;
   status: WatchStatus;
   subscribers: Map<string, WorkspaceFileSubscriber>;
   truncated: boolean;
   version: number;
+  watchMode: WatchMode;
   watcher: FSWatcher | null;
   watcherReadyPromise: Promise<void>;
+  wslRoot: WslUncRoot | null;
 }
 
 const CHANGE_DEBOUNCE_MS = 300;
 const MAX_CHANGED_PATHS_PER_EVENT = 200;
+// Sweep cadence for poll-mode roots. With a live inotify bridge the sweep is
+// only a consistency backstop; without one it is the sole change source and
+// must stay near-real-time.
+const POLL_SWEEP_FAST_MS = 2_000;
+const POLL_SWEEP_SLOW_MS = 60_000;
+const POLL_UNUSED_GRACE_MS = 60_000;
+const POLL_IDLE_CLOSE_MS = 5 * 60_000;
+
+// Recursive fs watching over network redirectors (e.g. \\wsl.localhost via 9P)
+// is unreliable: chokidar takes 10s+ to become ready, errors with EISDIR, and
+// never reports changes. Those roots use a periodic re-walk instead of a watcher.
+function isNetworkShareRoot(root: string): boolean {
+  return root.startsWith("\\\\") || root.startsWith("//");
+}
 
 function subscriberKey(connectionId: string, sessionId: string, subscriberId: string): string {
   return `${connectionId}:${sessionId}:${subscriberId}`;
@@ -124,6 +154,7 @@ export class WorkspaceFileWatchManager {
 
     const entry = this.getOrCreateEntry(root);
     entry.subscribers.set(key, options);
+    this.cancelScheduledClose(entry);
 
     options.sendToUser(options.userId, {
       type: "workspace_file_watch_status",
@@ -164,6 +195,7 @@ export class WorkspaceFileWatchManager {
       onChange: options.onChange,
     };
     entry.rootChangeListeners.set(options.listenerId, listener);
+    this.cancelScheduledClose(entry);
 
     let active = true;
     const dispose = () => {
@@ -260,6 +292,47 @@ export class WorkspaceFileWatchManager {
 
     await entry.readyPromise;
     if (entry.status !== "active" || entry.truncated) return null;
+    return this.serveSnapshot(entry);
+  }
+
+  /**
+   * Like getIndexedSnapshotForRoot, but for network-share roots it also creates
+   * and bootstraps the index on first use, so repeat requests are served from
+   * memory instead of re-walking the share. Watch-capable roots keep the
+   * passive behavior: no entry is created on behalf of a plain REST read.
+   */
+  async ensureSnapshotForRoot(root: string): Promise<WorkspaceFileWalkResult | null> {
+    const canonicalRoot = await resolveCanonicalWorkspaceRoot(root);
+    const existing = this.entriesByRoot.get(canonicalRoot);
+    if (!existing && !isNetworkShareRoot(canonicalRoot)) {
+      return this.getIndexedSnapshotForRoot(canonicalRoot);
+    }
+
+    const entry = existing ?? this.getOrCreateEntry(canonicalRoot);
+    await entry.readyPromise;
+    if (entry.status !== "active" || entry.truncated) return null;
+    return this.serveSnapshot(entry);
+  }
+
+  /** Fire-and-forget index prewarm for a session's network-share workspace. */
+  warmSessionWorkspace(sessionId: string): void {
+    void (async () => {
+      const root = await this.resolveRootForSession(sessionId);
+      if (!root || !isNetworkShareRoot(root)) return;
+      const entry = this.getOrCreateEntry(root);
+      this.touchEntry(entry);
+      await entry.readyPromise;
+    })().catch((error) => {
+      logger.warn({ error, sessionId }, "Workspace index prewarm failed");
+    });
+  }
+
+  private serveSnapshot(entry: WorkspaceWatchEntry): WorkspaceFileWalkResult {
+    this.touchEntry(entry);
+    const staleAfterMs = entry.bridgeActive ? POLL_SWEEP_SLOW_MS : POLL_SWEEP_FAST_MS;
+    if (entry.watchMode === "poll" && Date.now() - entry.lastIndexedAt > staleAfterMs) {
+      void this.refreshPollIndex(entry);
+    }
     return applyMaxFiles(entry.files);
   }
 
@@ -276,24 +349,32 @@ export class WorkspaceFileWatchManager {
     if (existing) return existing;
 
     const entry: WorkspaceWatchEntry = {
+      bridge: null,
+      bridgeActive: false,
+      closeTimer: null,
       debounceTimer: null,
       files: new Set(),
+      lastIndexedAt: 0,
       pendingAddedPaths: new Set(),
       pendingChangedPaths: new Set(),
       pendingDeletedPaths: new Set(),
       pendingEventsBeforeReady: [],
       pendingHasMoreChangedPaths: false,
       pendingTreeChanged: false,
+      pollTimer: null,
       ready: false,
       readyPromise: Promise.resolve(),
+      refreshing: false,
       root,
       rootChangeListeners: new Map(),
       status: "starting",
       subscribers: new Map(),
       truncated: false,
       version: 0,
+      watchMode: isNetworkShareRoot(root) ? "poll" : "watch",
       watcher: null,
       watcherReadyPromise: Promise.resolve(),
+      wslRoot: parseWslUncRoot(root),
     };
     this.entriesByRoot.set(root, entry);
     this.startWatcher(entry);
@@ -306,6 +387,7 @@ export class WorkspaceFileWatchManager {
       const snapshot = await walkWorkspaceFiles(entry.root);
       entry.files = new Set(snapshot.files);
       entry.truncated = snapshot.truncated;
+      entry.lastIndexedAt = Date.now();
       entry.ready = true;
 
       const pending = entry.pendingEventsBeforeReady.splice(0);
@@ -328,6 +410,19 @@ export class WorkspaceFileWatchManager {
   }
 
   private startWatcher(entry: WorkspaceWatchEntry): void {
+    if (entry.watchMode === "poll") {
+      this.setPollCadence(entry, POLL_SWEEP_FAST_MS);
+      const useBridge = Boolean(entry.wslRoot && process.platform === "win32");
+      if (entry.wslRoot && useBridge) {
+        this.startBridge(entry, entry.wslRoot);
+      }
+      logger.info({
+        root: entry.root,
+        bridge: useBridge,
+      }, "Workspace root is a network share; using poll-based indexing");
+      return;
+    }
+
     let resolveWatcherReady!: () => void;
     entry.watcherReadyPromise = new Promise<void>((resolve) => {
       resolveWatcherReady = resolve;
@@ -442,6 +537,107 @@ export class WorkspaceFileWatchManager {
     }
   }
 
+  private setPollCadence(entry: WorkspaceWatchEntry, intervalMs: number): void {
+    if (entry.pollTimer) clearInterval(entry.pollTimer);
+    const timer = setInterval(() => {
+      if (entry.subscribers.size === 0 && entry.rootChangeListeners.size === 0) return;
+      void this.refreshPollIndex(entry);
+    }, intervalMs);
+    timer.unref?.();
+    entry.pollTimer = timer;
+  }
+
+  private startBridge(entry: WorkspaceWatchEntry, wslRoot: WslUncRoot): void {
+    const bridge = new WslInotifyBridge({
+      root: wslRoot,
+      onEvent: (event) => this.handleBridgeEvent(entry, event),
+      onEstablished: () => {
+        if (this.entriesByRoot.get(entry.root) !== entry) return;
+        entry.bridgeActive = true;
+        this.setPollCadence(entry, POLL_SWEEP_SLOW_MS);
+        // Reconcile anything that changed while watches were being set up.
+        void this.refreshPollIndex(entry);
+        logger.info({ root: entry.root, distro: wslRoot.distro }, "WSL inotify bridge established");
+      },
+      onDown: (reason) => {
+        entry.bridgeActive = false;
+        entry.bridge = null;
+        if (this.entriesByRoot.get(entry.root) !== entry) return;
+        this.setPollCadence(entry, POLL_SWEEP_FAST_MS);
+        logger.warn({
+          root: entry.root,
+          distro: wslRoot.distro,
+          reason,
+        }, "WSL inotify bridge unavailable; falling back to fast polling (install inotify-tools in the distro for real-time sync)");
+      },
+    });
+    entry.bridge = bridge;
+    bridge.start();
+  }
+
+  private handleBridgeEvent(entry: WorkspaceWatchEntry, event: BridgeEvent): void {
+    const relativePath = normalizeWorkspaceRelativePath(event.relativePath);
+    if (!relativePath || isIgnoredWorkspacePath(relativePath)) return;
+    if (!entry.ready) {
+      entry.pendingEventsBeforeReady.push({ eventName: event.eventName, relativePath });
+      return;
+    }
+    this.applyWatchEvent(entry, event.eventName, relativePath);
+    // A moved-in directory carries no per-file events; re-walk to pick up its
+    // contents (refreshing flag coalesces bursts).
+    if (event.eventName === "addDir") void this.refreshPollIndex(entry);
+  }
+
+  private async refreshPollIndex(entry: WorkspaceWatchEntry): Promise<void> {
+    if (entry.refreshing || !entry.ready) return;
+    // Touching \\wsl.localhost boots a stopped distro; after `wsl --shutdown`
+    // stay quiet and serve the last snapshot until the distro is back.
+    if (
+      entry.wslRoot
+      && process.platform === "win32"
+      && !(await isWslDistroRunning(entry.wslRoot.distro))
+    ) {
+      return;
+    }
+    if (entry.refreshing || !entry.ready) return;
+    entry.refreshing = true;
+    try {
+      const snapshot = await walkWorkspaceFiles(entry.root);
+      if (this.entriesByRoot.get(entry.root) !== entry) return;
+      const previous = entry.files;
+      const next = new Set(snapshot.files);
+      entry.files = next;
+      entry.truncated = snapshot.truncated;
+      entry.lastIndexedAt = Date.now();
+
+      let changed = false;
+      for (const filePath of next) {
+        if (previous.has(filePath)) continue;
+        changed = true;
+        this.addPendingPath(entry, entry.pendingAddedPaths, filePath);
+        this.addPendingPath(entry, entry.pendingChangedPaths, filePath);
+      }
+      for (const filePath of previous) {
+        if (next.has(filePath)) continue;
+        changed = true;
+        this.addPendingPath(entry, entry.pendingDeletedPaths, filePath);
+        this.addPendingPath(entry, entry.pendingChangedPaths, filePath);
+      }
+      if (changed) {
+        entry.pendingTreeChanged = true;
+        if (entry.debounceTimer) {
+          clearTimeout(entry.debounceTimer);
+          entry.debounceTimer = null;
+        }
+        this.flushChanges(entry);
+      }
+    } catch (error) {
+      logger.warn({ error, root: entry.root }, "Workspace poll index refresh failed");
+    } finally {
+      entry.refreshing = false;
+    }
+  }
+
   private scheduleChange(
     entry: WorkspaceWatchEntry,
     relativePath: string,
@@ -550,9 +746,57 @@ export class WorkspaceFileWatchManager {
     }
   }
 
+  private touchEntry(entry: WorkspaceWatchEntry): void {
+    if (entry.watchMode !== "poll") return;
+    if (entry.subscribers.size > 0 || entry.rootChangeListeners.size > 0) return;
+    this.scheduleClose(entry, POLL_IDLE_CLOSE_MS);
+  }
+
+  private scheduleClose(entry: WorkspaceWatchEntry, delayMs: number): void {
+    if (entry.closeTimer) clearTimeout(entry.closeTimer);
+    const timer = setTimeout(() => {
+      entry.closeTimer = null;
+      this.closeEntryNow(entry);
+    }, delayMs);
+    timer.unref?.();
+    entry.closeTimer = timer;
+  }
+
+  private cancelScheduledClose(entry: WorkspaceWatchEntry): void {
+    if (!entry.closeTimer) return;
+    clearTimeout(entry.closeTimer);
+    entry.closeTimer = null;
+  }
+
   private closeEntryIfUnused(entry: WorkspaceWatchEntry): void {
+    if (entry.subscribers.size > 0 || entry.rootChangeListeners.size > 0) {
+      this.cancelScheduledClose(entry);
+      return;
+    }
+
+    // Poll-mode entries are expensive to rebuild (a full walk over a network
+    // share), so keep them warm briefly for quick tab re-entry. Watcher-backed
+    // entries keep the original immediate teardown.
+    if (entry.watchMode === "poll") {
+      this.scheduleClose(entry, POLL_UNUSED_GRACE_MS);
+      return;
+    }
+    this.closeEntryNow(entry);
+  }
+
+  private closeEntryNow(entry: WorkspaceWatchEntry): void {
     if (entry.subscribers.size > 0 || entry.rootChangeListeners.size > 0) return;
 
+    this.cancelScheduledClose(entry);
+    if (entry.pollTimer) {
+      clearInterval(entry.pollTimer);
+      entry.pollTimer = null;
+    }
+    if (entry.bridge) {
+      entry.bridge.stop();
+      entry.bridge = null;
+      entry.bridgeActive = false;
+    }
     this.entriesByRoot.delete(entry.root);
     for (const [sessionId, root] of Array.from(this.rootBySessionId.entries())) {
       if (root === entry.root) {

--- a/src/lib/workspace-files/workspace-file-watch-manager.ts
+++ b/src/lib/workspace-files/workspace-file-watch-manager.ts
@@ -87,11 +87,12 @@ const POLL_SWEEP_SLOW_MS = 60_000;
 const POLL_UNUSED_GRACE_MS = 60_000;
 const POLL_IDLE_CLOSE_MS = 5 * 60_000;
 
-// Recursive fs watching over network redirectors (e.g. \\wsl.localhost via 9P)
-// is unreliable: chokidar takes 10s+ to become ready, errors with EISDIR, and
-// never reports changes. Those roots use a periodic re-walk instead of a watcher.
-function isNetworkShareRoot(root: string): boolean {
-  return root.startsWith("\\\\") || root.startsWith("//");
+// Recursive watching through the Windows WSL 9P redirector is unreliable:
+// chokidar takes 10s+ to become ready, emits EISDIR storms, and starves the
+// server event loop that also carries PTY input. Keep unrelated SMB shares on
+// their existing watcher path; only Windows-hosted WSL roots use the bridge.
+export function isWindowsHostedWslRoot(root: string): boolean {
+  return parseWslUncRoot(root) !== null;
 }
 
 function subscriberKey(connectionId: string, sessionId: string, subscriberId: string): string {
@@ -296,7 +297,7 @@ export class WorkspaceFileWatchManager {
   }
 
   /**
-   * Like getIndexedSnapshotForRoot, but for network-share roots it also creates
+   * Like getIndexedSnapshotForRoot, but for Windows-hosted WSL roots it also creates
    * and bootstraps the index on first use, so repeat requests are served from
    * memory instead of re-walking the share. Watch-capable roots keep the
    * passive behavior: no entry is created on behalf of a plain REST read.
@@ -304,7 +305,7 @@ export class WorkspaceFileWatchManager {
   async ensureSnapshotForRoot(root: string): Promise<WorkspaceFileWalkResult | null> {
     const canonicalRoot = await resolveCanonicalWorkspaceRoot(root);
     const existing = this.entriesByRoot.get(canonicalRoot);
-    if (!existing && !isNetworkShareRoot(canonicalRoot)) {
+    if (!existing && !isWindowsHostedWslRoot(canonicalRoot)) {
       return this.getIndexedSnapshotForRoot(canonicalRoot);
     }
 
@@ -314,11 +315,11 @@ export class WorkspaceFileWatchManager {
     return this.serveSnapshot(entry);
   }
 
-  /** Fire-and-forget index prewarm for a session's network-share workspace. */
+  /** Fire-and-forget index prewarm for a Windows-hosted WSL workspace. */
   warmSessionWorkspace(sessionId: string): void {
     void (async () => {
       const root = await this.resolveRootForSession(sessionId);
-      if (!root || !isNetworkShareRoot(root)) return;
+      if (!root || !isWindowsHostedWslRoot(root)) return;
       const entry = this.getOrCreateEntry(root);
       this.touchEntry(entry);
       await entry.readyPromise;
@@ -347,6 +348,7 @@ export class WorkspaceFileWatchManager {
   private getOrCreateEntry(root: string): WorkspaceWatchEntry {
     const existing = this.entriesByRoot.get(root);
     if (existing) return existing;
+    const wslRoot = parseWslUncRoot(root);
 
     const entry: WorkspaceWatchEntry = {
       bridge: null,
@@ -371,10 +373,10 @@ export class WorkspaceFileWatchManager {
       subscribers: new Map(),
       truncated: false,
       version: 0,
-      watchMode: isNetworkShareRoot(root) ? "poll" : "watch",
+      watchMode: wslRoot ? "poll" : "watch",
       watcher: null,
       watcherReadyPromise: Promise.resolve(),
-      wslRoot: parseWslUncRoot(root),
+      wslRoot,
     };
     this.entriesByRoot.set(root, entry);
     this.startWatcher(entry);
@@ -442,7 +444,11 @@ export class WorkspaceFileWatchManager {
         followSymlinks: false,
         ignoreInitial: true,
         ignored: (filePath, stats) => (
-          isIgnoredWorkspacePath(toWorkspaceRelativePath(entry.root, String(filePath)), stats)
+          isIgnoredWorkspacePath(
+            toWorkspaceRelativePath(entry.root, String(filePath)),
+            stats,
+            { includeHidden: true },
+          )
         ),
         persistent: true,
       });
@@ -451,7 +457,7 @@ export class WorkspaceFileWatchManager {
         if (!this.isWatchEventName(eventName)) return;
         if (!this.isWatchEventShape(eventName, stats)) return;
         const relativePath = toWorkspaceRelativePath(entry.root, String(filePath));
-        if (!relativePath || isIgnoredWorkspacePath(relativePath)) return;
+        if (!relativePath || isIgnoredWorkspacePath(relativePath, undefined, { includeHidden: true })) return;
         if (!entry.ready) {
           entry.pendingEventsBeforeReady.push({ eventName, relativePath });
           return;
@@ -563,7 +569,9 @@ export class WorkspaceFileWatchManager {
         entry.bridgeActive = false;
         entry.bridge = null;
         if (this.entriesByRoot.get(entry.root) !== entry) return;
+        entry.status = "fallback";
         this.setPollCadence(entry, POLL_SWEEP_FAST_MS);
+        this.emitWatchStatus(entry, "fallback", "wsl_bridge_unavailable");
         logger.warn({
           root: entry.root,
           distro: wslRoot.distro,
@@ -577,7 +585,7 @@ export class WorkspaceFileWatchManager {
 
   private handleBridgeEvent(entry: WorkspaceWatchEntry, event: BridgeEvent): void {
     const relativePath = normalizeWorkspaceRelativePath(event.relativePath);
-    if (!relativePath || isIgnoredWorkspacePath(relativePath)) return;
+    if (!relativePath || isIgnoredWorkspacePath(relativePath, undefined, { includeHidden: true })) return;
     if (!entry.ready) {
       entry.pendingEventsBeforeReady.push({ eventName: event.eventName, relativePath });
       return;
@@ -630,6 +638,11 @@ export class WorkspaceFileWatchManager {
           entry.debounceTimer = null;
         }
         this.flushChanges(entry);
+      } else if (!entry.bridgeActive && entry.rootChangeListeners.size > 0) {
+        // A filename-only snapshot cannot see edits to an existing file. In
+        // bridge fallback mode, periodically invalidate terminal git stats so
+        // content-only changes are still observed.
+        this.notifyRootChangeListeners(entry);
       }
     } catch (error) {
       logger.warn({ error, root: entry.root }, "Workspace poll index refresh failed");
@@ -696,13 +709,7 @@ export class WorkspaceFileWatchManager {
     entry.pendingTreeChanged = false;
     entry.pendingHasMoreChangedPaths = false;
 
-    for (const listener of entry.rootChangeListeners.values()) {
-      try {
-        listener.onChange(entry.root);
-      } catch (error) {
-        logger.warn({ error, listenerId: listener.listenerId, root: entry.root }, "Workspace root change listener failed");
-      }
-    }
+    this.notifyRootChangeListeners(entry);
 
     const subscribersByUser = new Map<string, WorkspaceFileSubscriber[]>();
     for (const subscriber of entry.subscribers.values()) {
@@ -725,6 +732,16 @@ export class WorkspaceFileWatchManager {
         deletedPaths,
         hasMoreChangedPaths,
       });
+    }
+  }
+
+  private notifyRootChangeListeners(entry: WorkspaceWatchEntry): void {
+    for (const listener of entry.rootChangeListeners.values()) {
+      try {
+        listener.onChange(entry.root);
+      } catch (error) {
+        logger.warn({ error, listenerId: listener.listenerId, root: entry.root }, "Workspace root change listener failed");
+      }
     }
   }
 

--- a/src/lib/workspace-files/wsl-inotify-bridge.ts
+++ b/src/lib/workspace-files/wsl-inotify-bridge.ts
@@ -30,6 +30,7 @@ export interface BridgeEvent {
 const WSL_UNC_HOSTS = new Set(["wsl.localhost", "wsl$"]);
 const RESTART_DELAY_MS = 3_000;
 const MAX_RESTARTS = 2;
+const STABLE_UPTIME_MS = 30_000;
 const DISTRO_STATE_TTL_MS = 5_000;
 const DISTRO_WAIT_POLL_MS = 15_000;
 
@@ -113,10 +114,15 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/** POSIX ERE handed to inotifywait so ignored trees are never watched. */
-export function buildInotifyExcludeRegex(): string {
+/** POSIX ERE handed to inotifywait so known high-churn trees are never watched. */
+export function buildInotifyExcludeRegex(posixRoot: string): string {
   const names = Array.from(IGNORED_WORKSPACE_DIR_NAMES, escapeRegExp).join("|");
-  return `/(\\.[^/]+|${names})(/|$)`;
+  const normalizedRoot = posixRoot.replace(/\/+$/, "");
+  // inotifywait compares this regex with absolute paths. Anchor it below the
+  // workspace root so a hidden ancestor such as ~/.tessera does not suppress
+  // every event. Other hidden descendants are cheap to watch and are filtered
+  // after delivery; this also preserves the explicitly allowed .env.example.
+  return `^${escapeRegExp(normalizedRoot)}/(.*/)?(${names})(/|$)`;
 }
 
 export class WslInotifyBridge {
@@ -125,6 +131,7 @@ export class WslInotifyBridge {
   private established = false;
   private restartCount = 0;
   private restartTimer: NodeJS.Timeout | null = null;
+  private stableUptimeTimer: NodeJS.Timeout | null = null;
   private stdoutBuffer = "";
   private stderrTail = "";
   private stopped = false;
@@ -151,7 +158,7 @@ export class WslInotifyBridge {
         "--exec", "stdbuf", "-oL",
         "inotifywait", "-m", "-r",
         "-e", "create,delete,move,modify,close_write",
-        "--exclude", buildInotifyExcludeRegex(),
+        "--exclude", buildInotifyExcludeRegex(this.options.root.posixPath),
         "--format", "%e|%w%f",
         "--", this.options.root.posixPath,
       ], {
@@ -170,16 +177,18 @@ export class WslInotifyBridge {
       this.stderrTail = (this.stderrTail + text).slice(-500);
       if (!this.established && text.includes("Watches established")) {
         this.established = true;
-        this.restartCount = 0;
+        this.armStableUptimeReset();
         this.options.onEstablished();
       }
     });
     child.on("error", (error) => {
       this.child = null;
+      this.clearStableUptimeTimer();
       this.reportDown(`unable to launch wsl.exe: ${error.message}`);
     });
     child.on("close", (code) => {
       this.child = null;
+      this.clearStableUptimeTimer();
       if (this.stopped) return;
       if (!this.established) {
         this.reportDown(`inotifywait unavailable in distro (exit ${code}): ${this.stderrTail.trim()}`);
@@ -236,6 +245,7 @@ export class WslInotifyBridge {
 
   stop(): void {
     this.stopped = true;
+    this.clearStableUptimeTimer();
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
@@ -261,9 +271,25 @@ export class WslInotifyBridge {
     }
   }
 
+  private armStableUptimeReset(): void {
+    this.clearStableUptimeTimer();
+    this.stableUptimeTimer = setTimeout(() => {
+      this.stableUptimeTimer = null;
+      this.restartCount = 0;
+    }, STABLE_UPTIME_MS);
+    this.stableUptimeTimer.unref?.();
+  }
+
+  private clearStableUptimeTimer(): void {
+    if (!this.stableUptimeTimer) return;
+    clearTimeout(this.stableUptimeTimer);
+    this.stableUptimeTimer = null;
+  }
+
   private reportDown(reason: string): void {
     if (this.stopped) return;
     this.stopped = true;
+    this.clearStableUptimeTimer();
     this.options.onDown(reason);
   }
 }

--- a/src/lib/workspace-files/wsl-inotify-bridge.ts
+++ b/src/lib/workspace-files/wsl-inotify-bridge.ts
@@ -1,0 +1,269 @@
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import logger from "@/lib/logger";
+import { IGNORED_WORKSPACE_DIR_NAMES } from "./workspace-file-scan";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Real-time file events for \\wsl.localhost\ workspace roots.
+ *
+ * The 9P redirector that backs \\wsl.localhost cannot deliver filesystem
+ * notifications to Windows (watchers stall or error), so this bridge runs
+ * `inotifywait` inside the distro — where inotify is native and instant — and
+ * streams its events back over stdout. If inotifywait is unavailable in the
+ * distro the bridge reports down and callers fall back to polling.
+ */
+
+export interface WslUncRoot {
+  distro: string;
+  posixPath: string;
+}
+
+export type BridgeEventName = "add" | "addDir" | "change" | "unlink" | "unlinkDir";
+
+export interface BridgeEvent {
+  eventName: BridgeEventName;
+  relativePath: string;
+}
+
+const WSL_UNC_HOSTS = new Set(["wsl.localhost", "wsl$"]);
+const RESTART_DELAY_MS = 3_000;
+const MAX_RESTARTS = 2;
+const DISTRO_STATE_TTL_MS = 5_000;
+const DISTRO_WAIT_POLL_MS = 15_000;
+
+const distroStateCache = new Map<string, { at: number; running: boolean }>();
+
+export function parseWslRunningDistros(stdout: string): string[] {
+  return Array.from(new Set(
+    stdout
+      .replace(/\0/g, "")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean),
+  ));
+}
+
+/**
+ * True when the distro is currently running. `wsl.exe --list --running` only
+ * queries the WSL service — unlike touching \\wsl.localhost or spawning
+ * `wsl.exe -d`, it never boots a stopped distro. After `wsl --shutdown` the
+ * watcher must go quiet instead of waking the distro right back up.
+ */
+export async function isWslDistroRunning(distro: string): Promise<boolean> {
+  const cached = distroStateCache.get(distro);
+  if (cached && Date.now() - cached.at < DISTRO_STATE_TTL_MS) return cached.running;
+
+  let running = true;
+  try {
+    const { stdout } = await execFileAsync("wsl.exe", ["--list", "--running", "--quiet"], {
+      encoding: "utf16le",
+      timeout: 5_000,
+      windowsHide: true,
+    });
+    running = parseWslRunningDistros(stdout)
+      .some((name) => name.toLowerCase() === distro.toLowerCase());
+  } catch (error) {
+    // Exits non-zero when nothing is running; stdout still tells the truth.
+    const stdout = (error as { stdout?: unknown })?.stdout;
+    if (typeof stdout === "string") {
+      running = parseWslRunningDistros(stdout)
+        .some((name) => name.toLowerCase() === distro.toLowerCase());
+    }
+  }
+  distroStateCache.set(distro, { at: Date.now(), running });
+  return running;
+}
+
+export function parseWslUncRoot(root: string): WslUncRoot | null {
+  if (!root.startsWith("\\\\") && !root.startsWith("//")) return null;
+  const parts = root.replace(/\//g, "\\").split("\\").filter(Boolean);
+  const [host, distro, ...rest] = parts;
+  if (!host || !WSL_UNC_HOSTS.has(host.toLowerCase())) return null;
+  if (!distro || rest.length === 0) return null;
+  return { distro, posixPath: `/${rest.join("/")}` };
+}
+
+export function parseInotifyLine(line: string, posixRoot: string): BridgeEvent | null {
+  const separator = line.indexOf("|");
+  if (separator <= 0) return null;
+  const events = line.slice(0, separator).split(",");
+  const absolutePath = line.slice(separator + 1).replace(/\r$/, "");
+
+  const prefix = posixRoot.endsWith("/") ? posixRoot : `${posixRoot}/`;
+  if (!absolutePath.startsWith(prefix)) return null;
+  const relativePath = absolutePath.slice(prefix.length);
+  if (!relativePath) return null;
+
+  const isDirectory = events.includes("ISDIR");
+  if (events.includes("CREATE") || events.includes("MOVED_TO")) {
+    return { eventName: isDirectory ? "addDir" : "add", relativePath };
+  }
+  if (events.includes("DELETE") || events.includes("MOVED_FROM")) {
+    return { eventName: isDirectory ? "unlinkDir" : "unlink", relativePath };
+  }
+  if (!isDirectory && (events.includes("CLOSE_WRITE") || events.includes("MODIFY"))) {
+    return { eventName: "change", relativePath };
+  }
+  return null;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** POSIX ERE handed to inotifywait so ignored trees are never watched. */
+export function buildInotifyExcludeRegex(): string {
+  const names = Array.from(IGNORED_WORKSPACE_DIR_NAMES, escapeRegExp).join("|");
+  return `/(\\.[^/]+|${names})(/|$)`;
+}
+
+export class WslInotifyBridge {
+  private child: ChildProcess | null = null;
+  private distroWaitTimer: NodeJS.Timeout | null = null;
+  private established = false;
+  private restartCount = 0;
+  private restartTimer: NodeJS.Timeout | null = null;
+  private stdoutBuffer = "";
+  private stderrTail = "";
+  private stopped = false;
+
+  constructor(private readonly options: {
+    root: WslUncRoot;
+    onEvent(event: BridgeEvent): void;
+    onEstablished(): void;
+    onDown(reason: string): void;
+  }) {}
+
+  start(): void {
+    if (this.stopped || this.child) return;
+    this.established = false;
+    this.stdoutBuffer = "";
+    this.stderrTail = "";
+
+    let child: ChildProcess;
+    try {
+      child = spawn("wsl.exe", [
+        "-d", this.options.root.distro,
+        // No -q: it would also suppress the "Watches established." stderr line
+        // this bridge relies on to detect readiness.
+        "--exec", "stdbuf", "-oL",
+        "inotifywait", "-m", "-r",
+        "-e", "create,delete,move,modify,close_write",
+        "--exclude", buildInotifyExcludeRegex(),
+        "--format", "%e|%w%f",
+        "--", this.options.root.posixPath,
+      ], {
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } catch (error) {
+      this.reportDown(`spawn failed: ${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
+    this.child = child;
+
+    child.stdout?.on("data", (chunk: Buffer) => this.consumeStdout(chunk.toString("utf8")));
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      this.stderrTail = (this.stderrTail + text).slice(-500);
+      if (!this.established && text.includes("Watches established")) {
+        this.established = true;
+        this.restartCount = 0;
+        this.options.onEstablished();
+      }
+    });
+    child.on("error", (error) => {
+      this.child = null;
+      this.reportDown(`unable to launch wsl.exe: ${error.message}`);
+    });
+    child.on("close", (code) => {
+      this.child = null;
+      if (this.stopped) return;
+      if (!this.established) {
+        this.reportDown(`inotifywait unavailable in distro (exit ${code}): ${this.stderrTail.trim()}`);
+        return;
+      }
+      void this.recoverAfterExit(code);
+    });
+  }
+
+  private async recoverAfterExit(code: number | null): Promise<void> {
+    const running = await isWslDistroRunning(this.options.root.distro);
+    if (this.stopped) return;
+
+    if (!running) {
+      // wsl --shutdown killed the watcher. Restarting `wsl.exe -d` would boot
+      // the distro right back up, so wait quietly until it returns on its own.
+      logger.info({
+        distro: this.options.root.distro,
+        posixPath: this.options.root.posixPath,
+      }, "WSL distro stopped; inotify bridge waiting for it to return");
+      this.distroWaitTimer = setInterval(() => {
+        void (async () => {
+          if (this.stopped || this.child) return;
+          if (!(await isWslDistroRunning(this.options.root.distro))) return;
+          if (this.distroWaitTimer) {
+            clearInterval(this.distroWaitTimer);
+            this.distroWaitTimer = null;
+          }
+          this.restartCount = 0;
+          this.start();
+        })();
+      }, DISTRO_WAIT_POLL_MS);
+      this.distroWaitTimer.unref?.();
+      return;
+    }
+
+    if (this.restartCount >= MAX_RESTARTS) {
+      this.reportDown(`inotifywait exited repeatedly (exit ${code})`);
+      return;
+    }
+    this.restartCount += 1;
+    logger.warn({
+      distro: this.options.root.distro,
+      posixPath: this.options.root.posixPath,
+      code,
+      attempt: this.restartCount,
+    }, "WSL inotify bridge exited; restarting");
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null;
+      this.start();
+    }, RESTART_DELAY_MS);
+    this.restartTimer.unref?.();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+    if (this.distroWaitTimer) {
+      clearInterval(this.distroWaitTimer);
+      this.distroWaitTimer = null;
+    }
+    const child = this.child;
+    this.child = null;
+    if (child) child.kill();
+  }
+
+  private consumeStdout(text: string): void {
+    this.stdoutBuffer += text;
+    let newline = this.stdoutBuffer.indexOf("\n");
+    while (newline !== -1) {
+      const line = this.stdoutBuffer.slice(0, newline);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      const event = parseInotifyLine(line, this.options.root.posixPath);
+      if (event) this.options.onEvent(event);
+      newline = this.stdoutBuffer.indexOf("\n");
+    }
+  }
+
+  private reportDown(reason: string): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.options.onDown(reason);
+  }
+}

--- a/src/stores/workspace-file-view-store.ts
+++ b/src/stores/workspace-file-view-store.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface WorkspaceFileViewState {
+  /** Whether dotfiles/dotfolders (e.g. .github, .env, .claude) are shown in the
+   * workspace file tree. Build/VCS output dirs stay hidden regardless. */
+  showHiddenFiles: boolean;
+  toggleShowHiddenFiles: () => void;
+  setShowHiddenFiles: (value: boolean) => void;
+}
+
+export const useWorkspaceFileViewStore = create<WorkspaceFileViewState>()(
+  persist(
+    (set) => ({
+      showHiddenFiles: false,
+      toggleShowHiddenFiles: () =>
+        set((state) => ({ showHiddenFiles: !state.showHiddenFiles })),
+      setShowHiddenFiles: (value) => set({ showHiddenFiles: value }),
+    }),
+    { name: 'tessera:workspace-file-view' },
+  ),
+);

--- a/tests/folder-browser-environment-sync.e2e.mjs
+++ b/tests/folder-browser-environment-sync.e2e.mjs
@@ -1,0 +1,432 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { chromium } from '@playwright/test';
+
+const repoRoot = path.resolve(new URL('..', import.meta.url).pathname);
+const tempRoot = path.join(os.homedir(), 'tmp');
+await fs.mkdir(tempRoot, { recursive: true });
+const dataDir = await fs.mkdtemp(path.join(tempRoot, 'tessera-folder-browser-env-'));
+const appRoot = path.join(dataDir, 'app');
+await fs.mkdir(appRoot);
+await Promise.all([
+  'next.config.mjs',
+  'package.json',
+  'public',
+  'runtime',
+  'server.ts',
+  'src',
+  'tsconfig.json',
+].map((entry) => hardlinkCopy(path.join(repoRoot, entry), path.join(appRoot, entry))));
+await hardlinkCopy(path.join(repoRoot, 'node_modules'), path.join(appRoot, 'node_modules'));
+const port = await reservePort();
+const appOrigin = `http://127.0.0.1:${port}`;
+let serverOutput = '';
+
+const server = spawn(
+  process.execPath,
+  [path.join(appRoot, 'node_modules/tsx/dist/cli.mjs'), 'server.ts'],
+  {
+    cwd: appRoot,
+    detached: true,
+    env: {
+      ...process.env,
+      HOST: '127.0.0.1',
+      PORT: String(port),
+      NODE_ENV: 'development',
+      TESSERA_DATA_DIR: dataDir,
+      TESSERA_ELECTRON_AUTH_BYPASS: '1',
+      LOG_LEVEL: 'error',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  },
+);
+
+server.stdout.on('data', (chunk) => {
+  serverOutput = `${serverOutput}${chunk}`.slice(-20_000);
+});
+server.stderr.on('data', (chunk) => {
+  serverOutput = `${serverOutput}${chunk}`.slice(-20_000);
+});
+
+let browser;
+try {
+  await waitForServer(`${appOrigin}/api/settings`, server);
+
+  browser = await chromium.launch({ headless: true });
+  await testWaitsForAuthoritativeNative(browser, appOrigin);
+  await testUsesAuthoritativeWsl(browser, appOrigin);
+  await testIgnoresBrowseFromPreviousOpen(browser, appOrigin);
+  await testReinitializesAfterEnvironmentChange(browser, appOrigin);
+  await testStopsWhenSettingsLoadFails(browser, appOrigin);
+} catch (error) {
+  if (serverOutput) process.stderr.write(`\n--- isolated server output ---\n${serverOutput}\n`);
+  throw error;
+} finally {
+  await browser?.close().catch(() => undefined);
+  if (server.pid) {
+    try {
+      process.kill(-server.pid, 'SIGTERM');
+    } catch {
+      // The isolated server may already have exited after a startup failure.
+    }
+  }
+  await waitForExit(server, 5_000);
+  await fs.rm(dataDir, { recursive: true, force: true });
+}
+
+async function testWaitsForAuthoritativeNative(browserInstance, origin) {
+  const { context, page } = await createElectronPage(browserInstance, 'wsl');
+  const settingsGate = createDeferred();
+  const browseRequests = collectBrowseRequests(page);
+
+  try {
+    await page.route('**/api/settings', async (route) => {
+      if (route.request().method() === 'GET') await settingsGate.promise;
+      await route.continue();
+    });
+
+    await openAddProject(page, origin);
+
+    // A hard-coded native request would make the original one-way assertion
+    // pass, but it is still unsafe until the server setting has resolved.
+    await page.waitForTimeout(200);
+    assert.equal(
+      browseRequests.length,
+      0,
+      'Add Project must not browse before authoritative settings resolve',
+    );
+    settingsGate.resolve();
+
+    await waitForPathValue(page);
+    assert.equal(
+      getRequestEnvironment(browseRequests[0]),
+      'native',
+      'a stale WSL renderer must adopt the server-authoritative native environment',
+    );
+    assert.equal(
+      await page.getByText(/Current Agent Environment is .*Switch Agent Environment/).count(),
+      0,
+      'the authoritative home browse must not render an environment mismatch',
+    );
+    assert.equal(
+      await page.getByTestId('folder-browser-environment-native').isDisabled(),
+      false,
+      'the native control must agree with the authoritative settings',
+    );
+  } finally {
+    settingsGate.resolve();
+    await context.close();
+  }
+}
+
+async function testUsesAuthoritativeWsl(browserInstance, origin) {
+  const { context, page } = await createElectronPage(browserInstance, 'native');
+  const settingsGate = createDeferred();
+  const browseRequests = collectBrowseRequests(page);
+
+  try {
+    await page.route('**/api/settings', async (route) => {
+      if (route.request().method() === 'GET') await settingsGate.promise;
+      await route.fulfill(jsonResponse(settingsPayload('wsl')));
+    });
+    await page.route('**/api/filesystem/browse**', async (route) => {
+      await route.fulfill(jsonResponse(browsePayload('/home/wsl-user')));
+    });
+
+    await openAddProject(page, origin);
+    await page.waitForTimeout(200);
+    assert.equal(
+      browseRequests.length,
+      0,
+      'the opposite stale-cache direction must also wait for settings',
+    );
+    settingsGate.resolve();
+
+    await waitForPathValue(page, '/home/wsl-user');
+    assert.equal(
+      getRequestEnvironment(browseRequests[0]),
+      'wsl',
+      'a stale native renderer must adopt the server-authoritative WSL environment',
+    );
+    assert.equal(
+      await page.getByTestId('folder-browser-environment-wsl').isDisabled(),
+      false,
+      'the WSL control must agree with the authoritative settings',
+    );
+  } finally {
+    settingsGate.resolve();
+    await context.close();
+  }
+}
+
+async function testIgnoresBrowseFromPreviousOpen(browserInstance, origin) {
+  const { context, page } = await createElectronPage(browserInstance, 'native');
+  const firstBrowseStarted = createDeferred();
+  const releaseFirstBrowse = createDeferred();
+  let browseCount = 0;
+
+  try {
+    await page.route('**/api/settings', async (route) => {
+      await route.fulfill(jsonResponse(settingsPayload('native')));
+    });
+    await page.route('**/api/filesystem/browse**', async (route) => {
+      browseCount += 1;
+      if (browseCount === 1) {
+        firstBrowseStarted.resolve();
+        await releaseFirstBrowse.promise;
+        await route.fulfill(jsonResponse(browsePayload('C:\\stale-home'))).catch(() => undefined);
+        return;
+      }
+      await route.fulfill(jsonResponse(browsePayload('C:\\fresh-home')));
+    });
+
+    await openAddProject(page, origin);
+    await withTimeout(firstBrowseStarted.promise, 10_000, 'first browse request');
+    await page.getByTestId('folder-browser-cancel').click();
+    await page.getByTestId('folder-browser-dialog').waitFor({ state: 'hidden' });
+
+    await page.getByTestId('project-strip-add').click();
+    await page.getByTestId('folder-browser-dialog').waitFor();
+    await waitForPathValue(page, 'C:\\fresh-home');
+
+    releaseFirstBrowse.resolve();
+    await page.waitForTimeout(200);
+    assert.equal(
+      await page.getByTestId('folder-browser-path-input').inputValue(),
+      'C:\\fresh-home',
+      'a late response from the previous open must not replace the current directory',
+    );
+  } finally {
+    releaseFirstBrowse.resolve();
+    await context.close();
+  }
+}
+
+async function testStopsWhenSettingsLoadFails(browserInstance, origin) {
+  const { context, page } = await createElectronPage(browserInstance, 'wsl');
+  const browseRequests = collectBrowseRequests(page);
+
+  try {
+    await page.route('**/api/settings', async (route) => {
+      await route.fulfill(jsonResponse({ error: 'settings unavailable' }, 503));
+    });
+    await page.route('**/api/filesystem/browse**', async (route) => {
+      await route.fulfill(jsonResponse({ error: 'unexpected browse request' }, 500));
+    });
+
+    await openAddProject(page, origin);
+    await page.getByText('Failed to load settings').waitFor({ timeout: 10_000 });
+    const pathInput = page.getByTestId('folder-browser-path-input');
+    await pathInput.fill('C:\\stale-home');
+    await pathInput.press('Enter');
+    await page.waitForTimeout(100);
+    assert.equal(
+      browseRequests.length,
+      0,
+      'Add Project must not browse with a stale persisted environment after settings fail',
+    );
+  } finally {
+    await context.close();
+  }
+}
+
+async function testReinitializesAfterEnvironmentChange(browserInstance, origin) {
+  const { context, page } = await createElectronPage(browserInstance, 'native');
+  const browseRequests = collectBrowseRequests(page);
+
+  try {
+    await page.route('**/api/settings', async (route) => {
+      await route.fulfill(jsonResponse(settingsPayload('native')));
+    });
+    await page.route('**/api/filesystem/browse**', async (route) => {
+      const environment = new URL(route.request().url()).searchParams.get('environment');
+      const currentPath = environment === 'wsl' ? '/home/wsl-user' : 'C:\\native-home';
+      await route.fulfill(jsonResponse(browsePayload(currentPath)));
+    });
+
+    await openAddProject(page, origin);
+    await waitForPathValue(page, 'C:\\native-home');
+    const initialBrowseCount = browseRequests.length;
+
+    await page.evaluate(() => {
+      const channel = new BroadcastChannel('tessera:settings-sync');
+      channel.postMessage({
+        type: 'settings-updated',
+        settings: { agentEnvironment: 'wsl' },
+        senderId: 'folder-browser-e2e-external-renderer',
+      });
+      channel.close();
+    });
+
+    await waitForPathValue(page, '/home/wsl-user');
+    assert.ok(
+      browseRequests.length > initialBrowseCount,
+      'an Agent Environment change must start a fresh home browse',
+    );
+    assert.equal(
+      getRequestEnvironment(browseRequests.at(-1)),
+      'wsl',
+      'the refreshed browse must use the newly synchronized Agent Environment',
+    );
+  } finally {
+    await context.close();
+  }
+}
+
+async function createElectronPage(browserInstance, persistedEnvironment) {
+  const context = await browserInstance.newContext({ viewport: { width: 1200, height: 850 } });
+  await context.addInitScript((environment) => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { isElectron: true, platform: 'win32' },
+    });
+    localStorage.setItem('tessera:settings', JSON.stringify({
+      state: {
+        settings: { agentEnvironment: environment },
+      },
+      version: 0,
+    }));
+  }, persistedEnvironment);
+  const page = await context.newPage();
+  return { context, page };
+}
+
+async function openAddProject(page, origin) {
+  await page.goto(`${origin}/chat`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+  await page.getByTestId('chat-layout').waitFor({ timeout: 30_000 });
+  await page.getByTestId('project-strip-add').click();
+  await page.getByTestId('folder-browser-dialog').waitFor();
+}
+
+function collectBrowseRequests(page) {
+  const requests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/filesystem/browse') {
+      requests.push(request.url());
+    }
+  });
+  return requests;
+}
+
+async function waitForPathValue(page, expectedValue = null) {
+  await page.getByTestId('folder-browser-path-input').waitFor();
+  await page.waitForFunction((expected) => {
+    const input = document.querySelector('[data-testid="folder-browser-path-input"]');
+    if (!(input instanceof HTMLInputElement)) return false;
+    return expected === null ? input.value.length > 0 : input.value === expected;
+  }, expectedValue, { timeout: 10_000 });
+}
+
+function getRequestEnvironment(requestUrl) {
+  assert.ok(requestUrl, 'opening Add Project must browse the home directory');
+  return new URL(requestUrl).searchParams.get('environment');
+}
+
+function settingsPayload(agentEnvironment) {
+  return {
+    settings: { agentEnvironment },
+    serverHostInfo: { isWindowsEcosystem: true },
+  };
+}
+
+function browsePayload(currentPath) {
+  return {
+    currentPath,
+    filesystemPath: currentPath,
+    parentPath: null,
+    entries: [],
+    isGitRepo: false,
+  };
+}
+
+function jsonResponse(body, status = 200) {
+  return {
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  };
+}
+
+function createDeferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function withTimeout(promise, timeoutMs, label) {
+  let timeoutId;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function hardlinkCopy(source, destination) {
+  await new Promise((resolve, reject) => {
+    const copy = spawn('cp', ['-al', source, destination], { stdio: 'ignore' });
+    copy.once('error', reject);
+    copy.once('exit', (code) => (
+      code === 0 ? resolve() : reject(new Error(`cp -al exited with code ${code}`))
+    ));
+  });
+}
+
+async function waitForExit(child, timeoutMs) {
+  if (child.exitCode !== null) return;
+  const exited = new Promise((resolve) => child.once('exit', resolve));
+  const timedOut = new Promise((resolve) => setTimeout(() => resolve('timeout'), timeoutMs));
+  if (await Promise.race([exited, timedOut]) !== 'timeout') return;
+  if (child.pid) {
+    try {
+      process.kill(-child.pid, 'SIGKILL');
+    } catch {
+      // The process exited between the timeout and the forced cleanup.
+    }
+  }
+  await exited;
+}
+
+async function reservePort() {
+  const listener = net.createServer();
+  await new Promise((resolve, reject) => {
+    listener.once('error', reject);
+    listener.listen(0, '127.0.0.1', resolve);
+  });
+  const address = listener.address();
+  assert.ok(address && typeof address === 'object');
+  const selectedPort = address.port;
+  await new Promise((resolve, reject) => listener.close((error) => (
+    error ? reject(error) : resolve()
+  )));
+  return selectedPort;
+}
+
+async function waitForServer(url, child) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`isolated Tessera server exited with code ${child.exitCode}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // The development server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`timed out waiting for isolated Tessera server at ${url}`);
+}

--- a/tests/terminal-contract.test.mjs
+++ b/tests/terminal-contract.test.mjs
@@ -418,7 +418,7 @@ test('server filesystem reads resolve WSL POSIX paths before calling node fs', (
   assert.match(sessionFileRouteSource, /resolveSessionWorkspaceFilesystemRoot\(id\)/);
   assert.match(sessionFileRouteSource, /getFilesystemPathModule\(root\)/);
   assert.match(sessionFilesRouteSource, /resolveSessionWorkspaceFilesystemRoot\(id\)/);
-  assert.match(sessionFilesRouteSource, /workspaceFileWatchManager\.getIndexedSnapshotForRoot\(root\)/);
+  assert.match(sessionFilesRouteSource, /workspaceFileWatchManager\.ensureSnapshotForRoot\(root\)/);
   assert.match(sessionFilesRouteSource, /walkWorkspaceFiles\(root\)/);
   assert.match(projectsRouteSource, /resolveBrowsePath\(\n\s+folderPath,\n\s+settings\.agentEnvironment,/);
   assert.match(archiveServiceSource, /pathExists\(workDir\)/);

--- a/tests/workspace-file-watch-manager.test.ts
+++ b/tests/workspace-file-watch-manager.test.ts
@@ -3,9 +3,13 @@ import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { WorkspaceFileWatchManager } from '@/lib/workspace-files/workspace-file-watch-manager';
+import {
+  isWindowsHostedWslRoot,
+  WorkspaceFileWatchManager,
+} from '@/lib/workspace-files/workspace-file-watch-manager';
 
 interface TestWatchEntry {
+  bridgeActive: boolean;
   closeTimer: NodeJS.Timeout | null;
   debounceTimer: NodeJS.Timeout | null;
   files: Set<string>;
@@ -31,6 +35,17 @@ function waitFor<T>(promise: Promise<T>, timeoutMs = 5_000): Promise<T> {
     }),
   ]);
 }
+
+test('only Windows-hosted WSL roots bypass chokidar', () => {
+  assert.equal(
+    isWindowsHostedWslRoot('\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\project'),
+    true,
+  );
+  assert.equal(isWindowsHostedWslRoot('//wsl$/Ubuntu-24.04/home/work/project'), true);
+  assert.equal(isWindowsHostedWslRoot('\\\\fileserver\\share\\project'), false);
+  assert.equal(isWindowsHostedWslRoot('C:\\Users\\work\\project'), false);
+  assert.equal(isWindowsHostedWslRoot('/home/work/project'), false);
+});
 
 test('internal root listener observes file changes without a websocket subscriber and disposes cleanly', async () => {
   const root = mkdtempSync(path.join(tmpdir(), 'tessera-workspace-watch-'));
@@ -139,6 +154,14 @@ test('poll-mode refresh diffs the index, notifies listeners, and delays teardown
   assert.ok(entry.files.has('added.txt'));
   assert.ok(entry.files.has('seed.txt'));
   assert.ok(changeCount >= 2, `listener should observe poll diff (changeCount=${changeCount})`);
+
+  const beforeContentOnlyRefresh = changeCount;
+  writeFileSync(path.join(root, 'seed.txt'), 'changed content');
+  await internals.refreshPollIndex(entry);
+  assert.ok(
+    changeCount > beforeContentOnlyRefresh,
+    'bridge fallback should invalidate listeners for content-only changes',
+  );
 
   rmSync(path.join(root, 'added.txt'));
   await internals.refreshPollIndex(entry);

--- a/tests/workspace-file-watch-manager.test.ts
+++ b/tests/workspace-file-watch-manager.test.ts
@@ -1,9 +1,26 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { WorkspaceFileWatchManager } from '@/lib/workspace-files/workspace-file-watch-manager';
+
+interface TestWatchEntry {
+  closeTimer: NodeJS.Timeout | null;
+  debounceTimer: NodeJS.Timeout | null;
+  files: Set<string>;
+  readyPromise: Promise<void>;
+  watchMode: 'watch' | 'poll';
+  watcher: { close(): Promise<void> } | null;
+}
+
+function managerInternals(manager: WorkspaceFileWatchManager): {
+  entriesByRoot: Map<string, TestWatchEntry>;
+  refreshPollIndex(entry: TestWatchEntry): Promise<void>;
+  closeEntryNow(entry: TestWatchEntry): void;
+} {
+  return manager as unknown as ReturnType<typeof managerInternals>;
+}
 
 function waitFor<T>(promise: Promise<T>, timeoutMs = 5_000): Promise<T> {
   return Promise.race([
@@ -83,4 +100,56 @@ test('disposing immediately after a write flushes the pending root change', asyn
   assert.equal(changeCount, 2);
   await new Promise((resolve) => setTimeout(resolve, 400));
   assert.equal(changeCount, 2);
+});
+
+test('ensureSnapshotForRoot stays passive for watch-capable roots without an entry', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'tessera-workspace-ensure-'));
+  writeFileSync(path.join(root, 'present.txt'), 'x');
+  const manager = new WorkspaceFileWatchManager();
+
+  assert.equal(await manager.ensureSnapshotForRoot(root), null);
+  assert.equal(managerInternals(manager).entriesByRoot.size, 0);
+});
+
+test('poll-mode refresh diffs the index, notifies listeners, and delays teardown', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'tessera-workspace-poll-'));
+  writeFileSync(path.join(root, 'seed.txt'), 'seed');
+  const manager = new WorkspaceFileWatchManager();
+  const internals = managerInternals(manager);
+  let changeCount = 0;
+
+  const dispose = await manager.subscribeRootChanges({
+    listenerId: 'terminal:poll-test',
+    root,
+    onChange: () => { changeCount += 1; },
+  });
+  const canonicalRoot = realpathSync(root);
+  const entry = internals.entriesByRoot.get(canonicalRoot);
+  assert.ok(entry);
+  await entry.readyPromise;
+  await waitFor((async () => { while (changeCount < 1) await new Promise((r) => setTimeout(r, 10)); })());
+
+  // Simulate a network-share root: no watcher, poll-based indexing.
+  await entry.watcher?.close();
+  entry.watcher = null;
+  entry.watchMode = 'poll';
+
+  writeFileSync(path.join(root, 'added.txt'), 'new');
+  await internals.refreshPollIndex(entry);
+  assert.ok(entry.files.has('added.txt'));
+  assert.ok(entry.files.has('seed.txt'));
+  assert.ok(changeCount >= 2, `listener should observe poll diff (changeCount=${changeCount})`);
+
+  rmSync(path.join(root, 'added.txt'));
+  await internals.refreshPollIndex(entry);
+  assert.equal(entry.files.has('added.txt'), false);
+
+  // Poll entries are kept warm briefly instead of closing on last unsubscribe.
+  dispose();
+  assert.ok(internals.entriesByRoot.has(canonicalRoot), 'poll entry should linger after dispose');
+  assert.ok(entry.closeTimer, 'poll entry should have a scheduled close');
+  clearTimeout(entry.closeTimer);
+  entry.closeTimer = null;
+  internals.closeEntryNow(entry);
+  assert.equal(internals.entriesByRoot.has(canonicalRoot), false);
 });

--- a/tests/wsl-inotify-bridge.test.ts
+++ b/tests/wsl-inotify-bridge.test.ts
@@ -75,14 +75,21 @@ test('parseWslRunningDistros reads wsl.exe --list --running output', () => {
   assert.deepEqual(parseWslRunningDistros('U\0b\0u\0n\0t\0u\0\r\0\n\0'), ['Ubuntu']);
 });
 
-test('buildInotifyExcludeRegex skips ignored and hidden trees only', () => {
-  const regex = new RegExp(buildInotifyExcludeRegex());
+test('buildInotifyExcludeRegex skips high-churn descendants without excluding a hidden root', () => {
+  const regex = new RegExp(buildInotifyExcludeRegex('/home/work/proj'));
   assert.ok(regex.test('/home/work/proj/node_modules/pkg/index.js'));
   assert.ok(regex.test('/home/work/proj/.git/HEAD'));
   assert.ok(regex.test('/home/work/proj/.next/'));
   assert.ok(regex.test('/home/work/proj/dist'));
-  assert.ok(regex.test('/home/work/proj/src/.hidden/file.ts'));
+  assert.equal(regex.test('/home/work/proj/src/.hidden/file.ts'), false);
+  assert.equal(regex.test('/home/work/proj/.env.example'), false);
   assert.equal(regex.test('/home/work/proj/src/app/route.ts'), false);
   assert.equal(regex.test('/home/work/proj/distribution/file.ts'), false);
   assert.equal(regex.test('/home/work/proj/outbox/file.ts'), false);
+
+  const hiddenRootRegex = new RegExp(
+    buildInotifyExcludeRegex('/home/work/.tessera/worktrees/proj'),
+  );
+  assert.equal(hiddenRootRegex.test('/home/work/.tessera/worktrees/proj/src/app.ts'), false);
+  assert.ok(hiddenRootRegex.test('/home/work/.tessera/worktrees/proj/node_modules/pkg/index.js'));
 });

--- a/tests/wsl-inotify-bridge.test.ts
+++ b/tests/wsl-inotify-bridge.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildInotifyExcludeRegex,
+  parseInotifyLine,
+  parseWslRunningDistros,
+  parseWslUncRoot,
+} from '@/lib/workspace-files/wsl-inotify-bridge';
+
+test('parseWslUncRoot extracts distro and posix path from wsl UNC roots', () => {
+  assert.deepEqual(
+    parseWslUncRoot('\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\proj'),
+    { distro: 'Ubuntu-24.04', posixPath: '/home/work/proj' },
+  );
+  assert.deepEqual(
+    parseWslUncRoot('//wsl.localhost/Ubuntu-24.04/home/work/proj'),
+    { distro: 'Ubuntu-24.04', posixPath: '/home/work/proj' },
+  );
+  assert.deepEqual(
+    parseWslUncRoot('\\\\wsl$\\Debian\\srv'),
+    { distro: 'Debian', posixPath: '/srv' },
+  );
+  assert.equal(parseWslUncRoot('\\\\fileserver\\share\\dir'), null);
+  assert.equal(parseWslUncRoot('/home/work/proj'), null);
+  assert.equal(parseWslUncRoot('C:\\Users\\work'), null);
+  assert.equal(parseWslUncRoot('\\\\wsl.localhost\\Ubuntu-24.04'), null);
+});
+
+test('parseInotifyLine maps inotifywait events onto watch events', () => {
+  const root = '/home/work/proj';
+  assert.deepEqual(
+    parseInotifyLine('CREATE|/home/work/proj/src/new.ts', root),
+    { eventName: 'add', relativePath: 'src/new.ts' },
+  );
+  assert.deepEqual(
+    parseInotifyLine('CREATE,ISDIR|/home/work/proj/src/lib', root),
+    { eventName: 'addDir', relativePath: 'src/lib' },
+  );
+  assert.deepEqual(
+    parseInotifyLine('DELETE|/home/work/proj/old.txt', root),
+    { eventName: 'unlink', relativePath: 'old.txt' },
+  );
+  assert.deepEqual(
+    parseInotifyLine('MOVED_FROM,ISDIR|/home/work/proj/gone', root),
+    { eventName: 'unlinkDir', relativePath: 'gone' },
+  );
+  assert.deepEqual(
+    parseInotifyLine('MOVED_TO|/home/work/proj/renamed.md', root),
+    { eventName: 'add', relativePath: 'renamed.md' },
+  );
+  assert.deepEqual(
+    parseInotifyLine('CLOSE_WRITE,CLOSE|/home/work/proj/edited.ts\r', root),
+    { eventName: 'change', relativePath: 'edited.ts' },
+  );
+  assert.deepEqual(
+    parseInotifyLine('MODIFY|/home/work/proj/edited.ts', root),
+    { eventName: 'change', relativePath: 'edited.ts' },
+  );
+
+  assert.equal(parseInotifyLine('MODIFY,ISDIR|/home/work/proj/dir', root), null);
+  assert.equal(parseInotifyLine('CREATE|/home/other/file.txt', root), null);
+  assert.equal(parseInotifyLine('CREATE|/home/work/proj', root), null);
+  assert.equal(parseInotifyLine('OPEN|/home/work/proj/read.txt', root), null);
+  assert.equal(parseInotifyLine('not-an-event-line', root), null);
+});
+
+test('parseWslRunningDistros reads wsl.exe --list --running output', () => {
+  assert.deepEqual(parseWslRunningDistros('Ubuntu-24.04\r\n'), ['Ubuntu-24.04']);
+  assert.deepEqual(
+    parseWslRunningDistros('Ubuntu-24.04\r\nDebian\r\n'),
+    ['Ubuntu-24.04', 'Debian'],
+  );
+  assert.deepEqual(parseWslRunningDistros(''), []);
+  // Stray NULs from a mis-decoded UTF-16 stream must not break matching.
+  assert.deepEqual(parseWslRunningDistros('U\0b\0u\0n\0t\0u\0\r\0\n\0'), ['Ubuntu']);
+});
+
+test('buildInotifyExcludeRegex skips ignored and hidden trees only', () => {
+  const regex = new RegExp(buildInotifyExcludeRegex());
+  assert.ok(regex.test('/home/work/proj/node_modules/pkg/index.js'));
+  assert.ok(regex.test('/home/work/proj/.git/HEAD'));
+  assert.ok(regex.test('/home/work/proj/.next/'));
+  assert.ok(regex.test('/home/work/proj/dist'));
+  assert.ok(regex.test('/home/work/proj/src/.hidden/file.ts'));
+  assert.equal(regex.test('/home/work/proj/src/app/route.ts'), false);
+  assert.equal(regex.test('/home/work/proj/distribution/file.ts'), false);
+  assert.equal(regex.test('/home/work/proj/outbox/file.ts'), false);
+});


### PR DESCRIPTION
## What changed

- Watch WSL workspaces through an in-distro `inotifywait` bridge with a bounded polling fallback.
- Prevent watcher work from stalling PTY traffic and flush pending changes safely on shutdown.
- Synchronize the selected runtime environment before folder browsing.
- Add a persisted show-hidden-files toggle to workspace file panels.

## Why

Windows-hosted UNC watching is slow and unreliable for WSL trees, while folder browsing could run before the selected distro environment was ready.

## Impact

WSL workspace changes appear in real time, folder selection uses the correct environment, and hidden files can be shown on demand.

## Validation

- `npm run server:compile`
- `npm run electron:compile`
- Workspace watcher and WSL bridge Node/tsx tests
- Folder-browser Playwright end-to-end script
- Targeted ESLint on changed workspace, API, and Electron files
