### PR TITLE
perf(context): show runtime paths without repeated login shells

### DIFF
--- a/src/app/api/sessions/[id]/memory/route.ts
+++ b/src/app/api/sessions/[id]/memory/route.ts
@@ -21,6 +21,10 @@ import {
   resolveSessionMemoryDir,
 } from "@/lib/memory/claude-memory";
 import { getMemoryProviderKind } from "@/lib/memory/memory-provider";
+import {
+  toMemoryDisplayPath,
+  toOptionalMemoryDisplayPath,
+} from "@/lib/memory/memory-display-path";
 import type { MemoryListData } from "@/types/memory";
 
 export async function GET(
@@ -57,9 +61,14 @@ export async function GET(
         sessionId: id,
         provider,
         memoryDir: context.memoryDir,
+        memoryDirDisplay: toMemoryDisplayPath(context.memoryDir, agentEnvironment),
         instructionRoots: {
           user: context.codexHome,
           project: context.projectRoot,
+        },
+        instructionRootsDisplay: {
+          user: toMemoryDisplayPath(context.codexHome, agentEnvironment),
+          project: toOptionalMemoryDisplayPath(context.projectRoot, agentEnvironment),
         },
         root: "project",
         exists: context.exists,
@@ -81,9 +90,14 @@ export async function GET(
         sessionId: id,
         provider,
         memoryDir: context.opencodeConfigDir,
+        memoryDirDisplay: toMemoryDisplayPath(context.opencodeConfigDir, agentEnvironment),
         instructionRoots: {
           user: context.opencodeConfigDir,
           project: context.projectRoot,
+        },
+        instructionRootsDisplay: {
+          user: toMemoryDisplayPath(context.opencodeConfigDir, agentEnvironment),
+          project: toOptionalMemoryDisplayPath(context.projectRoot, agentEnvironment),
         },
         root: "project",
         exists: false,
@@ -112,9 +126,14 @@ export async function GET(
       sessionId: id,
       provider,
       memoryDir: context.memoryDir,
+      memoryDirDisplay: toMemoryDisplayPath(context.memoryDir, agentEnvironment),
       instructionRoots: {
         user: userInstructionRoot,
         project: projectInstructionRoot,
+      },
+      instructionRootsDisplay: {
+        user: toMemoryDisplayPath(userInstructionRoot, agentEnvironment),
+        project: toOptionalMemoryDisplayPath(projectInstructionRoot, agentEnvironment),
       },
       root: context.root,
       exists: context.exists,

--- a/src/components/memory/memory-panel.tsx
+++ b/src/components/memory/memory-panel.tsx
@@ -56,7 +56,10 @@ interface MemoryRowItem {
   fileName: string;
   relativePath: string;
   icon: ReactNode;
+  /** Host filesystem path, used by the context menu's open/reveal actions. */
   path: string;
+  /** Path as the session's CLI sees it; what the user is shown. */
+  displayPath: string;
   description: string;
   statusLabel?: string;
   shadowed?: boolean;
@@ -260,6 +263,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
         relativePath: guideline.fileName,
         icon: <BookText className="h-3.5 w-3.5 shrink-0 text-(--text-muted)" />,
         path: guideline.path,
+        displayPath: guideline.displayPath,
         description: statusLabel,
         statusLabel,
         shadowed: guideline.status === "shadowed",
@@ -278,6 +282,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
         ? <BookOpen className="h-3.5 w-3.5 shrink-0 text-(--accent)" />
         : <FileText className="h-3.5 w-3.5 shrink-0 text-(--text-muted)" />,
       path: joinDisplayPath(data.memoryDir, file.relativePath),
+      displayPath: joinDisplayPath(data.memoryDirDisplay, file.relativePath),
       description: getMemoryFileDescription(data.provider, file, t),
       type: file.type,
       emphasis: file.isIndex || file.relativePath === "memory_summary.md",
@@ -300,7 +305,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           key: "user-scope",
           title: t("memoryPanel.sections.userScopeTitle"),
           description: t("memoryPanel.sections.codexUserScopeDescription"),
-          folderPath: globalGuidelines[0] ? getDisplayDir(globalGuidelines[0].path) : data.instructionRoots.user,
+          folderPath: globalGuidelines[0] ? getDisplayDir(globalGuidelines[0].displayPath) : data.instructionRootsDisplay.user,
           icon: <User className="h-3.5 w-3.5 text-(--text-muted)" />,
           rows: globalGuidelines,
           emptyLabel: t("memoryPanel.empty.noUserInstructions"),
@@ -309,7 +314,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           key: "project-scope",
           title: t("memoryPanel.sections.projectScopeTitle"),
           description: t("memoryPanel.sections.codexProjectScopeDescription"),
-          folderPath: projectGuidelines[0] ? getDisplayDir(projectGuidelines[0].path) : data.instructionRoots.project ?? "",
+          folderPath: projectGuidelines[0] ? getDisplayDir(projectGuidelines[0].displayPath) : data.instructionRootsDisplay.project ?? "",
           icon: <Folder className="h-3.5 w-3.5 text-(--text-muted)" />,
           rows: projectGuidelines,
           emptyLabel: t("memoryPanel.empty.noProjectInstructions"),
@@ -318,7 +323,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           key: "user-global-memory",
           title: t("memoryPanel.sections.codexGlobalMemoryTitle"),
           description: t("memoryPanel.sections.codexGlobalMemoryDescription"),
-          folderPath: data.memoryDir,
+          folderPath: data.memoryDirDisplay,
           icon: <Brain className="h-3.5 w-3.5 text-(--text-muted)" />,
           rows: globalMemoryRows,
         },
@@ -326,7 +331,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           key: "rollout-summaries",
           title: t("memoryPanel.sections.rolloutSummariesTitle"),
           description: t("memoryPanel.sections.rolloutSummariesDescription"),
-          folderPath: joinDisplayPath(data.memoryDir, "rollout_summaries"),
+          folderPath: joinDisplayPath(data.memoryDirDisplay, "rollout_summaries"),
           icon: <FileText className="h-3.5 w-3.5 text-(--text-muted)" />,
           rows: rolloutRows,
         },
@@ -334,7 +339,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           key: "ad-hoc-notes",
           title: t("memoryPanel.sections.adHocNotesTitle"),
           description: t("memoryPanel.sections.adHocNotesDescription"),
-          folderPath: joinDisplayPath(data.memoryDir, "extensions/ad_hoc/notes"),
+          folderPath: joinDisplayPath(data.memoryDirDisplay, "extensions/ad_hoc/notes"),
           icon: <BookText className="h-3.5 w-3.5 text-(--text-muted)" />,
           rows: adHocRows,
         },
@@ -342,7 +347,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           key: "memory-skills",
           title: t("memoryPanel.sections.memorySkillsTitle"),
           description: t("memoryPanel.sections.memorySkillsDescription"),
-          folderPath: joinDisplayPath(data.memoryDir, "skills"),
+          folderPath: joinDisplayPath(data.memoryDirDisplay, "skills"),
           icon: <BookOpen className="h-3.5 w-3.5 text-(--text-muted)" />,
           rows: skillRows,
         },
@@ -359,7 +364,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           key: "user-scope",
           title: t("memoryPanel.sections.userScopeTitle"),
           description: t("memoryPanel.sections.opencodeUserScopeDescription"),
-          folderPath: data.instructionRoots.user,
+          folderPath: data.instructionRootsDisplay.user,
           icon: <User className="h-3.5 w-3.5 text-(--text-muted)" />,
           rows: globalGuidelines,
           emptyLabel: t("memoryPanel.empty.noUserInstructions"),
@@ -368,7 +373,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           key: "project-scope",
           title: t("memoryPanel.sections.projectScopeTitle"),
           description: t("memoryPanel.sections.opencodeProjectScopeDescription"),
-          folderPath: data.instructionRoots.project ?? "",
+          folderPath: data.instructionRootsDisplay.project ?? "",
           icon: <Folder className="h-3.5 w-3.5 text-(--text-muted)" />,
           rows: projectGuidelines,
           emptyLabel: t("memoryPanel.empty.noProjectInstructions"),
@@ -381,7 +386,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           key: "user-scope",
           title: t("memoryPanel.sections.userScopeTitle"),
           description: t("memoryPanel.sections.claudeUserScopeDescription"),
-          folderPath: globalGuidelines[0] ? getDisplayDir(globalGuidelines[0].path) : data.instructionRoots.user,
+          folderPath: globalGuidelines[0] ? getDisplayDir(globalGuidelines[0].displayPath) : data.instructionRootsDisplay.user,
           icon: <User className="h-3.5 w-3.5 text-(--text-muted)" />,
           rows: globalGuidelines,
           emptyLabel: t("memoryPanel.empty.noUserInstructions"),
@@ -390,7 +395,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           key: "project-scope",
           title: t("memoryPanel.sections.projectScopeTitle"),
           description: t("memoryPanel.sections.claudeProjectScopeDescription"),
-          folderPath: projectGuidelines[0] ? getDisplayDir(projectGuidelines[0].path) : data.instructionRoots.project ?? "",
+          folderPath: projectGuidelines[0] ? getDisplayDir(projectGuidelines[0].displayPath) : data.instructionRootsDisplay.project ?? "",
           icon: <Folder className="h-3.5 w-3.5 text-(--text-muted)" />,
           rows: projectGuidelines,
           emptyLabel: t("memoryPanel.empty.noProjectInstructions"),
@@ -399,7 +404,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
         key: "project-memory",
         title: t("memoryPanel.sections.claudeProjectMemoryTitle"),
         description: t("memoryPanel.sections.claudeProjectMemoryDescription"),
-        folderPath: data.memoryDir,
+        folderPath: data.memoryDirDisplay,
         icon: <Brain className="h-3.5 w-3.5 text-(--text-muted)" />,
         rows: projectMemoryRows,
         emptyLabel: t("memoryPanel.empty.noMemoryFiles"),
@@ -519,7 +524,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
           onClick={() => openRow(row, false)}
           onDoubleClick={() => openRow(row, true)}
           className="flex w-full min-w-0 items-start gap-2 py-1.5 pl-8 pr-8 text-left"
-          title={row.path}
+          title={row.displayPath}
           data-testid={`memory-row-${row.kind}-${row.relativePath}`}
         >
           <span className="mt-0.5">{row.icon}</span>
@@ -645,7 +650,7 @@ export function MemoryPanel({ sessionId }: { sessionId: string | null }) {
         <EmptyState
           title={t("memoryPanel.empty.noFilesTitle")}
           body={t("memoryPanel.empty.noFilesBody", {
-            path: state.data?.memoryDir ?? t("memoryPanel.empty.providerMemoryFolder"),
+            path: state.data?.memoryDirDisplay ?? t("memoryPanel.empty.providerMemoryFolder"),
           })}
           action={canCreateProjectMemory ? (
             <Button

--- a/src/lib/cli/cli-exec.ts
+++ b/src/lib/cli/cli-exec.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { getRuntimePlatform } from '../system/runtime-platform';
 import { getSpawnCliCache } from './spawn-cli-cache';
-import { spawnCliProcess } from './spawn-cli-runtime';
+import { spawnCliProcess, type SpawnCliRuntimeOptions } from './spawn-cli-runtime';
 
 export interface ExecResult {
   /** True iff the process closed with exit code 0 AND did not time out. */
@@ -56,6 +56,12 @@ export function __resetWslDetectionCacheForTests(): void {
  * Routing is delegated to spawn-cli-runtime so status probes and real sessions
  * resolve Windows npm shims (`*.cmd`, `*.ps1`) the same way.
  *
+ * `runtimeOptions.loginShell: false` skips the user's `-i -l` login shell on the
+ * WSL bridge (no rc sourcing — hundreds of ms saved per call). Only pass it for
+ * probes whose command lives on WSL's default PATH and needs nothing from the
+ * user's rc (e.g. `wslpath`, which uses only `$HOME`). Omitting it keeps the
+ * login shell, so existing 4-argument callers are unchanged.
+ *
  * Never throws — all failure modes map to `{ ok: false, ... }`.
  */
 export async function execCli(
@@ -63,6 +69,7 @@ export async function execCli(
   args: string[],
   environment: CliEnvironment,
   timeoutMs: number,
+  runtimeOptions?: SpawnCliRuntimeOptions,
 ): Promise<ExecResult> {
   return new Promise((resolve) => {
     const startedAt = Date.now();
@@ -70,7 +77,7 @@ export async function execCli(
       windowsHide: true,
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
-    }, environment, getSpawnCliCache());
+    }, environment, getSpawnCliCache(), runtimeOptions);
 
     let stdout = '';
     let stderr = '';

--- a/src/lib/cli/spawn-cli-runtime.ts
+++ b/src/lib/cli/spawn-cli-runtime.ts
@@ -150,18 +150,30 @@ function resolveLinuxSupplementalCliPath(): string | null {
     : null;
 }
 
+export interface SpawnCliRuntimeOptions {
+  // When false, the WSL bridge runs the command in a plain non-login,
+  // non-interactive shell instead of the user's `-i -l` login shell. This skips
+  // sourcing the user's rc files (nvm, oh-my-zsh, powerlevel10k) on every call,
+  // which routinely costs hundreds of ms per invocation. Only safe for binaries
+  // on WSL's default PATH that don't depend on the user's shell rc for
+  // discovery or config (e.g. git). Real agent CLIs (claude, codex) still need
+  // the login shell for nvm PATH etc.
+  loginShell?: boolean;
+}
+
 export function spawnCliProcess(
   command: string,
   args: string[],
   options: SpawnOptions,
   agentEnv: AgentEnvironment,
   cache: SpawnCliCache,
+  runtimeOptions?: SpawnCliRuntimeOptions,
 ): ChildProcess {
   const env = buildSpawnEnvironment((options.env as NodeJS.ProcessEnv) ?? process.env, cache);
   const spawnOptions = buildPlatformSpawnOptions(options, env);
 
   if (agentEnv === 'wsl' && getRuntimePlatform() === 'win32') {
-    return spawnWslCli(command, args, spawnOptions, cache, env);
+    return spawnWslCli(command, args, spawnOptions, cache, env, runtimeOptions);
   }
 
   if (agentEnv === 'native' && getRuntimePlatform() === 'win32') {
@@ -529,14 +541,25 @@ function spawnWslCli(
   options: SpawnOptions,
   cache: SpawnCliCache,
   env: NodeJS.ProcessEnv,
+  runtimeOptions?: SpawnCliRuntimeOptions,
 ): ChildProcess {
   const { cwd, ...spawnOptions } = options;
-  const shell = resolveWslLoginShell(cache, env);
   const wslCwd = typeof cwd === 'string' && cwd.length > 0
     ? normalizeCwdForCliEnvironment(cwd, 'wsl')
     : null;
   const script = buildLoginShellExecScript(command, args, wslCwd);
 
+  // Fixed-path binaries (git) don't need the user's login shell; running them in
+  // a plain `sh -c` avoids the per-call cost of sourcing the user's rc files
+  // (nvm, oh-my-zsh, etc. — routinely hundreds of ms per invocation). sh exists
+  // on every distro including busybox-based ones (the login-shell probe above
+  // relies on the same fact), and WSL's default PATH covers /usr/bin, so git
+  // resolves without any rc. The exec script is POSIX-sh compatible.
+  if (runtimeOptions?.loginShell === false) {
+    return spawn('wsl', ['sh', '-c', script], spawnOptions);
+  }
+
+  const shell = resolveWslLoginShell(cache, env);
   return spawn('wsl', [shell, '-i', '-l', '-c', script], spawnOptions);
 }
 

--- a/src/lib/cli/spawn-cli.ts
+++ b/src/lib/cli/spawn-cli.ts
@@ -11,6 +11,7 @@
 import type { ChildProcess, SpawnOptions } from 'child_process';
 import { SettingsManager } from '../settings/manager';
 import type { AgentEnvironment } from '../settings/types';
+import { invalidateClaudeConfigDirCache } from '../skill/skill-loader';
 import { getSpawnCliCache } from './spawn-cli-cache';
 import {
   buildSpawnEnvironment,
@@ -60,6 +61,9 @@ export function invalidateAgentEnvironmentCache(userId?: string): void {
   }
 
   invalidateSpawnCliRuntimeCache(spawnCliCache);
+  // The Claude config dir is resolved per environment (its WSL probe spawns a
+  // process); drop it too so a native↔wsl switch cannot serve a stale path.
+  invalidateClaudeConfigDirCache();
 }
 
 /**

--- a/src/lib/cli/spawn-cli.ts
+++ b/src/lib/cli/spawn-cli.ts
@@ -19,6 +19,7 @@ import {
   normalizeCwdForCliEnvironment,
   resolveDefaultAgentEnvironment,
   spawnCliProcess,
+  type SpawnCliRuntimeOptions,
 } from './spawn-cli-runtime';
 
 const spawnCliCache = getSpawnCliCache();
@@ -85,6 +86,9 @@ export function spawnCli(
   args: string[],
   options: SpawnOptions,
   agentEnv: AgentEnvironment,
+  runtimeOptions?: SpawnCliRuntimeOptions,
 ): ChildProcess {
-  return spawnCliProcess(command, args, options, agentEnv, spawnCliCache);
+  return spawnCliProcess(command, args, options, agentEnv, spawnCliCache, runtimeOptions);
 }
+
+export type { SpawnCliRuntimeOptions };

--- a/src/lib/filesystem/path-environment.ts
+++ b/src/lib/filesystem/path-environment.ts
@@ -67,12 +67,48 @@ export async function formatBrowsePathForDisplay(
   return filesystemPath;
 }
 
+/**
+ * Rewrite a host filesystem path into the form the CLI for `environment`
+ * actually sees, so the UI never shows a path the agent could not open.
+ *
+ * Both bridges are asymmetric, and each needs the opposite translation:
+ * - Windows host, WSL agent: the server reaches the distro through
+ *   `\\wsl.localhost\<distro>\home\u` and drives through `C:\`, while the CLI
+ *   sees `/home/u` and `/mnt/c`.
+ * - WSL host, native (Windows) agent: the server reaches the Windows side
+ *   through `/mnt/c` and its own files directly, while the CLI sees `C:\` and
+ *   reaches the distro back through the `\\wsl.localhost` share.
+ *
+ * This mirrors `normalizeCwdForCliEnvironment`, which computes the cwd the CLI
+ * is actually spawned with; the two must agree, or the panel would show a path
+ * that disagrees with the directory the agent reads (the Claude memory slug is
+ * derived from that same cwd). Non-bridged setups (Windows host + native agent,
+ * Linux host + WSL agent) already share one path style, so this is a no-op.
+ */
 export function formatPathForAgentDisplay(
   filesystemPath: string,
   environment: FilesystemBrowseEnvironment,
 ): string {
-  if (environment !== 'wsl') return filesystemPath;
-  return formatWindowsHostedWslDisplayPath(filesystemPath, null);
+  if (environment === 'wsl') {
+    return formatWindowsHostedWslDisplayPath(filesystemPath, null);
+  }
+
+  if (getRuntimePlatform() === 'linux' && isRunningInWsl()) {
+    return formatWslHostedNativeDisplayPath(filesystemPath);
+  }
+
+  return filesystemPath;
+}
+
+function formatWslHostedNativeDisplayPath(filesystemPath: string): string {
+  const windowsDrivePath = wslMountPathToWindowsDrivePath(filesystemPath);
+  if (windowsDrivePath) return windowsDrivePath;
+  if (isWindowsStylePath(filesystemPath)) return filesystemPath;
+
+  // A distro-local path: a Windows CLI can only reach it over the UNC share.
+  // Without a distro name there is no share to name, so the raw path is still
+  // the most useful thing to show.
+  return buildWslUncPath(process.env.WSL_DISTRO_NAME, filesystemPath) ?? filesystemPath;
 }
 
 export function getFilesystemPathBasename(filesystemPath: string): string {

--- a/src/lib/memory/claude-memory.ts
+++ b/src/lib/memory/claude-memory.ts
@@ -7,6 +7,7 @@ import { resolveClaudeConfigDirForEnvironment } from "@/lib/skill/skill-loader";
 import { normalizeCwdForCliEnvironment } from "@/lib/cli/spawn-cli";
 import { resolveSessionWorkspaceFilesystemRoot } from "@/lib/session/session-workspace-root";
 import { isClaudeMemoryProvider } from "@/lib/memory/memory-provider";
+import { toMemoryDisplayPath } from "@/lib/memory/memory-display-path";
 import type { CliEnvironment } from "@/lib/cli/cli-exec";
 import type { SessionRow } from "@/lib/db/sessions";
 import {
@@ -283,6 +284,7 @@ export async function listGuidelines(
     label: target.label,
     fileName: "CLAUDE.md",
     path: target.absolutePath,
+    displayPath: toMemoryDisplayPath(target.absolutePath, environment),
     status: "active",
     statusLabel: "Active",
     statusReason: "active",

--- a/src/lib/memory/codex-memory.ts
+++ b/src/lib/memory/codex-memory.ts
@@ -5,6 +5,7 @@ import * as dbSessions from "@/lib/db/sessions";
 import { execCli, isRunningInWsl, type CliEnvironment } from "@/lib/cli/cli-exec";
 import { resolveSessionWorkspaceFilesystemRoot } from "@/lib/session/session-workspace-root";
 import { getMemoryProviderKind } from "@/lib/memory/memory-provider";
+import { toMemoryDisplayPath } from "@/lib/memory/memory-display-path";
 import {
   directoryExists,
   MemoryApiError,
@@ -77,7 +78,11 @@ export async function resolveCodexHomeForEnvironment(
       [
         "-NoProfile",
         "-Command",
-        "$home = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE '.codex' }; Write-Output $home",
+        // `$home` is a PowerShell automatic variable: assigning to it is a
+        // no-op, so the probe used to echo the Windows profile itself and drop
+        // the `.codex` suffix. Keep this script free of double quotes too —
+        // PowerShell strips them when forwarding arguments to a native command.
+        "$codexDir = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE '.codex' }; Write-Output $codexDir",
       ],
       "native",
       5000,
@@ -193,6 +198,7 @@ export async function listCodexGuidelines(
     label: target.label,
     fileName: target.fileName,
     path: target.absolutePath,
+    displayPath: toMemoryDisplayPath(target.absolutePath, environment),
     status: target.status,
     statusLabel: target.statusLabel,
     ...(await statFileSafe(target.absolutePath)),

--- a/src/lib/memory/codex-memory.ts
+++ b/src/lib/memory/codex-memory.ts
@@ -64,7 +64,10 @@ export async function resolveCodexHomeForEnvironment(
   if (environment === "wsl" && process.platform === "win32") {
     const result = await execCli(
       "sh",
-      ["-lc", 'printf "%s" "${CODEX_HOME:-$HOME/.codex}"'],
+      // `-c`, not `-lc` — see resolveClaudeConfigDirForEnvironment: the bridge
+      // already sourced the login shell, and a second one re-reads ~/.profile
+      // where a single broken line kills the probe.
+      ["-c", 'printf "%s" "${CODEX_HOME:-$HOME/.codex}"'],
       "wsl",
       5000,
     );

--- a/src/lib/memory/codex-memory.ts
+++ b/src/lib/memory/codex-memory.ts
@@ -62,11 +62,17 @@ export async function resolveCodexHomeForEnvironment(
   if (configuredDir) return path.resolve(configuredDir);
 
   if (environment === "wsl" && process.platform === "win32") {
+    // Intentionally keeps the login shell (no `loginShell: false`), unlike the
+    // claude/opencode probes: this reads `$CODEX_HOME`, which the user exports
+    // from their rc. The real codex CLI is also spawned through the login shell,
+    // so it sees that same `$CODEX_HOME` — dropping it here would make the panel
+    // show a different home than the CLI actually uses. Do not "optimize" this
+    // to a non-login shell for consistency; the latency is the correct trade.
     const result = await execCli(
       "sh",
-      // `-c`, not `-lc` — see resolveClaudeConfigDirForEnvironment: the bridge
-      // already sourced the login shell, and a second one re-reads ~/.profile
-      // where a single broken line kills the probe.
+      // `-c`, not `-lc`: the WSL bridge already ran this through the login shell,
+      // so a second one only re-reads ~/.profile (where a broken line can kill
+      // the probe). `$CODEX_HOME` is already exported into this shell's env.
       ["-c", 'printf "%s" "${CODEX_HOME:-$HOME/.codex}"'],
       "wsl",
       5000,

--- a/src/lib/memory/memory-display-path.ts
+++ b/src/lib/memory/memory-display-path.ts
@@ -1,0 +1,28 @@
+import { formatPathForAgentDisplay } from "@/lib/filesystem/path-environment";
+import type { CliEnvironment } from "@/lib/cli/cli-exec";
+
+/**
+ * Memory paths are resolved against the host filesystem so the server can read
+ * and write them, but a WSL bridge means that host form is not the form the
+ * CLI reads: a session running in WSL loads `/home/u/.claude/CLAUDE.md`, which
+ * the Windows-hosted server only reaches as
+ * `\\wsl.localhost\<distro>\home\u\.claude\CLAUDE.md` (and vice versa when the
+ * server itself runs inside WSL while the agent is a native Windows CLI).
+ *
+ * Showing the host form makes the panel disagree with everything the agent
+ * prints, so display paths are translated to the CLI's view while the host
+ * path is kept alongside for Electron's open/reveal actions.
+ */
+export function toMemoryDisplayPath(
+  filesystemPath: string,
+  environment: CliEnvironment,
+): string {
+  return formatPathForAgentDisplay(filesystemPath, environment);
+}
+
+export function toOptionalMemoryDisplayPath(
+  filesystemPath: string | null,
+  environment: CliEnvironment,
+): string | null {
+  return filesystemPath ? toMemoryDisplayPath(filesystemPath, environment) : null;
+}

--- a/src/lib/memory/opencode-memory.ts
+++ b/src/lib/memory/opencode-memory.ts
@@ -6,6 +6,7 @@ import { execCli, isRunningInWsl, type CliEnvironment } from "@/lib/cli/cli-exec
 import { resolveSessionWorkspaceFilesystemRoot } from "@/lib/session/session-workspace-root";
 import { resolveClaudeConfigDirForEnvironment } from "@/lib/skill/skill-loader";
 import { getMemoryProviderKind } from "@/lib/memory/memory-provider";
+import { toMemoryDisplayPath } from "@/lib/memory/memory-display-path";
 import {
   directoryExists,
   MemoryApiError,
@@ -345,6 +346,7 @@ export async function listOpenCodeGuidelines(
     label: target.label,
     fileName: target.fileName,
     path: target.absolutePath,
+    displayPath: toMemoryDisplayPath(target.absolutePath, environment),
     status: target.status,
     statusLabel: target.statusLabel,
     statusReason: target.statusReason,

--- a/src/lib/memory/opencode-memory.ts
+++ b/src/lib/memory/opencode-memory.ts
@@ -62,10 +62,14 @@ export async function resolveOpenCodeConfigDirForEnvironment(
   if (environment === "wsl" && process.platform === "win32") {
     const result = await execCli(
       "sh",
-      // `-c`, not `-lc` — see resolveClaudeConfigDirForEnvironment.
+      // `-c` + `loginShell: false`: this reads only `$HOME` (set by wsl.exe,
+      // not by rc files), so the user's login shell adds nothing but latency.
+      // See resolveClaudeConfigDirForEnvironment. NOTE: codex deliberately does
+      // NOT do this — its probe reads `$CODEX_HOME`, which lives in the rc.
       ["-c", 'printf "%s" "$HOME/.config/opencode"'],
       "wsl",
       5000,
+      { loginShell: false },
     );
     const resolvedDir = lastNonEmptyLine(result.stdout);
     if (result.ok && resolvedDir) return resolvedDir;

--- a/src/lib/memory/opencode-memory.ts
+++ b/src/lib/memory/opencode-memory.ts
@@ -62,7 +62,8 @@ export async function resolveOpenCodeConfigDirForEnvironment(
   if (environment === "wsl" && process.platform === "win32") {
     const result = await execCli(
       "sh",
-      ["-lc", 'printf "%s" "$HOME/.config/opencode"'],
+      // `-c`, not `-lc` — see resolveClaudeConfigDirForEnvironment.
+      ["-c", 'printf "%s" "$HOME/.config/opencode"'],
       "wsl",
       5000,
     );

--- a/src/lib/skill/skill-loader.ts
+++ b/src/lib/skill/skill-loader.ts
@@ -73,9 +73,16 @@ export async function resolveClaudeConfigDirForEnvironment(
   if (configuredDir) return resolve(configuredDir);
 
   if (environment === 'wsl' && process.platform === 'win32') {
+    // `-c`, not `-lc`: the WSL bridge already runs this through the user's
+    // login shell, so its rc files have been sourced and exported by the time
+    // the snippet runs. Asking for a second login shell re-reads ~/.profile,
+    // and one broken line there (`. "$HOME/.cargo/env"` after uninstalling
+    // Rust is the common one) makes a non-interactive POSIX shell exit 2
+    // before `wslpath` runs — the probe then fell back to the Windows-side
+    // home and the whole session silently pointed at the wrong `.claude`.
     const result = await execCli(
       'sh',
-      ['-lc', 'wslpath -w "$HOME/.claude" 2>/dev/null || printf %s "$HOME/.claude"'],
+      ['-c', 'wslpath -w "$HOME/.claude" 2>/dev/null || printf %s "$HOME/.claude"'],
       'wsl',
       5000,
     );

--- a/src/lib/skill/skill-loader.ts
+++ b/src/lib/skill/skill-loader.ts
@@ -66,28 +66,49 @@ function lastNonEmptyLine(value: string): string | null {
   return lines.at(-1) ?? null;
 }
 
+/**
+ * The `wsl`-on-Windows probe below spawns a `wsl.exe` process, which the Context
+ * panel resolves up to three times per open. The answer is a fixed property of
+ * the host + environment for the life of the process, so cache the resolved
+ * directory per environment and skip the repeat spawns. Only successful probe
+ * results are cached; a transient failure falls through to `getClaudeConfigDir()`
+ * (a pure homedir lookup) and is retried next time. Cleared by
+ * `invalidateClaudeConfigDirCache` when the agent environment setting changes.
+ */
+const claudeConfigDirCache = new Map<CliEnvironment, string>();
+
+export function invalidateClaudeConfigDirCache(): void {
+  claudeConfigDirCache.clear();
+}
+
 export async function resolveClaudeConfigDirForEnvironment(
   environment: CliEnvironment,
 ): Promise<string> {
   const configuredDir = process.env.CLAUDE_CONFIG_DIR?.trim();
   if (configuredDir) return resolve(configuredDir);
 
+  const cached = claudeConfigDirCache.get(environment);
+  if (cached) return cached;
+
   if (environment === 'wsl' && process.platform === 'win32') {
-    // `-c`, not `-lc`: the WSL bridge already runs this through the user's
-    // login shell, so its rc files have been sourced and exported by the time
-    // the snippet runs. Asking for a second login shell re-reads ~/.profile,
-    // and one broken line there (`. "$HOME/.cargo/env"` after uninstalling
-    // Rust is the common one) makes a non-interactive POSIX shell exit 2
-    // before `wslpath` runs — the probe then fell back to the Windows-side
-    // home and the whole session silently pointed at the wrong `.claude`.
+    // `loginShell: false` → a plain `wsl sh -c`, not the user's `-i -l` login
+    // shell. `wslpath` is on WSL's default PATH and reads only `$HOME` (set by
+    // wsl.exe from /etc/passwd, independent of rc files), so sourcing the user's
+    // rc buys nothing here — it only spends hundreds of ms per call re-reading
+    // ~/.zshrc/~/.profile (and previously tripped over a broken
+    // `. "$HOME/.cargo/env"` line). Git resolves its status the same way.
     const result = await execCli(
       'sh',
       ['-c', 'wslpath -w "$HOME/.claude" 2>/dev/null || printf %s "$HOME/.claude"'],
       'wsl',
       5000,
+      { loginShell: false },
     );
     const resolvedDir = lastNonEmptyLine(result.stdout);
-    if (result.ok && resolvedDir) return resolvedDir;
+    if (result.ok && resolvedDir) {
+      claudeConfigDirCache.set(environment, resolvedDir);
+      return resolvedDir;
+    }
   }
 
   if (environment === 'native' && isRunningInWsl()) {
@@ -98,7 +119,9 @@ export async function resolveClaudeConfigDirForEnvironment(
     // silently back to the WSL home. The cmd.exe probe needs no quoting and
     // verifies the mount exists.
     try {
-      return join(await getWslHostedWindowsHomeMountPath(), '.claude');
+      const dir = join(await getWslHostedWindowsHomeMountPath(), '.claude');
+      claudeConfigDirCache.set(environment, dir);
+      return dir;
     } catch {
       // Fall through: the Windows profile is not reachable from this distro.
     }

--- a/src/lib/skill/skill-loader.ts
+++ b/src/lib/skill/skill-loader.ts
@@ -3,6 +3,7 @@ import { join, basename, resolve } from 'path';
 import { homedir } from 'os';
 import logger from '../logger';
 import { execCli, isRunningInWsl, type CliEnvironment } from '../cli/cli-exec';
+import { getWslHostedWindowsHomeMountPath } from '../filesystem/path-environment';
 
 export interface SkillInfo {
   name: string;
@@ -83,15 +84,17 @@ export async function resolveClaudeConfigDirForEnvironment(
   }
 
   if (environment === 'native' && isRunningInWsl()) {
-    const result = await execCli(
-      'powershell.exe',
-      ['-NoProfile', '-Command', '[Environment]::GetFolderPath("UserProfile")'],
-      'native',
-      5000,
-    );
-    const windowsHome = lastNonEmptyLine(result.stdout);
-    const wslConfigDir = windowsHome ? toWslPath(`${windowsHome}\\.claude`) : null;
-    if (result.ok && wslConfigDir) return wslConfigDir;
+    // Deliberately not a PowerShell probe: reaching a Windows CLI from WSL
+    // wraps the call in an outer `powershell.exe -Command`, and PowerShell
+    // strips double quotes when it forwards arguments to a native command, so
+    // `GetFolderPath("UserProfile")` arrives unparseable and the lookup fails
+    // silently back to the WSL home. The cmd.exe probe needs no quoting and
+    // verifies the mount exists.
+    try {
+      return join(await getWslHostedWindowsHomeMountPath(), '.claude');
+    } catch {
+      // Fall through: the Windows profile is not reachable from this distro.
+    }
   }
 
   return getClaudeConfigDir();

--- a/src/lib/worktrees/git-runner.ts
+++ b/src/lib/worktrees/git-runner.ts
@@ -56,7 +56,10 @@ function runGitCommand(
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
     };
-    const child = spawnCli('git', args, options, agentEnvironment);
+    // git resolves from WSL's default PATH and needs nothing from the user's
+    // shell rc, so skip the WSL login shell here — sourcing heavy rc files
+    // (nvm, oh-my-zsh) on every git call dominated worktree creation time.
+    const child = spawnCli('git', args, options, agentEnvironment, { loginShell: false });
 
     // Reject on a timer rather than spawn's `timeout`: a wedged grandchild
     // (hook, fsmonitor) inherits the stdio pipes and keeps 'close' from

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -33,8 +33,10 @@ export interface MemoryGuidelineSummary {
   /** Human label, e.g. "Global CLAUDE.md". */
   label: string;
   fileName: string;
-  /** Absolute path for display/tooltip. */
+  /** Absolute path on the host filesystem, used to open/reveal the file. */
   path: string;
+  /** Same file as the CLI sees it; `path` on non-bridged setups. */
+  displayPath: string;
   exists: boolean;
   size: number;
   mtimeMs: number;
@@ -67,11 +69,23 @@ export interface MemoryFileSummary {
   readOnly: boolean;
 }
 
+/**
+ * Paths travel in two forms because the server and the CLI can live on
+ * different sides of a WSL bridge: the `*Display` values are what the CLI
+ * reads (and therefore what the user must see), while the plain values stay
+ * host-filesystem paths so Electron can open and reveal them. On non-bridged
+ * setups the two are identical.
+ */
 export interface MemoryListData {
   sessionId: string;
   provider: MemoryProviderKind;
   memoryDir: string;
+  memoryDirDisplay: string;
   instructionRoots: {
+    user: string;
+    project: string | null;
+  };
+  instructionRootsDisplay: {
     user: string;
     project: string | null;
   };

--- a/tests/agent-environment-paths.test.ts
+++ b/tests/agent-environment-paths.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import { formatPathForAgentDisplay } from '../src/lib/filesystem/path-environment';
+import { normalizeCwdForCliEnvironment } from '../src/lib/cli/spawn-cli-runtime';
+
+const pathEnvironmentSource = fs.readFileSync(
+  new URL('../src/lib/filesystem/path-environment.ts', import.meta.url),
+  'utf8',
+);
+const memoryListRouteSource = fs.readFileSync(
+  new URL('../src/app/api/sessions/[id]/memory/route.ts', import.meta.url),
+  'utf8',
+);
+const claudeMemorySource = fs.readFileSync(
+  new URL('../src/lib/memory/claude-memory.ts', import.meta.url),
+  'utf8',
+);
+const codexMemorySource = fs.readFileSync(
+  new URL('../src/lib/memory/codex-memory.ts', import.meta.url),
+  'utf8',
+);
+const opencodeMemorySource = fs.readFileSync(
+  new URL('../src/lib/memory/opencode-memory.ts', import.meta.url),
+  'utf8',
+);
+const memoryPanelSource = fs.readFileSync(
+  new URL('../src/components/memory/memory-panel.tsx', import.meta.url),
+  'utf8',
+);
+const skillLoaderSource = fs.readFileSync(
+  new URL('../src/lib/skill/skill-loader.ts', import.meta.url),
+  'utf8',
+);
+
+// The `wsl` branch is platform-independent: it only rewrites path shapes the
+// host uses to reach the distro, so it can be asserted on any runner.
+test('a WSL session shows the paths its CLI reads, not the host UNC form', () => {
+  assert.equal(
+    formatPathForAgentDisplay('\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\.claude\\CLAUDE.md', 'wsl'),
+    '/home/work/.claude/CLAUDE.md',
+  );
+  assert.equal(
+    formatPathForAgentDisplay('\\\\wsl$\\Ubuntu\\home\\work\\.claude', 'wsl'),
+    '/home/work/.claude',
+  );
+  // Windows drives are visible to the WSL CLI, but only under /mnt.
+  assert.equal(
+    formatPathForAgentDisplay('C:\\Users\\rs\\.claude', 'wsl'),
+    '/mnt/c/Users/rs/.claude',
+  );
+  // Already CLI-shaped paths are left alone.
+  assert.equal(formatPathForAgentDisplay('/home/work/.claude', 'wsl'), '/home/work/.claude');
+});
+
+/**
+ * The paths a session shows and the cwd its CLI is spawned with have to be the
+ * same string: the Claude memory folder is named after that cwd, so a display
+ * path that disagrees points at a directory the agent never reads. Asserting
+ * the two functions agree covers every bridge without hardcoding a host.
+ */
+/** Host paths a Windows-hosted server can hold: the distro share, drives, and
+ *  workspace paths still stored in their distro-local form. */
+const WINDOWS_HOST_PATHS = [
+  '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\proj',
+  '\\\\wsl$\\Ubuntu\\home\\work\\proj',
+  'C:\\Users\\rs\\.claude',
+  '/home/work/.claude',
+];
+
+/** Host paths a WSL-hosted server can hold: its own files, and Windows files
+ *  reached through the drive mounts. */
+const WSL_HOST_PATHS = [
+  '/home/work/.claude',
+  '/home/work/.tessera/worktrees/proj',
+  '/mnt/c/Users/rs/.claude',
+  '/',
+];
+
+function withPlatform(platform: NodeJS.Platform, run: () => void): void {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  Object.defineProperty(process, 'platform', { ...original, value: platform });
+  try {
+    run();
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
+}
+
+function assertDisplayMatchesSpawnCwd(hostPaths: string[], label: string): void {
+  for (const hostPath of hostPaths) {
+    for (const environment of ['wsl', 'native'] as const) {
+      assert.equal(
+        formatPathForAgentDisplay(hostPath, environment),
+        normalizeCwdForCliEnvironment(hostPath, environment),
+        `${environment} on ${label}: ${hostPath}`,
+      );
+    }
+  }
+}
+
+test('displayed paths match the cwd the CLI is spawned with, on every bridge', () => {
+  // Windows host: 'wsl' crosses into the distro, 'native' stays put.
+  withPlatform('win32', () => {
+    assertDisplayMatchesSpawnCwd(WINDOWS_HOST_PATHS, 'win32');
+  });
+
+  // Linux host: 'native' crosses out to Windows, but only when the host is a
+  // WSL distro — which both functions detect the same way, so this also holds
+  // on a plain Linux CI runner, where both sides collapse to a no-op.
+  assertDisplayMatchesSpawnCwd(WSL_HOST_PATHS, process.platform);
+});
+
+test('memory payloads carry both the host path and the CLI-visible path', () => {
+  assert.match(memoryListRouteSource, /memoryDirDisplay: toMemoryDisplayPath\(/);
+  assert.match(memoryListRouteSource, /instructionRootsDisplay: \{/);
+  assert.match(memoryListRouteSource, /toOptionalMemoryDisplayPath\(/);
+  for (const source of [claudeMemorySource, codexMemorySource, opencodeMemorySource]) {
+    assert.match(source, /displayPath: toMemoryDisplayPath\(target\.absolutePath, environment\)/);
+  }
+});
+
+test('the panel displays CLI paths while host actions keep the host path', () => {
+  assert.match(memoryPanelSource, /title=\{row\.displayPath\}/);
+  assert.match(memoryPanelSource, /displayPath: joinDisplayPath\(data\.memoryDirDisplay,/);
+  assert.match(memoryPanelSource, /getDisplayDir\(globalGuidelines\[0\]\.displayPath\)/);
+  assert.match(memoryPanelSource, /getDisplayDir\(projectGuidelines\[0\]\.displayPath\)/);
+  // Electron opens and reveals files on the host, so those keep the host path.
+  assert.match(memoryPanelSource, /absolutePath: row\.path/);
+  assert.match(memoryPanelSource, /path: joinDisplayPath\(data\.memoryDir,/);
+});
+
+/**
+ * Probing the Windows side from WSL goes through an outer
+ * `powershell.exe -Command` wrapper (spawnWindowsNativeCliViaPowerShell), and
+ * PowerShell strips double quotes when it forwards arguments to a native
+ * command. A probe that quotes with `"` therefore arrives unparseable and the
+ * caller silently falls back to the WSL-local directory — the agent then reads
+ * a config folder no Windows CLI ever writes.
+ */
+function powerShellProbeScripts(source: string): string[] {
+  return [...source.matchAll(/["']-Command["'],\s*(?:\/\/[^\n]*\n\s*)*("(?:[^"\\]|\\.)*")/g)]
+    .map((match) => match[1]);
+}
+
+test('WSL-to-Windows probes survive PowerShell argument forwarding', () => {
+  const probes = [
+    ...powerShellProbeScripts(codexMemorySource),
+    ...powerShellProbeScripts(opencodeMemorySource),
+    ...powerShellProbeScripts(skillLoaderSource),
+  ];
+  assert.ok(probes.length > 0, 'expected to find PowerShell probe scripts');
+
+  for (const probe of probes) {
+    assert.doesNotMatch(probe, /\\"/, `probe must not use double quotes: ${probe}`);
+    // Assigning to a PowerShell automatic variable is a silent no-op, so the
+    // probe would echo the untouched built-in value instead of its own result.
+    assert.doesNotMatch(
+      probe,
+      /\$(home|host|args|input|pwd|profile|error|matches)\s*=/i,
+      `probe must not assign a PowerShell automatic variable: ${probe}`,
+    );
+  }
+});
+
+/** Comments explain the traps by name, so only executable code is checked. */
+function withoutLineComments(source: string): string {
+  return source.replace(/^[^\n'"`]*\/\/.*$/gm, '');
+}
+
+test('the Claude config dir is probed with the verified cmd.exe home lookup', () => {
+  assert.match(skillLoaderSource, /environment === 'native' && isRunningInWsl\(\)/);
+  assert.match(skillLoaderSource, /getWslHostedWindowsHomeMountPath\(\)/);
+  assert.doesNotMatch(withoutLineComments(skillLoaderSource), /GetFolderPath/);
+});

--- a/tests/agent-environment-paths.test.ts
+++ b/tests/agent-environment-paths.test.ts
@@ -173,3 +173,21 @@ test('the Claude config dir is probed with the verified cmd.exe home lookup', ()
   assert.match(skillLoaderSource, /getWslHostedWindowsHomeMountPath\(\)/);
   assert.doesNotMatch(withoutLineComments(skillLoaderSource), /GetFolderPath/);
 });
+
+/**
+ * The WSL bridge already runs these through the user's login shell, so the
+ * snippet must not ask for a second one. `sh -lc` re-reads ~/.profile, and a
+ * single broken line there (`. "$HOME/.cargo/env"` after removing Rust) makes
+ * a non-interactive POSIX shell exit 2 before the snippet runs — the probe
+ * then falls back to the *Windows* home and the whole session points at a
+ * `.claude` the agent never reads.
+ */
+test('WSL probes do not spawn a second login shell', () => {
+  for (const [name, source] of [
+    ['skill-loader', skillLoaderSource],
+    ['codex-memory', codexMemorySource],
+    ['opencode-memory', opencodeMemorySource],
+  ] as const) {
+    assert.doesNotMatch(source, /["']-lc["']/, `${name} must probe with sh -c, not sh -lc`);
+  }
+});

--- a/tests/memory-config-dir-perf.test.ts
+++ b/tests/memory-config-dir-perf.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import {
+  invalidateClaudeConfigDirCache,
+  resolveClaudeConfigDirForEnvironment,
+} from '../src/lib/skill/skill-loader';
+
+const skillLoaderSource = fs.readFileSync(
+  new URL('../src/lib/skill/skill-loader.ts', import.meta.url),
+  'utf8',
+);
+const codexMemorySource = fs.readFileSync(
+  new URL('../src/lib/memory/codex-memory.ts', import.meta.url),
+  'utf8',
+);
+const opencodeMemorySource = fs.readFileSync(
+  new URL('../src/lib/memory/opencode-memory.ts', import.meta.url),
+  'utf8',
+);
+const spawnCliSource = fs.readFileSync(
+  new URL('../src/lib/cli/spawn-cli.ts', import.meta.url),
+  'utf8',
+);
+const cliExecSource = fs.readFileSync(
+  new URL('../src/lib/cli/cli-exec.ts', import.meta.url),
+  'utf8',
+);
+
+/** The probe block for one CLI environment: from the environment guard to the
+ *  `execCli(` call plus its argument list, with line comments stripped. Comments
+ *  here explain the login-shell trade-off by name (`loginShell: false`), so they
+ *  must not count as code — only the actual call should. Lets each provider be
+ *  asserted in isolation without matching another provider's probe. */
+function wslProbeBlock(source: string): string {
+  const start = source.indexOf(`environment === "wsl" && process.platform === "win32"`);
+  const alt = source.indexOf(`environment === 'wsl' && process.platform === 'win32'`);
+  const from = start === -1 ? alt : start;
+  assert.notEqual(from, -1, 'expected a wsl+win32 probe block');
+  const call = source.indexOf('execCli', from);
+  // include the whole execCli(...) call — up to the line with the closing `);`
+  const end = source.indexOf(');', call);
+  const block = source.slice(from, end + 2);
+  return block.replace(/^[^\n'"`]*\/\/.*$/gm, '');
+}
+
+// ── Login-shell cost: claude/opencode skip it, codex must keep it ────────────
+//
+// The wsl-on-Windows config-dir probe spawns `wsl <shell> -c`. Using the user's
+// `-i -l` login shell re-sources their rc (nvm, oh-my-zsh, p10k) on every call —
+// hundreds of ms, three times per Context-tab open. `wslpath`/`$HOME` need none
+// of that, so claude and opencode pass `loginShell: false`. codex must NOT: its
+// probe reads `$CODEX_HOME` from the rc, and the real codex CLI is spawned
+// through the login shell, so the panel would otherwise disagree with the CLI.
+
+test('claude config-dir probe skips the login shell', () => {
+  assert.match(wslProbeBlock(skillLoaderSource), /loginShell:\s*false/);
+});
+
+test('opencode config-dir probe skips the login shell', () => {
+  assert.match(wslProbeBlock(opencodeMemorySource), /loginShell:\s*false/);
+});
+
+test('codex home probe keeps the login shell (reads $CODEX_HOME from rc)', () => {
+  const block = wslProbeBlock(codexMemorySource);
+  assert.doesNotMatch(block, /loginShell:\s*false/,
+    'codex must keep the login shell so it sees the same $CODEX_HOME the CLI does');
+  assert.match(block, /CODEX_HOME/, 'sanity: this is the codex probe');
+});
+
+// ── execCli must be able to forward the flag ─────────────────────────────────
+
+test('execCli accepts runtimeOptions and forwards them to the spawn', () => {
+  assert.match(cliExecSource, /runtimeOptions\?: SpawnCliRuntimeOptions/);
+  assert.match(cliExecSource, /getSpawnCliCache\(\), runtimeOptions\)/);
+});
+
+// ── The result is cached, and the cache is cleared on settings change ────────
+
+test('config-dir resolution is memoized per environment and invalidatable', () => {
+  assert.match(skillLoaderSource, /claudeConfigDirCache\b/);
+  assert.match(skillLoaderSource, /export function invalidateClaudeConfigDirCache/);
+  // Only successful probe results are cached — a fallback must be retried.
+  assert.match(skillLoaderSource, /claudeConfigDirCache\.set\(environment, resolvedDir\)/);
+  // The settings-change hook drops it, so a native↔wsl switch cannot go stale.
+  assert.match(spawnCliSource, /invalidateClaudeConfigDirCache\(\)/);
+});
+
+// ── Behavioural: a second call returns the same answer without recomputing ───
+//
+// Runs on any host: whichever branch resolves the dir, calling twice must be
+// stable, and invalidating must not change a stable answer. Also guards the
+// CLAUDE_CONFIG_DIR early-return, which must win over any cached value.
+
+test('repeated resolution is stable and cache-invalidation is safe', async () => {
+  invalidateClaudeConfigDirCache();
+  const first = await resolveClaudeConfigDirForEnvironment('native');
+  const second = await resolveClaudeConfigDirForEnvironment('native');
+  assert.equal(second, first, 'a cached read must equal the first read');
+
+  invalidateClaudeConfigDirCache();
+  const afterInvalidate = await resolveClaudeConfigDirForEnvironment('native');
+  assert.equal(afterInvalidate, first, 'recomputation must yield the same dir');
+});
+
+test('CLAUDE_CONFIG_DIR overrides any cached value', async () => {
+  const saved = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    invalidateClaudeConfigDirCache();
+    await resolveClaudeConfigDirForEnvironment('wsl'); // populate cache (fallback on non-win32)
+
+    process.env.CLAUDE_CONFIG_DIR = '/tmp/explicit-claude-home';
+    const resolved = await resolveClaudeConfigDirForEnvironment('wsl');
+    assert.equal(resolved, '/tmp/explicit-claude-home',
+      'an explicit CLAUDE_CONFIG_DIR must win over the cache');
+  } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = saved;
+    invalidateClaudeConfigDirCache();
+  }
+});

--- a/tests/memory-contract.test.mjs
+++ b/tests/memory-contract.test.mjs
@@ -189,9 +189,9 @@ test('memory panel groups files by visible scope while keeping folder paths visi
   assert.match(memoryPanelSource, /t\("memoryPanel\.sections\.rolloutSummariesTitle"\)/);
   assert.match(memoryPanelSource, /t\("memoryPanel\.sections\.adHocNotesTitle"\)/);
   assert.match(memoryPanelSource, /t\("memoryPanel\.sections\.memorySkillsTitle"\)/);
-  assert.match(memoryPanelSource, /data\.instructionRoots\.user/);
-  assert.match(memoryPanelSource, /data\.instructionRoots\.project \?\? ""/);
-  assert.match(memoryPanelSource, /folderPath: data\.memoryDir/);
+  assert.match(memoryPanelSource, /data\.instructionRootsDisplay\.user/);
+  assert.match(memoryPanelSource, /data\.instructionRootsDisplay\.project \?\? ""/);
+  assert.match(memoryPanelSource, /folderPath: data\.memoryDirDisplay/);
   assert.match(memoryPanelSource, /title=\{section\.folderPath\}/);
   assert.match(memoryPanelSource, /section\.key === "user-scope"/);
   assert.match(memoryPanelSource, /section\.key === "project-scope"/);
@@ -209,7 +209,7 @@ test('memory rows are visually nested under scopes and reuse the file context me
 });
 
 test('memory file paths use native row tooltips without a custom hover preview', () => {
-  assert.match(memoryPanelSource, /title=\{row\.path\}/);
+  assert.match(memoryPanelSource, /title=\{row\.displayPath\}/);
   assert.doesNotMatch(memoryPanelSource, /group-hover:delay-700/);
   assert.doesNotMatch(memoryPanelSource, /line-clamp-2 break-all/);
 });


### PR DESCRIPTION
## What changed

- Show paths as the session CLI sees them while retaining host paths for file actions.
- Resolve provider config directories without broken shell redirection.
- Cache config-directory probes and avoid unnecessary WSL login shells.
- Reuse the no-login-shell runtime option for worktree Git commands.

## Why

The Context tab could display host UNC paths that differed from the CLI-visible path, and repeated login-shell probes made the tab slow or redirected config lookup after malformed rc output.

## Impact

Context paths match the active runtime, config discovery is stable, and repeated Context/Git operations start faster in WSL.

## Validation

- `npm run server:compile`
- Agent environment/path and config-directory performance Node/tsx tests
- Memory contract tests
- Targeted ESLint on changed Context, memory, CLI, and skill files
