### PR TITLE
fix(terminal): keep the PTY hook fallback alive when a foreign server answers

### DIFF
--- a/src/lib/terminal/hook-command.ts
+++ b/src/lib/terminal/hook-command.ts
@@ -14,6 +14,15 @@
  *     않는다. curl.exe는 Windows 프로세스라 그쪽 127.0.0.1이 호스트 loopback이다.
  *     interop PATH가 꺼진 환경을 위해 /mnt/c 절대경로도 폴백으로 둔다.
  *
+ * --fail은 그 폴백의 전제("게스트 포트가 비어 연결 거부로 실패한다")를 지키는 장치다.
+ * npm CLI(bin/tessera.mjs)와 Electron의 기본 포트가 둘 다 32123이고 win32/WSL은 네트워크
+ * 스택이 분리돼 서로의 포트 스캔이 상대를 못 보므로, 게스트에 tessera를 띄우면 같은 포트에
+ * 리스너가 생긴다. 그러면 1차 curl이 연결에 성공해 폴백이 죽는데, 그 서버는 pane token을
+ * 모르니 401/403을 준다 — --fail이 없으면 curl이 exit 0이라 훅이 통째로 유실된다
+ * (인디케이터 정지 + history 미기록으로 resume까지 깨짐). --fail은 4xx/5xx를 exit 22로
+ * 바꿔 폴백을 살린다. 토큰 레지스트리는 in-memory라 남의 인스턴스가 204를 줄 수 없어,
+ * "204 = 이 훅의 주인"이 항상 성립한다(정상 수신은 204라 --fail에 걸리지 않는다).
+ *
  * stdin(훅 페이로드 JSON)은 한 번만 읽을 수 있으므로 변수에 담아 재시도에 재사용한다.
  * $TESSERA_HOOK_PORT / $TESSERA_SESSION_ID / $TESSERA_PANE_TOKEN 은 훅 셸의
  * env(=PTY env)에서 확장된다. 셸 인젝션 표면 없음: 값은 전부 서버가 주입한 env 참조뿐.
@@ -28,7 +37,7 @@ const POSIX_HOOK_URL =
 // 인자: $1=curl 바이너리, $2=connect-timeout, $3=max-time.
 // 게스트 curl은 짧게(연결 거부는 즉시 실패), curl.exe는 부하 내성 있게(orca의 3/5초).
 const POSIX_HOOK_POST_FN =
-  'tessera_hook_post() { printf \'%s\' "$payload" | "$1" -sS --connect-timeout "$2" --max-time "$3" '
+  'tessera_hook_post() { printf \'%s\' "$payload" | "$1" -sS --fail --connect-timeout "$2" --max-time "$3" '
   + '--noproxy 127.0.0.1 -X POST '
   + POSIX_HOOK_URL
   + ' -H "X-Tessera-Pane-Token: $TESSERA_PANE_TOKEN" --data-binary @- >/dev/null 2>&1; }';

--- a/tests/codex-overlay-trust.test.ts
+++ b/tests/codex-overlay-trust.test.ts
@@ -11,12 +11,12 @@ import {
 // 훅 커맨드(hook-command.ts)나 timeout이 바뀌면 함께 바뀐다 — codex의
 // command_hook_hash 계약(정규화·직렬화)이 유지되는지 고정하는 값.
 const EXPECTED_TRUSTED_HASHES = {
-  session_start: 'sha256:0626b462a12e80f8416336be018bbdfabdf833c5e13151c958a57d9fe0c9aced',
-  user_prompt_submit: 'sha256:854cacc598204def316a423448c232ce2c942b812541806270aa3ea97c9fcb01',
-  pre_tool_use: 'sha256:821062830a944ef60378d1c5691a2ec89fe460af1859b398bdbb8d20d40277c9',
-  permission_request: 'sha256:24918cff6d9dd35779ddf31a75a8e4af3750ae4c3532034fe4faaa9fb57d7c7c',
-  post_tool_use: 'sha256:89c598cdcec1623498676672866af5166c3fd051a57b16284091514a4472424d',
-  stop: 'sha256:93de6115736b90124a5856879795d5e9a1165e1ab8e004ed10e221f18846d267',
+  session_start: 'sha256:54118a230f5a83c3bd07b62077af4c27a38bd3d2e7087c3771b2effb1318e2f9',
+  user_prompt_submit: 'sha256:0f11b1e78a95d841d47f37b1bd79b598ce91ba11f0962e4fb4b30c264fb4d9f1',
+  pre_tool_use: 'sha256:c6164b8a833972d6597fb603f95193db1a327b1c6bebd379fad3d06e42509285',
+  permission_request: 'sha256:dbfc8a48b3def5b466ef460fdc822ba1521ec4ed587227d237c8cccc19f3c2e3',
+  post_tool_use: 'sha256:9417b820045acf8a0ada4b56ab7d0295b36fe475949ce9bf77b3db36b3bd6ba1',
+  stop: 'sha256:5af8ee0181c8ee533e4a53fc56e393ee95096c6c7699613d56438d98a198e5a1',
 } as const;
 
 test('Codex overlay pre-trusts exactly the lifecycle hooks it installs', () => {

--- a/tests/hook-command.test.ts
+++ b/tests/hook-command.test.ts
@@ -98,7 +98,100 @@ test('posix hook command retries through curl.exe on WSL runtimes', () => {
   assert.match(command, /\/proc\/version/);
   // interop PATH의 curl.exe → 절대경로 폴백 순.
   assert.match(command, /tessera_hook_post curl\.exe 3 5 \|\| tessera_hook_post \/mnt\/c\/Windows\/System32\/curl\.exe 3 5/);
+  // --fail이 빠지면 남의 서버의 401/403이 exit 0으로 취급돼 폴백 전체가 무력화된다.
+  assert.match(command, /-sS --fail /);
   assert.match(command, /\|\| true$/);
+});
+
+/**
+ * 회귀: 게스트 포트를 다른 Tessera 인스턴스가 선점한 상황(npm CLI와 Electron의 기본 포트가
+ * 둘 다 32123). 그 서버는 pane token을 모르니 401/403을 주는데, --fail이 없으면 curl이
+ * exit 0을 반환해 폴백이 죽고 훅이 통째로 유실된다 — 인디케이터가 멈추고 history가 안 쌓여
+ * resume까지 깨진다. 연결 거부(exit 7)가 아니라 "연결은 됐지만 남의 서버"를 재현한다.
+ */
+test('posix hook command falls through to curl.exe when a foreign server rejects the token', async () => {
+  let rejected = 0;
+  const foreign = http.createServer((req, res) => {
+    req.resume();
+    req.on('end', () => { rejected += 1; res.writeHead(403).end(); });
+  });
+  await new Promise<void>((resolve) => foreign.listen(0, '127.0.0.1', resolve));
+  const port = (foreign.address() as AddressInfo).port;
+
+  // curl은 스텁하지 않는다 — 실제 curl이 403을 어떻게 다루는지가 이 테스트의 핵심.
+  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-curl-foreign-'));
+  const marker = path.join(stubDir, 'fallback-used');
+  fs.writeFileSync(path.join(stubDir, 'curl.exe'), `#!/bin/sh\ncat >/dev/null\n: > '${marker}'\nexit 0\n`);
+  fs.chmodSync(path.join(stubDir, 'curl.exe'), 0o755);
+
+  try {
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const child = spawn('sh', ['-c', buildHookCommand('posix')], {
+        env: {
+          ...process.env,
+          PATH: `${stubDir}:${process.env.PATH ?? ''}`,
+          // 비-WSL CI에서도 폴백 분기를 타도록 런타임 감지를 강제한다.
+          WSL_DISTRO_NAME: 'Ubuntu-test',
+          TESSERA_HOOK_PORT: String(port),
+          TESSERA_SESSION_ID: 's',
+          TESSERA_PANE_TOKEN: 'wrong-token',
+        },
+        stdio: ['pipe', 'ignore', 'ignore'],
+      });
+      child.on('error', reject);
+      child.on('close', resolve);
+      child.stdin.end('{}');
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(rejected, 1, '남의 서버가 훅을 한 번 거절해야 한다');
+    assert.ok(fs.existsSync(marker), '403을 받으면 curl.exe 폴백으로 넘어가야 한다');
+  } finally {
+    foreign.close();
+    fs.rmSync(stubDir, { recursive: true, force: true });
+  }
+});
+
+/** --fail이 정상 경로를 건드리지 않는지: 204를 받으면 폴백을 타면 안 된다(훅 중복 전송 방지). */
+test('posix hook command does not fall through when the owning server accepts', async () => {
+  let accepted = 0;
+  const owner = http.createServer((req, res) => {
+    req.resume();
+    req.on('end', () => { accepted += 1; res.writeHead(204).end(); });
+  });
+  await new Promise<void>((resolve) => owner.listen(0, '127.0.0.1', resolve));
+  const port = (owner.address() as AddressInfo).port;
+
+  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-curl-owner-'));
+  const marker = path.join(stubDir, 'fallback-used');
+  fs.writeFileSync(path.join(stubDir, 'curl.exe'), `#!/bin/sh\ncat >/dev/null\n: > '${marker}'\nexit 0\n`);
+  fs.chmodSync(path.join(stubDir, 'curl.exe'), 0o755);
+
+  try {
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const child = spawn('sh', ['-c', buildHookCommand('posix')], {
+        env: {
+          ...process.env,
+          PATH: `${stubDir}:${process.env.PATH ?? ''}`,
+          WSL_DISTRO_NAME: 'Ubuntu-test',
+          TESSERA_HOOK_PORT: String(port),
+          TESSERA_SESSION_ID: 's',
+          TESSERA_PANE_TOKEN: 't',
+        },
+        stdio: ['pipe', 'ignore', 'ignore'],
+      });
+      child.on('error', reject);
+      child.on('close', resolve);
+      child.stdin.end('{}');
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(accepted, 1);
+    assert.equal(fs.existsSync(marker), false, '204를 받으면 폴백을 타면 안 된다');
+  } finally {
+    owner.close();
+    fs.rmSync(stubDir, { recursive: true, force: true });
+  }
 });
 
 test('windows-cmd hook command uses the fully-qualified curl.exe with %VAR% expansion', () => {


### PR DESCRIPTION
## Summary

- The PTY status hook POSTs to `127.0.0.1:$TESSERA_HOOK_PORT` with the guest `curl`, falling back to `curl.exe` only when that first attempt fails. The fallback assumed an unused guest port would refuse the connection outright.
- `bin/tessera.mjs` and `electron/main.ts` both default to port **32123**, and win32/WSL have separate network stacks, so neither port scan can see the other. Running `tessera` inside WSL parks a second listener on that same port — and the first `curl` then *connects*.
- That instance holds no matching pane token, so `hook-receiver` answers `403`. Without `--fail`, `curl` still exits `0`, so the `||` fallback never ran and every hook was silently swallowed.
- All three reported symptoms trace back to this one cause: the PTY activity indicator stalls for **both Claude and Codex** (they share the hook path), and since `UserPromptSubmit` never reaches `sessionHistory`, `historyExists()` returns false — so the next launch reuses `--session-id` instead of `--resume`, which the CLI rejects with a session-id error. macOS is unaffected, as the dual-stack loopback situation cannot arise there.
- **Fix:** add `--fail` to the POSIX hook `curl`. It maps 4xx/5xx to exit 22 so the fallback runs. A delivered hook returns `204` and is untouched, and the pane token registry is in-memory (`src/lib/terminal/pane-token-registry.ts:11`), so a foreign instance can never answer `204` — "204 means the rightful owner" always holds. `windows-cmd` has no fallback chain and is left unchanged.
- Codex pre-trusts each hook by hashing its command, so the golden `trusted_hash` values in `codex-overlay-trust.test.ts` move with the command. They are recomputed here; the hash covers only the command, event name and timeout, so it stays path-independent and reproducible (verified across two runs in separate temp dirs).

Measured `curl` exit codes:

| server reply | before | with `--fail` |
| --- | --- | --- |
| `204` (delivered) | 0 | 0 — no fallback, as intended |
| `403` (foreign server) | **0** — the bug | 22 — fallback runs |
| no listener | 7 | 7 — fallback runs |

## Testing

- [x] `npm run lint` — 0 errors (2 pre-existing warnings in unrelated files)
- [x] `npx tsc --noEmit`
- [x] `NODE_ENV=production npm run build`
- [x] Manual test: reproduced the hijack on Windows Electron 0.2.2 with a `tessera` server running inside WSL — the guest listener answered `403` with `curl` exiting `0`, and the desktop app received no hooks at all. After stopping the guest listener, the guest `curl` failed with exit `7` and `curl.exe` reached the app.
- [x] Two regression tests added in `tests/hook-command.test.ts`: a real HTTP server returning `403` on the guest port must trigger the `curl.exe` fallback, and a server returning `204` must *not*. `curl` is deliberately not stubbed — how the real `curl` treats `403` is the whole point. Removing `--fail` fails exactly these tests and leaves the `204` case passing.
- [ ] Not tested: end-to-end on a repackaged Windows desktop build. The fix is verified at the hook-command layer and by the reproduction above, but a rebuilt installer has not been exercised.

## Screenshots or Recordings

Not applicable — no UI changes.

## Notes

The port collision itself is untouched: the npm CLI and Electron still both default to 32123. This PR makes the hook route correctly regardless, so it is safe to run a `tessera` server inside WSL alongside the desktop app. Separating the default ports would additionally remove the "which server is on localhost:32123?" ambiguity, but that affects existing bookmarks and settings and is better judged separately.

One residual, worth recording: because `403` is returned only after the body is read, a hook payload — including the full prompt text in `UserPromptSubmit` — reaches the foreign server once before being rejected. Both servers are the user's own on loopback, so practical risk is low, and closing it would require a pre-flight token handshake that is disproportionate for a single fire-and-forget POST.
