### PR TITLE
fix(tab-bar): keep the active tab's close button clear of the scroll arrows

### DIFF
--- a/src/components/tab/tab-bar.tsx
+++ b/src/components/tab/tab-bar.tsx
@@ -59,8 +59,11 @@ export const TabBar = memo(function TabBar() {
     position: { x: number; y: number };
   } | null>(null);
 
-  // Track previous tab count for scroll-to-new-tab effect
+  // Track previous tab count / active tab for the scroll-into-view effect.
+  // The null sentinel makes the first run treat the active tab as "changed",
+  // so a restored session opens with its active tab in view.
   const prevTabCountRef = useRef(tabs.length);
+  const prevActiveTabIdRef = useRef<string | null>(null);
 
   const updateScrollState = useCallback(function updateScrollState() {
     const container = containerRef.current;
@@ -123,10 +126,17 @@ export const TabBar = memo(function TabBar() {
     [tabs, updateScrollState],
   );
 
-  // Scroll to newly added tab (BR-UI-019 / UX improvement)
+  // Keep the active tab (including its close button) in view — on creation
+  // (BR-UI-019) and on activation, which also covers keyboard tab switching.
   useEffect(
-    function scrollToNewTab() {
-      if (tabs.length > prevTabCountRef.current) {
+    function scrollActiveTabIntoView() {
+      const isInitialSync = prevActiveTabIdRef.current === null;
+      const tabAdded = tabs.length > prevTabCountRef.current;
+      const activeTabChanged = activeTabId !== prevActiveTabIdRef.current;
+      prevTabCountRef.current = tabs.length;
+      prevActiveTabIdRef.current = activeTabId;
+
+      if (tabAdded || activeTabChanged) {
         const container = containerRef.current;
         const tabElements = container
           ? Array.from(container.querySelectorAll<HTMLElement>('[data-tab-id]'))
@@ -136,10 +146,9 @@ export const TabBar = memo(function TabBar() {
         activeTabElement?.scrollIntoView({
           block: 'nearest',
           inline: 'nearest',
-          behavior: 'smooth',
+          behavior: isInitialSync ? 'instant' : 'smooth',
         });
       }
-      prevTabCountRef.current = tabs.length;
       const frameId = requestAnimationFrame(updateScrollState);
       return () => cancelAnimationFrame(frameId);
     },
@@ -424,9 +433,14 @@ export const TabBar = memo(function TabBar() {
 
       {/* Scrollable tab items container */}
       <div className="relative flex min-w-0 items-stretch">
+        {/*
+          scroll-px-8 keeps scrollIntoView from parking a tab flush against an edge:
+          the scroll arrows are absolutely positioned over the strip (left-1/right-1, w-6)
+          and would otherwise cover the tab's close button (BR-UI-024).
+        */}
         <div
           ref={containerRef}
-          className="flex min-w-0 items-stretch overflow-x-auto scrollbar-none"
+          className="flex min-w-0 items-stretch overflow-x-auto scroll-px-8 scrollbar-none"
           data-testid="tab-bar-items"
         >
           {tabs.map((tab) => (
@@ -448,10 +462,11 @@ export const TabBar = memo(function TabBar() {
               onContextMenu={handleContextMenu}
             />
           ))}
-          {/* End drop zone — allows moving a tab to the last position */}
+          {/* End drop zone — allows moving a tab to the last position.
+              Also gives the last tab enough trailing scroll room to satisfy scroll-px-8. */}
           <div
             className={cn(
-              'electron-no-drag shrink-0 w-6 transition-colors',
+              'electron-no-drag shrink-0 w-8 transition-colors',
               isWindowsElectron && 'h-[39px]',
               isLinuxElectron && 'h-[39px]',
               isEndZoneDragOver && 'border-l-2 border-l-(--accent)',


### PR DESCRIPTION
## Summary

- Once the tab strip overflows, the active tab's close button sits hidden under the `>` scroll arrow. Pressing `>` scrolls further and reveals it, so the tab was reachable — but only after an extra click that should not be needed.
- The scroll arrows are absolutely positioned **over** the strip (`left-1`/`right-1`, `w-6`, `src/components/tab/tab-bar.tsx:495`), covering roughly the outer 28px of each edge. `scrollIntoView({ inline: 'nearest' })` parks the active tab flush against that same edge, and a tab's close button sits 12–28px in from its right edge (`px-3` + a 12px `X`) — precisely under the arrow.
- The 24px end drop zone compounded it: with the last tab flush to the edge, that zone still left 24px of scrollable width, so `canScrollRight` stayed true and the arrow never disappeared. The last tab's close button therefore stayed covered no matter what.
- Separately, the scroll-into-view effect only fired when the **tab count grew**, so switching tabs by keyboard never scrolled an off-screen tab into view, and a restored session could open with its active tab outside the viewport.

**Fix**

- `scroll-px-8` on the scroll container — `scroll-padding` is honoured by `scrollIntoView`, so the active tab now lands 32px clear of each edge, outside the arrows.
- End drop zone `w-6` → `w-8`, giving the last tab the trailing scroll room that 32px of clearance requires.
- Scroll on **active-tab change** as well as tab creation, with a null sentinel so the first run scrolls too.

Measured in Chromium on a minimal repro of the same geometry (400px strip, 150px tabs, 24/32px end zone):

| | gap from tab's right edge to strip edge | `canScrollRight` |
| --- | --- | --- |
| before (no scroll-padding, 24px end zone) | **0px** — close button under the arrow | `true` — arrow stays, still covering it |
| after (`scroll-px-8`, 32px end zone) | **32px** — close button fully clear | `false` — arrow gone on the last tab |

The "after" row reproduces the second screenshot in the report (the state reached only by clicking `>`); the "before" row reproduces the first.

## Testing

- [x] `npm run lint` — 0 errors (2 pre-existing warnings in unrelated files: `preview-markdown.tsx`, `use-virtual-message-list.ts`)
- [x] `npx tsc --noEmit`
- [x] `NODE_ENV=production npm run build`
- [x] Chromium measurement of the repro above, confirming the geometry claim and that `scroll-padding` is applied by `scrollIntoView`
- [x] Verified Tailwind v4 emits the utility: `.scroll-px-8 { scroll-padding-inline: calc(var(--spacing) * 8) }` = 32px
- [ ] Not tested: the running Electron app. The fix is verified at the CSS/geometry layer and by static checks, but the tab bar was not exercised by hand in a live window.

## Screenshots or Recordings

Not included — the reported screenshots are the bug report itself, and the fix is a scroll-offset change best expressed by the measurement table above. Repro: open enough tabs to overflow the strip, then look at the active tab's `×`.

## Notes

`scroll-padding` applies to both edges, so the same clearance now protects the left arrow (`<`) as well; the first tab is unaffected because `scrollLeft: 0` already satisfies it and the left arrow is hidden there.
