### PR TITLE
fix(git): stop diff stats from staying stale when push triggers go quiet

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,3 +53,15 @@ The mode actually used by a session after applying the user's preferred executio
 ### Session execution mode
 
 The effective execution mode fixed when a session is created. A session cannot switch between GUI and PTY modes, and conversation state cannot resume across those modes.
+
+### Worktree diff stats
+
+The uncommitted work in a working directory, measured against its last commit and counted as added lines, removed lines, and changed files. Lines in new untracked files count as added. Every session sharing a working directory shows the same stats.
+
+_Avoid_: diff count, change count, line count
+
+### Diff stats safety sweep
+
+The periodic refresh that recomputes worktree diff stats for sessions with a live runtime, so displayed stats cannot stay wrong indefinitely when the signals that normally trigger a recompute all go quiet.
+
+_Avoid_: diff polling, stats refresh loop

--- a/src/lib/git/diff-stats-safety-sweep-runner.ts
+++ b/src/lib/git/diff-stats-safety-sweep-runner.ts
@@ -1,0 +1,77 @@
+import logger from '@/lib/logger';
+import { getActiveSessionIds } from '@/lib/session/active-session-runtime';
+import { getManagedSessionWorkDir } from './session-diff-refresh';
+import {
+  getCachedDiffStats,
+  isDiffStatsStale,
+  scheduleRecompute,
+} from './worktree-diff-stats-cache';
+import {
+  runDiffStatsSafetySweep,
+  type DiffStatsSafetySweepDependencies,
+} from './diff-stats-safety-sweep';
+
+/**
+ * Sweep cadence. Matches the interval Orca uses for its equivalent git status
+ * safety refresh: frequent enough that a wrong badge is short-lived, slow
+ * enough that it costs one debounced git pass per active worktree at most.
+ */
+const SWEEP_INTERVAL_MS = 60_000;
+
+interface SweepState {
+  timer: NodeJS.Timeout | null;
+}
+
+// globalThis so Next.js hot reload cannot leave a second timer running.
+const SWEEP_KEY = Symbol.for('tessera.diffStatsSafetySweep');
+const g = globalThis as unknown as { [SWEEP_KEY]?: SweepState };
+
+function getState(): SweepState {
+  if (!g[SWEEP_KEY]) g[SWEEP_KEY] = { timer: null };
+  return g[SWEEP_KEY]!;
+}
+
+function buildDependencies(
+  getConnectedUserIds: () => Iterable<string>,
+): DiffStatsSafetySweepDependencies {
+  return {
+    getConnectedUserIds,
+    getActiveSessionIds: (userId) => getActiveSessionIds(userId),
+    getSessionWorkDir: (sessionId) => getManagedSessionWorkDir(sessionId),
+    needsRefresh: (workDir) =>
+      getCachedDiffStats(workDir) === undefined || isDiffStatsStale(workDir),
+    recompute: (workDir, userId) => scheduleRecompute(workDir, userId),
+  };
+}
+
+/**
+ * Start the periodic sweep. Idempotent — a second call is a no-op while a
+ * timer is already armed.
+ */
+export function installDiffStatsSafetySweep(
+  getConnectedUserIds: () => Iterable<string>,
+): void {
+  const state = getState();
+  if (state.timer) return;
+
+  const dependencies = buildDependencies(getConnectedUserIds);
+  state.timer = setInterval(() => {
+    try {
+      const { refreshed, inspected } = runDiffStatsSafetySweep(dependencies);
+      if (refreshed.length > 0) {
+        logger.debug({ refreshed, inspected }, 'Diff stats safety sweep re-armed stale worktrees');
+      }
+    } catch (error) {
+      logger.warn({ error }, 'Diff stats safety sweep failed');
+    }
+  }, SWEEP_INTERVAL_MS);
+  // Never hold the process open for a backstop.
+  state.timer.unref?.();
+}
+
+export function uninstallDiffStatsSafetySweep(): void {
+  const state = getState();
+  if (!state.timer) return;
+  clearInterval(state.timer);
+  state.timer = null;
+}

--- a/src/lib/git/diff-stats-safety-sweep.ts
+++ b/src/lib/git/diff-stats-safety-sweep.ts
@@ -1,0 +1,58 @@
+/**
+ * Periodic backstop that re-arms worktree diff stats for sessions with a live
+ * runtime.
+ *
+ * Why: every existing recompute trigger is push-driven, and all of them can go
+ * quiet at the same time — a dead file-watch channel, a PTY session that never
+ * emits tool side effects, and no turn boundary to flush. When that happens the
+ * badge keeps whatever number it last saw until some unrelated activity
+ * happens to touch the same workDir. This sweep bounds that window without
+ * touching the push paths.
+ */
+
+export interface DiffStatsSafetySweepDependencies {
+  /** Users with a live transport; nobody connected means nobody to broadcast to. */
+  getConnectedUserIds(): Iterable<string>;
+  /** Sessions backed by a running GUI process or PTY, for one user. */
+  getActiveSessionIds(userId: string): Iterable<string>;
+  getSessionWorkDir(sessionId: string): string | null;
+  /** True when the cached entry is missing or older than the TTL. */
+  needsRefresh(workDir: string): boolean;
+  recompute(workDir: string, userId: string): void;
+}
+
+export interface DiffStatsSafetySweepResult {
+  /** workDirs handed to recompute this pass. */
+  refreshed: string[];
+  /** Distinct workDirs the sweep considered, refreshed or not. */
+  inspected: number;
+}
+
+/**
+ * Run a single sweep pass. Pure apart from the injected dependencies so the
+ * scheduling policy can be tested without timers, git, or a live server.
+ */
+export function runDiffStatsSafetySweep(
+  dependencies: DiffStatsSafetySweepDependencies,
+): DiffStatsSafetySweepResult {
+  const refreshed: string[] = [];
+  // First user seen for a workDir wins: a shared worktree only needs one
+  // recompute, and the broadcast fans out to every session on that workDir.
+  const ownerByWorkDir = new Map<string, string>();
+
+  for (const userId of dependencies.getConnectedUserIds()) {
+    for (const sessionId of dependencies.getActiveSessionIds(userId)) {
+      const workDir = dependencies.getSessionWorkDir(sessionId);
+      if (!workDir || ownerByWorkDir.has(workDir)) continue;
+      ownerByWorkDir.set(workDir, userId);
+    }
+  }
+
+  for (const [workDir, userId] of ownerByWorkDir) {
+    if (!dependencies.needsRefresh(workDir)) continue;
+    dependencies.recompute(workDir, userId);
+    refreshed.push(workDir);
+  }
+
+  return { refreshed, inspected: ownerByWorkDir.size };
+}

--- a/src/lib/git/git-panel.ts
+++ b/src/lib/git/git-panel.ts
@@ -14,7 +14,10 @@ import {
   computeWorktreeFileDiffStats,
   computeWorktreeFileDiffStatsFromRaw,
 } from "@/lib/git/worktree-diff-stats";
-import { getCachedDiffStats } from "@/lib/git/worktree-diff-stats-cache";
+import {
+  getCachedDiffStats,
+  getCachedDiffStatsRevalidating,
+} from "@/lib/git/worktree-diff-stats-cache";
 import { getAgentEnvironment, spawnCli } from "@/lib/cli/spawn-cli";
 import { getManagedWorktreeRelativeDisplayPath } from "@/lib/worktrees/managed";
 import { getRuntimePlatform } from "@/lib/system/runtime-platform";
@@ -991,8 +994,14 @@ export async function getGitPanelData(
     changedFilesTruncated: changedFiles.truncated,
     recentCommits: parseRecentCommits(recentCommitsRaw ?? ""),
     github,
+    // changedFiles below is always freshly probed, so serving a stale cached
+    // diffStats next to it puts two contradicting numbers in one panel. Reading
+    // through the revalidating accessor re-arms the cache whenever the panel is
+    // opened, which is also the moment a user is most likely to notice a lie.
     diffStats: sessionContext.worktreeBranch
-      ? getCachedDiffStats(workDir) ?? undefined
+      ? (userId
+        ? getCachedDiffStatsRevalidating(workDir, userId)
+        : getCachedDiffStats(workDir)) ?? undefined
       : undefined,
     prStatus: prContext?.prStatus ?? bareSessionPr?.prStatus,
     prUnsupported:

--- a/src/lib/git/worktree-diff-stats-bulk.ts
+++ b/src/lib/git/worktree-diff-stats-bulk.ts
@@ -1,13 +1,17 @@
 import {
   computeAndCache,
   getCachedDiffStats,
+  isDiffStatsStale,
+  scheduleRecompute,
 } from './worktree-diff-stats-cache';
 import type { WorktreeDiffStats } from '@/types/worktree-diff-stats';
 
 /**
  * Return cached diff stats for each unique workDir. For any workDir without a
  * cache entry, kick off a background compute so the client receives the update
- * via WebSocket push shortly. Never blocks the caller.
+ * via WebSocket push shortly. A cached-but-stale entry is returned as-is and
+ * refreshed in the background, so a list load always re-arms counts that a
+ * missed push signal left frozen. Never blocks the caller.
  */
 export function getCachedOrScheduleBulk(
   workDirs: Array<string | undefined>,
@@ -23,6 +27,10 @@ export function getCachedOrScheduleBulk(
     const cached = getCachedDiffStats(wd);
     if (cached !== undefined) {
       result.set(wd, cached);
+      if (isDiffStatsStale(wd)) {
+        // Debounced so a burst of list loads collapses into one git invocation.
+        scheduleRecompute(wd, userId);
+      }
     } else {
       scheduled.add(wd);
       // fire-and-forget — broadcast listener will push to the user when ready

--- a/src/lib/git/worktree-diff-stats-cache.ts
+++ b/src/lib/git/worktree-diff-stats-cache.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { getAgentEnvironment } from '@/lib/cli/spawn-cli';
 import { computeWorktreeDiffStats } from './worktree-diff-stats';
+import { isDiffStatsEntryStale } from './worktree-diff-stats-staleness';
 import type { WorktreeDiffStats } from '@/types/worktree-diff-stats';
 
 const DEBOUNCE_MS = 300;
@@ -54,6 +55,33 @@ export function getCachedDiffStats(workDir: string): WorktreeDiffStats | null | 
   const key = normalize(workDir);
   const entry = getState().entries.get(key);
   return entry ? entry.stats : undefined;
+}
+
+/**
+ * True when a cache entry exists but is older than the TTL. A cache miss is
+ * NOT stale — callers distinguish the two because a miss needs a blocking-free
+ * first compute while a stale hit still has a usable value to return meanwhile.
+ */
+export function isDiffStatsStale(workDir: string, now: number = Date.now()): boolean {
+  const entry = getState().entries.get(normalize(workDir));
+  if (!entry) return false;
+  return isDiffStatsEntryStale(entry.computedAt, now);
+}
+
+/**
+ * Cached value for a read path, refreshing it in the background when the entry
+ * has gone stale. The returned value is whatever is cached right now (possibly
+ * stale); the refresh reaches the client via the diff-stats broadcast.
+ */
+export function getCachedDiffStatsRevalidating(
+  workDir: string,
+  userId: string,
+): WorktreeDiffStats | null | undefined {
+  const cached = getCachedDiffStats(workDir);
+  if (cached !== undefined && isDiffStatsStale(workDir)) {
+    scheduleRecompute(workDir, userId);
+  }
+  return cached;
 }
 
 export function subscribeDiffStats(listener: Listener): () => void {

--- a/src/lib/git/worktree-diff-stats-staleness.ts
+++ b/src/lib/git/worktree-diff-stats-staleness.ts
@@ -1,0 +1,22 @@
+/**
+ * Age policy for cached worktree diff stats.
+ *
+ * Kept free of imports so the policy can be exercised without pulling in the
+ * cache's git/settings dependency chain.
+ */
+
+/**
+ * Age past which a cached entry is no longer trusted on read.
+ *
+ * Why: recompute is purely push-driven (file watch, per-tool side effect,
+ * turn-end flush). Every one of those can go silent at once — a dead WSL
+ * inotify bridge plus PTY-only sessions plus no turn boundary pinned real
+ * counts for two hours in practice. This TTL is the sole backstop that bounds
+ * how long a missed signal can keep wrong numbers on screen.
+ */
+export const DIFF_STATS_STALE_TTL_MS = 2 * 60_000;
+
+/** True once an entry computed at `computedAt` has reached the TTL. */
+export function isDiffStatsEntryStale(computedAt: number, now: number): boolean {
+  return now - computedAt >= DIFF_STATS_STALE_TTL_MS;
+}

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -15,6 +15,10 @@ import { rateLimitPoller } from '../rate-limit/poller';
 import logger from '../logger';
 import { sessionHistory } from '../session-history';
 import { installDiffStatsBroadcast } from '../git/worktree-diff-stats-broadcast';
+import {
+  installDiffStatsSafetySweep,
+  uninstallDiffStatsSafetySweep,
+} from '../git/diff-stats-safety-sweep-runner';
 import { installGitPanelBroadcast } from '../git/git-panel-broadcast';
 import { bindTerminalRuntimeSender, terminalManager } from '../terminal/shared-terminal-manager';
 import { workspaceFileWatchManager } from '../workspace-files/workspace-file-watch-manager';
@@ -76,6 +80,8 @@ export class WebSocketServer {
 
     // Relay worktree diff-stats updates to connected users
     installDiffStatsBroadcast();
+    // Backstop for when every push trigger goes quiet at once (see the sweep module)
+    installDiffStatsSafetySweep(() => this.connections.keys());
     // Relay git panel state updates (commits, branch, changedFiles, prStatus)
     installGitPanelBroadcast();
 
@@ -470,6 +476,7 @@ export class WebSocketServer {
    */
   async shutdown(): Promise<void> {
     this.stopPingPong();
+    uninstallDiffStatsSafetySweep();
     this.analysisUnsubscribe?.();
     this.analysisUnsubscribe = null;
     await terminalManager.shutdownAll();

--- a/tests/diff-stats-safety-sweep.test.ts
+++ b/tests/diff-stats-safety-sweep.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  runDiffStatsSafetySweep,
+  type DiffStatsSafetySweepDependencies,
+} from '@/lib/git/diff-stats-safety-sweep';
+
+interface Fixture {
+  connectedUserIds?: string[];
+  sessionsByUser?: Record<string, string[]>;
+  workDirBySession?: Record<string, string | null>;
+  staleWorkDirs?: string[];
+}
+
+function createDependencies(fixture: Fixture): {
+  dependencies: DiffStatsSafetySweepDependencies;
+  recomputed: Array<{ workDir: string; userId: string }>;
+} {
+  const recomputed: Array<{ workDir: string; userId: string }> = [];
+  const stale = new Set(fixture.staleWorkDirs ?? []);
+
+  return {
+    recomputed,
+    dependencies: {
+      getConnectedUserIds: () => fixture.connectedUserIds ?? [],
+      getActiveSessionIds: (userId) => fixture.sessionsByUser?.[userId] ?? [],
+      getSessionWorkDir: (sessionId) => fixture.workDirBySession?.[sessionId] ?? null,
+      needsRefresh: (workDir) => stale.has(workDir),
+      recompute: (workDir, userId) => {
+        recomputed.push({ workDir, userId });
+      },
+    },
+  };
+}
+
+test('sweep refreshes only the worktrees whose cached stats went stale', () => {
+  const { dependencies, recomputed } = createDependencies({
+    connectedUserIds: ['user-a'],
+    sessionsByUser: { 'user-a': ['session-stale', 'session-fresh'] },
+    workDirBySession: {
+      'session-stale': '/repo/stale',
+      'session-fresh': '/repo/fresh',
+    },
+    staleWorkDirs: ['/repo/stale'],
+  });
+
+  const result = runDiffStatsSafetySweep(dependencies);
+
+  assert.deepEqual(recomputed, [{ workDir: '/repo/stale', userId: 'user-a' }]);
+  assert.deepEqual(result.refreshed, ['/repo/stale']);
+  assert.equal(result.inspected, 2);
+});
+
+test('sweep does nothing when no user is connected to receive the broadcast', () => {
+  const { dependencies, recomputed } = createDependencies({
+    connectedUserIds: [],
+    sessionsByUser: { 'user-a': ['session-stale'] },
+    workDirBySession: { 'session-stale': '/repo/stale' },
+    staleWorkDirs: ['/repo/stale'],
+  });
+
+  const result = runDiffStatsSafetySweep(dependencies);
+
+  assert.deepEqual(recomputed, []);
+  assert.equal(result.inspected, 0);
+});
+
+test('sessions sharing one workDir produce a single recompute', () => {
+  const { dependencies, recomputed } = createDependencies({
+    connectedUserIds: ['user-a'],
+    sessionsByUser: { 'user-a': ['session-1', 'session-2', 'session-3'] },
+    workDirBySession: {
+      'session-1': '/repo/shared',
+      'session-2': '/repo/shared',
+      'session-3': '/repo/shared',
+    },
+    staleWorkDirs: ['/repo/shared'],
+  });
+
+  runDiffStatsSafetySweep(dependencies);
+
+  assert.deepEqual(recomputed, [{ workDir: '/repo/shared', userId: 'user-a' }]);
+});
+
+test('a workDir shared across users is recomputed once, for the first owner seen', () => {
+  const { dependencies, recomputed } = createDependencies({
+    connectedUserIds: ['user-a', 'user-b'],
+    sessionsByUser: {
+      'user-a': ['session-a'],
+      'user-b': ['session-b'],
+    },
+    workDirBySession: {
+      'session-a': '/repo/shared',
+      'session-b': '/repo/shared',
+    },
+    staleWorkDirs: ['/repo/shared'],
+  });
+
+  runDiffStatsSafetySweep(dependencies);
+
+  assert.deepEqual(recomputed, [{ workDir: '/repo/shared', userId: 'user-a' }]);
+});
+
+test('sessions without a work_dir are skipped', () => {
+  const { dependencies, recomputed } = createDependencies({
+    connectedUserIds: ['user-a'],
+    sessionsByUser: { 'user-a': ['session-no-dir'] },
+    workDirBySession: { 'session-no-dir': null },
+    staleWorkDirs: ['/repo/stale'],
+  });
+
+  const result = runDiffStatsSafetySweep(dependencies);
+
+  assert.deepEqual(recomputed, []);
+  assert.equal(result.inspected, 0);
+});
+
+test('idle sessions are out of scope: only live runtimes are swept', () => {
+  // getActiveSessionIds is the sole source of sessions, so a stopped session's
+  // workDir never reaches needsRefresh even when its cached stats are stale.
+  const inspectedWorkDirs: string[] = [];
+  const { dependencies } = createDependencies({
+    connectedUserIds: ['user-a'],
+    sessionsByUser: { 'user-a': [] },
+    workDirBySession: { 'session-idle': '/repo/idle' },
+    staleWorkDirs: ['/repo/idle'],
+  });
+
+  const result = runDiffStatsSafetySweep({
+    ...dependencies,
+    needsRefresh: (workDir) => {
+      inspectedWorkDirs.push(workDir);
+      return true;
+    },
+  });
+
+  assert.deepEqual(inspectedWorkDirs, []);
+  assert.equal(result.inspected, 0);
+});

--- a/tests/worktree-diff-stats-cache-revalidation.test.ts
+++ b/tests/worktree-diff-stats-cache-revalidation.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  getCachedDiffStats,
+  isDiffStatsStale,
+} from '@/lib/git/worktree-diff-stats-cache';
+import { DIFF_STATS_STALE_TTL_MS } from '@/lib/git/worktree-diff-stats-staleness';
+import type { WorktreeDiffStats } from '@/types/worktree-diff-stats';
+
+interface CacheEntry {
+  stats: WorktreeDiffStats | null;
+  computedAt: number;
+}
+
+/**
+ * Seed the module's globalThis-backed cache directly. Going through the real
+ * compute path would shell out to git; what needs proving here is only how a
+ * seeded entry's age is reported back to read paths.
+ */
+function seedCacheEntry(workDir: string, computedAt: number): void {
+  const state = (globalThis as unknown as Record<
+    symbol,
+    { entries: Map<string, CacheEntry> } | undefined
+  >)[Symbol.for('tessera.worktreeDiffStatsCache')];
+  assert.ok(state, 'importing the cache module should create its global state');
+  state.entries.set(workDir, {
+    stats: {
+      added: 8,
+      removed: 0,
+      changedFiles: 2,
+      newFiles: 0,
+      deletedFiles: 0,
+      computedAt: new Date(computedAt).toISOString(),
+    },
+    computedAt,
+  });
+}
+
+test('a cache miss is not stale — it is a distinct state with no value to serve', () => {
+  assert.equal(getCachedDiffStats('/repo/never-computed'), undefined);
+  assert.equal(isDiffStatsStale('/repo/never-computed'), false);
+});
+
+test('a fresh entry is served without being marked stale', () => {
+  const now = 5_000_000;
+  seedCacheEntry('/repo/fresh', now - 1_000);
+
+  assert.equal(isDiffStatsStale('/repo/fresh', now), false);
+  assert.equal(getCachedDiffStats('/repo/fresh')?.added, 8);
+});
+
+test('a stale entry keeps serving its value so the read path never blocks', () => {
+  const now = 5_000_000;
+  seedCacheEntry('/repo/stale', now - DIFF_STATS_STALE_TTL_MS - 1);
+
+  assert.equal(isDiffStatsStale('/repo/stale', now), true);
+  // Staleness marks the entry for refresh; it does not withdraw the value.
+  assert.equal(getCachedDiffStats('/repo/stale')?.added, 8);
+});

--- a/tests/worktree-diff-stats-staleness.test.ts
+++ b/tests/worktree-diff-stats-staleness.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  DIFF_STATS_STALE_TTL_MS,
+  isDiffStatsEntryStale,
+} from '@/lib/git/worktree-diff-stats-staleness';
+
+test('an entry younger than the TTL is trusted', () => {
+  const now = 1_000_000;
+
+  assert.equal(isDiffStatsEntryStale(now - (DIFF_STATS_STALE_TTL_MS - 1), now), false);
+});
+
+test('an entry that reached the TTL is stale', () => {
+  const now = 1_000_000;
+
+  assert.equal(isDiffStatsEntryStale(now - DIFF_STATS_STALE_TTL_MS, now), true);
+});
+
+test('a just-computed entry is never stale', () => {
+  const now = 1_000_000;
+
+  assert.equal(isDiffStatsEntryStale(now, now), false);
+});
+
+/**
+ * The freeze this backstop exists for: a diff badge kept two-hour-old counts
+ * because every push trigger stayed quiet. Any TTL that fails this assertion
+ * would let that recur.
+ */
+test('a two-hour-old entry is stale', () => {
+  const now = 1_000_000;
+
+  assert.equal(isDiffStatsEntryStale(now - 2 * 60 * 60_000, now), true);
+});


### PR DESCRIPTION
## Summary

- Diff stats badges could show hours-old numbers. Recompute was purely push-driven — workspace file-watch events, per-tool side effects, turn-end flushes — and all of those can go quiet at the same time. Observed on a base checkout: a `+39 -0 / 2` badge stayed on screen for about two hours while the real diff was `+2 -0 / 1`, and it only corrected itself when an unrelated session happened to touch the same working directory.
- The git panel made this self-contradicting: `changedFiles` is probed fresh on every panel build (`git status`), while `diffStats` was read from cache and never revalidated, so one panel showed `DIFF +39 -0 / 2` directly above `CHANGED FILES 1`.
- Fix adds an age-based backstop without touching the push paths:
  - **Read-path revalidation** — the task-list bulk endpoint and the git panel serve the cached value and schedule a background recompute once an entry passes the TTL. The refresh reaches the client over the existing diff-stats broadcast.
  - **Safety sweep** — a periodic pass re-arms working directories for sessions with a live GUI or PTY runtime, so a screen nobody is interacting with still self-corrects. Gated on there being a connected user to broadcast to; one recompute per working directory regardless of how many sessions share it.
- A cache miss stays distinct from a stale hit: a miss has no value to serve and keeps the existing first-compute path.
- TTL (2 min) and sweep interval (60 s) match the values Orca uses for its equivalent git status refresh, so both products degrade on the same timescale.

**Rejected alternatives** (recorded because they look like the obvious fixes): watching `.git` for commits, and comparing `HEAD` SHA to invalidate the cache. Neither would have caught the observed freeze — no commit was involved. A `.gitignore` edit changed which untracked files counted while `HEAD` stayed put.

**Deliberate scope limit:** stats for sessions with no live runtime are refreshed only when something reads them, so a stopped task's badge can stay stale until its project list or git panel is next loaded. Sweeping idle work has an unbounded cost and no viewer.

**Follow-up, not in this PR:** the file-watch channel that went quiet in the first place. `WslInotifyBridge` gives up permanently after `MAX_RESTARTS = 2` (`src/lib/workspace-files/wsl-inotify-bridge.ts`), and the cause of the original death is still unconfirmed. Worth a separate issue with a reproduction (bulk file creation in a watched root) rather than a blind hardening here.

## Testing

- [x] `npm run lint` — 0 errors (2 pre-existing React Compiler warnings in `use-virtual-message-list.ts`, unrelated to this change)
- [x] `npx tsc --noEmit`
- [x] `NODE_ENV=production npm run build`
- [x] Manual test: verified the real git state behind the bug report — `git diff --numstat HEAD` on the affected checkout returned `2 0 .gitignore` with no untracked files while the UI showed `+39 -0 / 2`, confirming the displayed value was unreachable from current state rather than a computation error.
- [x] Unit tests: `tests/diff-stats-safety-sweep.test.ts` (sweep scope and dedup), `tests/worktree-diff-stats-staleness.test.ts` (TTL boundaries), `tests/worktree-diff-stats-cache-revalidation.test.ts` (miss vs stale hit). 13 tests. Existing related suites re-run green (44 tests across `active-session-runtime`, `git-panel-wsl-batch`, `session-runtime-presentation`, `terminal-session-runtime-state`, `wsl-inotify-bridge`).
- [ ] Not tested: the sweep firing against a live server on its real 60-second timer. The scheduling policy is covered by unit tests through injected dependencies; the timer wiring itself is not exercised end-to-end.

## Screenshots or Recordings

No UI changes — the badge and panel render exactly as before, they just stop showing stale numbers.

## Notes

An ADR describing this decision and the rejected alternatives was written to `docs/adr/0001-diff-stats-staleness-backstop.md`, but `docs/*` is git-ignored in this repository (`.gitignore:50`), so it is intentionally not part of this PR. The rationale is reproduced in the Summary above.

`CONTEXT.md` gains two glossary entries — **Worktree diff stats** and **Diff stats safety sweep** — since both now appear in code and review conversations.
