### PR TITLE
fix(build): fail fast on symlinked Electron dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12876,6 +12876,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/scripts/prepare-electron-runtime.mjs
+++ b/scripts/prepare-electron-runtime.mjs
@@ -277,7 +277,26 @@ async function ensureExecutableRuntimeFiles() {
   }
 }
 
+async function assertOwnNodeModules() {
+  const nodeModulesPath = path.join(rootDir, 'node_modules');
+  const nodeModulesStat = await fs.lstat(nodeModulesPath).catch(() => null);
+  if (!nodeModulesStat?.isSymbolicLink()) return;
+
+  const linkTarget = await fs.readlink(nodeModulesPath).catch(() => '(unreadable)');
+  throw new Error(
+    [
+      `node_modules is a symlink (-> ${linkTarget}).`,
+      'Next.js cannot trace individual files through it, so every .nft.json falls back to',
+      'referencing the whole node_modules directory. That pulls devDependencies into',
+      '.electron-runtime and electron-builder rejects the build.',
+      'Install dependencies inside this worktree instead of linking them.',
+    ].join(' ')
+  );
+}
+
 async function main() {
+  await assertOwnNodeModules();
+
   if (!(await pathExists(requiredServerFilesPath))) {
     throw new Error('Missing .next/required-server-files.json. Run `npm run build` first.');
   }


### PR DESCRIPTION
## What changed

- Fail Electron runtime preparation immediately when `node_modules` is a symlink.
- Explain why symlinked dependencies break Next.js tracing and how to fix the worktree.
- Normalize the optional Playwright `fsevents` lockfile metadata.

## Why

Symlinked worktree dependencies caused Next.js tracing to include the entire dependency tree, bloating the Electron runtime and failing only after several minutes.

## Impact

Misconfigured worktrees now fail fast with an actionable message before expensive packaging work begins.

## Validation

- Dedicated temporary-worktree test confirmed the symlink guard exits with the expected diagnostic.
- `npm run electron:compile`
- `npm install --package-lock-only --ignore-scripts` leaves the normalized lockfile stable.
- Targeted ESLint on the runtime preparation script

Full runtime preparation still requires a prior Next.js build and correctly reported the missing `.next/required-server-files.json` in this isolated worktree.
