### PR TITLE
fix(chat): restore OpenCode slash command discovery

### DIFF
--- a/src/app/dev-opencode-skills-repro/opencode-skills-repro-client.tsx
+++ b/src/app/dev-opencode-skills-repro/opencode-skills-repro-client.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { SkillPicker } from '@/components/chat/skill-picker';
+import { useSkillPicker } from '@/hooks/use-skill-picker';
+
+const SESSION_ID = 'opencode-skills-browser-repro';
+
+export function OpenCodeSkillsReproClient() {
+  const [isSessionRunning, setIsSessionRunning] = useState(false);
+  const skillPicker = useSkillPicker(SESSION_ID, 'opencode', isSessionRunning);
+  const { onInputChange } = skillPicker;
+
+  useEffect(function replaySessionStateHydration() {
+    const markRunning = window.setTimeout(() => setIsSessionRunning(true), 25);
+    const markStopped = window.setTimeout(() => setIsSessionRunning(false), 50);
+    return () => {
+      window.clearTimeout(markRunning);
+      window.clearTimeout(markStopped);
+    };
+  }, []);
+
+  useEffect(
+    function typeSlashOnMount() {
+      onInputChange('/');
+    },
+    [onInputChange],
+  );
+
+  const state = skillPicker.isLoading
+    ? 'loading'
+    : skillPicker.filteredSkills.length > 0
+      ? 'ready'
+      : 'empty';
+
+  return (
+    <main data-testid="opencode-skills-repro">
+      <strong data-testid="opencode-skills-state">{state}</strong>
+      <SkillPicker
+        isOpen={skillPicker.isOpen}
+        isLoading={skillPicker.isLoading}
+        isInactive={skillPicker.isInactive}
+        isEmpty={skillPicker.isEmpty}
+        skills={skillPicker.filteredSkills}
+        selectedIndex={skillPicker.selectedIndex}
+        onSelect={skillPicker.selectSkill}
+        onClose={skillPicker.close}
+      />
+    </main>
+  );
+}

--- a/src/app/dev-opencode-skills-repro/page.tsx
+++ b/src/app/dev-opencode-skills-repro/page.tsx
@@ -1,0 +1,10 @@
+import { notFound } from 'next/navigation';
+import { OpenCodeSkillsReproClient } from './opencode-skills-repro-client';
+
+export default function OpenCodeSkillsReproPage() {
+  if (process.env.NODE_ENV !== 'development') {
+    notFound();
+  }
+
+  return <OpenCodeSkillsReproClient />;
+}

--- a/src/hooks/use-skill-picker.ts
+++ b/src/hooks/use-skill-picker.ts
@@ -173,23 +173,25 @@ export function useSkillPicker(
   const lastInputRef = useRef('');
   const loadPromiseRef = useRef<{ key: string; promise: Promise<void> } | null>(null);
   const loadTokenRef = useRef<object | null>(null);
+  const skillLoadKey = sessionId && providerId
+    ? `${providerId}:${sessionId}:${skillRevision}`
+    : null;
 
   useEffect(
-    function invalidateStaleSkillLoad() {
-      loadTokenRef.current = null;
-      return function cancelSkillLoad() {
+    function invalidateDifferentSkillLoad() {
+      if (loadPromiseRef.current?.key !== skillLoadKey) {
         loadTokenRef.current = null;
-      };
+      }
     },
-    [isSessionRunning, providerId, sessionId, skillRevision],
+    [skillLoadKey],
   );
 
   const loadProviderSkills = useCallback(async () => {
-    if (!sessionId || !providerId) {
+    if (!sessionId || !providerId || !skillLoadKey) {
       return;
     }
 
-    const loadKey = `${providerId}:${sessionId}:${skillRevision}`;
+    const loadKey = skillLoadKey;
     if (loadPromiseRef.current?.key === loadKey) {
       return loadPromiseRef.current.promise;
     }
@@ -199,6 +201,9 @@ export function useSkillPicker(
     const isCurrentLoad = () =>
       loadTokenRef.current === loadToken
       && (useCommandStore.getState().revisions[sessionId] ?? 0) === skillRevision;
+    const canApplyLoad = () =>
+      isCurrentLoad()
+      && useCommandStore.getState().commands[sessionId] === undefined;
 
     const task = (async () => {
       if (providerId === 'opencode') {
@@ -212,7 +217,7 @@ export function useSkillPicker(
         const skills = await loadCodexSkills(sessionId, {
           shouldContinue: isCurrentLoad,
         });
-        if (skills !== null && isCurrentLoad()) {
+        if (skills !== null && canApplyLoad()) {
           setCommands(sessionId, skills);
         }
         return;
@@ -234,11 +239,11 @@ export function useSkillPicker(
               }))
           : [];
 
-        if (isCurrentLoad()) {
+        if (canApplyLoad()) {
           setCommands(sessionId, skills);
         }
       } catch {
-        if (isCurrentLoad()) {
+        if (canApplyLoad()) {
           setCommands(sessionId, []);
         }
       }
@@ -253,7 +258,7 @@ export function useSkillPicker(
         loadPromiseRef.current = null;
       }
     }
-  }, [isSessionRunning, providerId, sessionId, setCommands, skillRevision]);
+  }, [isSessionRunning, providerId, sessionId, setCommands, skillLoadKey, skillRevision]);
 
   useEffect(
     function loadProviderSkillsWhenReady() {

--- a/tests/opencode-skills-load-race.e2e.mjs
+++ b/tests/opencode-skills-load-race.e2e.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { chromium } from '@playwright/test';
+
+const appUrl = process.env.TESSERA_E2E_APP_URL
+  ?? 'http://127.0.0.1:3100/dev-opencode-skills-repro';
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+let requestCount = 0;
+
+try {
+  await page.route('**/api/sessions/opencode-skills-browser-repro/skills', async (route) => {
+    requestCount += 1;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        skills: [{
+          name: 'diagnosing-bugs',
+          description: 'Diagnose hard bugs',
+        }],
+      }),
+    });
+  });
+
+  await page.goto(appUrl, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+  await page.getByTestId('opencode-skills-repro').waitFor({ timeout: 30_000 });
+  await page.getByTestId('opencode-skills-state').filter({ hasText: 'loading' }).waitFor();
+  await page.getByRole('option', { name: /diagnosing-bugs/ }).waitFor({ timeout: 3_000 });
+
+  assert.equal(await page.getByTestId('opencode-skills-state').textContent(), 'ready');
+  assert.equal(requestCount, 1, 'session state changes must share one in-flight request');
+  console.log(JSON.stringify({ requestCount, state: 'ready' }));
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## What changed

- Preserve a same-key slash discovery request while GUI session state hydrates or changes.
- Invalidate only when the actual provider/session/skill revision load key changes.
- Prevent delayed HTTP results from overwriting commands already delivered over WebSocket.
- Add a browser regression route and E2E that reproduces the OpenCode loading race.

## Root cause

The Codex skill refresh change invalidated the active request token whenever `isSessionRunning` changed. The hook then deduplicated the replacement load onto that already-invalidated promise, so a successful OpenCode `/skills` response was discarded and the picker stayed on “Loading skills...”.

## User impact

OpenCode now shows the same discovered slash command list before the first message and after a real conversation has started.

## Validation

- Red-before/green-after browser race regression: one delayed request, final picker state `ready`
- Real OpenCode GUI before first message: 47 commands visible
- Real OpenCode GUI after a completed prompt: 47 commands visible
- Existing Codex refresh browser E2E: recovery remains `ready`
- 59 targeted provider/session tests
- ESLint on changed files
- `npm run build`
