### PR TITLE
fix(wsl): render inline images when the server runs on Windows

### DIFF
--- a/src/app/api/sessions/[id]/tool-image/route.ts
+++ b/src/app/api/sessions/[id]/tool-image/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as fs from 'fs/promises';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
+import { resolvePathForHostFilesystem } from '@/lib/filesystem/host-path';
 import { jsonError } from '@/lib/http/json-error';
 import logger from '@/lib/logger';
 import * as dbSessions from '@/lib/db/sessions';
@@ -56,9 +57,16 @@ export async function GET(
       return jsonError('unsupported_media', 'Tool call path is not an image', 415);
     }
 
+    // The recorded path is the one the CLI saw, which is not always readable by
+    // this process: a Windows-hosted server driving a WSL agent records
+    // `/home/...` and `/mnt/c/...`, neither of which `fs` can open. Re-resolve
+    // against the host filesystem (`\\wsl.localhost\<distro>\...`, `C:\...`)
+    // before touching disk.
+    const hostPath = await resolvePathForHostFilesystem(rawPath);
+
     let stat;
     try {
-      stat = await fs.stat(rawPath);
+      stat = await fs.stat(hostPath);
     } catch {
       return jsonError('file_not_found', 'Image file not found', 404);
     }
@@ -69,7 +77,7 @@ export async function GET(
       return jsonError('file_too_large', 'Image is too large to preview', 413);
     }
 
-    const buffer = await fs.readFile(rawPath);
+    const buffer = await fs.readFile(hostPath);
     return new NextResponse(buffer, {
       headers: {
         'Content-Type': inferImageMime(rawPath) ?? 'application/octet-stream',

--- a/src/lib/filesystem/path-environment.ts
+++ b/src/lib/filesystem/path-environment.ts
@@ -370,9 +370,15 @@ function isWindowsDriveMountPath(value: string): boolean {
 
 async function getWslPathInfo(): Promise<WslPathInfo | null> {
   if (!wslPathInfoPromise) {
-    wslPathInfoPromise = loadWslPathInfo();
+    wslPathInfoPromise = loadWslPathInfo().catch(() => null);
   }
-  return wslPathInfoPromise;
+
+  const wslPathInfo = await wslPathInfoPromise;
+  // Only a successful probe is cached. A failure is usually a race with a
+  // distro that was still starting, and caching it would strand every later
+  // WSL path lookup — file browsing, git, inline images — until restart.
+  if (!wslPathInfo) wslPathInfoPromise = null;
+  return wslPathInfo;
 }
 
 export async function getWslHostedWindowsHomeMountPath(): Promise<string> {

--- a/tests/agent-environment-paths.test.ts
+++ b/tests/agent-environment-paths.test.ts
@@ -54,6 +54,21 @@ test('a WSL session shows the paths its CLI reads, not the host UNC form', () =>
 });
 
 /**
+ * The distro probe shells out to `wsl.exe`, which can lose a race with a distro
+ * that is still starting. Caching that failure would strand every later WSL
+ * lookup — file browsing, git, inline images — until the server restarts.
+ */
+test('a failed distro probe is not cached for the process lifetime', () => {
+  const probe = pathEnvironmentSource.match(
+    /async function getWslPathInfo\(\)[\s\S]*?\n\}/,
+  )?.[0] ?? '';
+
+  assert.match(probe, /if \(!wslPathInfo\) wslPathInfoPromise = null;/);
+  // A rejection must not be cached as a permanently rejected promise either.
+  assert.match(probe, /loadWslPathInfo\(\)\.catch\(\(\) => null\)/);
+});
+
+/**
  * The paths a session shows and the cwd its CLI is spawned with have to be the
  * same string: the Claude memory folder is named after that cwd, so a display
  * path that disagrees points at a directory the agent never reads. Asserting

--- a/tests/tool-image-rendering.test.ts
+++ b/tests/tool-image-rendering.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import test from 'node:test';
 
 import {
@@ -37,6 +38,22 @@ test('buildToolImageUrl / buildImageToolResult encode session + toolUseId', () =
     contentType: 'image',
     url: '/api/sessions/s/tool-image?toolUseId=call_x',
   });
+});
+
+// --- the route reads through the host filesystem, not the CLI's path ---
+
+test('tool-image route resolves the recorded path for the host filesystem', () => {
+  const routeSource = fs.readFileSync(
+    new URL('../src/app/api/sessions/[id]/tool-image/route.ts', import.meta.url),
+    'utf8',
+  );
+
+  // A Windows-hosted server driving a WSL agent records `/home/...` and
+  // `/mnt/c/...`; reading those verbatim is what broke inline images there.
+  assert.match(routeSource, /resolvePathForHostFilesystem\(rawPath\)/);
+  assert.match(routeSource, /fs\.stat\(hostPath\)/);
+  assert.match(routeSource, /fs\.readFile\(hostPath\)/);
+  assert.doesNotMatch(routeSource, /fs\.(stat|readFile)\(rawPath\)/);
 });
 
 // --- codex view_image (imageView) end-to-end through the parser ---


### PR DESCRIPTION
## Summary

- Inline images never rendered in chat when the Electron server runs on Windows while the CLI runs in WSL (`agentEnvironment: wsl`). The chat showed a broken thumbnail with the raw path as alt text, for both a Codex `view_image` and a Claude Code image `Read`.
- `/api/sessions/{id}/tool-image` re-derives the on-disk path from the recorded tool call and hands it straight to `fs` (`src/app/api/sessions/[id]/tool-image/route.ts:61`). That recorded path is the one the **CLI** saw — `/mnt/c/Users/.../Temp/shot.png`, or `/home/...` for a distro-local file — and a Windows-hosted server can open neither, so every request answered `file_not_found`.
- The translation already exists and is what the file route, git panel, archive service and worktree code all read through (`resolvePathForHostFilesystem`, `src/lib/filesystem/host-path.ts:28`). The tool-image route was the only reader that skipped it. It now resolves `/mnt/c/...` → `C:\...` and `/home/...` → `\\wsl.localhost\<distro>\home\...` before touching disk.
- Path safety is unchanged: the path is still re-derived server-side from the session's recorded tool call by `toolUseId`, never supplied by the client.
- Second fix on the same path — `getWslPathInfo` cached its first probe result for the process lifetime, failures included (`src/lib/filesystem/path-environment.ts:371`). The probe shells out to `wsl.exe` under a 5s timeout and can lose a race with a distro that is still starting; once it did, every later WSL lookup — file browsing, git, inline images — stayed broken until the server restarted. Only a success is cached now, and a rejected promise can no longer be cached either.

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `NODE_ENV=production npm run build`
- [ ] Manual test:
- [x] Not tested: the actual render on a Windows-hosted server. Reproducing needs a Windows-side server build, so this was verified by code path and tests only.

Test suite: 551 tests, 548 pass. The two failures (`workspace-file-drag-contract`, `workspace-file-scan`) reproduce on `origin/dev` without this change.

Regression coverage added:
- `tests/tool-image-rendering.test.ts` — the route resolves for the host filesystem instead of reading the recorded path.
- `tests/agent-environment-paths.test.ts` — a failed distro probe is not cached for the process lifetime.

## Screenshots or Recordings

No UI code changed; the fix is server-side path resolution. The visible effect is that a thumbnail which previously failed to load now renders.

## Notes

Bug fix, no issue filed. An earlier draft also added a distro-independent fallback so `/mnt/c/...` could resolve while the probe was down — dropped as over-engineering, since it duplicated `resolveWindowsHostedWslBrowsePath` and only applied in a window the probe-retry fix already closes.
