### PR TITLE
fix(tab): rename the active session when the tab title is edited

### DIFF
--- a/src/components/tab/tab-item.tsx
+++ b/src/components/tab/tab-item.tsx
@@ -13,6 +13,7 @@ import type { Tab } from '@/types/tab';
 import type { Panel, TabPanelData } from '@/types/panel';
 import { SESSION_DRAG_MIME, TAB_DRAG_MIME, TAB_PANEL_TREE_DND_MIME } from '@/types/panel';
 import { getSpecialSessionTitle, getSpecialSessionTitleKey, isSpecialSession } from '@/lib/constants/special-sessions';
+import { requestSessionRename } from '@/lib/session/rename-session-request';
 import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
 import { useAnySessionProcessing } from '@/hooks/use-session-processing';
 
@@ -72,6 +73,40 @@ export function getTabDragSessionId(
     .map((panel) => panel.sessionId)
     .filter(Boolean) as string[];
   return sessionIds.length === 1 ? sessionIds[0] : null;
+}
+
+export type TabTitleCommit =
+  | { kind: 'session'; sessionId: string; title: string }
+  | { kind: 'tab'; title: string | null }
+  | { kind: 'noop' };
+
+/**
+ * 탭 제목 편집을 어디에 반영할지 결정한다.
+ *
+ * 탭에 보이는 제목은 활성 패널 세션의 제목이므로, rename 가능한 세션이 있으면
+ * 세션을 rename해야 사이드바·태스크·DB가 함께 따라온다. 탭 전용 제목은 rename할
+ * 세션이 없는 탭(빈 탭, 세션 없는 터미널 패널, 특수 세션)에서만 쓴다.
+ */
+export function resolveTabTitleCommit({
+  nextTitle,
+  displayTitle,
+  tabTitle,
+  renameTargetSessionId,
+}: {
+  nextTitle: string;
+  displayTitle: string;
+  tabTitle: string | null;
+  renameTargetSessionId: string | null;
+}): TabTitleCommit {
+  if (renameTargetSessionId) {
+    if (!nextTitle || nextTitle === displayTitle) return { kind: 'noop' };
+    return { kind: 'session', sessionId: renameTargetSessionId, title: nextTitle };
+  }
+  if (!nextTitle) {
+    return tabTitle !== null ? { kind: 'tab', title: null } : { kind: 'noop' };
+  }
+  if (nextTitle === displayTitle) return { kind: 'noop' };
+  return { kind: 'tab', title: nextTitle };
 }
 
 export function shouldDragTabPanelTree(tabData: TabPanelData | null | undefined): boolean {
@@ -220,6 +255,12 @@ export const TabItem = memo(function TabItem({
     displayTitle = session.title ?? session.id;
   }
 
+  // 특수 세션(Skills Dashboard 등)은 rename 대상이 아니다 — 탭 로컬 제목으로 남긴다.
+  const renameTargetSessionId =
+    activePanelSessionId && !isSpecialSession(activePanelSessionId) && session
+      ? activePanelSessionId
+      : null;
+
   const sessionCount = isActive ? liveSessionCount : deriveSessionCount(inactiveTabData?.panels ?? {});
   const label = formatTabLabel(displayTitle, sessionCount);
 
@@ -300,14 +341,25 @@ export const TabItem = memo(function TabItem({
   );
 
   const commitTitleEdit = useCallback(() => {
-    const nextTitle = titleInput.trim();
-    if (!nextTitle && tab.title !== null) {
-      useTabStore.getState().renameTab(tab.id, null);
-    } else if (nextTitle && nextTitle !== displayTitle) {
-      useTabStore.getState().renameTab(tab.id, nextTitle);
-    }
+    const commit = resolveTabTitleCommit({
+      nextTitle: titleInput.trim(),
+      displayTitle,
+      tabTitle: tab.title,
+      renameTargetSessionId,
+    });
     setIsEditingTitle(false);
-  }, [displayTitle, tab.id, tab.title, titleInput]);
+
+    if (commit.kind === 'session') {
+      // 예전에 붙여둔 탭 로컬 제목이 남아 있으면 새 세션 제목을 계속 가린다.
+      if (tab.title !== null) {
+        useTabStore.getState().renameTab(tab.id, null);
+      }
+      useTabStore.getState().pinTab(tab.id);
+      void requestSessionRename(commit.sessionId, commit.title, t);
+    } else if (commit.kind === 'tab') {
+      useTabStore.getState().renameTab(tab.id, commit.title);
+    }
+  }, [displayTitle, renameTargetSessionId, t, tab.id, tab.title, titleInput]);
 
   const cancelTitleEdit = useCallback(() => {
     setTitleInput(displayTitle);

--- a/src/hooks/use-session-crud.ts
+++ b/src/hooks/use-session-crud.ts
@@ -13,6 +13,7 @@ import { useSettingsStore } from '@/stores/settings-store';
 import { useTabStore } from '@/stores/tab-store';
 import { useTaskStore } from '@/stores/task-store';
 import { generateSessionTitle } from '@/lib/session/title-generator';
+import { requestSessionRename } from '@/lib/session/rename-session-request';
 import { getProviderSessionRuntimeConfig } from '@/lib/settings/provider-defaults';
 import { toast } from '@/stores/notification-store';
 import { useI18n } from '@/lib/i18n';
@@ -445,44 +446,14 @@ export function useSessionCrud() {
    */
   const renameSession = useCallback(
     async (sessionId: string, newTitle: string) => {
-      const session = sessionStore.getSession(sessionId);
-      const oldTitle = session?.title;
-      const oldHasCustomTitle = session?.hasCustomTitle;
-      const linkedTask = useTaskStore.getState().getTaskBySessionId(sessionId);
-      const oldTaskTitle = linkedTask?.title;
-      sessionStore.updateSessionTitle(sessionId, newTitle, true);
-      useTaskStore.getState().syncLinkedTaskTitle(sessionId, newTitle);
-
       setIsRenaming(true);
-
       try {
-        const response = await fetchWithClientId(`/api/sessions/${sessionId}/rename`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title: newTitle }),
-        });
-
-        if (!response.ok) {
-          throw new Error(t('errors.renameSessionFailed'));
-        }
-
-        toast.success(t('notifications.sessionRenamed'));
-      } catch (err) {
-        if (oldTitle) {
-          sessionStore.updateSessionTitle(sessionId, oldTitle, oldHasCustomTitle);
-        }
-        if (linkedTask?.sessions.length === 1 && oldTaskTitle) {
-          useTaskStore.getState().syncLinkedTaskTitle(sessionId, oldTaskTitle);
-        } else if (oldTitle) {
-          useTaskStore.getState().syncLinkedTaskTitle(sessionId, oldTitle);
-        }
-        toast.error(t('errors.renameSessionFailed'));
-        console.error('Rename session error:', err);
+        await requestSessionRename(sessionId, newTitle, t);
       } finally {
         setIsRenaming(false);
       }
     },
-    [sessionStore, t]
+    [t]
   );
 
   /**

--- a/src/lib/session/rename-session-request.ts
+++ b/src/lib/session/rename-session-request.ts
@@ -1,0 +1,55 @@
+/**
+ * Session rename request
+ *
+ * 세션 제목 변경의 단일 경로 — 낙관적 업데이트 → PATCH → 실패 시 롤백.
+ * 훅이 아닌 순수 함수로 두어, 탭 헤더처럼 useSessionCrud의 전체 스토어 구독을
+ * 감당할 수 없는 곳(리렌더가 탭 수만큼 번지는 곳)에서도 같은 경로를 쓰게 한다.
+ */
+
+import { useSessionStore } from '@/stores/session-store';
+import { useTaskStore } from '@/stores/task-store';
+import { toast } from '@/stores/notification-store';
+import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
+import type { useI18n } from '@/lib/i18n';
+
+type Translate = ReturnType<typeof useI18n>['t'];
+
+export async function requestSessionRename(
+  sessionId: string,
+  newTitle: string,
+  t: Translate,
+): Promise<void> {
+  const session = useSessionStore.getState().getSession(sessionId);
+  const oldTitle = session?.title;
+  const oldHasCustomTitle = session?.hasCustomTitle;
+  const linkedTask = useTaskStore.getState().getTaskBySessionId(sessionId);
+  const oldTaskTitle = linkedTask?.title;
+
+  useSessionStore.getState().updateSessionTitle(sessionId, newTitle, true);
+  useTaskStore.getState().syncLinkedTaskTitle(sessionId, newTitle);
+
+  try {
+    const response = await fetchWithClientId(`/api/sessions/${sessionId}/rename`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: newTitle }),
+    });
+
+    if (!response.ok) {
+      throw new Error(t('errors.renameSessionFailed'));
+    }
+
+    toast.success(t('notifications.sessionRenamed'));
+  } catch (err) {
+    if (oldTitle) {
+      useSessionStore.getState().updateSessionTitle(sessionId, oldTitle, oldHasCustomTitle);
+    }
+    if (linkedTask?.sessions.length === 1 && oldTaskTitle) {
+      useTaskStore.getState().syncLinkedTaskTitle(sessionId, oldTaskTitle);
+    } else if (oldTitle) {
+      useTaskStore.getState().syncLinkedTaskTitle(sessionId, oldTitle);
+    }
+    toast.error(t('errors.renameSessionFailed'));
+    console.error('Rename session error:', err);
+  }
+}

--- a/tests/tab-title-rename.test.ts
+++ b/tests/tab-title-rename.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { useTabStore } from '@/stores/tab-store';
+import { resolveTabTitleCommit } from '@/components/tab/tab-item';
 
 test('a tab can be given a custom title without changing its identity', () => {
   const tab = {
@@ -62,4 +63,62 @@ test('clearing a custom title restores derived-title behavior', () => {
   useTabStore.getState().renameTab(tab.id, null);
 
   assert.deepEqual(useTabStore.getState().tabs, [{ ...tab, title: null }]);
+});
+
+test('editing the tab title renames the active session, not just the tab', () => {
+  assert.deepEqual(
+    resolveTabTitleCommit({
+      nextTitle: 'Deploy script',
+      displayTitle: 'session-1',
+      tabTitle: null,
+      renameTargetSessionId: 'session-1',
+    }),
+    { kind: 'session', sessionId: 'session-1', title: 'Deploy script' },
+  );
+});
+
+test('a tab without a renameable session falls back to a tab-local title', () => {
+  assert.deepEqual(
+    resolveTabTitleCommit({
+      nextTitle: 'Scratch',
+      displayTitle: 'New tab',
+      tabTitle: null,
+      renameTargetSessionId: null,
+    }),
+    { kind: 'tab', title: 'Scratch' },
+  );
+});
+
+test('an empty title clears a tab-local name but never renames a session', () => {
+  assert.deepEqual(
+    resolveTabTitleCommit({
+      nextTitle: '',
+      displayTitle: 'Temporary name',
+      tabTitle: 'Temporary name',
+      renameTargetSessionId: null,
+    }),
+    { kind: 'tab', title: null },
+  );
+
+  assert.deepEqual(
+    resolveTabTitleCommit({
+      nextTitle: '',
+      displayTitle: 'Deploy script',
+      tabTitle: null,
+      renameTargetSessionId: 'session-1',
+    }),
+    { kind: 'noop' },
+  );
+});
+
+test('committing an unchanged title does nothing', () => {
+  assert.deepEqual(
+    resolveTabTitleCommit({
+      nextTitle: 'Deploy script',
+      displayTitle: 'Deploy script',
+      tabTitle: null,
+      renameTargetSessionId: 'session-1',
+    }),
+    { kind: 'noop' },
+  );
 });


### PR DESCRIPTION
## Summary

- Editing a tab title only wrote tab-store's local `tab.title`, so the sidebar — which reads `session.title` — never updated. In PTY mode the session header is hidden for single panels (`src/lib/terminal/session-header-visibility.ts`), leaving the tab as the only rename entry point, which is where the gap showed.
- A tab title is the active panel session's title, so committing an edit now renames that session through the same path the sidebar uses (optimistic update → `PATCH /api/sessions/:id/rename` → rollback on failure).
- The rename request moves out of `useSessionCrud` into `src/lib/session/rename-session-request.ts`. `tab-item` cannot use that hook: it subscribes to the whole session and chat stores, which would re-render every tab on any session change, undoing the targeted subscriptions that file is built around.
- The commit branch is extracted as `resolveTabTitleCommit()`, following the "pure functions testable without mounting the component" convention already in `tab-item.tsx`. Tabs with no renameable session (empty tab, session-less terminal panel, special sessions) keep the tab-local title. A stale `tab.title` is cleared on session rename so it no longer masks the new title, and preview tabs are still pinned.

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] `NODE_ENV=production npm run build`
- [x] Manual test: `npx tsx --test tests/tab-title-rename.test.ts` — 7/7 pass (4 new cases covering the session-rename branch, the tab-local fallback, empty titles, and unchanged titles)
- [ ] Not tested: in-app UI verification

## Screenshots or Recordings

Not captured — no visual change; the fix is where the edited title is written.

## Notes

A panel holding a terminal with no session (the slash-command fallback path, `message-input.tsx:823` clears `sessionId` via `assignTerminal`) still uses a tab-local title, since its tab label is the fixed `'Terminal'` rather than a session title.