### PR TITLE
fix(tab): reuse the selected empty tab for sessions

### DIFF
--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -607,7 +607,20 @@ export const useTabStore = create<TabStore>()((set, get) => ({
   },
 
   createTabWithSession: (sessionId: string): void => {
-    // Ctrl+클릭 시나리오용 시맨틱 래퍼 (내부는 createTab)
+    const state = get();
+    const panelStore = usePanelStore.getState();
+    const tabData = panelStore.tabPanels[state.activeTabId];
+    const activePanel = tabData?.panels[tabData.activePanelId];
+
+    // 선택된 New Tab은 이미 세션을 담기 위한 빈 화면이다. 새 탭을 하나 더
+    // 만들지 않고 이 탭을 고정 세션 탭으로 채운다.
+    if (tabData?.layout.type === 'leaf' && activePanel?.sessionId === null) {
+      panelStore.assignSession(tabData.activePanelId, sessionId);
+      get().syncTabProjectFromSession(state.activeTabId, sessionId);
+      get().pinTab(state.activeTabId);
+      return;
+    }
+
     get().createTab(sessionId);
   },
 

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -146,8 +146,8 @@ export interface TabStoreActions {
   reorderTab(dragTabId: string, dropTabId: string): void;
 
   /**
-   * 특정 세션을 새 탭에서 열기 (Ctrl+클릭 시나리오용 시맨틱 래퍼).
-   * 내부적으로 createTab(sessionId)을 호출.
+   * 특정 세션을 고정 탭에서 열기.
+   * 선택된 탭이 빈 단일 패널이면 그 New Tab을 재사용하고, 아니면 새 탭을 생성.
    */
   createTabWithSession(sessionId: string): void;
 

--- a/tests/tab-session-open.test.ts
+++ b/tests/tab-session-open.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { usePanelStore } from '@/stores/panel-store';
+import { useTabStore } from '@/stores/tab-store';
+
+test('opening a session reuses the selected empty New Tab', () => {
+  const tabId = 'empty-tab';
+  const panelId = 'empty-panel';
+
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: null, title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: null } },
+        activePanelId: panelId,
+      },
+    },
+    activeTabId: tabId,
+  });
+
+  useTabStore.getState().createTabWithSession('session-1');
+
+  assert.equal(useTabStore.getState().tabs.length, 1);
+  assert.equal(useTabStore.getState().activeTabId, tabId);
+  assert.equal(
+    usePanelStore.getState().tabPanels[tabId]?.panels[panelId]?.sessionId,
+    'session-1',
+  );
+});
+
+test('opening a session preserves an occupied selected tab', () => {
+  const tabId = 'occupied-tab';
+  const panelId = 'occupied-panel';
+
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: null, title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: 'session-1' } },
+        activePanelId: panelId,
+      },
+    },
+    activeTabId: tabId,
+  });
+
+  useTabStore.getState().createTabWithSession('session-2');
+
+  assert.equal(useTabStore.getState().tabs.length, 2);
+  assert.equal(
+    usePanelStore.getState().tabPanels[tabId]?.panels[panelId]?.sessionId,
+    'session-1',
+  );
+  const activeTabId = useTabStore.getState().activeTabId;
+  const activeTabData = usePanelStore.getState().tabPanels[activeTabId];
+  assert.equal(
+    activeTabData?.panels[activeTabData.activePanelId]?.sessionId,
+    'session-2',
+  );
+});


### PR DESCRIPTION
## Summary

- Reuse the currently selected empty New Tab when opening a pinned session.
- Preserve occupied or split tabs by continuing to open those sessions in a new tab.
- Add regression coverage for both empty-tab reuse and occupied-tab preservation.

## Root cause

`createTabWithSession()` always called `createTab(sessionId)` without checking whether the active tab was already an empty single-panel New Tab. This left the empty tab behind and created an unnecessary additional tab.

## User impact

Opening a session from the menu while an empty New Tab is selected now opens the session in that tab, preventing unused New Tabs from accumulating.

## Validation

- 14 focused Node tests passed.
- `tsc --noEmit` passed.
- ESLint passed for the changed files.
- `git diff --check` passed.