### PR TITLE
fix(board): render Peek session state from the visible workspace

### DIFF
--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -43,9 +43,9 @@ import {
   getKanbanScrollPositionKey,
   saveKanbanScrollPosition,
 } from '@/lib/kanban-scroll-position';
-import { getSessionSelectionId } from '@/lib/constants/special-sessions';
 import type { Collection } from '@/types/collection';
 import { resolveSessionRuntimePresentation } from '@/lib/session/session-runtime-presentation';
+import { resolveVisibleWorkspaceSessionId } from '@/lib/session/active-workspace-session';
 
 /**
  * KanbanBoard -- collection-based kanban with Chat column + Workflow columns.
@@ -89,7 +89,6 @@ export const KanbanBoard = memo(function KanbanBoard() {
   const setCollectionFilter = useBoardStore((s) => s.setCollectionFilter);
   const peekSessionId = useBoardStore((s) => s.peekSessionId);
   const peekFileRef = useBoardStore((s) => s.peekFileRef);
-  const selectedBoardSessionId = useBoardStore((s) => s.selectedBoardSessionId);
   const openSessionPeek = useBoardStore((s) => s.openSessionPeek);
   const closeSessionPeek = useBoardStore((s) => s.closeSessionPeek);
   const kanbanSessionOpenMode = useSettingsStore(
@@ -104,9 +103,11 @@ export const KanbanBoard = memo(function KanbanBoard() {
   const tasksByProject = useTaskStore((s) => s.tasksByProject);
   // Session store
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
-  const selectionSessionId = getSessionSelectionId(
-    kanbanSessionOpenMode === 'peek' ? selectedBoardSessionId : activeSessionId,
-  );
+  const selectionSessionId = resolveVisibleWorkspaceSessionId({
+    activeSessionId,
+    peekSessionId,
+    isKanbanPeekLayout: kanbanSessionOpenMode === 'peek',
+  });
   const projects = useSessionStore((s) => s.projects);
   const scrollPositionKey = getKanbanScrollPositionKey(selectedProjectDir, activeCollectionFilter);
   const [portfolioProjectFilter, setPortfolioProjectFilter] = useState<string | null>(null);

--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -17,6 +17,7 @@ import {
 import { useProvidersStore } from '@/stores/providers-store';
 import { useSettingsStore } from '@/stores/settings-store';
 import { useSessionStore } from '@/stores/session-store';
+import { useNotificationStore } from '@/stores/notification-store';
 import { useSelectionStore } from '@/stores/selection-store';
 import { useTaskStore } from '@/stores/task-store';
 import { TASK_MULTI_DND_MIME } from '@/types/task';
@@ -182,7 +183,23 @@ export const KanbanChatCard = memo(function KanbanChatCard({
   const workflowIconFill = workflowStatus
     ? CHAT_WORKFLOW_ICON_FILL[workflowStatus]
     : null;
-  const hasUnread = !isActive && (session.unreadCount ?? 0) > 0;
+  // unreadCount는 session-store에서 직접 구독한다. prop의 session.unreadCount는
+  // board→scope→column 경유라, 완료 시 terminal-session-store(isProcessing) 리렌더와
+  // board 리렌더 타이밍이 어긋나면 낡은 값을 읽어 unread를 놓친다(칸반 카드는 memo).
+  // 리스트뷰가 쓰는 것과 같은 직접 구독으로 타이밍을 일치시킨다.
+  const liveUnreadCount = useSessionStore((state) => {
+    for (const project of state.projects) {
+      const s = project.sessions.find((item) => item.id === session.id);
+      if (s) return s.unreadCount ?? 0;
+    }
+    return session.unreadCount ?? 0;
+  });
+  const hasUnreadNotification = useNotificationStore((state) =>
+    state.notifications.some((notification) =>
+      notification.sessionId === session.id && !notification.read
+    )
+  );
+  const hasUnread = !isActive && (liveUnreadCount > 0 || hasUnreadNotification);
   const runtimePresentation = resolveSessionRuntimePresentation(session);
   const visibleUnread = session.kind === 'terminal' && isProcessing ? false : hasUnread;
   const stripeClass = isAwaitingUser
@@ -650,8 +667,12 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
     hasTerminalProcessingSession,
   } = useSessionProcessingSummary(task.sessions);
   const hasAwaitingUserSession = useAnySessionAwaitingUser(task.sessions);
+  // task에 활성 세션이 하나라도 있으면 unread를 통째로 억제하던 `!isActive` 가드를
+  // 제거한다. multi-session task에서 한 세션이 활성이면 다른 완료+안읽음 세션의 unread가
+  // 다 숨겨져 초록 running 스트라이프로 밀리던 버그(리스트뷰는 단일세션+활성일 때만
+  // 억제해 이 문제가 없었다). 활성 세션 자체는 아래 개별 제외로 이미 빠진다.
   const hasUnreadSession = useSessionStore((state) =>
-    !isActive && taskSessionIds.some((id) => {
+    taskSessionIds.some((id) => {
       if (id === activeSessionId) return false;
       for (const p of state.projects) {
         const s = p.sessions.find((ss) => ss.id === id);
@@ -660,9 +681,21 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
       return false;
     })
   );
-  const hasTaskStatus = hasProcessingSession || hasAwaitingUserSession || hasUnreadSession || hasVisibleRuntimeSession;
+  const hasUnreadNotification = useNotificationStore((state) =>
+    state.notifications.some((notification) =>
+      notification.sessionId !== activeSessionId
+      && taskSessionIds.includes(notification.sessionId)
+      && !notification.read
+    )
+  );
+  const hasVisibleTaskUnread = hasUnreadSession || hasUnreadNotification;
+  const hasTaskStatus = hasProcessingSession || hasAwaitingUserSession || hasVisibleTaskUnread || hasVisibleRuntimeSession;
 
-  const visibleTaskUnread = hasTerminalProcessingSession ? false : hasUnreadSession;
+  // PTY turn processing is the live state and outranks stale unread. Once the
+  // turn completes, processing clears and the unread completion becomes yellow.
+  const visibleTaskUnread = hasTerminalProcessingSession
+    ? false
+    : hasVisibleTaskUnread;
 
   // Left-edge status stripe — mirrors the session dot so the signal
   // travels on two channels. PTY processing outranks stale unread state.
@@ -908,7 +941,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                 <ItemStatusIndicator
                   isProcessing={hasProcessingSession}
                   isAwaitingUser={hasAwaitingUserSession}
-                  hasUnread={hasUnreadSession}
+                  hasUnread={visibleTaskUnread}
                   isRunning={hasVisibleRuntimeSession}
                   sessionKind={hasTerminalProcessingSession ? 'terminal' : undefined}
                   placement="corner"
@@ -920,7 +953,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                 <ItemStatusIndicator
                   isProcessing={hasProcessingSession}
                   isAwaitingUser={hasAwaitingUserSession}
-                  hasUnread={hasUnreadSession}
+                  hasUnread={visibleTaskUnread}
                   isRunning={hasVisibleRuntimeSession}
                   sessionKind={hasTerminalProcessingSession ? 'terminal' : undefined}
                   placement="inline"
@@ -971,7 +1004,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                   <ItemStatusIndicator
                     isProcessing={hasProcessingSession}
                     isAwaitingUser={hasAwaitingUserSession}
-                    hasUnread={hasUnreadSession}
+                    hasUnread={visibleTaskUnread}
                     isRunning={hasVisibleRuntimeSession}
                     sessionKind={hasTerminalProcessingSession ? 'terminal' : undefined}
                     placement="corner"
@@ -1213,7 +1246,12 @@ function KanbanSubSessionItem({
     isRunning: liveIsRunning,
   });
   const liveUnreadCount = liveSession?.unreadCount ?? 0;
-  const hasLiveUnread = !isActive && liveUnreadCount > 0;
+  const hasUnreadNotification = useNotificationStore((state) =>
+    state.notifications.some((notification) =>
+      notification.sessionId === session.id && !notification.read
+    )
+  );
+  const hasLiveUnread = !isActive && (liveUnreadCount > 0 || hasUnreadNotification);
   const isAwaitingUser = useIsSessionAwaitingUser(session.id, session.kind);
   const displayTitle = liveSession?.title ?? session.title;
   const isArchived = liveSession?.archived ?? false;

--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -46,9 +46,9 @@ import { cn } from "@/lib/utils";
 import { useI18n } from "@/lib/i18n";
 import { ALL_PROJECTS_SENTINEL } from "@/lib/constants/project-strip";
 import {
-  isSpecialSession,
-} from "@/lib/constants/special-sessions";
-import { resolveActiveWorkspaceSessionId } from "@/lib/session/active-workspace-session";
+  resolveActiveWorkspaceSessionId,
+  resolveVisibleWorkspaceSessionId,
+} from "@/lib/session/active-workspace-session";
 import { activateSessionPanel } from "@/lib/session/focus-session-panel";
 import { resolveSessionTabOpenMode } from "@/lib/terminal/terminal-preview-policy";
 
@@ -98,6 +98,7 @@ export function ChatLayout() {
   const { t } = useI18n();
   const activeSessionId = useSessionStore((state) => state.activeSessionId);
   const viewMode = useBoardStore((state) => state.viewMode);
+  const peekSessionId = useBoardStore((state) => state.peekSessionId);
   const selectedBoardSessionId = useBoardStore((state) => state.selectedBoardSessionId);
   const kanbanSessionOpenMode = useSettingsStore(
     (state) => state.settings.kanbanSessionOpenMode,
@@ -144,6 +145,11 @@ export function ChatLayout() {
   const [projectsLoaded, setProjectsLoaded] = useState(initiallyHasProjects);
   const isCompactViewport = viewportWidth < COMPACT_VIEWPORT_BREAKPOINT;
   const isKanbanPeekLayout = isKanbanPeekMode && !sidebarCollapsed;
+  const visibleWorkspaceSessionId = resolveVisibleWorkspaceSessionId({
+    activeSessionId,
+    peekSessionId,
+    isKanbanPeekLayout,
+  });
 
   const sidebarBaseMinWidth =
     viewMode === "board" ? BOARD_SIDEBAR_MIN_WIDTH : LIST_SIDEBAR_MIN_WIDTH;
@@ -387,10 +393,10 @@ export function ChatLayout() {
   );
 
   useEffect(() => {
-    if (activeSessionId && !isSpecialSession(activeSessionId)) {
-      markSessionAsRead(activeSessionId);
+    if (visibleWorkspaceSessionId) {
+      markSessionAsRead(visibleWorkspaceSessionId);
     }
-  }, [activeSessionId, markSessionAsRead]);
+  }, [markSessionAsRead, visibleWorkspaceSessionId]);
 
   // Bridge Effect: sync activeSessionId from session-store → panel-store.
   useEffect(

--- a/src/lib/session/active-workspace-session.ts
+++ b/src/lib/session/active-workspace-session.ts
@@ -21,3 +21,24 @@ export function resolveActiveWorkspaceSessionId({
   return getWorkspaceSourceSessionId(activePanelSessionId)
     ?? getWorkspaceSourceSessionId(activeSessionId);
 }
+
+/**
+ * Resolve the session whose conversation is actually visible.
+ *
+ * Full-board Kanban Peek deliberately keeps the tab workspace mounted but
+ * hidden. In that layout, the hidden tab's active session must not suppress
+ * unread notifications or make a closed Peek card look active.
+ */
+export function resolveVisibleWorkspaceSessionId({
+  activeSessionId,
+  isKanbanPeekLayout,
+  peekSessionId,
+}: {
+  activeSessionId: string | null | undefined;
+  isKanbanPeekLayout: boolean;
+  peekSessionId: string | null | undefined;
+}): string | null {
+  return getWorkspaceSourceSessionId(
+    isKanbanPeekLayout ? peekSessionId : activeSessionId,
+  );
+}

--- a/src/lib/terminal/opencode-hook-plugin.ts
+++ b/src/lib/terminal/opencode-hook-plugin.ts
@@ -29,6 +29,7 @@ export const TesseraLifecyclePlugin = async ({ directory }) => {
   let startSent = false
   let sessionIdle = false
   let turnHasSubmittedPrompt = false
+  let turnSawUserMessage = false
   // 이번 턴에 세션이 실제로 busy(작업)를 거쳤는지. 완료(Stop) 보고를 프롬프트 캡처
   // 대신 이 신호에 건다 — 프롬프트 주입/타이밍으로 UserPromptSubmit 캡처를 놓쳐도
   // idle 완료를 놓치지 않기 위함(Orca 방식). busy를 안 거친 순수 idle은 억제한다.
@@ -185,6 +186,7 @@ export const TesseraLifecyclePlugin = async ({ directory }) => {
     startSent = false
     sessionIdle = false
     turnHasSubmittedPrompt = false
+    turnSawUserMessage = false
     turnWasActive = false
     awaitingUserInput = false
     userMessageIDs.clear()
@@ -196,15 +198,18 @@ export const TesseraLifecyclePlugin = async ({ directory }) => {
     idleFinalizeTimer = undefined
     clearPromptFlushTimer()
     flushUserPrompts()
+    const shouldEmitStop =
+      turnHasSubmittedPrompt || (turnWasActive && turnSawUserMessage)
     for (const messageID of userMessageIDs) textPartsByMessage.delete(messageID)
     userMessageIDs.clear()
     // 완료 보고를 프롬프트 캡처에 묶지 않는다(Orca 방식). UserPromptSubmit을 놓친
     // 턴이라도 세션이 busy를 거쳤으면 idle 완료를 보고한다. busy 없이 온 순수 idle
     // (세션 로드/resume 직후)만 빈 완료로 억제한다.
-    if (!turnHasSubmittedPrompt && !turnWasActive) return
     turnHasSubmittedPrompt = false
+    turnSawUserMessage = false
     turnWasActive = false
     awaitingUserInput = false
+    if (!shouldEmitStop) return
     enqueue({ hook_event_name: "Stop", session_id: targetSessionID })
   }
 
@@ -265,6 +270,7 @@ export const TesseraLifecyclePlugin = async ({ directory }) => {
             return
           }
           if (!messageID || submittedMessageIDs.has(messageID)) return
+          turnSawUserMessage = true
           userMessageIDs.add(messageID)
           if (textPartsByMessage.has(messageID)) schedulePromptFlush()
           if (sessionIdle) scheduleFinalizeTurn()

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/chat/session-client-effects';
 import { serverMessageToReplayEvents } from '@/lib/chat/server-message-to-replay-events';
 import { useChatStore } from '@/stores/chat-store';
+import { useBoardStore } from '@/stores/board-store';
 import { useTerminalSessionStore } from '@/stores/terminal-session-store';
 import { useCommandStore } from '@/stores/command-store';
 import { useGitPanelStore } from '@/stores/git-panel-store';
@@ -17,6 +18,7 @@ import { useNotificationStore } from '@/stores/notification-store';
 import { usePanelStore } from '@/stores/panel-store';
 import { useRateLimitStore } from '@/stores/rate-limit-store';
 import { useSessionStore } from '@/stores/session-store';
+import { useSettingsStore } from '@/stores/settings-store';
 import { useSessionPrStore } from '@/stores/session-pr-store';
 import { useSkillAnalysisStore } from '@/stores/skill-analysis-store';
 import { useTaskStore } from '@/stores/task-store';
@@ -28,6 +30,7 @@ import type { ServerTransportMessage } from './message-types';
 import { getClientId } from './client-id';
 import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 import { invalidateProviderSessionOptionsClientCache } from '@/hooks/use-provider-session-options';
+import { resolveVisibleWorkspaceSessionId } from '@/lib/session/active-workspace-session';
 
 interface HandleIncomingServerMessageOptions {
   msg: ServerTransportMessage;
@@ -42,6 +45,19 @@ interface PendingTerminalRebound {
 }
 
 const pendingTerminalRebounds = new Map<string, PendingTerminalRebound>();
+
+function getVisibleWorkspaceSessionId(activeSessionId: string | null): string | null {
+  const boardState = useBoardStore.getState();
+  const settingsState = useSettingsStore.getState();
+  return resolveVisibleWorkspaceSessionId({
+    activeSessionId,
+    peekSessionId: boardState.peekSessionId,
+    isKanbanPeekLayout:
+      boardState.viewMode === 'board'
+      && settingsState.settings.kanbanSessionOpenMode === 'peek'
+      && !settingsState.sidebarCollapsed,
+  });
+}
 
 export function handleIncomingServerMessage({
   msg,
@@ -100,7 +116,7 @@ export function handleIncomingServerMessage({
 
     case 'notification':
       sessionStore.touchSessionActivity(msg.sessionId);
-      handleNotificationMessage(msg, sessionStore.activeSessionId);
+      handleNotificationMessage(msg, getVisibleWorkspaceSessionId(sessionStore.activeSessionId));
       if (msg.event === 'completed') {
         finalizeInFlightTurn(msg.sessionId, { clearPrompt: true });
         sessionStore.updateSessionStatus(msg.sessionId, 'completed');
@@ -125,7 +141,10 @@ export function handleIncomingServerMessage({
         if (location) useTabStore.getState().pinTab(location.tabId);
       }
       if (changed && (msg.status === 'completed' || msg.status === 'input_required')) {
-        handleTerminalSessionStateMessage(msg, sessionStore.activeSessionId);
+        handleTerminalSessionStateMessage(
+          msg,
+          getVisibleWorkspaceSessionId(sessionStore.activeSessionId),
+        );
       }
       return { wasReconnect };
     }
@@ -197,7 +216,10 @@ export function handleIncomingServerMessage({
 
     case 'interactive_prompt':
       sessionStore.touchSessionActivity(msg.sessionId);
-      handleInteractivePromptMessage(msg, sessionStore.activeSessionId);
+      handleInteractivePromptMessage(
+        msg,
+        getVisibleWorkspaceSessionId(sessionStore.activeSessionId),
+      );
       return { wasReconnect };
 
     case 'error': {

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -969,22 +969,19 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 
   // Unread count actions
   incrementUnreadCount: (sessionId) =>
-    set((state) => {
-      if (state.activeSessionId === sessionId) {
-        return state; // Don't increment for active session
-      }
-
-      return {
-        projects: state.projects.map((project) => ({
-          ...project,
-          sessions: project.sessions.map((s) =>
-            s.id === sessionId
-              ? { ...s, unreadCount: (s.unreadCount || 0) + 1 }
-              : s
-          ),
-        })),
-      };
-    }),
+    set((state) => ({
+      // Notification handlers already decide whether the session is visibly
+      // active. Re-checking the hidden tab's activeSessionId here breaks
+      // full-board Peek after light-dismiss.
+      projects: state.projects.map((project) => ({
+        ...project,
+        sessions: project.sessions.map((s) =>
+          s.id === sessionId
+            ? { ...s, unreadCount: (s.unreadCount || 0) + 1 }
+            : s
+        ),
+      })),
+    })),
 
   clearUnreadCount: (sessionId) =>
     set((state) => ({

--- a/tests/active-workspace-session.test.ts
+++ b/tests/active-workspace-session.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { resolveActiveWorkspaceSessionId } from '../src/lib/session/active-workspace-session';
+import {
+  resolveActiveWorkspaceSessionId,
+  resolveVisibleWorkspaceSessionId,
+} from '../src/lib/session/active-workspace-session';
 import {
   buildWorkspaceExplorerSessionId,
   buildWorkspaceFileSessionId,
@@ -51,5 +54,38 @@ test('active workspace session ignores non-workspace special sessions', () => {
       activeSessionId: null,
     }),
     null,
+  );
+});
+
+test('full-board Peek only treats the open Peek session as visible', () => {
+  assert.equal(
+    resolveVisibleWorkspaceSessionId({
+      activeSessionId: 'hidden-tab-session',
+      isKanbanPeekLayout: true,
+      peekSessionId: 'peek-session',
+    }),
+    'peek-session',
+  );
+});
+
+test('dismissed full-board Peek does not fall back to the hidden tab session', () => {
+  assert.equal(
+    resolveVisibleWorkspaceSessionId({
+      activeSessionId: 'hidden-tab-session',
+      isKanbanPeekLayout: true,
+      peekSessionId: null,
+    }),
+    null,
+  );
+});
+
+test('split and list layouts continue using the active workspace session', () => {
+  assert.equal(
+    resolveVisibleWorkspaceSessionId({
+      activeSessionId: 'active-session',
+      isKanbanPeekLayout: false,
+      peekSessionId: null,
+    }),
+    'active-session',
   );
 });

--- a/tests/opencode-hook-plugin.test.ts
+++ b/tests/opencode-hook-plugin.test.ts
@@ -275,6 +275,33 @@ test('OpenCode waits for all real text parts and ignores synthetic expansion tex
   }
 });
 
+test('OpenCode completes a real busy turn even when prompt text parts are missed', async () => {
+  const plugin = await loadPlugin({ resumeId: 'ses_resume' });
+  try {
+    await settlePosts(1, plugin.payloads);
+    await plugin.event({
+      event: {
+        type: 'message.updated',
+        properties: { info: { id: 'msg-missed-parts', sessionID: 'ses_resume', role: 'user' } },
+      },
+    });
+    await plugin.event({
+      event: { type: 'session.status', properties: { sessionID: 'ses_resume', status: { type: 'busy' } } },
+    });
+    await plugin.event({
+      event: { type: 'session.status', properties: { sessionID: 'ses_resume', status: { type: 'idle' } } },
+    });
+
+    await settlePosts(2, plugin.payloads);
+    assert.deepEqual(plugin.payloads[1], {
+      hook_event_name: 'Stop',
+      session_id: 'ses_resume',
+    });
+  } finally {
+    plugin.restore();
+  }
+});
+
 test('OpenCode does not emit Stop for background busy and tolerates idle before the final part', async () => {
   const plugin = await loadPlugin({ resumeId: 'ses_resume' });
   try {

--- a/tests/unread-notification-priority-contract.test.mjs
+++ b/tests/unread-notification-priority-contract.test.mjs
@@ -53,7 +53,7 @@ test('kanban stripes keep GUI unread priority while PTY processing takes precede
   );
   assert.match(
     kanbanCardSource,
-    /visibleTaskUnread = hasTerminalProcessingSession \? false : hasUnreadSession/,
+    /visibleTaskUnread = hasTerminalProcessingSession\s*\?\s*false\s*:\s*hasVisibleTaskUnread/,
   );
   assert.ok(chatUnreadBranch < chatProcessingBranch, 'chat card unread stripe must precede processing stripe');
   assert.ok(taskUnreadBranch < taskProcessingBranch, 'task card unread stripe must precede processing stripe');


### PR DESCRIPTION
## 배경

로컬 dev가 origin/dev와 크게 갈라져 있었으나(ahead 109/behind 68), patch 단위로 비교한 결과 **origin/dev에 아직 반영되지 않은 순수 신규 작업은 이 커밋 하나**였습니다. 나머지 로컬 커밋은 이미 별도 PR로 origin/dev에 (대부분 더 발전된 형태로) 머지된 상태라, 로컬 dev를 통째로 올리면 git-panel 성능 리팩터 등 origin 최신 작업을 되돌리게 됩니다. 그래서 이 신규분만 origin/dev 위에 cherry-pick 해 올립니다.

## 변경

Peek 패널이 세션 상태를 **현재 보이는 workspace 기준**으로 렌더링하도록 수정합니다. 함께 OpenCode 완료(Stop) 게이팅을 `turnSawUserMessage`로 정련해, 실제 사용자 메시지 없이 busy만 거친 턴(워크스페이스 전환에 따른 재렌더 등)의 가짜 완료 알림을 억제합니다.

- `active-workspace-session`: visible workspace 기준 세션 ID 해석 추가
- board(kanban-card/board), chat-layout, session-store: 보이는 워크스페이스 상태로 Peek 렌더
- opencode-hook-plugin: busy 게이팅에 사용자 메시지 관찰 조건 추가

## 검증

- 관련 유닛 테스트 14개 통과 (`active-workspace-session`, `opencode-hook-plugin`) — origin의 busy 게이팅 위에서 정합 확인
- 변경 파일 eslint 통과
- origin/dev 위 cherry-pick 충돌 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)