### PR TITLE
feat(session-ref): make session references work with PTY sessions

### DIFF
--- a/src/app/api/sessions/[id]/export/route.ts
+++ b/src/app/api/sessions/[id]/export/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
+import { getAgentEnvironment, normalizeCwdForCliEnvironment } from '@/lib/cli/spawn-cli';
 import * as dbSessions from '@/lib/db/sessions';
 import { jsonError } from '@/lib/http/json-error';
 import logger from '@/lib/logger';
@@ -67,16 +68,26 @@ export async function POST(
     }
 
     const exportOptions = await readExportOptions(request);
-    const exportPath = await exportSessionLog(sessionId, dbSession.title, exportOptions);
+    const exportPath = await exportSessionLog(sessionId, dbSession.title, {
+      ...exportOptions,
+      userId: auth.userId,
+    });
+    // The path is handed to the agent as prompt text, so it must be spelled the
+    // way that CLI sees the filesystem — a server-local path is unopenable from
+    // a WSL guest (and vice versa).
+    const agentEnvironment = await getAgentEnvironment(auth.userId);
+    const agentPath = normalizeCwdForCliEnvironment(exportPath, agentEnvironment);
 
     logger.info({
       userId: auth.userId,
       sessionId,
       exportPath,
+      agentPath,
+      agentEnvironment,
       partial: Boolean(exportOptions.untilMessageId) || exportOptions.untilMessageIndex !== undefined,
     }, 'Session export requested');
 
-    return NextResponse.json({ exportPath });
+    return NextResponse.json({ exportPath: agentPath });
   } catch (err) {
     const message = (err as Error).message;
 

--- a/src/components/panel/panel-wrapper.tsx
+++ b/src/components/panel/panel-wrapper.tsx
@@ -9,25 +9,53 @@ import { useTabStore } from '@/stores/tab-store';
 import { useSessionNavigation } from '@/hooks/use-session-navigation';
 import { wsClient } from '@/lib/ws/client';
 import { PanelDropZone, type DropEdge } from './panel-drop-zone';
-import { PANEL_NODE_DRAG_MIME, SESSION_DRAG_MIME, TAB_DRAG_MIME, TAB_PANEL_TREE_DND_MIME } from '@/types/panel';
+import {
+  PANEL_NODE_DRAG_MIME,
+  PANEL_SESSION_DRAG_MIME,
+  SESSION_DRAG_MIME,
+  TAB_DRAG_MIME,
+  TAB_PANEL_TREE_DND_MIME,
+} from '@/types/panel';
 import { useSettingsStore } from '@/stores/settings-store';
 import { useI18n } from '@/lib/i18n';
 import {
   getWorkspaceFileDragAbsolutePath,
   hasWorkspaceFileDragData,
   isPathInsertOnlyDragData,
+  isSessionReferenceDragData,
   parsePanelNodeDragData,
   parsePanelTitleDragData,
 } from '@/lib/dnd/panel-session-drag';
+import { insertSessionReferenceIntoTerminal } from '@/lib/session/session-reference';
 import {
   insertFilePathIntoTerminal,
   resolvePanelTerminalId,
 } from '@/lib/terminal/terminal-file-path-insert';
+import { getTerminalPromptBounds } from '@/lib/terminal/terminal-surface-registry';
 import {
   getNativeFileDropAbsolutePaths,
   isNativeFileDrag,
 } from '@/lib/dnd/native-file-drop';
 import { focusPanelControl } from '@/lib/session/focus-session-panel';
+
+/**
+ * Drags that rearrange panes. They also carry `SESSION_DRAG_MIME`, so a
+ * terminal pane must not mistake them for a context reference.
+ */
+const LAYOUT_DRAG_MIMES = [
+  PANEL_SESSION_DRAG_MIME,
+  PANEL_NODE_DRAG_MIME,
+  TAB_DRAG_MIME,
+  TAB_PANEL_TREE_DND_MIME,
+] as const;
+
+/**
+ * A session dropped on the CLI's input box becomes a context reference;
+ * everywhere else in the pane keeps the normal split/replace behaviour, which
+ * is by far the more common drop. Used as the strip's height only when the
+ * prompt cannot be located.
+ */
+const SESSION_INSERT_ZONE_FALLBACK_HEIGHT = 56;
 
 /** Edge zone threshold — the outer 25% of each edge triggers a split. */
 const EDGE_THRESHOLD = 0.25;
@@ -81,6 +109,11 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
   // --- DnD state ---
   const [dropEdge, setDropEdge] = useState<DropEdge | null>(null);
   const [insertPathHint, setInsertPathHint] = useState(false);
+  /** Insert strip geometry relative to the pane; null when inactive. */
+  const [sessionInsertZone, setSessionInsertZone] = useState<
+    { top: number; height: number } | null
+  >(null);
+  const sessionInsertZoneRef = useRef(false);
   const dropEdgeRef = useRef<DropEdge | null>(null);
   const dragCounterRef = useRef(0);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -143,6 +176,30 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     isNativeFileDrag(e.dataTransfer) && resolveInsertTargetTerminalId() !== null
   ), [resolveInsertTargetTerminalId]);
 
+  /**
+   * Terminal sessions render no composer, so a session dropped on the pane
+   * itself is how they receive a reference — it is typed into the prompt the
+   * way the composer would have inserted it.
+   *
+   * Layout drags carry the same session MIME but mean "move this pane", so
+   * they keep the split/replace behaviour.
+   */
+  const isTerminalSessionRefTarget = useCallback((e: React.DragEvent) => {
+    if (!isSessionReferenceDragData(e.dataTransfer)) return false;
+    const isLayoutDrag = LAYOUT_DRAG_MIMES.some((mime) => e.dataTransfer.types.includes(mime));
+    return !isLayoutDrag && resolveInsertTargetTerminalId() !== null;
+  }, [resolveInsertTargetTerminalId]);
+
+  /** Client-coordinate band that accepts the reference: the CLI's input box. */
+  const resolveSessionInsertZoneBounds = useCallback((rect: DOMRect) => {
+    const terminalId = resolveInsertTargetTerminalId();
+    const promptBounds = terminalId ? getTerminalPromptBounds(terminalId) : null;
+    return promptBounds ?? {
+      top: rect.bottom - SESSION_INSERT_ZONE_FALLBACK_HEIGHT,
+      bottom: rect.bottom,
+    };
+  }, [resolveInsertTargetTerminalId]);
+
   const isPanelCompatibleDrag = useCallback((e: React.DragEvent) => {
     // OS file drags carry the synthetic 'Files' type and no in-app payload;
     // accept only over a terminal pane, where the drop inserts the path.
@@ -179,6 +236,23 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     const rect = wrapperRef.current?.getBoundingClientRect();
     if (!rect) return;
 
+    const insertBounds = isTerminalSessionRefTarget(e)
+      ? resolveSessionInsertZoneBounds(rect)
+      : null;
+    const inSessionInsertZone = insertBounds !== null
+      && e.clientY >= insertBounds.top
+      && e.clientY <= insertBounds.bottom;
+    sessionInsertZoneRef.current = inSessionInsertZone;
+    setSessionInsertZone(inSessionInsertZone && insertBounds
+      ? { top: insertBounds.top - rect.top, height: insertBounds.bottom - insertBounds.top }
+      : null);
+    if (inSessionInsertZone) {
+      dropEdgeRef.current = null;
+      setDropEdge(null);
+      setInsertPathHint(false);
+      return;
+    }
+
     // Insert-only drags (folders, OS files) have no split behavior, so the
     // whole pane acts as center.
     const edge = isNativeFile || isPathInsertOnlyDragData(e.dataTransfer)
@@ -190,7 +264,13 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
       edge === 'center' &&
       (isNativeFile ? isNativeFilePathInsertTarget(e) : isTerminalPathInsertTarget(e)),
     );
-  }, [isPanelCompatibleDrag, isTerminalPathInsertTarget, isNativeFilePathInsertTarget]);
+  }, [
+    isPanelCompatibleDrag,
+    isTerminalPathInsertTarget,
+    isNativeFilePathInsertTarget,
+    isTerminalSessionRefTarget,
+    resolveSessionInsertZoneBounds,
+  ]);
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     if (!isPanelCompatibleDrag(e)) return;
@@ -199,18 +279,23 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     if (dragCounterRef.current <= 0) {
       dragCounterRef.current = 0;
       dropEdgeRef.current = null;
+      sessionInsertZoneRef.current = false;
       setDropEdge(null);
       setInsertPathHint(false);
+      setSessionInsertZone(null);
     }
   }, [isPanelCompatibleDrag]);
 
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     const currentEdge = dropEdgeRef.current;
+    const droppedInSessionInsertZone = sessionInsertZoneRef.current;
     dragCounterRef.current = 0;
     dropEdgeRef.current = null;
+    sessionInsertZoneRef.current = false;
     setDropEdge(null);
     setInsertPathHint(false);
+    setSessionInsertZone(null);
 
     // OS (Finder/Explorer) file drop → insert each absolute path into the PTY.
     if (currentEdge === 'center' && isNativeFilePathInsertTarget(e)) {
@@ -235,6 +320,28 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
       if (filePath && targetTerminalId && insertFilePathIntoTerminal(targetTerminalId, filePath)) {
         usePanelStore.getState().setActivePanelId(panelId);
         focusPanelControl(panelId);
+      }
+      return;
+    }
+
+    // Session dropped on a terminal pane's insert strip → type its export
+    // reference at the prompt, mirroring what the composer does for chat
+    // sessions.
+    if (droppedInSessionInsertZone && isTerminalSessionRefTarget(e)) {
+      const referencedSessionId = e.dataTransfer.getData(SESSION_DRAG_MIME);
+      const targetTerminalId = resolveInsertTargetTerminalId();
+      if (referencedSessionId && targetTerminalId) {
+        const title = useSessionStore.getState().getSession(referencedSessionId)?.title
+          ?? referencedSessionId.slice(0, 8);
+        // Unlike a path insert this needs a round trip (the session is exported
+        // first), so the focus move waits for the text to actually land.
+        void insertSessionReferenceIntoTerminal(targetTerminalId, referencedSessionId, title)
+          .then((inserted) => {
+            if (!inserted) return;
+            usePanelStore.getState().setActivePanelId(panelId);
+            focusPanelControl(panelId);
+          })
+          .catch(() => toast.error(t('errors.sessionExportFailed')));
       }
       return;
     }
@@ -424,7 +531,15 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     if (session) {
       viewSession(session, { forceReload: true });
     }
-  }, [panelId, t, viewSession, isTerminalPathInsertTarget, isNativeFilePathInsertTarget, resolveInsertTargetTerminalId]);
+  }, [
+    panelId,
+    t,
+    viewSession,
+    isTerminalPathInsertTarget,
+    isNativeFilePathInsertTarget,
+    isTerminalSessionRefTarget,
+    resolveInsertTargetTerminalId,
+  ]);
 
   return (
     <div
@@ -456,6 +571,18 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
           edge={dropEdge}
           label={insertPathHint ? t('panel.dropToInsertPath') : undefined}
         />
+      )}
+      {sessionInsertZone && (
+        <div
+          // Solid + denser fill so it never reads as the dashed split overlay.
+          className="pointer-events-none absolute inset-x-1 z-50 flex items-center justify-center rounded-md border-2 border-solid border-(--accent) bg-(--accent)/25"
+          style={{ top: sessionInsertZone.top, height: sessionInsertZone.height }}
+          data-testid="session-insert-drop-zone"
+        >
+          <span className="rounded-md bg-(--accent) px-2 py-1 text-xs font-medium text-white shadow-sm">
+            {t('panel.dropToInsertSessionReference')}
+          </span>
+        </div>
       )}
     </div>
   );

--- a/src/lib/cli/providers/claude-code/native-transcript.ts
+++ b/src/lib/cli/providers/claude-code/native-transcript.ts
@@ -1,0 +1,62 @@
+import type { NativeTranscriptMessage } from '@/lib/session/native-transcript-types';
+
+/**
+ * Claude writes one JSONL line per streaming chunk into
+ * `~/.claude/projects/<slug>/<session-id>.jsonl`. The envelope is documented in
+ * `@/types/cli-jsonl-schemas`; only the fields this reader needs are typed here
+ * so a schema change degrades to "no text" instead of throwing.
+ */
+interface ClaudeTranscriptLine {
+  type?: unknown;
+  isSidechain?: unknown;
+  message?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Text blocks only: `thinking`, `redacted_thinking`, `tool_use` and the
+ * `tool_result` blocks that ride on `user` lines are all dropped.
+ */
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!isRecord(block) || block.type !== 'text') continue;
+    if (typeof block.text === 'string' && block.text.trim()) parts.push(block.text);
+  }
+  return parts.join('\n');
+}
+
+export function parseClaudeNativeTranscript(content: string): NativeTranscriptMessage[] {
+  const messages: NativeTranscriptMessage[] = [];
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let entry: ClaudeTranscriptLine;
+    try {
+      entry = JSON.parse(trimmed) as ClaudeTranscriptLine;
+    } catch {
+      continue;
+    }
+
+    if (entry.type !== 'user' && entry.type !== 'assistant') continue;
+    // Sidechain lines are subagent turns — they are not part of the
+    // conversation the user had with the lead agent.
+    if (entry.isSidechain === true) continue;
+    if (!isRecord(entry.message)) continue;
+
+    const text = extractText(entry.message.content).trim();
+    if (!text) continue;
+
+    messages.push({ role: entry.type, text });
+  }
+
+  return messages;
+}

--- a/src/lib/cli/providers/codex/native-transcript.ts
+++ b/src/lib/cli/providers/codex/native-transcript.ts
@@ -1,0 +1,95 @@
+import {
+  normalizePromptForComparison,
+  type NativeTranscriptMessage,
+  type NativeTranscriptParseOptions,
+} from '@/lib/session/native-transcript-types';
+
+/**
+ * Codex rollout JSONL lines are `{ type, payload, timestamp }`. Conversation
+ * turns live in `response_item` payloads of type `message`; `event_msg` lines
+ * mirror the same turns for the TUI, so reading both would duplicate every
+ * message.
+ */
+interface CodexRolloutLine {
+  type?: unknown;
+  payload?: unknown;
+}
+
+/**
+ * Codex replays instruction context as `user` turns inside its own transcript:
+ * a rollout for a two-line chat also contains AGENTS.md and environment
+ * preambles. Tessera's own `user_message` history is the reliable list of what
+ * the person actually typed, so these markers are only the fallback for
+ * sessions whose prompts were never recorded.
+ */
+const SYNTHETIC_USER_MARKERS = [
+  '# AGENTS.md instructions',
+  '<INSTRUCTIONS>',
+  '<environment_context>',
+  '<user_instructions>',
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!isRecord(block)) continue;
+    if (block.type !== 'input_text' && block.type !== 'output_text' && block.type !== 'text') {
+      continue;
+    }
+    if (typeof block.text === 'string' && block.text.trim()) parts.push(block.text);
+  }
+  return parts.join('\n');
+}
+
+function looksSynthetic(text: string): boolean {
+  return SYNTHETIC_USER_MARKERS.some((marker) => text.includes(marker));
+}
+
+export function parseCodexNativeTranscript(
+  content: string,
+  options: NativeTranscriptParseOptions = {},
+): NativeTranscriptMessage[] {
+  const knownPrompts = new Set(
+    (options.knownUserPrompts ?? [])
+      .map(normalizePromptForComparison)
+      .filter(Boolean),
+  );
+  const messages: NativeTranscriptMessage[] = [];
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let entry: CodexRolloutLine;
+    try {
+      entry = JSON.parse(trimmed) as CodexRolloutLine;
+    } catch {
+      continue;
+    }
+
+    if (entry.type !== 'response_item' || !isRecord(entry.payload)) continue;
+    const payload = entry.payload;
+    if (payload.type !== 'message') continue;
+    // `developer` carries the system prompt and sandbox policy — never a turn.
+    if (payload.role !== 'user' && payload.role !== 'assistant') continue;
+
+    const text = extractText(payload.content).trim();
+    if (!text) continue;
+
+    if (payload.role === 'user') {
+      const isKnownPrompt = knownPrompts.has(normalizePromptForComparison(text));
+      if (knownPrompts.size > 0 ? !isKnownPrompt : looksSynthetic(text)) continue;
+    }
+
+    messages.push({ role: payload.role, text });
+  }
+
+  return messages;
+}

--- a/src/lib/cli/providers/opencode/native-transcript.ts
+++ b/src/lib/cli/providers/opencode/native-transcript.ts
@@ -1,0 +1,136 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import logger from '@/lib/logger';
+import type { NativeTranscriptMessage } from '@/lib/session/native-transcript-types';
+
+/**
+ * OpenCode moved its conversation store from `storage/{message,part}/*.json`
+ * into `opencode.db`; the JSON tree still exists but stops at the migration.
+ * Reading the database is therefore the only way to see recent turns.
+ *
+ * Tessera has no native SQLite binding (see `lib/db/database.ts` — sql.js WASM,
+ * chosen to keep the install dependency-free), so the file is loaded as an
+ * image. That means uncheckpointed WAL content is invisible: a session still
+ * being written may be missing its last turns, which is logged below.
+ */
+interface OpenCodeSqlStatement {
+  bind(params?: (string | number | null | Uint8Array)[]): void;
+  step(): boolean;
+  getAsObject(): Record<string, string | number | null | Uint8Array>;
+  free(): void;
+}
+
+interface OpenCodeSqlDatabase {
+  prepare(sql: string): OpenCodeSqlStatement;
+  close(): void;
+}
+
+const initSqlJs = require('sql.js') as () => Promise<{
+  Database: new (data?: ArrayLike<number>) => OpenCodeSqlDatabase;
+}>;
+
+const TRANSCRIPT_QUERY = `
+  SELECT m.data AS message_data, p.data AS part_data
+  FROM part p
+  JOIN message m ON m.id = p.message_id
+  WHERE p.session_id = ?
+  ORDER BY m.time_created ASC, p.time_created ASC
+`;
+
+export interface OpenCodeTranscriptLocation {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+}
+
+/**
+ * OpenCode follows the XDG data convention; the Windows build falls back to
+ * LOCALAPPDATA. Probing in order keeps this working without a platform switch.
+ */
+export function resolveOpenCodeDatabasePath(
+  options: OpenCodeTranscriptLocation = {},
+): string | null {
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? os.homedir();
+
+  const roots: string[] = [];
+  const xdgDataHome = env.XDG_DATA_HOME?.trim();
+  if (xdgDataHome) roots.push(path.join(xdgDataHome, 'opencode'));
+  roots.push(path.join(homeDir, '.local', 'share', 'opencode'));
+  const localAppData = env.LOCALAPPDATA?.trim();
+  if (localAppData) roots.push(path.join(localAppData, 'opencode'));
+
+  for (const root of roots) {
+    const candidate = path.join(root, 'opencode.db');
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function parseJsonRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function warnOnPendingWal(databasePath: string): void {
+  try {
+    const walSize = fs.statSync(`${databasePath}-wal`).size;
+    if (walSize > 0) {
+      logger.warn(
+        { databasePath, walSize },
+        'OpenCode transcript read with a non-empty WAL — the newest turns may be missing',
+      );
+    }
+  } catch {
+    // No WAL file means everything is checkpointed into the main image.
+  }
+}
+
+export async function readOpenCodeNativeTranscript(
+  providerSessionId: string,
+  options: OpenCodeTranscriptLocation = {},
+): Promise<NativeTranscriptMessage[]> {
+  const databasePath = resolveOpenCodeDatabasePath(options);
+  if (!databasePath) return [];
+
+  warnOnPendingWal(databasePath);
+
+  const SqlJs = await initSqlJs();
+  const database = new SqlJs.Database(fs.readFileSync(databasePath));
+  const messages: NativeTranscriptMessage[] = [];
+
+  try {
+    const statement = database.prepare(TRANSCRIPT_QUERY);
+    try {
+      statement.bind([providerSessionId]);
+      while (statement.step()) {
+        const row = statement.getAsObject();
+        const message = parseJsonRecord(row.message_data);
+        const part = parseJsonRecord(row.part_data);
+        if (!message || !part) continue;
+
+        const role = message.role;
+        if (role !== 'user' && role !== 'assistant') continue;
+        if (part.type !== 'text' || part.synthetic === true) continue;
+
+        const text = typeof part.text === 'string' ? part.text.trim() : '';
+        if (!text) continue;
+
+        messages.push({ role, text });
+      }
+    } finally {
+      statement.free();
+    }
+  } finally {
+    database.close();
+  }
+
+  return messages;
+}

--- a/src/lib/codex-home.ts
+++ b/src/lib/codex-home.ts
@@ -95,6 +95,53 @@ export function resolveCodexAccountHome(
   return defaultHome;
 }
 
+/**
+ * `.../codex-overlay/session-<terminal-id>/<rest>` — matched by segment rather
+ * than against a resolved data dir so it also recognises an overlay path that
+ * was reported by a CLI in another environment (WSL guest, Windows host).
+ */
+const CODEX_OVERLAY_PATH_PATTERN = /^(.*)[/\\]codex-overlay[/\\](session-[^/\\]+)[/\\](.+)$/;
+
+/**
+ * Map a rollout path recorded under a per-session overlay home back to the real
+ * account home.
+ *
+ * Overlays are deleted when the terminal closes (`cleanupCodexOverlayForTerminal`),
+ * so a stored `transcript_path` pointing into one is dead on arrival. The
+ * rollout itself survives: `sessions/` is a symlink into the account home, so
+ * the same relative path resolves there.
+ *
+ * Non-overlay paths and unresolvable candidates are returned untouched — the
+ * caller reports a missing transcript, which is the honest outcome.
+ */
+export function resolveCodexAccountTranscriptPath(
+  transcriptPath: string,
+  options: ResolveCodexAccountHomeOptions = {},
+): string {
+  const match = transcriptPath.match(CODEX_OVERLAY_PATH_PATTERN);
+  if (!match) return transcriptPath;
+
+  const [, dataDir, overlayName, relativePath] = match;
+  const pathModule = /^[a-zA-Z]:[\\/]|^\\\\/.test(transcriptPath) ? path.win32 : path.posix;
+  const segments = relativePath.split(/[/\\]/).filter(Boolean);
+
+  const candidateHomes = [
+    // The overlay is still on disk (session running): its marker is exact.
+    readMarkedAccountHome(pathModule.join(dataDir, 'codex-overlay', overlayName)),
+    // Default layout — the data dir sits next to `.codex` under the same home.
+    pathModule.join(pathModule.dirname(dataDir), '.codex'),
+    resolveCodexAccountHome(options),
+  ];
+
+  for (const accountHome of candidateHomes) {
+    if (!accountHome) continue;
+    const candidate = pathModule.join(accountHome, ...segments);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  return transcriptPath;
+}
+
 export function buildCodexAccountEnvironment(
   baseEnv: NodeJS.ProcessEnv = process.env,
   agentEnvironment: CliEnvironment = 'native',

--- a/src/lib/filesystem/path-environment.ts
+++ b/src/lib/filesystem/path-environment.ts
@@ -100,6 +100,35 @@ export function formatPathForAgentDisplay(
   return filesystemPath;
 }
 
+/**
+ * Rewrite a path the CLI reported — hook payloads, provider transcript
+ * locations — into the form this server can open. Inverse of
+ * `formatPathForAgentDisplay`: the CLI names files in its own environment's
+ * style, so across a bridge the server must translate before touching disk.
+ *
+ * Non-bridged setups already share one path style, so this is a no-op.
+ */
+export async function resolveAgentReportedPath(
+  agentPath: string,
+  environment: FilesystemBrowseEnvironment,
+): Promise<string> {
+  const trimmed = agentPath.trim();
+  if (!trimmed) return agentPath;
+
+  if (environment === 'wsl' && getRuntimePlatform() === 'win32') {
+    const wslPathInfo = await getWslPathInfo();
+    return wslPathInfo
+      ? wslDisplayPathToWindowsFilesystemPath(trimmed, wslPathInfo)
+      : trimmed;
+  }
+
+  if (environment === 'native' && getRuntimePlatform() === 'linux' && isRunningInWsl()) {
+    return windowsDrivePathToWslMountPath(trimmed) ?? trimmed;
+  }
+
+  return trimmed;
+}
+
 function formatWslHostedNativeDisplayPath(filesystemPath: string): string {
   const windowsDrivePath = wslMountPathToWindowsDrivePath(filesystemPath);
   if (windowsDrivePath) return windowsDrivePath;
@@ -296,7 +325,7 @@ function normalizeWslDisplayPath(value: string): string {
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
 }
 
-function wslDisplayPathToWindowsFilesystemPath(
+export function wslDisplayPathToWindowsFilesystemPath(
   displayPath: string,
   wslPathInfo: WslPathInfo,
 ): string {

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -737,6 +737,7 @@ export const en: I18nMessages = {
     tooSmallToSplit: 'Panel is too small to split',
     cannotCloseLastPanel: 'Cannot close the last panel',
     dropToInsertPath: 'Insert path into terminal',
+    dropToInsertSessionReference: 'Insert session reference into terminal',
   },
   sidebar: {
     noProjects: 'No projects',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -737,6 +737,7 @@ export const ja: I18nMessages = {
     tooSmallToSplit: 'パネルが小さすぎて分割できません',
     cannotCloseLastPanel: '最後のパネルは閉じることができません',
     dropToInsertPath: 'ターミナルにパスを挿入',
+    dropToInsertSessionReference: 'ターミナルにセッション参照を挿入',
   },
   sidebar: {
     noProjects: 'プロジェクトがありません',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -744,6 +744,7 @@ export const ko: I18nMessages = {
     tooSmallToSplit: '패널이 너무 작아서 분할할 수 없습니다',
     cannotCloseLastPanel: '마지막 패널은 닫을 수 없습니다',
     dropToInsertPath: '터미널에 경로 삽입',
+    dropToInsertSessionReference: '터미널에 세션 참조 삽입',
   },
   sidebar: {
     noProjects: '프로젝트가 없습니다',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -730,6 +730,7 @@ export interface I18nMessages {
     tooSmallToSplit: string;
     cannotCloseLastPanel: string;
     dropToInsertPath: string;
+    dropToInsertSessionReference: string;
   };
   sidebar: {
     noProjects: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -737,6 +737,7 @@ export const zh: I18nMessages = {
     tooSmallToSplit: '面板太小，无法拆分',
     cannotCloseLastPanel: '无法关闭最后一个面板',
     dropToInsertPath: '将路径插入终端',
+    dropToInsertSessionReference: '将会话引用插入终端',
   },
   sidebar: {
     noProjects: '暂无项目',

--- a/src/lib/session-export.ts
+++ b/src/lib/session-export.ts
@@ -1,11 +1,17 @@
 import fs from 'fs/promises';
 import path from 'path';
+import * as dbSessions from './db/sessions';
 import logger from './logger';
 import {
   reduceHistoryEventsToReplayState,
   sessionHistory,
   type SessionHistoryEvent,
 } from './session-history';
+import {
+  readNativeTranscript,
+  resolveNativeTranscriptSourcePath,
+} from './session/native-transcript';
+import type { NativeTranscriptMessage } from './session/native-transcript-types';
 import { getTesseraDataPath } from './tessera-data-dir';
 import type { ContentBlock } from './ws/message-types';
 import type { EnhancedMessage, TextMessage } from '@/types/chat';
@@ -15,6 +21,11 @@ const EXPORT_DIR = getTesseraDataPath('session-exports');
 export interface SessionExportOptions {
   untilMessageId?: string;
   untilMessageIndex?: number;
+  /**
+   * Owner of the export request. Only needed for terminal sessions, where the
+   * agent environment decides how to translate the CLI-reported transcript path.
+   */
+  userId?: string;
 }
 
 function assertValidSessionId(sessionId: string): void {
@@ -37,6 +48,14 @@ function extractTextContent(content: string | ContentBlock[]): string {
     .join('\n');
 }
 
+function formatTurn(role: 'user' | 'assistant', text: string): string {
+  return `**${role === 'user' ? 'User' : 'Assistant'}:**\n${text}\n`;
+}
+
+function joinTurns(parts: string[]): string | null {
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
 function buildMarkdownFromTextMessages(messages: EnhancedMessage[]): string | null {
   const parts: string[] = [];
 
@@ -50,10 +69,10 @@ function buildMarkdownFromTextMessages(messages: EnhancedMessage[]): string | nu
       continue;
     }
 
-    parts.push(`**${message.role === 'user' ? 'User' : 'Assistant'}:**\n${text}\n`);
+    parts.push(formatTurn(message.role === 'user' ? 'user' : 'assistant', text));
   }
 
-  return parts.length > 0 ? parts.join('\n') : null;
+  return joinTurns(parts);
 }
 
 function resolveCutoffIndex(messages: EnhancedMessage[], options: SessionExportOptions): number {
@@ -96,29 +115,48 @@ function buildMarkdownFromHistoryEvents(events: SessionHistoryEvent[]): string |
     if (event.type === 'user_message') {
       const text = extractTextContent(event.content);
       if (text.trim()) {
-        parts.push(`**User:**\n${text.trim()}\n`);
+        parts.push(formatTurn('user', text.trim()));
       }
     } else if (event.type === 'assistant_message') {
       const text = typeof event.content === 'string' ? event.content : '';
       if (text.trim()) {
-        parts.push(`**Assistant:**\n${text.trim()}\n`);
+        parts.push(formatTurn('assistant', text.trim()));
       }
     }
   }
 
-  return parts.length > 0 ? parts.join('\n') : null;
+  return joinTurns(parts);
 }
 
-async function buildMarkdownFromHistory(sessionId: string): Promise<string | null> {
-  const events = await sessionHistory.readEvents(sessionId);
-  return buildMarkdownFromHistoryEvents(events);
+function buildMarkdownFromNativeMessages(messages: NativeTranscriptMessage[]): string | null {
+  return joinTurns(messages.map((message) => formatTurn(message.role, message.text)));
+}
+
+/**
+ * Terminal sessions only ever get `user_message` events: the hooks observe
+ * lifecycle, and a stock Stop payload carries no assistant text. Without this
+ * check the export would silently succeed as a list of bare prompts.
+ */
+function hasAssistantMessage(events: SessionHistoryEvent[]): boolean {
+  return events.some((event) => event.type === 'assistant_message');
+}
+
+/** What the user actually typed, as recorded by `UserPromptSubmit`. */
+function collectUserPrompts(events: SessionHistoryEvent[]): string[] {
+  const prompts: string[] = [];
+  for (const event of events) {
+    if (event.type !== 'user_message') continue;
+    const text = extractTextContent(event.content).trim();
+    if (text) prompts.push(text);
+  }
+  return prompts;
 }
 
 async function buildMarkdownUntilMessage(
   sessionId: string,
+  events: SessionHistoryEvent[],
   options: SessionExportOptions,
 ): Promise<string | null> {
-  const events = await sessionHistory.readEvents(sessionId);
   const replayState = reduceHistoryEventsToReplayState(sessionId, events, {
     lazyToolOutput: false,
   });
@@ -129,6 +167,40 @@ async function buildMarkdownUntilMessage(
   }
 
   return buildMarkdownFromTextMessages(replayState.messages.slice(0, cutoffIndex + 1));
+}
+
+async function statModifiedTime(filePath: string): Promise<number | null> {
+  try {
+    return (await fs.stat(filePath)).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when the cached export is newer than every source it was built from.
+ *
+ * Sources outlive nothing: Claude prunes `~/.claude/projects` on
+ * `cleanupPeriodDays` (30 by default), and a workspace can be deleted at any
+ * time. Once every source is gone the export Tessera wrote is the only
+ * surviving copy of that conversation, so it is served as-is rather than
+ * rebuilt into a failure.
+ */
+async function isExportUpToDate(
+  exportPath: string,
+  sourcePaths: Array<string | null>,
+): Promise<boolean> {
+  const sources = sourcePaths.filter((sourcePath): sourcePath is string => Boolean(sourcePath));
+  if (sources.length === 0) return false;
+
+  const exportModifiedAt = await statModifiedTime(exportPath);
+  if (exportModifiedAt === null) return false;
+
+  const sourceModifiedTimes = (await Promise.all(sources.map(statModifiedTime)))
+    .filter((modifiedAt): modifiedAt is number => modifiedAt !== null);
+  if (sourceModifiedTimes.length === 0) return true;
+
+  return sourceModifiedTimes.every((modifiedAt) => exportModifiedAt >= modifiedAt);
 }
 
 export async function exportSessionLog(
@@ -146,24 +218,39 @@ export async function exportSessionLog(
     ? buildPartialExportPath(sessionId, options)
     : path.join(EXPORT_DIR, `${sessionId}.md`);
   const historyPath = sessionHistory.getHistoryPath(sessionId);
+  const events = await sessionHistory.readEvents(sessionId);
 
-  // Cache: compare JSONL mtime vs export mtime
-  try {
-    const [exportStat, historyStat] = await Promise.all([
-      fs.stat(exportPath),
-      fs.stat(historyPath),
-    ]);
-    if (exportStat.mtimeMs >= historyStat.mtimeMs) {
-      logger.info({ sessionId, partial: isPartialExport }, 'Session export cache hit');
-      return exportPath;
-    }
-  } catch {
-    // Export or history doesn't exist yet — generate
+  // Partial exports replay Tessera-side messages, which terminal sessions never
+  // have — the native fallback only applies to a full export.
+  const session = !isPartialExport && !hasAssistantMessage(events)
+    ? dbSessions.getSession(sessionId)
+    : undefined;
+  const nativeSourcePath = session
+    ? await resolveNativeTranscriptSourcePath(session, options.userId)
+    : null;
+
+  if (await isExportUpToDate(exportPath, session ? [nativeSourcePath] : [historyPath])) {
+    logger.info({ sessionId, partial: isPartialExport }, 'Session export cache hit');
+    return exportPath;
   }
 
-  const logContent = isPartialExport
-    ? await buildMarkdownUntilMessage(sessionId, options)
-    : await buildMarkdownFromHistory(sessionId);
+  let logContent: string | null;
+  if (isPartialExport) {
+    logContent = await buildMarkdownUntilMessage(sessionId, events, options);
+  } else if (session) {
+    const { messages } = await readNativeTranscript(session, {
+      userId: options.userId,
+      knownUserPrompts: collectUserPrompts(events),
+    });
+    // Prompts alone are not a conversation: refuse rather than hand the agent a
+    // half-context it cannot tell is incomplete.
+    logContent = messages.some((message) => message.role === 'assistant')
+      ? buildMarkdownFromNativeMessages(messages)
+      : null;
+  } else {
+    logContent = buildMarkdownFromHistoryEvents(events);
+  }
+
   if (!logContent) {
     throw new Error('No conversation log found');
   }
@@ -174,6 +261,11 @@ export async function exportSessionLog(
   await fs.mkdir(EXPORT_DIR, { recursive: true });
   await fs.writeFile(exportPath, header + logContent, 'utf-8');
 
-  logger.info({ sessionId, exportPath, partial: isPartialExport }, 'Session exported');
+  logger.info({
+    sessionId,
+    exportPath,
+    partial: isPartialExport,
+    ...(session ? { source: 'native-transcript' } : {}),
+  }, 'Session exported');
   return exportPath;
 }

--- a/src/lib/session/native-transcript-types.ts
+++ b/src/lib/session/native-transcript-types.ts
@@ -1,0 +1,28 @@
+/**
+ * A conversation turn recovered from a CLI's own transcript.
+ *
+ * PTY sessions have no Tessera-side assistant record: the hooks only observe
+ * lifecycle, and a stock Stop payload carries no assistant text (see
+ * `hook-receiver.ts`). Session export therefore falls back to whatever the
+ * provider wrote for itself.
+ *
+ * This is a context handoff, not a replay — thinking blocks, tool calls and
+ * streaming chunks are dropped, and only user/assistant prose survives.
+ */
+export interface NativeTranscriptMessage {
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+/**
+ * Prompts Tessera recorded for the session (from `UserPromptSubmit`), used to
+ * tell real user turns apart from the synthetic ones a CLI injects into its
+ * own transcript (Codex replays AGENTS.md as a `user` message).
+ */
+export interface NativeTranscriptParseOptions {
+  knownUserPrompts?: readonly string[];
+}
+
+export function normalizePromptForComparison(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}

--- a/src/lib/session/native-transcript.ts
+++ b/src/lib/session/native-transcript.ts
@@ -1,0 +1,127 @@
+import fs from 'fs/promises';
+import { parseClaudeNativeTranscript } from '@/lib/cli/providers/claude-code/native-transcript';
+import { parseCodexNativeTranscript } from '@/lib/cli/providers/codex/native-transcript';
+import { readOpenCodeNativeTranscript } from '@/lib/cli/providers/opencode/native-transcript';
+import { getAgentEnvironment } from '@/lib/cli/spawn-cli';
+import { resolveCodexAccountTranscriptPath } from '@/lib/codex-home';
+import { extractOpenCodeTerminalSessionId, type SessionRow } from '@/lib/db/sessions';
+import { getTerminalProviderSessionForTesseraSession } from '@/lib/db/terminal-provider-sessions';
+import { resolveAgentReportedPath } from '@/lib/filesystem/path-environment';
+import logger from '@/lib/logger';
+import type { NativeTranscriptMessage } from './native-transcript-types';
+
+export interface NativeTranscriptResult {
+  messages: NativeTranscriptMessage[];
+  /** Cache key for export freshness. Absent when nothing was recovered. */
+  sourcePath?: string;
+}
+
+export interface ReadNativeTranscriptOptions {
+  userId?: string;
+  /** Prompts Tessera recorded, used to drop a CLI's synthetic `user` turns. */
+  knownUserPrompts?: readonly string[];
+}
+
+const EMPTY_RESULT: NativeTranscriptResult = { messages: [] };
+
+/**
+ * Locate the transcript file the CLI wrote for this session, translated into a
+ * path this server can open.
+ */
+async function resolveTranscriptPath(
+  session: SessionRow,
+  userId: string | undefined,
+): Promise<string | null> {
+  const storedPath = getTerminalProviderSessionForTesseraSession(session.id)?.transcript_path;
+  if (!storedPath) return null;
+
+  const agentEnvironment = await getAgentEnvironment(userId);
+  const serverPath = await resolveAgentReportedPath(storedPath, agentEnvironment);
+
+  return session.provider === 'codex'
+    ? resolveCodexAccountTranscriptPath(serverPath)
+    : serverPath;
+}
+
+/**
+ * The file whose mtime decides whether a cached export is still fresh.
+ *
+ * Null for OpenCode: its conversations live in a database shared by every
+ * session, so there is no per-session stamp to compare against.
+ */
+export async function resolveNativeTranscriptSourcePath(
+  session: SessionRow,
+  userId?: string,
+): Promise<string | null> {
+  if (session.provider !== 'claude-code' && session.provider !== 'codex') return null;
+  return resolveTranscriptPath(session, userId);
+}
+
+async function readClaudeOrCodexTranscript(
+  session: SessionRow,
+  options: ReadNativeTranscriptOptions,
+): Promise<NativeTranscriptResult> {
+  const transcriptPath = await resolveTranscriptPath(session, options.userId);
+  if (!transcriptPath) return EMPTY_RESULT;
+
+  let content: string;
+  try {
+    content = await fs.readFile(transcriptPath, 'utf-8');
+  } catch (error) {
+    logger.debug(
+      { sessionId: session.id, transcriptPath, error },
+      'Native transcript unreadable',
+    );
+    return EMPTY_RESULT;
+  }
+
+  const messages = session.provider === 'codex'
+    ? parseCodexNativeTranscript(content, { knownUserPrompts: options.knownUserPrompts })
+    : parseClaudeNativeTranscript(content);
+
+  return { messages, sourcePath: transcriptPath };
+}
+
+async function readOpenCodeTranscript(
+  session: SessionRow,
+): Promise<NativeTranscriptResult> {
+  const providerSessionId =
+    getTerminalProviderSessionForTesseraSession(session.id)?.provider_session_id
+    ?? extractOpenCodeTerminalSessionId(session.provider_state);
+  if (!providerSessionId) return EMPTY_RESULT;
+
+  try {
+    const messages = await readOpenCodeNativeTranscript(providerSessionId);
+    // OpenCode stores conversations in a database shared by every session, so
+    // there is no per-session file to date-stamp; the caller falls back to
+    // skipping the freshness cache rather than serving a stale export.
+    return { messages };
+  } catch (error) {
+    logger.debug({ sessionId: session.id, error }, 'OpenCode transcript unreadable');
+    return EMPTY_RESULT;
+  }
+}
+
+/**
+ * Recover a PTY session's conversation from the CLI's own transcript.
+ *
+ * Tessera only records `user_message` for terminal sessions — the hooks observe
+ * lifecycle and a stock Stop payload carries no assistant text — so this is the
+ * only source of assistant prose for those sessions. Failures degrade to an
+ * empty result: the caller decides whether a half-conversation is worth
+ * exporting.
+ */
+export async function readNativeTranscript(
+  session: SessionRow,
+  options: ReadNativeTranscriptOptions = {},
+): Promise<NativeTranscriptResult> {
+  if (session.provider === 'opencode') {
+    return readOpenCodeTranscript(session);
+  }
+
+  if (session.provider === 'claude-code' || session.provider === 'codex') {
+    return readClaudeOrCodexTranscript(session, options);
+  }
+
+  return EMPTY_RESULT;
+}

--- a/src/lib/session/session-reference.ts
+++ b/src/lib/session/session-reference.ts
@@ -1,3 +1,5 @@
+import { sendInputToTerminal } from '@/lib/terminal/terminal-surface-registry';
+
 export interface SessionReferenceExportOptions {
   untilMessageId?: string;
   untilMessageIndex?: number;
@@ -31,6 +33,21 @@ export async function exportSessionReference(
 
 export function formatSessionReference(title: string, exportPath: string): string {
   return `[Session: "${title}" → ${exportPath}]`;
+}
+
+/**
+ * Terminal sessions render no composer (`chat-area.tsx` skips `MessageInput`
+ * for them), so a dropped session reference is typed straight into the PTY —
+ * the same shape the composer would have produced, landing in whatever prompt
+ * the CLI is showing.
+ */
+export async function insertSessionReferenceIntoTerminal(
+  terminalId: string,
+  sessionId: string,
+  title: string,
+): Promise<boolean> {
+  const exportPath = await exportSessionReference(sessionId);
+  return sendInputToTerminal(terminalId, `${formatSessionReference(title, exportPath)} `);
 }
 
 export function formatContinueConversationPrompt(exportPath: string): string {

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -84,6 +84,14 @@ export interface TerminalSurfaceOptions {
   previewOwned?: boolean;
 }
 
+/**
+ * Rows around the cursor that belong to the CLI's input box — its border above,
+ * and the border plus hint/status line below (Claude Code and Codex both draw
+ * roughly this shape).
+ */
+const PROMPT_BOX_ROWS_ABOVE = 2;
+const PROMPT_BOX_ROWS_BELOW = 2;
+
 type XtermLike = TerminalScrollTarget & {
   cols: number;
   rows: number;
@@ -520,6 +528,33 @@ export class TerminalSurface {
 
   matchesTerminal(terminalId: string): boolean {
     return this.options.terminalId === terminalId || this.actualTerminalId === terminalId;
+  }
+
+  /**
+   * Client-coordinate band covering the CLI's input box, or null when the
+   * terminal is not mounted. A TUI frames its prompt with a border and a status
+   * line around the cursor row, and parks the whole thing wherever the content
+   * ends — so a drop target aimed at "the input area" has to follow the cursor
+   * and span the rows around it.
+   */
+  getPromptBounds(): { top: number; bottom: number } | null {
+    const terminal = this.terminal;
+    const element = terminal?.element;
+    if (!terminal || !element || terminal.rows <= 0) return null;
+
+    const rect = element.getBoundingClientRect();
+    if (rect.height <= 0) return null;
+
+    const rowHeight = rect.height / terminal.rows;
+    const cursorRow = Math.min(terminal.buffer.active.cursorY, terminal.rows - 1);
+    const cursorTop = rect.top + cursorRow * rowHeight;
+    return {
+      top: Math.max(cursorTop - rowHeight * PROMPT_BOX_ROWS_ABOVE, rect.top),
+      bottom: Math.min(
+        cursorTop + rowHeight * (1 + PROMPT_BOX_ROWS_BELOW),
+        rect.bottom,
+      ),
+    };
   }
 
   resetWebglTextureAtlas(): void {
@@ -1636,4 +1671,21 @@ export function sendInputToTerminal(terminalId: string, data: string): boolean {
 
 export function getSessionTerminalId(sessionId: string): string {
   return `session-${sessionId}`;
+}
+
+/** Where the input box currently sits on screen, preferring the running surface. */
+export function getTerminalPromptBounds(
+  terminalId: string,
+): { top: number; bottom: number } | null {
+  const candidates = [...surfaces.values()].filter((surface) => surface.matchesTerminal(terminalId));
+  for (const surface of candidates) {
+    if (surface.getSnapshot().status !== 'running') continue;
+    const bounds = surface.getPromptBounds();
+    if (bounds) return bounds;
+  }
+  for (const surface of candidates) {
+    const bounds = surface.getPromptBounds();
+    if (bounds) return bounds;
+  }
+  return null;
 }

--- a/tests/native-transcript.test.ts
+++ b/tests/native-transcript.test.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { parseClaudeNativeTranscript } from '@/lib/cli/providers/claude-code/native-transcript';
+import { parseCodexNativeTranscript } from '@/lib/cli/providers/codex/native-transcript';
+import { resolveCodexAccountTranscriptPath } from '@/lib/codex-home';
+import { wslDisplayPathToWindowsFilesystemPath } from '@/lib/filesystem/path-environment';
+
+function codexMessageLine(role: string, text: string): string {
+  return JSON.stringify({
+    type: 'response_item',
+    timestamp: '2026-07-22T18:06:06.000Z',
+    payload: {
+      type: 'message',
+      role,
+      content: [{ type: role === 'assistant' ? 'output_text' : 'input_text', text }],
+    },
+  });
+}
+
+test('claude transcript keeps only lead-agent prose', () => {
+  const transcript = [
+    JSON.stringify({ type: 'mode', mode: 'normal' }),
+    JSON.stringify({ type: 'user', message: { role: 'user', content: '웹에서도 잘되나' } }),
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '숨겨진 추론' },
+          { type: 'text', text: '확인했습니다' },
+          { type: 'tool_use', name: 'Read', input: {} },
+        ],
+      },
+    }),
+    // Subagent turn — not part of the conversation the user had.
+    JSON.stringify({
+      type: 'assistant',
+      isSidechain: true,
+      message: { role: 'assistant', content: [{ type: 'text', text: '서브에이전트' }] },
+    }),
+    // Tool results ride on `user` lines and carry no prose.
+    JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', content: 'output' }] },
+    }),
+  ].join('\n');
+
+  assert.deepEqual(parseClaudeNativeTranscript(transcript), [
+    { role: 'user', text: '웹에서도 잘되나' },
+    { role: 'assistant', text: '확인했습니다' },
+  ]);
+});
+
+test('claude transcript survives malformed lines', () => {
+  const transcript = [
+    'not json',
+    '',
+    JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: '살아남음' }] } }),
+  ].join('\n');
+
+  assert.deepEqual(parseClaudeNativeTranscript(transcript), [
+    { role: 'assistant', text: '살아남음' },
+  ]);
+});
+
+test('codex transcript drops developer turns and injected instructions', () => {
+  const transcript = [
+    JSON.stringify({ type: 'session_meta', payload: { session_id: 'abc' } }),
+    codexMessageLine('developer', '<permissions instructions> sandboxing...'),
+    codexMessageLine('user', '# AGENTS.md instructions\n\n<INSTRUCTIONS>\n# Global Rules\n'),
+    codexMessageLine('user', '웹에서 지금 테스트중'),
+    codexMessageLine('assistant', '네, 확인했습니다.'),
+  ].join('\n');
+
+  assert.deepEqual(parseCodexNativeTranscript(transcript), [
+    { role: 'user', text: '웹에서 지금 테스트중' },
+    { role: 'assistant', text: '네, 확인했습니다.' },
+  ]);
+});
+
+test('codex transcript trusts recorded prompts over marker heuristics', () => {
+  const transcript = [
+    codexMessageLine('user', '# AGENTS.md instructions\n\n<INSTRUCTIONS>\n주입된 내용\n'),
+    codexMessageLine('user', 'AGENTS.md 고쳐줘'),
+    codexMessageLine('assistant', '네'),
+  ].join('\n');
+
+  // A prompt that looks synthetic is still real when Tessera recorded it.
+  assert.deepEqual(
+    parseCodexNativeTranscript(transcript, { knownUserPrompts: ['AGENTS.md 고쳐줘'] }),
+    [
+      { role: 'user', text: 'AGENTS.md 고쳐줘' },
+      { role: 'assistant', text: '네' },
+    ],
+  );
+});
+
+test('codex rollout path under a removed overlay resolves to the account home', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-codex-transcript-'));
+  try {
+    const relativeParts = ['sessions', '2026', '07', '22', 'rollout-test.jsonl'];
+    const accountPath = path.join(root, '.codex', ...relativeParts);
+    fs.mkdirSync(path.dirname(accountPath), { recursive: true });
+    fs.writeFileSync(accountPath, '');
+
+    // The overlay directory itself is gone — only the recorded path remains.
+    const overlayPath = path.join(
+      root,
+      '.tessera',
+      'codex-overlay',
+      'session-e0f1',
+      ...relativeParts,
+    );
+
+    assert.equal(resolveCodexAccountTranscriptPath(overlayPath), accountPath);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('codex path outside an overlay is returned untouched', () => {
+  const plainPath = path.join('/home', 'u', '.codex', 'sessions', 'rollout-plain.jsonl');
+  assert.equal(resolveCodexAccountTranscriptPath(plainPath), plainPath);
+});
+
+// A Windows-hosted server (packaged Electron) reads transcripts the WSL agent
+// reported in guest form; without translation the read fails outright.
+const WSL_PATH_INFO = {
+  homeDisplayPath: '/home/work',
+  homeFilesystemPath: '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work',
+  rootFilesystemPath: '\\\\wsl.localhost\\Ubuntu-24.04',
+};
+
+test('a guest transcript path becomes the UNC path a Windows host can open', () => {
+  assert.equal(
+    wslDisplayPathToWindowsFilesystemPath(
+      '/home/work/.claude/projects/-home-work-repo/abc.jsonl',
+      WSL_PATH_INFO,
+    ),
+    '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\.claude\\projects\\-home-work-repo\\abc.jsonl',
+  );
+});
+
+test('a guest path on a mounted drive maps to the drive letter, not the share', () => {
+  assert.equal(
+    wslDisplayPathToWindowsFilesystemPath('/mnt/c/Users/work/rollout.jsonl', WSL_PATH_INFO),
+    'C:\\Users\\work\\rollout.jsonl',
+  );
+});


### PR DESCRIPTION
## Summary

- **PTY sessions produced a half-empty export.** Terminal sessions only ever record `user_message` — the hooks observe lifecycle, and a stock Stop payload carries no assistant text — so dragging one into a composer handed over a bare list of prompts. It succeeded silently, so the receiving agent could not tell the context was incomplete. The conversation is now recovered from the CLI's own transcript (Claude JSONL / Codex rollout / OpenCode SQLite), and the export is refused outright when nothing can be recovered.
- **Codex transcript paths were dead on arrival.** They were recorded under a per-session overlay home that is deleted with the terminal — all 13 stored paths on this machine pointed at nothing. Since `sessions/` is a symlink into the account home, the same relative path is now resolved there.
- **The export path was returned server-local.** It is handed to the agent as prompt text, so across a WSL/Windows bridge the agent could not open it. It now goes through `normalizeCwdForCliEnvironment`, the way attachment uploads already do (`api/upload/route.ts`).
- **Terminal sessions could not receive a reference.** `chat-area.tsx` skips `MessageInput` for them, so a session dropped on the pane was taken as a panel split. Dropping on the CLI's input box now inserts the reference; the strip tracks the xterm cursor so it follows the prompt as output grows. Everywhere else in the pane keeps split/replace, and layout drags are excluded.

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `NODE_ENV=production npm run build`
- [x] Manual test: exported real PTY sessions of all three providers against the live DB — Claude 1/1, Codex 1/1 (through a dead overlay path), OpenCode 3/3 turns recovered. A GUI session still exports 8 user / 56 assistant turns unchanged. A session whose transcript was pruned is refused with `No conversation log found`, and a previously written export survives its source being deleted. Drop-to-insert verified in the browser against a running Codex TUI.
- [ ] Not tested: packaged Electron. The translation it exercises (server on Windows, agent in WSL) is covered by unit tests rather than a live run.

## Screenshots or Recordings

Dragging a session over a terminal pane raises a solid-bordered strip over the CLI's input box — split zones stay dashed, so the two never read alike. Dropping types `[Session: "<title>" → <path>]` at the prompt, and the CLI reads the file on its next turn.

## Notes

`tests/native-transcript.test.ts` (8 cases): the three transcript parsers, the Codex overlay path mapping, and the WSL→Windows translation a Windows-hosted server needs to read a guest transcript.

One limitation worth knowing: a session whose current turn has not finished has no assistant text in its transcript yet, so its export fails until the turn completes. The composer already offers `Retry` for that.
