### PR TITLE
fix(chat): retire stopped GUI session surfaces

### DIFF
--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -93,7 +93,8 @@ export function handleIncomingServerMessage({
       useSessionPrStore.getState().clearSession(msg.sessionId);
       return { wasReconnect };
 
-    case 'session_stopped':
+    case 'session_stopped': {
+      const stoppedSession = sessionStore.getSession(msg.sessionId);
       sessionStore.markSessionStopped(msg.sessionId);
       finalizeInFlightTurn(msg.sessionId, { clearPrompt: true });
       // The session was stopped, so any workflow still flagged running can no
@@ -103,7 +104,14 @@ export function handleIncomingServerMessage({
       chatStore.setTodoSnapshot(msg.sessionId, []);
       sessionStore.setSessionWorkflowRunning(msg.sessionId, false);
       useCommandStore.getState().clearSession(msg.sessionId);
+      // PTY surfaces retire on terminal_session_runtime so a provider session
+      // rebound can transfer the existing panel first. GUI sessions have no
+      // later runtime event, so stopping one must retire its surface here.
+      if (stoppedSession && stoppedSession.kind !== 'terminal') {
+        useTabStore.getState().retireSessionSurface(msg.sessionId);
+      }
       return { wasReconnect };
+    }
 
     case 'replay_events':
       sessionStore.touchSessionActivity(msg.sessionId, getLatestReplayEventTimestamp(msg.events));

--- a/tests/terminal-session-runtime-state.test.ts
+++ b/tests/terminal-session-runtime-state.test.ts
@@ -274,6 +274,38 @@ test('PTY runtime exit closes a retained single-panel session tab', () => {
   assert.equal(useTabStore.getState().findSessionLocation(SESSION_ID), null);
 });
 
+test('stopping a GUI session closes its retained single-panel tab', () => {
+  const guiSessionId = 'gui-session-a';
+  const tabId = 'retained-gui-tab';
+  const panelId = 'retained-gui-panel';
+  useSessionStore.setState({
+    projects: [project(guiSession(guiSessionId, true))],
+  });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: guiSessionId } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  receive({
+    type: 'session_stopped',
+    sessionId: guiSessionId,
+  });
+
+  assert.equal(useTabStore.getState().tabs.some((tab) => tab.id === tabId), false);
+  assert.equal(useTabStore.getState().findSessionLocation(guiSessionId), null);
+});
+
 test('PTY runtime exit removes its panel without discarding unrelated panels', () => {
   const tabId = 'multi-panel-terminal-tab';
   const terminalPanelId = 'terminal-panel';
@@ -749,6 +781,45 @@ test('archiving a stopped PTY session retires its open surface after the request
 
   assert.equal(useTabStore.getState().tabs.some((tab) => tab.id === tabId), false);
   assert.equal(useTabStore.getState().findSessionLocation(SESSION_ID), null);
+});
+
+test('archiving a GUI session retires its open surface after the request succeeds', async (t) => {
+  const guiSessionId = 'archived-gui-session';
+  const tabId = 'archived-gui-tab';
+  const panelId = 'archived-gui-panel';
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  useSessionStore.setState({
+    projects: [project(guiSession(guiSessionId))],
+  });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: guiSessionId } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  useSessionStore.getState().toggleArchive(guiSessionId, true);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(useTabStore.getState().tabs.some((tab) => tab.id === tabId), false);
+  assert.equal(useTabStore.getState().findSessionLocation(guiSessionId), null);
 });
 
 test('PTY runtime exit defers surface retirement while archive rollback is still possible', () => {


### PR DESCRIPTION
## What changed

- Retire the open GUI session surface when a `session_stopped` event arrives.
- Keep PTY surface retirement on `terminal_session_runtime` so session rebound behavior remains intact.
- Add regression coverage for GUI stop and GUI archive surface retirement.

## Why

Stopping a GUI session updated its runtime state but left its open tab or split panel visible. PTY sessions already retired their surface through the terminal runtime shutdown event, while GUI sessions have no equivalent follow-up event.

## Impact

GUI sessions now match PTY sessions: stopping or archiving a session removes its open surface. Single-panel tabs close; split layouts retain unrelated panels.

## Validation

- `npx eslint src/lib/ws/client-message-handlers.ts tests/terminal-session-runtime-state.test.ts`
- `npx tsx --test tests/terminal-session-runtime-state.test.ts tests/active-session-runtime.test.ts` (37 passed)
- `git diff --check`
