### PR TITLE
feat(chat): discover slash commands before session start

### DIFF
--- a/opencode-pre-session-skill-discovery-research.md
+++ b/opencode-pre-session-skill-discovery-research.md
@@ -1,0 +1,160 @@
+# OpenCode 대화 시작 전 skill/slash command 조회 조사
+
+작성일: 2026-07-31
+검증 대상: OpenCode `1.14.48`, Tessera 현재 워크트리
+
+## 결론
+
+가능하다. OpenCode의 ACP(`opencode acp`)를 임시로 시작하는 방식은 적합하지 않지만, 공식 headless HTTP server(`opencode serve`)에는 세션 ID 없이 호출할 수 있는 두 API가 있다.
+
+| 목적 | 공식 API | 반환 범위 | Tessera 권장도 |
+|---|---|---|---|
+| 현재 ACP의 `available_commands_update`와 가장 비슷한 목록 | `GET /command?directory=<cwd>` | 기본 prompt command, 사용자 command, MCP prompt, skill | **권장** |
+| skill만 조회 | `GET /skill?directory=<cwd>` | 발견된 skill | `/skills` 전용 화면 등에 적합 |
+
+두 endpoint는 세션 경로(`/session/:id/...`)가 아니라 instance 경로이며, 요청 스키마에도 session ID가 없다. OpenCode `v1.14.48` 소스는 `/command`와 `/skill`을 각각 `command.list`, `app.skills` operation으로 선언하고 둘 다 `directory`가 포함된 workspace routing query를 받도록 정의한다. ([OpenCode v1.14.48 instance API source, lines 42–55 and 138–166](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/server/routes/instance/httpapi/groups/instance.ts#L42-L55), [same file, lines 138–166](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/server/routes/instance/httpapi/groups/instance.ts#L138-L166))
+
+따라서 Tessera는 새 GUI 대화를 만들지 않고, 작업 디렉터리 기준의 일회성 OpenCode server를 띄워 목록만 읽은 뒤 종료할 수 있다.
+
+## 공식 인터페이스
+
+### 1. `opencode serve`
+
+공식 문서는 `opencode serve`가 TUI 없이 OpenCode HTTP API를 노출하며, OpenAPI 3.1 문서를 `http://<host>:<port>/doc`에서 제공한다고 명시한다. 서버는 `--hostname`, `--port`, `--cors`를 지원한다. ([OpenCode Server documentation](https://opencode.ai/docs/server/))
+
+`v1.14.48`의 CLI 구현도 `serve`를 ambient project instance 없이 시작하고 요청별 directory로 instance를 로드한다고 주석으로 명시한다. 서버가 준비되면 실제 host/port를 stdout의 `opencode server listening on ...`으로 출력한다. ([OpenCode v1.14.48 `serve` source, lines 7–24](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/cli/cmd/serve.ts#L7-L24))
+
+인증은 `OPENCODE_SERVER_PASSWORD`가 설정되면 HTTP Basic Auth를 사용한다. 기본 username은 `opencode`이고 `OPENCODE_SERVER_USERNAME`으로 바꿀 수 있다. Tessera가 상속된 인증 환경을 유지한다면 이 값을 요청에 반영하되 로그에는 credential을 남기지 않아야 한다. ([OpenCode Server authentication](https://opencode.ai/docs/server/#authentication))
+
+### 2. `GET /skill`
+
+`GET /skill?directory=<cwd>`는 `Skill.Info[]`를 반환한다. `v1.14.48`의 `Skill.Info`는 `name`, optional `description`, `location`, `content`로 구성된다. ([OpenCode v1.14.48 Skill schema, lines 38–45](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/skill/index.ts#L38-L45), [instance API declaration](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/server/routes/instance/httpapi/groups/instance.ts#L158-L166))
+
+OpenCode는 cwd부터 git worktree까지 올라가며 project-local skills를 찾고, global OpenCode/Claude/Agents 호환 위치도 검색한다. 공식 문서에 나온 위치는 다음과 같다. ([OpenCode Agent Skills — discovery](https://opencode.ai/docs/skills/#understand-discovery))
+
+- `.opencode/skills/<name>/SKILL.md`
+- `~/.config/opencode/skills/<name>/SKILL.md`
+- project/global `.claude/skills/<name>/SKILL.md`
+- project/global `.agents/skills/<name>/SKILL.md`
+
+`directory`를 생략하면 server process의 cwd가 기본값이 된다. `v1.14.48` workspace router는 query의 `directory`, `x-opencode-directory` header, `process.cwd()` 순서로 directory를 정한다. Tessera는 세션의 `work_dir`을 명시적으로 query에 넣어야 한다. ([OpenCode v1.14.48 workspace routing, lines 56–58](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts#L56-L58))
+
+주의할 점은 이 endpoint가 metadata만 반환하지 않고 skill 본문 `content`까지 반환한다는 것이다. Tessera는 응답 직후 `{name, description}`만 투영하고 원문을 저장하거나 raw log에 남기지 않는 편이 안전하다. 또한 handler는 agent별 permission을 적용하는 `skill.available(agent)`가 아니라 `skill.all()`을 호출하므로, 이것은 “선택한 agent에게 허용된 skill”이 아니라 “해당 directory에서 등록된 skill” 목록이다. ([OpenCode v1.14.48 instance handler, lines 72–82](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/server/routes/instance/httpapi/handlers/instance.ts#L72-L82), [Skill service methods, lines 224–241](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/skill/index.ts#L224-L241))
+
+### 3. `GET /command`
+
+`GET /command?directory=<cwd>`의 응답은 `Command.Info[]`이다. 각 항목에는 `name`, optional `description`, optional `source`, `template`, `hints` 등이 있으며 `source`는 `command | mcp | skill`이다. ([OpenCode v1.14.48 Command schema, lines 32–47](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/command/index.ts#L32-L47))
+
+OpenCode의 command registry는 다음을 하나로 합친다.
+
+1. 기본 prompt command인 `init`, `review`
+2. `opencode.json` 또는 command Markdown으로 정의한 사용자 command
+3. MCP server가 제공하는 prompts
+4. 발견된 skills
+
+이 병합은 공식 `v1.14.48` command registry에 직접 구현되어 있다. Skill과 기존 command의 이름이 충돌하면 기존 command가 우선한다. ([OpenCode v1.14.48 Command registry, lines 78–158](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/command/index.ts#L78-L158))
+
+따라서 `/command`는 Tessera가 현재 ACP 세션에서 받는 provider-reported command 목록과 가장 가깝다. 다만 TUI 자체 화면을 여는 `/help`, `/theme` 같은 모든 built-in UI command를 뜻하지는 않는다. 공식 command 문서도 custom command가 TUI built-ins에 “추가”되는 별도 범주라고 설명한다. ([OpenCode Commands documentation](https://opencode.ai/docs/commands/))
+
+`/command`도 각 command/skill의 전체 `template`을 반환하므로 Tessera는 `{name, description}`만 유지하고 template을 로깅하지 않아야 한다. MCP prompts까지 합치기 위해 command registry가 `mcp.prompts()`를 호출하므로, 구성에 따라 `/skill`보다 느리거나 MCP 초기화/연결을 유발할 수 있다. ([OpenCode v1.14.48 Command registry, lines 118–145](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/command/index.ts#L118-L145))
+
+### 4. `opencode debug skill`은 대안이지만 권장하지 않음
+
+설치된 `1.14.48`의 공식 CLI에는 session 없이 실행할 수 있는 `opencode debug skill`도 있다. `--help`는 이 명령을 `list all available skills`로 설명하고, 공식 소스는 `skill.all()` 결과 전체를 pretty-printed JSON으로 stdout에 쓴다. Metadata-only/compact JSON option은 없다. ([OpenCode v1.14.48 debug skill source](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/cli/cmd/debug/skill.ts#L6-L14))
+
+그러나 이 환경에서는 skill 본문이 많은 상태에서 다음 명령의 stdout이 정확히 `196608` bytes에서 끝났고 JSON의 중간에서 잘렸다.
+
+```bash
+opencode debug skill | wc -c
+# 196608
+```
+
+따라서 skill 수가 적을 때는 작동하더라도 Tessera의 안정적인 discovery transport로 삼기 어렵다. 전체 `content`를 직렬화해 불필요하게 큰 응답을 만들고, slash commands/MCP prompts도 포함하지 않으며, 관찰된 설치본에서는 valid JSON을 보장하지 못했다. HTTP `/skill`도 본문을 반환하지만 HTTP response는 이 CLI stdout 잘림을 재현하지 않았고, `/command`는 ACP에 가까운 command catalog까지 제공하므로 transient server 방식이 더 안전하다.
+
+## ACP로는 왜 해결하면 안 되는가
+
+현재 Tessera의 OpenCode GUI adapter는 `opencode acp`를 시작한 뒤 `initialize`, 이어서 `session/new` 또는 `session/resume`을 보낸다. 즉 ACP 경로에서 command 목록을 얻으려면 이미 session 단계로 들어간다. ([Tessera OpenCode adapter](src/lib/cli/providers/opencode/adapter.ts#L475-L526))
+
+OpenCode `v1.14.48`도 `newSession`에서 session manager의 `create()`를 먼저 호출하고 그 다음 session mode를 로드한다. ([OpenCode v1.14.48 ACP agent, lines 559–574](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/acp/agent.ts#L559-L574)) Session manager의 `create()`는 실제 SDK `session.create()`를 호출하므로 단순 메모리상의 임시 조회가 아니다. ([OpenCode v1.14.48 ACP session manager, lines 17–40](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/acp/session.ts#L17-L40))
+
+ACP의 `available_commands_update`는 session mode를 로드하는 과정에서 `/command`와 같은 SDK `command.list({directory})` 결과를 읽고, `compact`가 없으면 추가한 뒤 session notification으로 보낸다. ([OpenCode v1.14.48 ACP agent, lines 1128–1146 and 1188–1196](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/acp/agent.ts#L1128-L1146), [same file, lines 1188–1196](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/acp/agent.ts#L1188-L1196))
+
+즉 ACP에는 session 이전의 별도 `commands/list` JSON-RPC request가 확인되지 않는다. 목록 자체는 HTTP `GET /command`로 얻고, ACP는 실제 대화가 시작된 후의 live update에만 계속 사용하는 것이 맞다.
+
+## 설치 버전 실증
+
+현재 개발 환경의 `opencode --version`은 `1.14.48`이었다. 아래 순서로 검증했다.
+
+```bash
+opencode serve --hostname 127.0.0.1 --port 43123
+curl 'http://127.0.0.1:43123/command?directory=<encoded-cwd>'
+curl 'http://127.0.0.1:43123/skill?directory=<encoded-cwd>'
+curl 'http://127.0.0.1:43123/doc'
+opencode session list --format json
+```
+
+관찰 결과:
+
+- `/doc`에 `/command` operation ID `command.list`와 `/skill` operation ID `app.skills`가 존재했다.
+- `/command`는 `source: "command"`인 `init`, `review`와 다수의 `source: "skill"` 항목을 함께 반환했다.
+- `/skill`은 `name`, `description`, `location`, `content` 구조의 skill 목록을 반환했다.
+- `directory=/tmp`로 바꾸면 project-local 발견 범위가 바뀌었다.
+- 두 GET 요청 전후 `opencode session list --format json | jq length` 값은 `66`으로 동일했다. HTTP 조회 자체는 conversation/session을 만들지 않았다.
+- `opencode debug skill`도 session은 만들지 않지만, 이 환경에서는 stdout이 `196608` bytes에서 잘려 invalid JSON이 됐다.
+
+이 실증은 공식 `v1.14.48` release tag에 맞춰 수행했다. ([OpenCode v1.14.48 release](https://github.com/anomalyco/opencode/releases/tag/v1.14.48))
+
+## Tessera 구현
+
+`listOpenCodeCommands()` 일회성 discovery client로 구현했다.
+
+```text
+세션의 provider command/opencode 환경과 work_dir 해석
+  -> 빈 loopback 포트를 확보
+  -> opencode serve --hostname 127.0.0.1 --port <확보한 포트> 시작
+  -> stdout에서 실제 listening URL 확인
+  -> GET /command?directory=<정규화한 work_dir>
+  -> 응답을 name/description만으로 축소
+  -> transient server 종료
+  -> 기존 /api/sessions/:id/skills 응답으로 전달
+```
+
+구현 선택:
+
+- 일반 `/` picker: `/command` 사용. 실행 중 ACP가 보고하는 목록과 맞추려면 누락 시 `compact`를 별도로 합친다. OpenCode ACP 자체도 같은 방식으로 `compact`를 추가한다. ([OpenCode v1.14.48 ACP agent](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/acp/agent.ts#L1128-L1146))
+- 정말 skill만 보여주는 UI: `/skill` 또는 `/command`에서 `source === "skill"`만 필터링한다.
+- request에는 반드시 session `work_dir`을 URL-encode한 `directory` query로 전달한다.
+- process가 실행 중이면 지금처럼 ACP의 최신 `available_commands_update` cache를 우선하고, 멈춘 새 세션에서만 transient HTTP discovery를 사용한다.
+- 설치된 `1.14.48`에서 `--port 0`은 OS가 배정하는 임의 포트가 아니라 기본 포트 `4096`으로 해석됐다. 기존 OpenCode 서버와 충돌하지 않도록 Tessera가 loopback의 빈 포트를 먼저 확보해 명시적으로 전달해야 한다.
+- timeout, child-process 종료, stdout의 listening URL 파싱, Basic Auth 환경, native/WSL command/cwd 정규화를 기존 Claude/Codex discovery client와 같은 수준으로 처리한다.
+- 응답의 `template`/`content`는 UI에 필요 없으므로 보관·로깅하지 않는다.
+
+현재 Tessera는 실행 중인 OpenCode process가 있으면 기존 ACP command cache를 그대로 사용하고, process가 없는 새 GUI 세션이면 `listOpenCodeCommands()`로 같은 `/command` catalog를 조회한다. Client hook도 새 OpenCode 세션에서 `/`를 입력하면 기존 `/api/sessions/:id/skills` 경로를 호출하도록 변경했다. ([Tessera skills route](src/app/api/sessions/[id]/skills/route.ts), [Tessera skill picker](src/hooks/use-skill-picker.ts), [OpenCode discovery client](src/lib/cli/providers/opencode/command-discovery-client.ts))
+
+실제 GUI 검증에서는 메시지 0개, `hasStarted: false`, `isRunning: false` 상태를 유지하면서 47개 항목을 표시했고 `/diagnosing-bugs`와 ACP가 보완하는 `/compact`도 포함했다. 검증용 세션과 transient server는 종료 후 모두 정리했다.
+
+## 제약과 리스크
+
+| 제약 | 영향/대응 |
+|---|---|
+| 확인된 버전 범위 | 이 조사는 설치본과 공식 tag `1.14.48`에서 검증했다. 더 오래된 OpenCode를 지원한다면 `/doc` 또는 version gate로 endpoint 존재 여부를 확인하고 빈 목록으로 안전하게 fallback해야 한다. |
+| 응답 과다 | `/command.template`, `/skill.content`가 포함된다. 이름/설명만 즉시 추출하고 raw payload를 남기지 않는다. |
+| `debug skill` stdout | full skill body를 stdout에 쓰며 설치본에서 196608-byte truncation이 재현됐다. HTTP endpoint를 사용한다. |
+| MCP 초기화 | `/command`는 MCP prompts를 합치므로 구성에 따라 느리거나 외부 MCP 연결을 시작할 수 있다. skill만 필요하면 `/skill`이 더 좁다. |
+| remote skill discovery | OpenCode skill 설정에 URL catalog가 있으면 discovery가 이를 pull할 수 있다. 모델 turn/session은 만들지 않지만 완전한 무네트워크 조회는 아니다. ([OpenCode v1.14.48 remote skill discovery, lines 174–180](https://github.com/anomalyco/opencode/blob/v1.14.48/packages/opencode/src/skill/index.ts#L174-L180)) |
+| permission 의미 | `/skill`과 `/command`는 agent별 `deny`가 적용된 model-facing 목록이 아니라 등록된 slash catalog에 가깝다. 선택 agent별 허용 목록이 필요하면 별도 정책 평가가 필요하다. |
+| built-in TUI commands | `/command`는 TUI 전용 command 전체를 반환하지 않는다. Tessera 자체 registry와 provider-reported 목록을 지금처럼 별도 병합해야 한다. |
+| server lifecycle | transient server는 반드시 loopback에만 bind하고, 성공·오류·timeout 모두에서 종료해야 한다. `--port 0`에 의존하지 말고 빈 loopback port를 확보해 명시적으로 넘긴 뒤 stdout의 listening URL과 일치하는지 확인한다. |
+
+## 최종 판단
+
+OpenCode도 Claude Code/Codex와 동일하게 “메시지 0개, 대화 세션 미생성” 상태에서 목록 조회를 지원할 수 있다. 가장 직접적인 공식 경로는 ACP가 아니라:
+
+```text
+opencode serve
+  -> GET /command?directory=<session work_dir>
+  -> name/description만 사용
+  -> server 종료
+```
+
+이다. Skill만 필요할 때는 같은 방식으로 `GET /skill`을 사용하면 된다.

--- a/src/app/api/sessions/[id]/skills/route.ts
+++ b/src/app/api/sessions/[id]/skills/route.ts
@@ -2,14 +2,17 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import * as dbSessions from '@/lib/db/sessions';
 import { processManager } from '@/lib/cli/process-manager';
+import { listClaudeSkills } from '@/lib/cli/providers/claude-code/skill-discovery-client';
+import { listCodexSkills } from '@/lib/cli/providers/codex/skill-discovery-client';
+import { listOpenCodeCommands } from '@/lib/cli/providers/opencode/command-discovery-client';
+import logger from '@/lib/logger';
 
 /**
  * GET /api/sessions/[id]/skills
  *
  * Returns the list of skills available for the given session's CLI provider.
- * Skills are discovered via the SkillSource attached to the active process.
- * If the session has no active process or the provider does not support skill
- * discovery, returns an empty skills array.
+ * Active processes remain authoritative. Fresh GUI sessions use provider-native
+ * discovery that does not start or resume a conversation.
  */
 export async function GET(
   request: NextRequest,
@@ -31,15 +34,45 @@ export async function GET(
     }
 
     const processInfo = processManager.getProcess(id);
-    const skillSource = processInfo?.skillSource;
+    const providerId = session.provider?.trim();
 
-    if (!skillSource) {
-      return NextResponse.json({ skills: [] });
+    if (providerId === 'codex') {
+      const skills = processInfo?.skillSource
+        ? await processInfo.skillSource.listSkills()
+        : await listCodexSkills({
+            userId: auth.userId,
+            workDir: session.work_dir,
+          });
+      return NextResponse.json({ skills });
     }
 
-    const skills = await skillSource.listSkills();
-    return NextResponse.json({ skills });
-  } catch {
+    if (providerId === 'claude-code') {
+      const reportedCommands = processManager.getCommands(id);
+      if (reportedCommands.length > 0) {
+        return NextResponse.json({ skills: reportedCommands });
+      }
+
+      return NextResponse.json({
+        skills: await listClaudeSkills({
+          userId: auth.userId,
+          workDir: session.work_dir,
+        }),
+      });
+    }
+
+    if (providerId === 'opencode') {
+      const commands = processInfo
+        ? processManager.getCommands(id)
+        : await listOpenCodeCommands({
+            userId: auth.userId,
+            workDir: session.work_dir,
+          });
+      return NextResponse.json({ skills: commands });
+    }
+
+    return NextResponse.json({ skills: [] });
+  } catch (error) {
+    logger.warn({ sessionId: id, error }, 'Failed to discover session skills');
     return NextResponse.json({ skills: [] });
   }
 }

--- a/src/hooks/use-skill-picker.ts
+++ b/src/hooks/use-skill-picker.ts
@@ -153,9 +153,13 @@ export function useSkillPicker(
   );
   const hasLoadedCommands = commands !== undefined;
   const hasBuiltInCommands = builtInCommands.length > 0;
+  const canDiscoverBeforeSession = providerId === 'claude-code'
+    || providerId === 'codex'
+    || providerId === 'opencode';
   const isInactive = isOpen && !hasLoadedCommands
     && (skillsOnlyMode || !hasBuiltInCommands)
-    && isSessionRunning === false;
+    && isSessionRunning === false
+    && !canDiscoverBeforeSession;
   const isLoading = isOpen && !hasLoadedCommands
     && (skillsOnlyMode || !hasBuiltInCommands)
     && !isInactive;
@@ -171,15 +175,11 @@ export function useSkillPicker(
     }
 
     const task = (async () => {
-      if (providerId === 'claude-code' || providerId === 'opencode') {
+      if (providerId === 'opencode') {
         if (isSessionRunning !== false) {
           wsClient.getCommands(sessionId);
+          return;
         }
-        return;
-      }
-
-      if (isSessionRunning === false) {
-        return;
       }
 
       try {

--- a/src/lib/cli/providers/claude-code/skill-discovery-client.ts
+++ b/src/lib/cli/providers/claude-code/skill-discovery-client.ts
@@ -1,0 +1,165 @@
+import { randomUUID } from 'node:crypto';
+import type { ChildProcess } from 'node:child_process';
+import type { CliEnvironment } from '@/lib/cli/cli-exec';
+import { resolveProviderCliCommand } from '@/lib/cli/provider-command';
+import {
+  getAgentEnvironment,
+  normalizeCwdForCliEnvironment,
+  spawnCli,
+} from '@/lib/cli/spawn-cli';
+import type { SkillInfo } from '../skill-types';
+
+const DISCOVERY_TIMEOUT_MS = 30_000;
+
+export interface ClaudeSkillDiscoveryContext {
+  userId?: string;
+  workDir?: string | null;
+  environment?: CliEnvironment;
+}
+
+export type ClaudeSkillDiscoveryResponse =
+  | { skills: SkillInfo[] }
+  | { error: string };
+
+/** Parses only the initialize response belonging to this discovery request. */
+export function parseClaudeSkillDiscoveryResponse(
+  line: string,
+  requestId: string,
+): ClaudeSkillDiscoveryResponse | null {
+  let message: any;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    return null;
+  }
+
+  const response = message?.type === 'control_response' ? message.response : null;
+  if (!response || response.request_id !== requestId) return null;
+  if (response.subtype === 'error') {
+    return { error: String(response.error || 'Claude initialize failed.') };
+  }
+
+  const commands = response.response?.commands;
+  if (!Array.isArray(commands)) return null;
+
+  return {
+    skills: commands
+      .filter((command: any) => command && typeof command.name === 'string')
+      .map((command: any) => ({
+        name: command.name.slice(0, 100),
+        description: typeof command.description === 'string'
+          ? command.description.slice(0, 500)
+          : '',
+      })),
+  };
+}
+
+function killDiscoveryProcess(proc: ChildProcess): void {
+  if (proc.killed || proc.exitCode !== null) return;
+  try {
+    proc.kill('SIGTERM');
+  } catch {
+    // The short-lived process may already have exited between the checks.
+  }
+}
+
+/** Lists Claude's provider-reported commands without creating a persisted session or turn. */
+export async function listClaudeSkills(
+  context: ClaudeSkillDiscoveryContext,
+): Promise<SkillInfo[]> {
+  const environment = context.environment ?? await getAgentEnvironment(context.userId);
+  const command = await resolveProviderCliCommand(
+    'claude-code',
+    'claude',
+    environment,
+    context.userId,
+  );
+  const requestedCwd = context.workDir?.trim() || process.cwd();
+  const cwd = normalizeCwdForCliEnvironment(requestedCwd, environment);
+  const requestId = randomUUID();
+  const spawnEnv: Record<string, string | undefined> = { ...process.env };
+  delete spawnEnv.CLAUDECODE;
+  delete spawnEnv.NODE_ENV;
+  delete spawnEnv.MAX_THINKING_TOKENS;
+
+  return new Promise<SkillInfo[]>((resolve, reject) => {
+    const proc = spawnCli(command, [
+      '--print',
+      '--verbose',
+      '--output-format', 'stream-json',
+      '--input-format', 'stream-json',
+      '--include-partial-messages',
+      '--permission-prompt-tool', 'stdio',
+      '--allow-dangerously-skip-permissions',
+      '--append-system-prompt', '',
+      '--no-session-persistence',
+    ], {
+      cwd,
+      shell: false,
+      env: spawnEnv as NodeJS.ProcessEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }, environment);
+    let buffer = '';
+    let stderr = '';
+    let settled = false;
+
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      proc.stdout?.removeListener('data', onStdout);
+      proc.stderr?.removeListener('data', onStderr);
+      proc.removeListener('spawn', onSpawn);
+      proc.removeListener('error', onError);
+      proc.removeListener('close', onClose);
+      killDiscoveryProcess(proc);
+      callback();
+    };
+    const fail = (error: Error) => finish(() => reject(error));
+    const onStdout = (chunk: Buffer | string) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const response = parseClaudeSkillDiscoveryResponse(line, requestId);
+        if (!response) continue;
+        if ('error' in response) {
+          fail(new Error(response.error));
+        } else {
+          finish(() => resolve(response.skills));
+        }
+        return;
+      }
+    };
+    const onStderr = (chunk: Buffer | string) => {
+      stderr = `${stderr}${chunk.toString()}`.slice(-2_000);
+    };
+    const onSpawn = () => {
+      if (!proc.stdin?.writable) {
+        fail(new Error('Claude discovery stdin is unavailable.'));
+        return;
+      }
+      proc.stdin.write(`${JSON.stringify({
+        type: 'control_request',
+        request_id: requestId,
+        request: { subtype: 'initialize' },
+      })}\n`);
+    };
+    const onError = (error: Error) => fail(error);
+    const onClose = (code: number | null) => {
+      fail(new Error(
+        `Claude exited before skill discovery completed (code ${code})${stderr ? `: ${stderr.trim()}` : ''}`,
+      ));
+    };
+    const timeout = setTimeout(() => {
+      fail(new Error('Timed out while discovering Claude skills.'));
+    }, DISCOVERY_TIMEOUT_MS);
+
+    proc.stdout?.on('data', onStdout);
+    proc.stderr?.on('data', onStderr);
+    proc.once('spawn', onSpawn);
+    proc.once('error', onError);
+    proc.once('close', onClose);
+  });
+}

--- a/src/lib/cli/providers/codex/adapter.ts
+++ b/src/lib/cli/providers/codex/adapter.ts
@@ -881,14 +881,14 @@ export class CodexAdapter implements CliProvider {
    * to 100 chars, descriptions to 500 chars. Entries with empty names are
    * filtered out. The `path` field from SkillMetadata is preserved in SkillInfo.
    *
-   * Returns null if no threadId is available for the process.
+   * Skill discovery is scoped by cwd and does not require a conversation turn.
    */
   createSkillSource(sessionId: string, proc: ChildProcess): SkillSource | null {
     return {
       listSkills: async (): Promise<SkillInfo[]> => {
-        const threadId = this._processThreadIds.get(proc);
-        if (!threadId) {
-          logger.debug('CodexAdapter: createSkillSource.listSkills — no threadId', { sessionId });
+        const cwd = this._processRuntimeConfig.get(proc)?.cwd;
+        if (!cwd) {
+          logger.debug('CodexAdapter: createSkillSource.listSkills — no cwd', { sessionId });
           return [];
         }
 
@@ -902,12 +902,12 @@ export class CodexAdapter implements CliProvider {
           jsonrpc: '2.0',
           id: requestId,
           method: 'skills/list',
-          params: { threadId },
+          params: { cwds: [cwd] },
         };
 
         codexProtocolParser.trackPendingRequest(sessionId, requestId, 'skills/list');
         this._writeStdin(proc, 'skills_list', `${JSON.stringify(request)}\n`);
-        logger.debug('CodexAdapter: sent skills/list request', { sessionId, requestId, threadId });
+        logger.debug('CodexAdapter: sent skills/list request', { sessionId, requestId, cwd });
 
         let response: { id: number; result?: Record<string, any>; error?: any };
         try {

--- a/src/lib/cli/providers/codex/skill-discovery-client.ts
+++ b/src/lib/cli/providers/codex/skill-discovery-client.ts
@@ -1,0 +1,63 @@
+import { getAgentEnvironment, normalizeCwdForCliEnvironment } from '@/lib/cli/spawn-cli';
+import type { SkillInfo } from '../skill-types';
+import {
+  executeCodexAppServerRequest,
+  setCodexAppServerRequestExecutorForTests,
+  type CodexAppServerRequestContext,
+  type CodexAppServerRequestExecutor,
+} from './app-server-request-client';
+
+interface CodexSkillsListResponse {
+  data?: Array<{
+    cwd?: unknown;
+    skills?: Array<{
+      name?: unknown;
+      description?: unknown;
+      path?: unknown;
+      enabled?: unknown;
+    }>;
+    errors?: unknown;
+  }>;
+}
+
+export type CodexSkillDiscoveryContext = CodexAppServerRequestContext;
+export type CodexSkillDiscoveryRequestExecutor = CodexAppServerRequestExecutor;
+export const setCodexSkillDiscoveryRequestExecutorForTests =
+  setCodexAppServerRequestExecutorForTests;
+
+/** Lists cwd-scoped Codex skills without starting or resuming a conversation thread. */
+export async function listCodexSkills(
+  context: CodexSkillDiscoveryContext,
+): Promise<SkillInfo[]> {
+  const environment = context.environment ?? await getAgentEnvironment(context.userId);
+  const requestedCwd = context.workDir?.trim() || process.cwd();
+  const cwd = normalizeCwdForCliEnvironment(requestedCwd, environment);
+  const result = await executeCodexAppServerRequest<CodexSkillsListResponse>(
+    { ...context, environment, workDir: requestedCwd },
+    'skills/list',
+    { cwds: [cwd] },
+  );
+  const entries: SkillInfo[] = [];
+
+  for (const group of Array.isArray(result?.data) ? result.data : []) {
+    for (const skill of Array.isArray(group.skills) ? group.skills : []) {
+      if (skill.enabled === false) continue;
+
+      const name = typeof skill.name === 'string' ? skill.name.slice(0, 100) : '';
+      if (!name) continue;
+
+      const entry: SkillInfo = {
+        name,
+        description: typeof skill.description === 'string'
+          ? skill.description.slice(0, 500)
+          : '',
+      };
+      if (typeof skill.path === 'string' && skill.path) {
+        entry.path = skill.path;
+      }
+      entries.push(entry);
+    }
+  }
+
+  return entries;
+}

--- a/src/lib/cli/providers/opencode/command-discovery-client.ts
+++ b/src/lib/cli/providers/opencode/command-discovery-client.ts
@@ -1,0 +1,200 @@
+import type { ChildProcess } from 'node:child_process';
+import { createServer } from 'node:net';
+import type { CliEnvironment } from '@/lib/cli/cli-exec';
+import { resolveProviderCliCommand } from '@/lib/cli/provider-command';
+import {
+  getAgentEnvironment,
+  normalizeCwdForCliEnvironment,
+  spawnCli,
+} from '@/lib/cli/spawn-cli';
+import type { SkillInfo } from '../skill-types';
+
+const DISCOVERY_TIMEOUT_MS = 30_000;
+const COMPACT_COMMAND: SkillInfo = {
+  name: 'compact',
+  description: 'compact the session',
+};
+
+export interface OpenCodeCommandDiscoveryContext {
+  userId?: string;
+  workDir?: string | null;
+  environment?: CliEnvironment;
+}
+
+interface OpenCodeCommandCatalogEntry {
+  name?: unknown;
+  description?: unknown;
+}
+
+export type OpenCodeCommandDiscoveryExecutor = (
+  context: OpenCodeCommandDiscoveryContext,
+) => Promise<unknown>;
+
+let discoveryExecutorOverride: OpenCodeCommandDiscoveryExecutor | null = null;
+
+/** Test seam for the external OpenCode HTTP server boundary. */
+export function setOpenCodeCommandDiscoveryExecutorForTests(
+  executor: OpenCodeCommandDiscoveryExecutor | null,
+): void {
+  discoveryExecutorOverride = executor;
+}
+
+function killDiscoveryProcess(proc: ChildProcess): void {
+  if (proc.killed || proc.exitCode !== null) return;
+  try {
+    proc.kill('SIGTERM');
+  } catch {
+    // The short-lived server may already have exited between the checks.
+  }
+}
+
+async function reserveLoopbackPort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Could not allocate an OpenCode discovery port.'));
+        return;
+      }
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(address.port);
+        }
+      });
+    });
+  });
+}
+
+function buildAuthorizationHeader(): string | undefined {
+  const password = process.env.OPENCODE_SERVER_PASSWORD;
+  if (!password) return undefined;
+  const username = process.env.OPENCODE_SERVER_USERNAME || 'opencode';
+  return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+}
+
+async function requestCatalogFromTransientServer(
+  command: string,
+  cwd: string,
+  environment: CliEnvironment,
+  port: number,
+): Promise<unknown> {
+  return new Promise<unknown>((resolve, reject) => {
+    const proc = spawnCli(command, [
+      'serve',
+      '--hostname', '127.0.0.1',
+      '--port', String(port),
+    ], {
+      cwd,
+      shell: false,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }, environment);
+    const abortController = new AbortController();
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let requestStarted = false;
+
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      abortController.abort();
+      proc.stdout?.removeListener('data', onStdout);
+      proc.stderr?.removeListener('data', onStderr);
+      proc.removeListener('error', onError);
+      proc.removeListener('close', onClose);
+      killDiscoveryProcess(proc);
+      callback();
+    };
+    const fail = (error: Error) => finish(() => reject(error));
+    const fetchCatalog = async () => {
+      const url = new URL(`http://127.0.0.1:${port}/command`);
+      url.searchParams.set('directory', cwd);
+      const authorization = buildAuthorizationHeader();
+      const response = await fetch(url, {
+        headers: authorization ? { Authorization: authorization } : undefined,
+        signal: abortController.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`OpenCode command discovery failed with HTTP ${response.status}.`);
+      }
+      return response.json();
+    };
+    const onStdout = (chunk: Buffer | string) => {
+      stdout = `${stdout}${chunk.toString()}`.slice(-4_000);
+      if (requestStarted || !stdout.includes('opencode server listening on ')) return;
+      requestStarted = true;
+      void fetchCatalog()
+        .then((catalog) => finish(() => resolve(catalog)))
+        .catch((error) => fail(error instanceof Error ? error : new Error(String(error))));
+    };
+    const onStderr = (chunk: Buffer | string) => {
+      stderr = `${stderr}${chunk.toString()}`.slice(-2_000);
+    };
+    const onError = (error: Error) => fail(error);
+    const onClose = (code: number | null) => {
+      fail(new Error(
+        `OpenCode discovery server exited before returning commands (code ${code})`
+        + (stderr ? `: ${stderr.trim()}` : ''),
+      ));
+    };
+    const timeout = setTimeout(() => {
+      fail(new Error('Timed out while discovering OpenCode commands.'));
+    }, DISCOVERY_TIMEOUT_MS);
+
+    proc.stdout?.on('data', onStdout);
+    proc.stderr?.on('data', onStderr);
+    proc.once('error', onError);
+    proc.once('close', onClose);
+  });
+}
+
+/** Reads the same command catalog OpenCode reports through ACP, without creating a session. */
+async function runOpenCodeCommandDiscovery(
+  context: OpenCodeCommandDiscoveryContext,
+): Promise<unknown> {
+  const environment = context.environment ?? await getAgentEnvironment(context.userId);
+  const command = await resolveProviderCliCommand(
+    'opencode',
+    'opencode',
+    environment,
+    context.userId,
+  );
+  const requestedCwd = context.workDir?.trim() || process.cwd();
+  const cwd = normalizeCwdForCliEnvironment(requestedCwd, environment);
+  const port = await reserveLoopbackPort();
+  return requestCatalogFromTransientServer(command, cwd, environment, port);
+}
+
+export async function listOpenCodeCommands(
+  context: OpenCodeCommandDiscoveryContext,
+): Promise<SkillInfo[]> {
+  const rawCatalog = await (
+    discoveryExecutorOverride
+      ? discoveryExecutorOverride(context)
+      : runOpenCodeCommandDiscovery(context)
+  );
+  const catalog = Array.isArray(rawCatalog)
+    ? rawCatalog as OpenCodeCommandCatalogEntry[]
+    : [];
+  const commands = catalog
+    .filter((entry) => entry && typeof entry.name === 'string' && entry.name.length > 0)
+    .map((entry) => ({
+      name: (entry.name as string).slice(0, 100),
+      description: typeof entry.description === 'string'
+        ? entry.description.slice(0, 500)
+        : '',
+    }));
+
+  if (!commands.some((command) => command.name === COMPACT_COMMAND.name)) {
+    commands.push(COMPACT_COMMAND);
+  }
+  return commands;
+}

--- a/tests/claude-skill-discovery-client.test.ts
+++ b/tests/claude-skill-discovery-client.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parseClaudeSkillDiscoveryResponse } from '@/lib/cli/providers/claude-code/skill-discovery-client';
+
+test('Claude initialize response exposes the provider-reported invocable command names', () => {
+  const response = parseClaudeSkillDiscoveryResponse(JSON.stringify({
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: 'request-1',
+      response: {
+        commands: [
+          {
+            name: 'diagnosing-bugs',
+            description: '(mattpocock-skills) Diagnose hard bugs',
+            argumentHint: '',
+          },
+          { name: 42, description: 'invalid' },
+        ],
+      },
+    },
+  }), 'request-1');
+
+  assert.deepEqual(response, {
+    skills: [{
+      name: 'diagnosing-bugs',
+      description: '(mattpocock-skills) Diagnose hard bugs',
+    }],
+  });
+});
+
+test('Claude discovery ignores unrelated control responses', () => {
+  assert.equal(parseClaudeSkillDiscoveryResponse(JSON.stringify({
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: 'another-request',
+      response: { commands: [] },
+    },
+  }), 'request-1'), null);
+});

--- a/tests/codex-skill-discovery-client.test.ts
+++ b/tests/codex-skill-discovery-client.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  listCodexSkills,
+  setCodexSkillDiscoveryRequestExecutorForTests,
+} from '@/lib/cli/providers/codex/skill-discovery-client';
+
+test.afterEach(() => {
+  setCodexSkillDiscoveryRequestExecutorForTests(null);
+});
+
+test('Codex skills are discovered by cwd without creating a thread', async () => {
+  const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+  setCodexSkillDiscoveryRequestExecutorForTests(async (_context, method, params) => {
+    requests.push({ method, params });
+    return {
+      data: [{
+        cwd: '/repo',
+        errors: [],
+        skills: [
+          { name: 'diagnosing-bugs', description: 'Diagnose bugs', path: '/skills/bugs/SKILL.md', enabled: true },
+          { name: 'disabled-skill', description: 'Disabled', path: '/skills/off/SKILL.md', enabled: false },
+          { name: '', description: 'Invalid', path: '/skills/invalid/SKILL.md', enabled: true },
+        ],
+      }],
+    };
+  });
+
+  const skills = await listCodexSkills({
+    userId: 'user-1',
+    workDir: '/repo',
+    environment: 'wsl',
+  });
+
+  assert.deepEqual(requests, [{
+    method: 'skills/list',
+    params: { cwds: ['/repo'] },
+  }]);
+  assert.deepEqual(skills, [{
+    name: 'diagnosing-bugs',
+    description: 'Diagnose bugs',
+    path: '/skills/bugs/SKILL.md',
+  }]);
+});

--- a/tests/opencode-command-discovery-client.test.ts
+++ b/tests/opencode-command-discovery-client.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  listOpenCodeCommands,
+  setOpenCodeCommandDiscoveryExecutorForTests,
+} from '@/lib/cli/providers/opencode/command-discovery-client';
+
+test.afterEach(() => {
+  setOpenCodeCommandDiscoveryExecutorForTests(null);
+});
+
+test('OpenCode commands match the post-start ACP catalog without creating a session', async () => {
+  const contexts: unknown[] = [];
+  setOpenCodeCommandDiscoveryExecutorForTests(async (context) => {
+    contexts.push(context);
+    return [
+      { name: 'init', description: 'guided AGENTS.md setup', source: 'command' },
+      { name: 'diagnosing-bugs', description: 'Diagnose hard bugs', source: 'skill' },
+      { name: 42, description: 'invalid' },
+    ];
+  });
+
+  const commands = await listOpenCodeCommands({
+    userId: 'user-1',
+    workDir: '/repo',
+    environment: 'wsl',
+  });
+
+  assert.deepEqual(contexts, [{
+    userId: 'user-1',
+    workDir: '/repo',
+    environment: 'wsl',
+  }]);
+  assert.deepEqual(commands, [
+    { name: 'init', description: 'guided AGENTS.md setup' },
+    { name: 'diagnosing-bugs', description: 'Diagnose hard bugs' },
+    { name: 'compact', description: 'compact the session' },
+  ]);
+});
+
+test('OpenCode discovery preserves a provider-reported compact command without duplicating it', async () => {
+  setOpenCodeCommandDiscoveryExecutorForTests(async () => [
+    { name: 'compact', description: 'Configured compact command', source: 'command' },
+  ]);
+
+  assert.deepEqual(await listOpenCodeCommands({
+    workDir: '/repo',
+    environment: 'wsl',
+  }), [
+    { name: 'compact', description: 'Configured compact command' },
+  ]);
+});

--- a/tests/pre-conversation-skill-discovery.test.mjs
+++ b/tests/pre-conversation-skill-discovery.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const skillPickerSource = fs.readFileSync(
+  new URL('../src/hooks/use-skill-picker.ts', import.meta.url),
+  'utf8',
+);
+const messageInputSource = fs.readFileSync(
+  new URL('../src/components/chat/message-input.tsx', import.meta.url),
+  'utf8',
+);
+const sessionSkillsRouteSource = fs.readFileSync(
+  new URL('../src/app/api/sessions/[id]/skills/route.ts', import.meta.url),
+  'utf8',
+);
+const codexAdapterSource = fs.readFileSync(
+  new URL('../src/lib/cli/providers/codex/adapter.ts', import.meta.url),
+  'utf8',
+);
+const codexSkillSourceBlock = codexAdapterSource.slice(
+  codexAdapterSource.indexOf('createSkillSource(sessionId'),
+  codexAdapterSource.indexOf('// CliProvider: generateTitle'),
+);
+
+test('opening the skill picker can discover skills without starting a fresh GUI session', () => {
+  assert.match(skillPickerSource, /canDiscoverBeforeSession/);
+  assert.match(
+    skillPickerSource,
+    /canDiscoverBeforeSession[\s\S]{0,200}providerId === 'opencode'/,
+    'OpenCode must use the same pre-conversation discovery path as Claude and Codex',
+  );
+  assert.doesNotMatch(
+    skillPickerSource,
+    /if \(isSessionRunning === false\) \{\s*return;\s*\}/,
+    'a stopped fresh session must use provider discovery instead of treating skills as unavailable',
+  );
+  assert.doesNotMatch(
+    skillPickerSource,
+    /if \(providerId === 'opencode'\)[\s\S]{0,200}setCommands\(sessionId, \[\]\)/,
+    'a stopped OpenCode session must not be cached as having no commands',
+  );
+  assert.doesNotMatch(messageInputSource, /prepareSessionForSkills/);
+  assert.match(sessionSkillsRouteSource, /listCodexSkills/);
+  assert.match(sessionSkillsRouteSource, /listClaudeSkills/);
+  assert.match(sessionSkillsRouteSource, /listOpenCodeCommands/);
+});
+
+test('Codex skill discovery uses the app-server cwd-scoped request contract', () => {
+  assert.match(codexSkillSourceBlock, /params:\s*\{\s*cwds:\s*\[cwd\]\s*\}/);
+  assert.doesNotMatch(codexSkillSourceBlock, /params:\s*\{\s*threadId\s*\}/);
+});


### PR DESCRIPTION
## What changed

- Discover Claude Code commands before the first GUI conversation turn using its non-persistent initialize control request.
- Discover Codex skills by workspace cwd with `skills/list`, without requiring a thread.
- Discover OpenCode's same post-start command catalog through a short-lived loopback `opencode serve` instance and `GET /command`, including the ACP-compatible `compact` fallback.
- Route fresh GUI sessions through provider-native discovery while keeping active process command caches authoritative.
- Add focused regression tests and an OpenCode implementation note.

## Why

Fresh GUI sessions previously treated slash commands as unavailable until the provider process had started. Typing `/` before the first message therefore showed an incomplete or empty picker even though each provider can report its catalog without creating a conversation.

## Impact

Claude Code, Codex, and OpenCode now show their usable slash/skill catalog as soon as `/` is typed in a new GUI session. Discovery keeps the session at zero messages and does not start or resume a provider conversation.

## Validation

- Real development-server GUI verification for all three providers before the first message
  - Claude Code: 78 visible slash entries
  - Codex: 53 visible slash entries
  - OpenCode: 48 visible slash entries, including `/compact`, `/init`, and `/review`
  - All sessions remained `hasStarted=false`, `isRunning=false`, with zero messages
- 45 focused unit/regression tests passed on latest `dev`
- `npx tsc --noEmit --pretty false`
- ESLint on all touched source and test files
- `npm run build`
