### PR TITLE
fix(board): make Kanban Peek interactions consistent

### DIFF
--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -874,6 +874,10 @@ export const KanbanBoard = memo(function KanbanBoard() {
       useSessionStore.getState().addSession(newSession);
       useChatStore.getState().loadHistory(newSessionId, []);
 
+      if (useSettingsStore.getState().settings.kanbanSessionOpenMode === 'peek') {
+        useBoardStore.getState().openSessionPeek(newSessionId);
+      }
+
       // Assign to active panel
       {
         const ps = usePanelStore.getState();

--- a/src/components/board/kanban-column.tsx
+++ b/src/components/board/kanban-column.tsx
@@ -10,6 +10,7 @@ import { getKanbanMultiSessionDragIds } from '@/lib/dnd/panel-session-drag';
 import { mergeTasksWithLiveSessions } from '@/lib/tasks/merge-tasks-with-live-sessions';
 import { useBoardStore } from '@/stores/board-store';
 import { useSelectionStore } from '@/stores/selection-store';
+import { useSettingsStore } from '@/stores/settings-store';
 import { useSessionStore } from '@/stores/session-store';
 import { useTaskStore } from '@/stores/task-store';
 import { TASK_DND_MIME, TASK_ENTITY_DND_MIME, TASK_MULTI_DND_MIME } from '@/types/task';
@@ -44,6 +45,12 @@ function KanbanQuickCreateButton({
   const { t } = useI18n();
   const addMenuRef = useRef<HTMLDivElement>(null);
   const isChatColumn = column === 'chat';
+  // Peek 모드에서는 새로 만든 세션도 즉시 Peek로 열어준다 — 그러지 않으면
+  // 카드만 생기고 사용자는 방금 만든 세션을 다시 클릭해야 한다.
+  const handleSessionCreated = useCallback((sessionId: string) => {
+    if (useSettingsStore.getState().settings.kanbanSessionOpenMode !== 'peek') return;
+    useBoardStore.getState().openSessionPeek(sessionId);
+  }, []);
 
   return (
     <div
@@ -83,6 +90,7 @@ function KanbanQuickCreateButton({
           allowCollectionSelection={collection === null}
           scopeId={`kanban-${column}`}
           anchorRef={addMenuRef}
+          onSessionCreated={handleSessionCreated}
           onClose={onClose}
         />
       )}

--- a/src/components/board/session-peek.tsx
+++ b/src/components/board/session-peek.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { MessageSquare, Terminal, X } from 'lucide-react';
 import { ChatArea } from '@/components/chat/chat-area';
+import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
 import { MemoryFileTab } from '@/components/memory/memory-file-tab';
 import { WorkspaceFileTab } from '@/components/workspace/workspace-file-tab';
 import { TabIdContext } from '@/stores/panel-store';
@@ -285,17 +286,18 @@ export function SessionPeek({
               <span className="rounded-full border border-(--divider) px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-(--text-muted)">
                 {surfaceBadge}
               </span>
-              <button
-                ref={closeButtonRef}
-                type="button"
-                onClick={onClose}
-                className="rounded-md p-1.5 text-(--text-muted) transition-colors hover:bg-(--sidebar-hover) hover:text-(--text-primary) focus:outline-none focus:ring-1 focus:ring-(--accent)"
-                aria-label={t('common.close')}
-                title={t('common.close')}
-                data-testid="kanban-session-peek-close"
-              >
-                <X className="h-4 w-4" />
-              </button>
+              <ShortcutTooltip id="close-tab" label={t('common.close')}>
+                <button
+                  ref={closeButtonRef}
+                  type="button"
+                  onClick={onClose}
+                  className="rounded-md p-1.5 text-(--text-muted) transition-colors hover:bg-(--sidebar-hover) hover:text-(--text-primary) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                  aria-label={t('common.close')}
+                  data-testid="kanban-session-peek-close"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </ShortcutTooltip>
             </header>
           ) : null}
           <div

--- a/src/components/chat/task-context-menu.tsx
+++ b/src/components/chat/task-context-menu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback, useMemo } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, SyntheticEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { Archive, ArchiveRestore, CircleStop, Pencil, Trash2, ExternalLink, FolderInput, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -146,7 +147,20 @@ export function TaskContextMenu({
     'cursor-default'
   );
 
-  const handleMenuKeyDown = useMenuNavigation(menuRef);
+  const navigateMenu = useMenuNavigation(menuRef);
+
+  // The menu renders through a portal, so DOM-wise it sits on document.body —
+  // but React still bubbles its events up the JSX tree, which lands on the card
+  // that owns the menu. Without this, clicking Stop Process or Delete also fires
+  // the card's onClick and opens Peek. Isolate every interaction event here.
+  const stopEventPropagation = useCallback((e: SyntheticEvent) => {
+    e.stopPropagation();
+  }, []);
+
+  const handleMenuKeyDown = useCallback((e: ReactKeyboardEvent<HTMLElement>) => {
+    e.stopPropagation();
+    navigateMenu(e);
+  }, [navigateMenu]);
 
   const handleStatusChange = useCallback((status: string) => {
     onClose();
@@ -217,6 +231,10 @@ export function TaskContextMenu({
       )}
       style={{ top: menuPos.top, left: menuPos.left, width: MENU_WIDTH }}
       onKeyDown={handleMenuKeyDown}
+      onClick={stopEventPropagation}
+      onDoubleClick={stopEventPropagation}
+      onMouseDown={stopEventPropagation}
+      onContextMenu={stopEventPropagation}
       data-testid="task-context-menu"
     >
       {isRunning && onStopProcess && (

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -11,6 +11,7 @@ import { useSessionStore } from '@/stores/session-store';
 import { useGitStore } from '@/stores/git-store';
 import { ALL_PROJECTS_SENTINEL, getProjectColor } from '@/lib/constants/project-strip';
 import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
+import { ElectronWindowControls } from '@/components/layout/electron-window-controls';
 import { ProjectViewModeToggle } from '@/components/tab/project-view-mode-toggle';
 
 /**
@@ -63,6 +64,9 @@ export const AppHeader = memo(function AppHeader() {
           className={cn(
             'flex min-w-0 flex-1 items-center gap-2 px-3',
             isMacElectron && 'pl-10',
+            // Peek mode stretches the header across the window, so it has to
+            // clear the native window controls the tab bar normally clears.
+            isKanbanPeekMode && isWindowsElectron && !gitPanelOpen && 'pr-[152px]',
           )}
         >
           {shouldShowProjectContext ? (
@@ -79,7 +83,10 @@ export const AppHeader = memo(function AppHeader() {
               </div>
               <div
                 className={cn(
-                  'min-w-0 flex-1',
+                  'min-w-0',
+                  // In peek mode the header spans the full window, so the project
+                  // name must not absorb the free space — the spacer below does.
+                  isKanbanPeekMode ? 'shrink' : 'flex-1',
                   isElectronTitlebar && 'electron-drag pointer-events-none',
                 )}
                 title={projectTitle}
@@ -93,23 +100,31 @@ export const AppHeader = memo(function AppHeader() {
                 labelMode="short"
               />
               {isKanbanPeekMode ? (
-                <button
-                  type="button"
-                  onClick={toggleGitPanel}
-                  className={cn(
-                    'electron-no-drag flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-(--divider) transition-colors',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35',
-                    gitPanelOpen
-                      ? 'bg-(--accent)/14 text-(--accent)'
-                      : 'bg-(--chat-bg) text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--text-primary)',
-                  )}
-                  aria-label={gitPanelOpen ? t('chat.closeGitPanel') : t('chat.openGitPanel')}
-                  aria-pressed={gitPanelOpen}
-                  title={gitPanelOpen ? t('chat.closeGitPanel') : t('chat.openGitPanel')}
-                  data-testid="kanban-git-panel-toggle"
-                >
-                  {gitPanelOpen ? <PanelRightClose size={16} /> : <PanelRightOpen size={16} />}
-                </button>
+                <>
+                  <div
+                    className={cn(
+                      'min-w-0 flex-1',
+                      isElectronTitlebar && 'electron-drag',
+                    )}
+                  />
+                  <button
+                    type="button"
+                    onClick={toggleGitPanel}
+                    className={cn(
+                      'electron-no-drag flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-(--divider) transition-colors',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35',
+                      gitPanelOpen
+                        ? 'bg-(--accent)/14 text-(--accent)'
+                        : 'bg-(--chat-bg) text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--text-primary)',
+                    )}
+                    aria-label={gitPanelOpen ? t('chat.closeGitPanel') : t('chat.openGitPanel')}
+                    aria-pressed={gitPanelOpen}
+                    title={gitPanelOpen ? t('chat.closeGitPanel') : t('chat.openGitPanel')}
+                    data-testid="kanban-git-panel-toggle"
+                  >
+                    {gitPanelOpen ? <PanelRightClose size={16} /> : <PanelRightOpen size={16} />}
+                  </button>
+                </>
               ) : null}
             </>
           ) : (
@@ -132,6 +147,7 @@ export const AppHeader = memo(function AppHeader() {
             </ShortcutTooltip>
           ) : null}
         </div>
+        {isKanbanPeekMode && isLinuxElectron && !gitPanelOpen ? <ElectronWindowControls /> : null}
       </header>
     </>
   );

--- a/src/components/notifications/notification-center.tsx
+++ b/src/components/notifications/notification-center.tsx
@@ -6,6 +6,8 @@ import { CheckCircle, AlertTriangle, Inbox } from 'lucide-react';
 import { useNotificationStore } from '@/stores/notification-store';
 import { useSessionStore } from '@/stores/session-store';
 import { useTabStore } from '@/stores/tab-store';
+import { useBoardStore } from '@/stores/board-store';
+import { useSettingsStore } from '@/stores/settings-store';
 import { wsClient } from '@/lib/ws/client';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
@@ -83,6 +85,15 @@ function NotificationCenterContent({
     wsClient.sendMarkAsRead(sessionId);
 
     const session = getSession(sessionId);
+
+    // Kanban peek mode: open the session in the board peek panel instead of a tab
+    const boardStore = useBoardStore.getState();
+    const peekMode = useSettingsStore.getState().settings.kanbanSessionOpenMode === 'peek';
+    if (boardStore.viewMode === 'board' && peekMode) {
+      boardStore.openSessionPeek(sessionId);
+      onClose();
+      return;
+    }
 
     // Tab-aware session focus: use findSessionLocation (same as sidebar click handler)
     const tabStore = useTabStore.getState();

--- a/src/components/notifications/toast-container.tsx
+++ b/src/components/notifications/toast-container.tsx
@@ -57,21 +57,21 @@ function ActionToastItem({ t: toastItem, onDismiss }: { t: ActionToast; onDismis
       exit={{ x: -400, opacity: 0 }}
       transition={{ type: 'spring', damping: 25, stiffness: 300 }}
       className={cn(
-        'w-[320px] rounded-lg border border-(--toast-border)',
+        'w-[17rem] rounded-lg border border-(--toast-border)',
         'bg-(--toast-bg) hover:bg-(--toast-bg-hover) transition-colors',
-        'flex items-center gap-2.5 p-3',
+        'flex items-center gap-2 p-2.5',
       )}
       style={{ boxShadow: 'var(--toast-shadow)' }}
       role="status"
     >
-      <div className="w-5 h-5 rounded-md bg-(--toast-icon-bg) border border-(--toast-icon-border) flex items-center justify-center shrink-0">
-        <Icon className="w-3 h-3" style={{ color }} />
+      <div className="w-4 h-4 rounded bg-(--toast-icon-bg) border border-(--toast-icon-border) flex items-center justify-center shrink-0">
+        <Icon className="w-2.5 h-2.5" style={{ color }} />
       </div>
-      <span className="text-[13px] font-medium text-(--text-primary) flex-1 min-w-0 truncate">{toastItem.message}</span>
+      <span className="text-[0.6875rem] font-medium text-(--text-primary) flex-1 min-w-0 truncate">{toastItem.message}</span>
       {toastItem.action && (
         <button
           onClick={(e) => { e.stopPropagation(); toastItem.action!.onClick(); onDismissRef.current(); }}
-          className="shrink-0 text-[12px] font-medium text-(--accent) hover:underline"
+          className="shrink-0 text-[0.625rem] font-medium text-(--accent) hover:underline"
         >
           {toastItem.action.label}
         </button>

--- a/src/components/notifications/toast-container.tsx
+++ b/src/components/notifications/toast-container.tsx
@@ -8,6 +8,8 @@ import { toast } from '@/stores/notification-store';
 import { useI18n } from '@/lib/i18n';
 import { useTabStore } from '@/stores/tab-store';
 import { useSessionStore } from '@/stores/session-store';
+import { useBoardStore } from '@/stores/board-store';
+import { useSettingsStore } from '@/stores/settings-store';
 import { ToastNotification } from './toast-notification';
 import { NotificationSound } from './notification-sound';
 import { useSessionNavigation } from '@/hooks/use-session-navigation';
@@ -112,6 +114,14 @@ export function ToastContainer() {
 
     clearUnreadCount(sessionId);
     wsClient.sendMarkAsRead(sessionId);
+
+    // Kanban peek mode: open the session in the board peek panel instead of a tab
+    const boardStore = useBoardStore.getState();
+    const peekMode = useSettingsStore.getState().settings.kanbanSessionOpenMode === 'peek';
+    if (boardStore.viewMode === 'board' && peekMode) {
+      boardStore.openSessionPeek(sessionId);
+      return;
+    }
 
     // Tab-aware session focus: use findSessionLocation (same as sidebar click handler)
     const tabStore = useTabStore.getState();

--- a/src/components/notifications/toast-notification.tsx
+++ b/src/components/notifications/toast-notification.tsx
@@ -100,7 +100,7 @@ export function ToastNotification({ notification, onDismiss, onClick }: ToastNot
       onClick={onClick}
       data-testid="toast-notification"
       className={cn(
-        'w-[320px] rounded-lg border border-(--toast-border) cursor-pointer',
+        'w-[17rem] rounded-lg border border-(--toast-border) cursor-pointer',
         'bg-(--toast-bg)',
         'hover:bg-(--toast-bg-hover) transition-colors'
       )}
@@ -109,18 +109,18 @@ export function ToastNotification({ notification, onDismiss, onClick }: ToastNot
       aria-live="assertive"
       aria-atomic="true"
     >
-      <div className="p-3">
-        <div className="flex items-start gap-2.5">
-          <div className="w-5 h-5 rounded-md bg-(--toast-icon-bg) border border-(--toast-icon-border) flex items-center justify-center shrink-0 mt-px">
-            <IconComponent className="w-3 h-3" style={{ color: iconColor }} />
+      <div className="p-2.5">
+        <div className="flex items-start gap-2">
+          <div className="w-4 h-4 rounded bg-(--toast-icon-bg) border border-(--toast-icon-border) flex items-center justify-center shrink-0 mt-px">
+            <IconComponent className="w-2.5 h-2.5" style={{ color: iconColor }} />
           </div>
 
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
-              <span className="text-[13px] font-medium truncate text-(--text-primary)">
+              <span className="text-[0.6875rem] font-medium truncate text-(--text-primary)">
                 {sessionTitle}
               </span>
-              <span className="text-[11px] text-(--toast-muted) shrink-0 ml-auto">{relativeTime}</span>
+              <span className="text-[0.625rem] text-(--toast-muted) shrink-0 ml-auto">{relativeTime}</span>
               <button
                 onClick={(e) => { e.stopPropagation(); onDismissRef.current(); }}
                 className="p-0.5 rounded text-(--toast-muted) hover:text-(--text-primary) hover:bg-(--toast-icon-bg) transition-colors shrink-0"
@@ -130,7 +130,7 @@ export function ToastNotification({ notification, onDismiss, onClick }: ToastNot
               </button>
             </div>
 
-            <p className="text-[12px] text-(--toast-muted) leading-snug line-clamp-2 mt-0.5">
+            <p className="text-[0.625rem] text-(--toast-muted) leading-snug line-clamp-2 mt-0.5">
               {notification.preview}
             </p>
 
@@ -146,7 +146,7 @@ export function ToastNotification({ notification, onDismiss, onClick }: ToastNot
                     onClick={(e) => { e.stopPropagation(); handleActionClick(action); }}
                     disabled={isSubmitting}
                     className={cn(
-                      'px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors',
+                      'px-2 py-0.5 rounded text-[0.625rem] font-medium transition-colors',
                       'disabled:opacity-50 disabled:cursor-not-allowed',
                       action.primary
                         ? 'bg-(--text-primary) text-(--toast-bg) hover:opacity-90'

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -14,6 +14,7 @@ const PANEL_DIRECTION_EPSILON = 1;
 import { useEffect, useCallback } from 'react';
 import { useSettingsStore } from '@/stores/settings-store';
 import { KeyboardManager } from '@/lib/keyboard/keyboard-manager';
+import { setGlobalShortcutKeys } from '@/lib/keyboard/terminal-passthrough';
 import { SHORTCUT_IDS, type ShortcutId } from '@/lib/keyboard/registry';
 import { getEffectiveShortcut } from '@/lib/keyboard/effective';
 import { usePanelStore, selectActiveTab, EMPTY_PANELS } from '@/stores/panel-store';
@@ -128,6 +129,13 @@ export function useKeyboardShortcuts(_options: UseKeyboardShortcutsOptions = {})
 
   // Same code path as the tab × button (tab-item.tsx) — closes the currently-active tab.
   const handleCloseTab = useCallback(() => {
+    // Kanban peek is the topmost close target; a dirty file sidecar may veto
+    // via confirm, in which case the tab underneath must stay open too.
+    const { peekSessionId, peekFileRef, closeSessionPeek } = useBoardStore.getState();
+    if (peekSessionId || peekFileRef) {
+      closeSessionPeek();
+      return;
+    }
     const { activeTabId: id, closeTab } = useTabStore.getState();
     if (!id) return;
     closeTab(id);
@@ -210,14 +218,20 @@ export function useKeyboardShortcuts(_options: UseKeyboardShortcutsOptions = {})
 
   useEffect(() => {
     const manager = new KeyboardManager();
+    const activeKeys: string[] = [];
     for (const id of SHORTCUT_IDS) {
       const handler = handlers[id];
       if (!handler) continue;
       const key = getEffectiveShortcut(id, overrides);
       if (!key) continue;
       manager.register(key, () => { void handler(); }, { ignoreInputFields: false });
+      activeKeys.push(key);
     }
-    return () => manager.unregisterAll();
+    setGlobalShortcutKeys(activeKeys);
+    return () => {
+      manager.unregisterAll();
+      setGlobalShortcutKeys([]);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     overrides,

--- a/src/lib/keyboard/terminal-passthrough.ts
+++ b/src/lib/keyboard/terminal-passthrough.ts
@@ -1,0 +1,27 @@
+/**
+ * Terminal passthrough for app-level shortcuts.
+ *
+ * xterm cancels (preventDefault + stopPropagation) most modifier keydowns it
+ * inspects, so registered app shortcuts never reach the window-level tinykeys
+ * listener while a terminal has focus. use-keyboard-shortcuts publishes the
+ * effective shortcut set here; the terminal surface's custom key event handler
+ * consults it and returns false for matches, letting the event bubble out of
+ * xterm untouched (and keeping it out of the PTY).
+ */
+import { matchKeyBindingPress, parseKeybinding, type KeyBindingPress } from 'tinykeys';
+
+let activePresses: KeyBindingPress[] = [];
+
+export function setGlobalShortcutKeys(keys: string[]): void {
+  // Multi-chord sequences are excluded: swallowing only the first chord of a
+  // sequence would drop real terminal input without ever firing the shortcut.
+  activePresses = keys
+    .map((key) => parseKeybinding(key))
+    .filter((chords) => chords.length === 1)
+    .map((chords) => chords[0]);
+}
+
+export function isGlobalShortcutKeydown(event: KeyboardEvent): boolean {
+  if (event.type !== 'keydown') return false;
+  return activePresses.some((press) => matchKeyBindingPress(event, press));
+}

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -11,6 +11,7 @@ import {
   takePendingTerminalLaunch,
   type PendingTerminalLaunch,
 } from './pending-terminal-launch';
+import { isGlobalShortcutKeydown } from '@/lib/keyboard/terminal-passthrough';
 import { dispatchTerminalLaunchResult } from './terminal-launch-result';
 import { clearClientTerminalHandoff } from './client-terminal-handoff-state';
 import {
@@ -854,6 +855,10 @@ export class TerminalSurface {
         window as Window & { electronAPI?: Partial<ElectronTerminalClipboardApi> }
       ).electronAPI;
       terminal.attachCustomKeyEventHandler((event) => {
+        // App-level shortcuts must bubble to the window listener instead of
+        // being cancelled by xterm or encoded into PTY input.
+        if (isGlobalShortcutKeydown(event)) return false;
+
         if (
           event.type === 'keydown'
           && event.shiftKey

--- a/src/types/tinykeys.d.ts
+++ b/src/types/tinykeys.d.ts
@@ -1,9 +1,18 @@
 declare module 'tinykeys' {
   export type KeyBindingMap = Record<string, (event: KeyboardEvent) => void>;
 
+  export type KeyBindingPress = [mods: string[], key: string | RegExp];
+
+  export function parseKeybinding(str: string): KeyBindingPress[];
+
+  export function matchKeyBindingPress(
+    event: KeyboardEvent,
+    press: KeyBindingPress
+  ): boolean;
+
   export function tinykeys(
     target: Window | HTMLElement,
     keyBindingMap: KeyBindingMap,
-    options?: { event?: 'keydown' | 'keyup' }
+    options?: { event?: 'keydown' | 'keyup'; capture?: boolean; timeout?: number }
   ): () => void;
 }


### PR DESCRIPTION
## What changed

- Open notification and newly created Kanban sessions in the Peek panel.
- Close Peek through the close-tab shortcut while passing unrelated keys through to terminals.
- Keep Peek header controls clear of desktop window controls.
- Prevent context-menu clicks from opening Peek.
- Scale toast cards with the configured font size.

## Why

Peek entry/exit behavior was inconsistent across notifications, session creation, shortcuts, and context menus, with a few desktop layout and scaling edge cases.

## Impact

Kanban Peek now opens and closes predictably and keeps notification/UI controls aligned with user appearance settings.

## Validation

- `npm run server:compile`
- `npm run electron:compile`
- Kanban open-mode, Peek sidecar, and font/status contract tests
- Targeted ESLint on changed board, notification, shortcut, and terminal files
