### PR TITLE
Default All Projects launcher to last active project

### DIFF
--- a/src/components/panel/empty-panel-state.tsx
+++ b/src/components/panel/empty-panel-state.tsx
@@ -32,6 +32,7 @@ import { setPanelNodeDragData } from '@/lib/dnd/panel-session-drag';
 import { v4 as uuidv4 } from 'uuid';
 import { ExecutionModeSelector } from '@/components/session/execution-mode-selector';
 import { getProviderExecutionCapabilities } from '@/lib/session/agent-execution-mode';
+import { resolveLastActiveProjectDir } from '@/lib/session/last-active-project';
 
 interface EmptyPanelStateProps {
   panelId: string;
@@ -96,8 +97,18 @@ export function EmptyPanelState({ panelId }: EmptyPanelStateProps) {
   const openFolderBrowser = useFolderBrowserStore((state) => state.open);
   const projects = useSessionStore((state) => state.projects);
   const activeSessionId = useSessionStore((state) => state.activeSessionId);
-  const [allProjectsProjectId, setAllProjectsProjectId] = useState<string | null>(null);
+  const lastActiveProjectDir = useSessionStore((state) => state.lastActiveProjectDir);
+  const [allProjectsProjectOverride, setAllProjectsProjectOverride] = useState<
+    string | null | undefined
+  >(undefined);
   const requiresProjectSelection = selectedProjectDir === ALL_PROJECTS_SENTINEL;
+  const defaultAllProjectsProjectId = resolveLastActiveProjectDir(
+    projects,
+    lastActiveProjectDir,
+  );
+  const allProjectsProjectId = allProjectsProjectOverride === undefined
+    ? defaultAllProjectsProjectId
+    : allProjectsProjectOverride;
   const resolvedProjectId = resolveEmptyPanelProjectId(
     selectedProjectDir,
     allProjectsProjectId,
@@ -154,7 +165,7 @@ export function EmptyPanelState({ panelId }: EmptyPanelStateProps) {
   }, []);
 
   const handleProjectChange = useCallback((projectId: string) => {
-    setAllProjectsProjectId(projectId || null);
+    setAllProjectsProjectOverride(projectId || null);
     setSelectedCollectionId(null);
     setError(null);
   }, []);

--- a/src/lib/session/last-active-project.ts
+++ b/src/lib/session/last-active-project.ts
@@ -1,0 +1,31 @@
+import { getSessionSelectionId } from '@/lib/constants/special-sessions';
+import type { UnifiedSession } from '@/types/chat';
+
+export const LAST_ACTIVE_PROJECT_DIR_KEY = 'ccw:lastActiveProjectDir';
+
+type ProjectSessionIndex = {
+  encodedDir: string;
+  sessions: readonly Pick<UnifiedSession, 'id'>[];
+};
+
+export function findSessionProjectDir(
+  projects: readonly ProjectSessionIndex[],
+  sessionId: string | null | undefined,
+): string | null {
+  const selectionSessionId = getSessionSelectionId(sessionId);
+  if (!selectionSessionId) return null;
+
+  return projects.find((project) =>
+    project.sessions.some((session) => session.id === selectionSessionId)
+  )?.encodedDir ?? null;
+}
+
+export function resolveLastActiveProjectDir(
+  projects: readonly Pick<ProjectSessionIndex, 'encodedDir'>[],
+  lastActiveProjectDir: string | null | undefined,
+): string | null {
+  if (!lastActiveProjectDir) return null;
+  return projects.some((project) => project.encodedDir === lastActiveProjectDir)
+    ? lastActiveProjectDir
+    : null;
+}

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -8,6 +8,12 @@ import { useTabStore } from './tab-store';
 import { toast } from './notification-store';
 import { captureTelemetryEvent } from '@/lib/telemetry/client';
 import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
+import { readUiStorageItem, writeUiStorageItem } from '@/lib/persistence/ui-storage';
+import {
+  findSessionProjectDir,
+  LAST_ACTIVE_PROJECT_DIR_KEY,
+  resolveLastActiveProjectDir,
+} from '@/lib/session/last-active-project';
 import {
   applySessionRuntimeLiveness,
   beginSessionRuntimeConnection,
@@ -24,6 +30,8 @@ export interface SessionState {
   // Core state - NEW (project-grouped)
   projects: ProjectGroup[];
   activeSessionId: string | null;
+  /** Project containing the most recently activated real conversation. */
+  lastActiveProjectDir: string | null;
   runtimeLiveness: SessionRuntimeLiveness;
 
   // REQ-002: Session creation loading state
@@ -332,6 +340,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   // Initial state
   projects: [],
   activeSessionId: null,
+  lastActiveProjectDir: null,
   runtimeLiveness: createSessionRuntimeLiveness(),
   creatingSessionId: null,
   loadingSessionId: null,
@@ -386,6 +395,12 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         projects: applySessionRuntimeLiveness(projects, state.runtimeLiveness),
       }));
       const loadedProjects = get().projects;
+      const storedLastActiveProjectDir = readUiStorageItem(LAST_ACTIVE_PROJECT_DIR_KEY);
+      const lastActiveProjectDir = resolveLastActiveProjectDir(
+        loadedProjects,
+        storedLastActiveProjectDir ?? get().lastActiveProjectDir,
+      );
+      set({ lastActiveProjectDir });
 
       // Initialize turn lifecycle state from server isGenerating state.
       const generatingSessionIds: string[] = [];
@@ -415,14 +430,17 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         // Ignore storage errors
       }
 
-      // Fallback: first running session or first session of current project
+      // Fallback: prefer the last conversation project, then the current project.
       if (!autoActiveId) {
-        const currentProject = loadedProjects.find((p) => p.isCurrent);
-        if (currentProject && currentProject.sessions.length > 0) {
-          const runningSession = currentProject.sessions.find((s) => s.isRunning);
-          autoActiveId = runningSession?.id || currentProject.sessions[0].id;
-        } else if (loadedProjects.length > 0 && loadedProjects[0].sessions.length > 0) {
-          autoActiveId = loadedProjects[0].sessions[0].id;
+        const lastActiveProject = loadedProjects.find(
+          (project) => project.encodedDir === lastActiveProjectDir,
+        );
+        const currentProject = loadedProjects.find((project) => project.isCurrent);
+        const fallbackProject = [lastActiveProject, currentProject, ...loadedProjects]
+          .find((project) => project && project.sessions.length > 0);
+        if (fallbackProject) {
+          const runningSession = fallbackProject.sessions.find((session) => session.isRunning);
+          autoActiveId = runningSession?.id ?? fallbackProject.sessions[0].id;
         }
       }
 
@@ -528,7 +546,12 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 
   // Session management
   setActiveSession: (sessionId) => {
-    set({ activeSessionId: sessionId });
+    const state = get();
+    const activatedProjectDir = findSessionProjectDir(state.projects, sessionId);
+    set({
+      activeSessionId: sessionId,
+      lastActiveProjectDir: activatedProjectDir ?? state.lastActiveProjectDir,
+    });
     // Persist to sessionStorage for restoration after page refresh
     try {
       if (sessionId !== null) {
@@ -539,9 +562,13 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     } catch {
       // Ignore storage errors (SSR, private browsing, etc.)
     }
+    if (activatedProjectDir) {
+      writeUiStorageItem(LAST_ACTIVE_PROJECT_DIR_KEY, activatedProjectDir);
+    }
   },
 
-  addSession: (session: UnifiedSession, options) =>
+  addSession: (session: UnifiedSession, options) => {
+    let activatedProjectDir: string | null = null;
     set((state) => {
       // Normalize projectDir — handle undefined from WebSocket messages missing workDir
       const projectDir = session.projectDir || 'unknown';
@@ -573,9 +600,13 @@ export const useSessionStore = create<SessionState>((set, get) => ({
           nextCursor: null,
           loadBatchIndex: 0,
         };
+        if (options?.activate !== false) activatedProjectDir = newProject.encodedDir;
         return {
           projects: [...state.projects, newProject],
           activeSessionId: options?.activate === false ? state.activeSessionId : session.id,
+          lastActiveProjectDir: options?.activate === false
+            ? state.lastActiveProjectDir
+            : newProject.encodedDir,
         };
       }
 
@@ -589,12 +620,20 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       project.totalSessions += 1;
       project.loadedCount += 1;
       updatedProjects[projectIndex] = project;
+      if (options?.activate !== false) activatedProjectDir = project.encodedDir;
 
       return {
         projects: updatedProjects,
         activeSessionId: options?.activate === false ? state.activeSessionId : session.id,
+        lastActiveProjectDir: options?.activate === false
+          ? state.lastActiveProjectDir
+          : project.encodedDir,
       };
-    }),
+    });
+    if (activatedProjectDir) {
+      writeUiStorageItem(LAST_ACTIVE_PROJECT_DIR_KEY, activatedProjectDir);
+    }
+  },
 
   removeSession: (sessionId) =>
     set((state) => {

--- a/tests/execution-mode-selection.test.ts
+++ b/tests/execution-mode-selection.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@/components/panel/empty-panel-state';
 import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
 import { getInitialTerminalCwd } from '@/lib/terminal/client-terminal-cwd';
+import { resolveLastActiveProjectDir } from '@/lib/session/last-active-project';
 import {
   shouldSubmitCollectionQuickCreateFromModeShortcut,
 } from '@/components/chat/collection-quick-create-sheet';
@@ -64,6 +65,17 @@ test('All Projects requires an explicit launcher project while a project scope r
     'project-b',
   );
   assert.equal(resolveEmptyPanelProjectId('project-a', null), 'project-a');
+});
+
+test('All Projects defaults to the most recently active conversation project when available', () => {
+  const projects = [
+    { encodedDir: 'project-a' },
+    { encodedDir: 'project-b' },
+  ];
+
+  assert.equal(resolveLastActiveProjectDir(projects, 'project-b'), 'project-b');
+  assert.equal(resolveLastActiveProjectDir(projects, 'removed-project'), null);
+  assert.equal(resolveLastActiveProjectDir(projects, null), null);
 });
 
 test('a standalone shell honors the project cwd selected in the launcher', () => {

--- a/tests/last-active-project.test.ts
+++ b/tests/last-active-project.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { useSessionStore } from '@/stores/session-store';
+import type { ProjectGroup, UnifiedSession } from '@/types/chat';
+
+function session(id: string, projectDir: string): UnifiedSession {
+  return {
+    id,
+    title: id,
+    projectDir,
+    isRunning: false,
+    status: 'completed',
+    lastModified: '2026-08-01T00:00:00.000Z',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    archived: false,
+    sortOrder: 0,
+  };
+}
+
+function project(encodedDir: string, sessions: UnifiedSession[]): ProjectGroup {
+  return {
+    encodedDir,
+    displayName: encodedDir,
+    decodedPath: `/workspace/${encodedDir}`,
+    isCurrent: false,
+    sessions,
+    totalSessions: sessions.length,
+    allLoaded: true,
+    loadedCount: sessions.length,
+    nextCursor: null,
+    loadBatchIndex: 0,
+  };
+}
+
+test('the last conversation project survives activation of an empty New Tab', (t) => {
+  const previousState = useSessionStore.getState();
+  t.after(() => useSessionStore.setState(previousState));
+
+  useSessionStore.setState({
+    projects: [
+      project('project-a', [session('session-a', 'project-a')]),
+      project('project-b', [session('session-b', 'project-b')]),
+    ],
+    activeSessionId: null,
+    lastActiveProjectDir: null,
+  });
+
+  useSessionStore.getState().setActiveSession('session-b');
+  useSessionStore.getState().setActiveSession(null);
+
+  assert.equal(useSessionStore.getState().activeSessionId, null);
+  assert.equal(useSessionStore.getState().lastActiveProjectDir, 'project-b');
+});
+
+test('background session additions do not replace the last conversation project', (t) => {
+  const previousState = useSessionStore.getState();
+  t.after(() => useSessionStore.setState(previousState));
+
+  useSessionStore.setState({
+    projects: [project('project-a', [session('session-a', 'project-a')])],
+    activeSessionId: 'session-a',
+    lastActiveProjectDir: 'project-a',
+  });
+
+  useSessionStore.getState().addSession(
+    session('background-session', 'project-b'),
+    { activate: false },
+  );
+
+  assert.equal(useSessionStore.getState().lastActiveProjectDir, 'project-a');
+});


### PR DESCRIPTION
## What changed
- Remember the project containing the most recently activated conversation
- Preselect that project in the All Projects New Tab launcher
- Keep an explicit launcher selection as a user override
- Restore the last conversation project across app restarts
- Ignore background-only session additions when updating the preference

## Why
Opening New Tab from All Projects always required a manual project selection, even when the user had just been working in a known project. The active session is cleared as soon as the empty tab becomes active, so the launcher had no project context to reuse.

## User impact
New sessions, worktrees, and shells default to the user's last conversation project while the project picker remains available. Users with no valid conversation history still select a project explicitly.

## Validation
- `npx tsc --noEmit`
- ESLint on all changed files
- `node --import tsx --test tests/execution-mode-selection.test.ts tests/last-active-project.test.ts` (14 passed)
- `node --import tsx --test tests/tab-new-tab.test.ts tests/tab-session-open.test.ts` (8 passed)
- `npm run build`
