### PR TITLE
fix(tab): keep a single empty New Tab

### DIFF
--- a/src/components/layout/electron-titlebar.tsx
+++ b/src/components/layout/electron-titlebar.tsx
@@ -124,7 +124,7 @@ export function ElectronTitlebar({ showMenu = true }: ElectronTitlebarProps) {
     return electronApi.onTitlebarMenuCommand((command) => {
       switch (command) {
         case 'new-tab':
-          useTabStore.getState().createTab();
+          useTabStore.getState().openNewTab();
           break;
         case 'open-settings':
           useSettingsStore.getState().open();

--- a/src/components/tab/tab-bar.tsx
+++ b/src/components/tab/tab-bar.tsx
@@ -172,7 +172,7 @@ export const TabBar = memo(function TabBar() {
   // ---------------------------------------------------------------------------
 
   const handleAddTab = useCallback(function handleAddTab() {
-    useTabStore.getState().createTab();
+    useTabStore.getState().openNewTab();
   }, []);
 
   const clearTabDragState = useCallback(function clearTabDragState() {

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -121,10 +121,10 @@ export function useKeyboardShortcuts(_options: UseKeyboardShortcutsOptions = {})
   const createTerminalPanel = usePanelStore((state) => state.createTerminalPanel);
   const setActivePanelId = usePanelStore((state) => state.setActivePanelId);
 
-  // Use the same code path as the UI "+" button (tab-bar.tsx) — creates an empty tab,
-  // not a full session. Session is materialized lazily when the user sends a message.
+  // Use the same code path as the UI "+" button (tab-bar.tsx) — reuses a pristine
+  // empty tab when available. A session is materialized lazily on first send.
   const handleNewTab = useCallback(() => {
-    useTabStore.getState().createTab();
+    useTabStore.getState().openNewTab();
   }, []);
 
   // Same code path as the tab × button (tab-item.tsx) — closes the currently-active tab.

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -79,6 +79,27 @@ function isWorkspaceFileTab(
   return isFileLikeSessionId(getTabActiveSessionId(tabId, panelStore));
 }
 
+/** 사용자 작업이 전혀 없는, New Tab으로 안전하게 재사용할 수 있는 탭인지 판별. */
+function isPristineEmptyTab(
+  tab: Tab,
+  panelStore: ReturnType<typeof usePanelStore.getState>,
+): boolean {
+  if (tab.title !== null) return false;
+
+  const tabData = panelStore.tabPanels[tab.id];
+  if (!tabData || tabData.layout.type !== 'leaf') return false;
+  if (Object.keys(tabData.panels).length !== 1) return false;
+
+  const panel = tabData.panels[tabData.layout.panelId];
+  return Boolean(
+    panel
+    && panel.sessionId === null
+    && !panel.terminalId
+    && !panel.terminalSessionId
+    && !panel.terminalCwd,
+  );
+}
+
 function insertTabAfter(tabs: Tab[], newTab: Tab, anchorTabId?: string | null): Tab[] {
   const anchorIndex = anchorTabId ? tabs.findIndex((tab) => tab.id === anchorTabId) : -1;
   if (anchorIndex === -1) return [...tabs, newTab];
@@ -392,6 +413,40 @@ export const useTabStore = create<TabStore>()((set, get) => ({
     panelStore.setActiveTabId(newTabId);
 
     return newTabId;
+  },
+
+  openNewTab: (): string => {
+    const state = get();
+    const panelStore = usePanelStore.getState();
+    const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
+    const emptyTabs = state.tabs.filter((tab) => isPristineEmptyTab(tab, panelStore));
+    const existingEmptyTab = activeTab && emptyTabs.some((tab) => tab.id === activeTab.id)
+      ? activeTab
+      : emptyTabs[0];
+
+    if (existingEmptyTab) {
+      const duplicateEmptyTabIds = new Set(
+        emptyTabs
+          .filter((tab) => tab.id !== existingEmptyTab.id)
+          .map((tab) => tab.id),
+      );
+      if (duplicateEmptyTabIds.size > 0) {
+        set({
+          tabs: state.tabs.filter((tab) => !duplicateEmptyTabIds.has(tab.id)),
+          lruTabIds: state.lruTabIds.filter((tabId) => !duplicateEmptyTabIds.has(tabId)),
+        });
+        for (const tabId of duplicateEmptyTabIds) {
+          panelStore.removeTab(tabId);
+        }
+        assertTabStoreInvariants(get());
+      }
+
+      get().setActiveTab(existingEmptyTab.id);
+      get().pinTab(existingEmptyTab.id);
+      return existingEmptyTab.id;
+    }
+
+    return get().createTab();
   },
 
   closeTab: (tabId: string): void => {

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -108,6 +108,13 @@ export interface TabStoreActions {
   createTab(initialSessionId?: string | null, options?: { insertAfterTabId?: string | null }): string;
 
   /**
+   * 사용자 New Tab 명령을 처리.
+   * 작업이 전혀 없는 빈 단일 패널 탭이 있으면 하나만 남겨 재사용하고, 없으면 새 탭을 생성.
+   * @returns 활성화된 빈 탭의 ID
+   */
+  openNewTab(): string;
+
+  /**
    * 지정한 탭을 닫음.
    * 마지막 탭을 닫으면 빈 탭을 자동 생성 (BR-001).
    */

--- a/tests/new-tab-singleton-contract.test.mjs
+++ b/tests/new-tab-singleton-contract.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const tabBarSource = fs.readFileSync(
+  new URL('../src/components/tab/tab-bar.tsx', import.meta.url),
+  'utf8',
+);
+const keyboardSource = fs.readFileSync(
+  new URL('../src/hooks/use-keyboard-shortcuts.ts', import.meta.url),
+  'utf8',
+);
+const titlebarSource = fs.readFileSync(
+  new URL('../src/components/layout/electron-titlebar.tsx', import.meta.url),
+  'utf8',
+);
+
+test('every user-facing New Tab command reuses an existing pristine empty tab', () => {
+  assert.equal(
+    /function handleAddTab\(\) \{\s*useTabStore\.getState\(\)\.openNewTab\(\);/.test(tabBarSource),
+    true,
+    'the tab-bar + button must use openNewTab()',
+  );
+  assert.equal(
+    /const handleNewTab = useCallback\(\(\) => \{\s*useTabStore\.getState\(\)\.openNewTab\(\);/.test(keyboardSource),
+    true,
+    'the New Tab keyboard shortcut must use openNewTab()',
+  );
+  assert.equal(
+    /case 'new-tab':\s*useTabStore\.getState\(\)\.openNewTab\(\);/.test(titlebarSource),
+    true,
+    'the Electron titlebar command must use openNewTab()',
+  );
+});

--- a/tests/tab-new-tab.test.ts
+++ b/tests/tab-new-tab.test.ts
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { usePanelStore } from '@/stores/panel-store';
+import { useTabStore } from '@/stores/tab-store';
+import type { Tab } from '@/types/tab';
+import type { TabPanelData } from '@/types/panel';
+
+function setVisibleTabs(
+  tabs: Tab[],
+  tabPanels: Record<string, TabPanelData>,
+  activeTabId: string,
+): void {
+  useTabStore.setState({
+    tabs,
+    activeTabId,
+    lruTabIds: [activeTabId, ...tabs.map((tab) => tab.id).filter((id) => id !== activeTabId)],
+    projectTabStates: {},
+    globalTabState: null,
+    currentProjectDir: null,
+  });
+  usePanelStore.setState({ tabPanels, activeTabId });
+}
+
+function leafTabData(panelId: string, sessionId: string | null): TabPanelData {
+  return {
+    layout: { type: 'leaf', panelId },
+    panels: { [panelId]: { id: panelId, sessionId } },
+    activePanelId: panelId,
+  };
+}
+
+test('repeated New Tab commands keep one pristine empty tab', () => {
+  const emptyTab: Tab = {
+    id: 'empty-tab',
+    projectDir: null,
+    title: null,
+    isPreview: false,
+  };
+  setVisibleTabs(
+    [emptyTab],
+    { [emptyTab.id]: leafTabData('empty-panel', null) },
+    emptyTab.id,
+  );
+
+  const firstId = useTabStore.getState().openNewTab();
+  const secondId = useTabStore.getState().openNewTab();
+
+  assert.equal(firstId, emptyTab.id);
+  assert.equal(secondId, emptyTab.id);
+  assert.equal(useTabStore.getState().tabs.length, 1);
+});
+
+test('New Tab activates an existing pristine empty tab instead of adding another', () => {
+  const occupiedTab: Tab = {
+    id: 'occupied-tab',
+    projectDir: '/workspace',
+    title: null,
+    isPreview: false,
+  };
+  const emptyTab: Tab = {
+    id: 'existing-empty-tab',
+    projectDir: '/workspace',
+    title: null,
+    isPreview: true,
+  };
+  setVisibleTabs(
+    [occupiedTab, emptyTab],
+    {
+      [occupiedTab.id]: leafTabData('occupied-panel', 'session-1'),
+      [emptyTab.id]: leafTabData('empty-panel', null),
+    },
+    occupiedTab.id,
+  );
+
+  const openedTabId = useTabStore.getState().openNewTab();
+
+  assert.equal(openedTabId, emptyTab.id);
+  assert.equal(useTabStore.getState().activeTabId, emptyTab.id);
+  assert.equal(usePanelStore.getState().activeTabId, emptyTab.id);
+  assert.equal(useTabStore.getState().tabs.length, 2);
+  assert.equal(
+    useTabStore.getState().tabs.find((tab) => tab.id === emptyTab.id)?.isPreview,
+    false,
+  );
+});
+
+test('New Tab collapses previously accumulated pristine empty tabs', () => {
+  const firstEmptyTab: Tab = {
+    id: 'first-empty-tab',
+    projectDir: null,
+    title: null,
+    isPreview: false,
+  };
+  const activeEmptyTab: Tab = {
+    id: 'active-empty-tab',
+    projectDir: null,
+    title: null,
+    isPreview: false,
+  };
+  setVisibleTabs(
+    [firstEmptyTab, activeEmptyTab],
+    {
+      [firstEmptyTab.id]: leafTabData('first-empty-panel', null),
+      [activeEmptyTab.id]: leafTabData('active-empty-panel', null),
+    },
+    activeEmptyTab.id,
+  );
+
+  const openedTabId = useTabStore.getState().openNewTab();
+
+  assert.equal(openedTabId, activeEmptyTab.id);
+  assert.deepEqual(useTabStore.getState().tabs.map((tab) => tab.id), [activeEmptyTab.id]);
+  assert.equal(usePanelStore.getState().tabPanels[firstEmptyTab.id], undefined);
+});
+
+test('New Tab preserves an empty-looking tab with a custom title', () => {
+  const namedTab: Tab = {
+    id: 'named-empty-tab',
+    projectDir: null,
+    title: 'Scratch layout',
+    isPreview: false,
+  };
+  setVisibleTabs(
+    [namedTab],
+    { [namedTab.id]: leafTabData('named-panel', null) },
+    namedTab.id,
+  );
+
+  const openedTabId = useTabStore.getState().openNewTab();
+
+  assert.notEqual(openedTabId, namedTab.id);
+  assert.equal(useTabStore.getState().tabs.length, 2);
+  assert.equal(useTabStore.getState().tabs[0]?.title, 'Scratch layout');
+});
+
+test('New Tab preserves an empty split layout', () => {
+  const splitTab: Tab = {
+    id: 'split-tab',
+    projectDir: null,
+    title: null,
+    isPreview: false,
+  };
+  setVisibleTabs(
+    [splitTab],
+    {
+      [splitTab.id]: {
+        layout: {
+          type: 'hsplit',
+          children: [
+            { type: 'leaf', panelId: 'left-panel' },
+            { type: 'leaf', panelId: 'right-panel' },
+          ],
+          ratio: 0.5,
+        },
+        panels: {
+          'left-panel': { id: 'left-panel', sessionId: null },
+          'right-panel': { id: 'right-panel', sessionId: null },
+        },
+        activePanelId: 'left-panel',
+      },
+    },
+    splitTab.id,
+  );
+
+  const openedTabId = useTabStore.getState().openNewTab();
+
+  assert.notEqual(openedTabId, splitTab.id);
+  assert.equal(useTabStore.getState().tabs.length, 2);
+  assert.equal(usePanelStore.getState().tabPanels[splitTab.id]?.layout.type, 'hsplit');
+});
+
+test('New Tab preserves a standalone terminal without a session', () => {
+  const terminalTab: Tab = {
+    id: 'terminal-tab',
+    projectDir: '/workspace',
+    title: null,
+    isPreview: false,
+  };
+  const terminalPanelData = leafTabData('terminal-panel', null);
+  terminalPanelData.panels['terminal-panel'].terminalId = 'terminal-1';
+  setVisibleTabs(
+    [terminalTab],
+    { [terminalTab.id]: terminalPanelData },
+    terminalTab.id,
+  );
+
+  const openedTabId = useTabStore.getState().openNewTab();
+
+  assert.notEqual(openedTabId, terminalTab.id);
+  assert.equal(useTabStore.getState().tabs.length, 2);
+  assert.equal(
+    usePanelStore.getState().tabPanels[terminalTab.id]?.panels['terminal-panel']?.terminalId,
+    'terminal-1',
+  );
+});


### PR DESCRIPTION
## Summary

- Reuse an existing pristine empty New Tab across the tab-bar button, keyboard shortcut, and Electron titlebar command.
- Collapse previously accumulated pristine empty tabs while preserving the active one.
- Preserve tabs that contain a session, standalone terminal, split layout, or custom title.
- Add behavior and routing regression coverage for all New Tab entry points.

## Root cause

Every user-facing New Tab command called the low-level `createTab()` action directly. Because that action always creates a tab, repeatedly pressing the button or shortcut accumulated empty tabs with no user-owned state.

## User impact

New Tab is now idempotent when a pristine empty tab already exists. Users can repeatedly invoke the command without accumulating unused tabs, while meaningful empty-looking tabs remain untouched.

## Validation

- 26 focused tests passed.
- `tsc --noEmit` passed.
- ESLint passed for the changed files.
- `git diff --check` passed.