### PR TITLE
fix(ws): keep workspace file subscriptions off the session existence check

### DIFF
--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -90,6 +90,20 @@ export function logReceivedClientTransportMessage(
   }, 'WebSocket message received');
 }
 
+// Messages whose sessionId is only a workspace-root lookup key, not a handle on
+// a live session. The workspace file feature already treats an unknown session
+// as an empty workspace — both the REST route and the watch manager resolve the
+// root through resolveSessionWorkspaceFilesystemRoot and answer with an empty
+// list / a `missing_work_dir` fallback. Rejecting them here turned a background
+// subscription into a user-facing error toast whenever a panel followed the
+// optimistic `temp-` session that exists while creation is in flight. Ownership
+// is still enforced; only the existence check is skipped.
+// Unrelated to the terminal-handoff exemptions in routeClientTransportMessage.
+const EXISTENCE_OPTIONAL_MESSAGE_TYPES: ReadonlySet<ClientMessage['type']> = new Set([
+  'subscribe_workspace_files',
+  'unsubscribe_workspace_files',
+]);
+
 export function verifyClientSessionAccess(
   userId: string,
   message: ClientMessage,
@@ -123,6 +137,9 @@ export function verifyClientSessionAccess(
   // ownership, so for unspawned sessions we trust the authenticated user.
   const session = dbSessions.getSession(message.sessionId);
   if (!session) {
+    if (EXISTENCE_OPTIONAL_MESSAGE_TYPES.has(message.type)) {
+      return true;
+    }
     logger.warn('Session not found', {
       sessionId: message.sessionId,
       messageType: message.type,

--- a/tests/ws-session-access-guard.test.ts
+++ b/tests/ws-session-access-guard.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-ws-access-test-'));
+process.env.TESSERA_DATA_DIR = dataDir;
+process.env.TESSERA_PRODUCTION_DB = '1';
+
+const USER_ID = 'user-1';
+const MISSING_SESSION_ID = 'temp-00000000-0000-4000-8000-000000000000';
+
+async function loadGuard() {
+  const [{ initDatabase }, { verifyClientSessionAccess }] = await Promise.all([
+    import('@/lib/db/database'),
+    import('@/lib/ws/server-message-routing'),
+  ]);
+  await initDatabase();
+  return verifyClientSessionAccess;
+}
+
+function collectSent() {
+  const sent: unknown[] = [];
+  return {
+    sent,
+    sendToUser: (_userId: string, message: unknown) => {
+      sent.push(message);
+    },
+  };
+}
+
+// Workspace file subscriptions use the session id only to look up a workspace
+// root. Both the REST route and the watch manager already answer "no such
+// session" with an empty list / a missing_work_dir fallback, so the guard must
+// not turn them into a user-facing error — that is what surfaced a "Session
+// does not exist" toast for the optimistic temp- session during creation.
+test('workspace file subscriptions pass the guard for an unknown session', async () => {
+  const verifyClientSessionAccess = await loadGuard();
+
+  for (const type of ['subscribe_workspace_files', 'unsubscribe_workspace_files'] as const) {
+    const { sendToUser, sent } = collectSent();
+    const allowed = verifyClientSessionAccess(
+      USER_ID,
+      {
+        type,
+        requestId: 'req-1',
+        sessionId: MISSING_SESSION_ID,
+        subscriberId: 'workspace-file-panel:test',
+      },
+      sendToUser,
+    );
+
+    assert.equal(allowed, true, `${type} should be allowed`);
+    assert.deepEqual(sent, [], `${type} should not emit an error`);
+  }
+});
+
+test('other session messages still fail for an unknown session', async () => {
+  const verifyClientSessionAccess = await loadGuard();
+  const { sendToUser, sent } = collectSent();
+
+  const allowed = verifyClientSessionAccess(
+    USER_ID,
+    { type: 'stop_session', requestId: 'req-2', sessionId: MISSING_SESSION_ID },
+    sendToUser,
+  );
+
+  assert.equal(allowed, false);
+  assert.equal(sent.length, 1);
+  assert.equal((sent[0] as { code?: string }).code, 'session_not_found');
+});


### PR DESCRIPTION
## Summary

- Creating a session shows a spurious **"Session does not exist"** toast — twice per creation, one on each side of the "session created" toast. The session itself is created fine; nothing is actually broken.
- Cause: session creation mounts an optimistic `temp-` session in the active panel for the duration of the `POST /api/sessions` round-trip (`use-session-crud.ts:134-142`). With the right panel on the **Files** tab, `WorkspaceFilePanel` follows that placeholder and subscribes with its id, so `verifyClientSessionAccess` rejects it — once for `subscribe_workspace_files`, again for the effect cleanup's `unsubscribe_workspace_files`. Reproduces with both PTY and GUI sessions, any provider; does not reproduce with the Files tab closed.
- The workspace file feature already treats an unknown session as an empty workspace: `GET /api/sessions/[id]/files` answers `200` with an empty list and the watch manager replies with a `missing_work_dir` fallback — both resolve through the same `resolveSessionWorkspaceFilesystemRoot`. Only the WS path had a guard in front of that, which turned a background subscription into a user-facing error.
- Fix: skip the **existence** check for those two message types. Ownership enforcement is untouched, and the existence check is not a security boundary anyway — as its own comment states, the DB tracks no per-user ownership, so any authenticated user passes it.
- Deliberately kept out of scope: the client still sends the `temp-` id (harmless round-trip), and `client-message-handlers.ts:249` still toasts every `error` message.

Verified against the running dev server, Files tab open, creating a PTY session:

| | before | after |
|---|---|---|
| client `session_not_found` errors | 4 (2 in prod — dev double-mounts under StrictMode) | 0 |
| server `Session not found` warns | 4 | 0 |
| temp session subscription reply | error toast | `status: "fallback", reason: "missing_work_dir"` |
| real session subscription reply | — | `status: "active"` with the correct workDir |

## Testing

- [x] `npm run lint` — ran as `npx eslint src tests electron server.ts`: **0 errors**, 2 pre-existing warnings unrelated to this change. The repo-root form also walks `.next` output inside local worktrees and times out; that is a local-environment artifact, not a lint failure.
- [x] `npx tsc --noEmit`
- [x] `NODE_ENV=production npm run build` — `✓ Compiled successfully in 42s`
- [x] Manual test: dev server + Files tab open → create PTY session, then GUI session. Toast gone, subscription falls back and then goes active on the real id. Also confirmed the toast still appears with this fix reverted.
- [x] Regression test added: `tests/ws-session-access-guard.test.ts` (`npx tsx --test`). Covers both the exempted subscriptions and that other message types still fail with `session_not_found`. Confirmed it fails without the fix.
- [ ] Not tested: packaged desktop app on Windows/macOS. The change is server-side and platform-independent.

## Screenshots or Recordings

No UI code changed — the visible difference is the absence of the toast. Captured from the browser console during creation with the Files tab open:

```
before: WebSocket error: {"code":"session_not_found","message":"Session does not exist",
                          "sessionId":"temp-16e9d21c-…"}   ×2 (×4 in dev)

after:  workspace_file_watch_status {"sessionId":"temp-93d82e03-…",
                                     "status":"fallback","reason":"missing_work_dir"}
        workspace_file_watch_status {"sessionId":"5baeaed1-…","status":"active",
                                     "workDir":"/home/work/Source/tessera-dev"}
```

## Notes

Small bug fix, no architecture change. One thing worth flagging for a follow-up: the exempt list here is intentionally **separate** from the `unguardedSessionMessage` list in `routeClientTransportMessage`. Their members overlap, but the policies differ — that one exempts messages from the Codex terminal handoff lock, and exempting `terminal_create` from the existence check would weaken the ownership re-check at line 522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
