### PR TITLE
fix(chat): follow keyboard focus with scroll in AskUserQuestion panel

### DIFF
--- a/src/components/chat/ask-user-question-floating-panel.tsx
+++ b/src/components/chat/ask-user-question-floating-panel.tsx
@@ -38,6 +38,8 @@ export function AskUserQuestionFloatingPanel({
 }: AskUserQuestionFloatingPanelProps) {
   const { t } = useI18n();
   const containerRef = useRef<HTMLDivElement>(null);
+  const scrollAreaRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<(HTMLDivElement | null)[]>([]);
   const { sendInteractiveResponse } = useWebSocket();
   const providerId = useSessionStore((state) => state.getSession(sessionId)?.provider);
   const providerBrand = getProviderBrand(providerId);
@@ -153,6 +155,29 @@ export function AskUserQuestionFloatingPanel({
   const refocusContainer = useCallback(() => {
     containerRef.current?.focus();
   }, []);
+
+  // ↑/↓로 옮긴 항목이 스크롤 영역 밖이면 따라 스크롤한다.
+  // 옵션 버튼은 tabIndex={-1}이라 DOM 포커스가 컨테이너에 머물러 브라우저 기본 스크롤이 안 걸린다.
+  // scrollIntoView 대신 scrollTop을 직접 계산하는 이유: 조상(채팅 본문)까지 같이 스크롤되면 안 된다.
+  useEffect(() => {
+    const area = scrollAreaRef.current;
+    const el = optionRefs.current[focusedOptionIdx];
+    if (!area || !el) return;
+
+    // 질문의 첫 옵션이면 header/질문 문구까지 보이도록 fieldset 기준으로 맞춘다
+    const target = el.hasAttribute('data-first-option') ? (el.closest('fieldset') ?? el) : el;
+    const areaBox = area.getBoundingClientRect();
+    const box = target.getBoundingClientRect();
+    const margin = 6;
+    // 타겟이 영역보다 크면(옵션 많은 질문) 하단 정렬은 하지 않는다 — 질문 문구가 위로 잘려 나간다
+    const overflows = box.height > areaBox.height - margin * 2;
+
+    if (box.top < areaBox.top + margin) {
+      area.scrollTop -= areaBox.top + margin - box.top;
+    } else if (!overflows && box.bottom > areaBox.bottom - margin) {
+      area.scrollTop += box.bottom - (areaBox.bottom - margin);
+    }
+  }, [focusedOptionIdx, density]);
 
   // Keyboard: ↑/↓ navigate, Space toggle, Enter select+submit, Esc decline, number keys
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -278,6 +303,7 @@ export function AskUserQuestionFloatingPanel({
 
       {/* Scrollable questions area */}
       <div
+        ref={scrollAreaRef}
         className="overflow-y-auto p-[var(--aqp-body-pad)] space-y-[var(--aqp-block-gap)]"
         style={{ containerType: 'inline-size' }}
       >
@@ -325,7 +351,13 @@ export function AskUserQuestionFloatingPanel({
                     const isFocused = globalIdx === focusedOptionIdx;
 
                     return (
-                      <div key={optKey}>
+                      <div
+                        key={optKey}
+                        ref={(el) => {
+                          optionRefs.current[globalIdx] = el;
+                        }}
+                        data-first-option={optIdx === 0 ? '' : undefined}
+                      >
                         <button
                           type="button"
                           aria-pressed={isSelected}


### PR DESCRIPTION
## Summary

AskUserQuestion 패널에서 ↑/↓로 항목을 옮겨도 스크롤이 따라오지 않아, 아래쪽 옵션은 마우스로 직접 내려야 했다.

옵션 버튼은 `tabIndex={-1}`이라 DOM 포커스가 패널 컨테이너에 머물고, ↑/↓는 `focusedOptionIdx` 상태만 바꾼다. 브라우저 입장에선 포커스가 이동한 게 없으니 기본 스크롤이 걸리지 않는다. #210에서 패널을 컴팩트하게 줄이면서 스크롤 영역이 좁아지자 드러났다.

포커스가 바뀔 때 스크롤 영역의 `scrollTop`을 직접 보정한다.

- `scrollIntoView`를 쓰지 않는다 — 조상(채팅 본문)까지 같이 스크롤돼 대화가 튄다.
- 질문의 **첫 옵션**에서는 옵션 버튼이 아니라 `fieldset` 기준으로 맞춰 질문 문구까지 보이게 한다.
- 단, 옵션이 많아 fieldset이 스크롤 영역보다 크면 하단 정렬을 건너뛴다. 그러지 않으면 질문 문구가 위로 잘린다(첫 구현에서 실제로 초기 `scrollTop`이 0 대신 25로 밀렸다).
- 밀도(`−`/`+`)로 높이가 달라질 때도 재보정한다.

숫자 키 선택도 같은 상태를 갱신하므로 자동으로 함께 동작한다.

## Testing

- [x] `npm run lint` — 0 errors (warning 2개는 기존 `preview-markdown.tsx` / `use-virtual-message-list.ts`)
- [x] `npx tsc --noEmit`
- [x] Manual test — `/dev-ask-user-question-preview`를 격리 dev 서버(PORT=34211, 별도 `TESSERA_DATA_DIR`)에 띄우고 Playwright로 실측

compact 밀도 기준 내용 646px / 보이는 영역 224px 상태에서 ↓ 9회, ↑ 9회를 눌러 매 단계를 측정:

| 확인 항목 | 결과 |
|---|---|
| 포커스 항목이 스크롤 영역 안에 있는가 | 19/19 단계 통과 |
| 질문 첫 옵션에서 질문 문구가 보이는가 | 6/6 단계 통과 (수정 전엔 초기 상태부터 잘림) |
| 초기 `scrollTop` | 0 (수정 전 25) |

**Not tested**
- 실제 CLI 세션에서 뜬 패널 경로는 미검증 (프리뷰 하네스로만 확인)
- macOS / Windows 네이티브 미검증 (WSL + headless chromium만)
- 마크다운 프리뷰가 함께 뜨는 옵션 레이아웃에서의 스크롤은 미검증

## Screenshots or Recordings

스크롤 위치는 정지 이미지로 판별이 어려워 위 실측 표로 갈음한다.

## Notes

#210의 후속. 동작 수정만이고 밀도 메트릭(`prompt-density-store.ts`)은 건드리지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)