### PR TITLE
fix(kanban-peek): open git-tab files in peek and keep the panel toggle clickable

### DIFF
--- a/src/components/git/git-panel.tsx
+++ b/src/components/git/git-panel.tsx
@@ -146,7 +146,9 @@ export function GitPanel({
       has_changes: Boolean(controller.changedFileCount),
       has_pr: Boolean(controller.data?.prStatus || controller.data?.github.pullRequest),
     });
-    previewWorkspaceFileTab(sessionId, "diff", file.path);
+    previewWorkspaceFileTab(sessionId, "diff", file.path, {
+      preferKanbanPeek: true,
+    });
   }, [
     controller.changedFileCount,
     controller.data?.github.pullRequest,
@@ -166,7 +168,9 @@ export function GitPanel({
       has_changes: Boolean(controller.changedFileCount),
       has_pr: Boolean(controller.data?.prStatus || controller.data?.github.pullRequest),
     });
-    openWorkspaceFileTab(sessionId, "diff", file.path);
+    openWorkspaceFileTab(sessionId, "diff", file.path, {
+      preferKanbanPeek: true,
+    });
   }, [
     controller.changedFileCount,
     controller.data?.github.pullRequest,
@@ -186,7 +190,9 @@ export function GitPanel({
       has_changes: Boolean(controller.changedFileCount),
       has_pr: Boolean(controller.data?.prStatus || controller.data?.github.pullRequest),
     });
-    openWorkspaceFileTab(sessionId, "file", file.path);
+    openWorkspaceFileTab(sessionId, "file", file.path, {
+      preferKanbanPeek: true,
+    });
   }, [
     controller.changedFileCount,
     controller.data?.github.pullRequest,

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -111,7 +111,10 @@ export const AppHeader = memo(function AppHeader() {
                     type="button"
                     onClick={toggleGitPanel}
                     className={cn(
-                      'electron-no-drag flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-(--divider) transition-colors',
+                      // Lift above the Session Peek backdrop (z-50) so the panel
+                      // toggle stays clickable while a peek is open — otherwise the
+                      // backdrop swallows the click and light-dismisses the peek.
+                      'relative z-[60] electron-no-drag flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-(--divider) transition-colors',
                       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35',
                       gitPanelOpen
                         ? 'bg-(--accent)/14 text-(--accent)'


### PR DESCRIPTION
## 변경

Kanban Peek 모드의 두 가지 문제를 수정합니다.

- **git 탭 파일 열기**: git 탭의 파일 열기 핸들러(diff/pin/read-only)가 `preferKanbanPeek`을 넘기지 않아, board peek 모드에서도 파일이 peek이 아닌 일반 탭 경로로 빠지던 문제. 파일 탭과 동일하게 `{ preferKanbanPeek: true }`를 전달합니다.
- **패널 토글 클릭 유실**: Session Peek backdrop(`z-50`)이 우측 패널 토글 버튼을 덮어, 버튼 자리를 누르면 backdrop이 클릭을 받아 peek이 light-dismiss되던 문제. 토글 버튼을 `z-[60]`으로 올려 peek을 유지한 채 우측 git 패널을 여닫을 수 있게 합니다.

## 검증

- 변경 파일 eslint 통과
- origin/dev 바로 위 1커밋, 충돌 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)