### PR TITLE
fix(opencode): retry WSL command discovery loopback

### DIFF
--- a/src/lib/cli/providers/opencode/command-discovery-client.ts
+++ b/src/lib/cli/providers/opencode/command-discovery-client.ts
@@ -10,6 +10,7 @@ import {
 import type { SkillInfo } from '../skill-types';
 
 const DISCOVERY_TIMEOUT_MS = 30_000;
+const LOOPBACK_RETRY_DELAY_MS = 100;
 const COMPACT_COMMAND: SkillInfo = {
   name: 'compact',
   description: 'compact the session',
@@ -29,6 +30,11 @@ interface OpenCodeCommandCatalogEntry {
 export type OpenCodeCommandDiscoveryExecutor = (
   context: OpenCodeCommandDiscoveryContext,
 ) => Promise<unknown>;
+
+export interface OpenCodeCommandCatalogRequestOptions {
+  signal: AbortSignal;
+  authorization?: string;
+}
 
 let discoveryExecutorOverride: OpenCodeCommandDiscoveryExecutor | null = null;
 
@@ -78,6 +84,54 @@ function buildAuthorizationHeader(): string | undefined {
   return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
 }
 
+function waitForLoopbackRetry(signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, LOOPBACK_RETRY_DELAY_MS);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** HTTP boundary kept separate so bridged localhost readiness is regression-testable. */
+export async function fetchOpenCodeCommandCatalog(
+  url: URL,
+  options: OpenCodeCommandCatalogRequestOptions,
+): Promise<unknown> {
+  while (true) {
+    try {
+      const response = await fetch(url, {
+        headers: options.authorization ? { Authorization: options.authorization } : undefined,
+        signal: options.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`OpenCode command discovery failed with HTTP ${response.status}.`);
+      }
+      return response.json();
+    } catch (error) {
+      // In Windows-host + WSL-agent mode, OpenCode can announce that its WSL
+      // listener is ready before WSL's localhost proxy has exposed the port to
+      // Windows. Node reports those short-lived connection failures as a
+      // TypeError. HTTP and payload errors are ordinary Error/SyntaxError
+      // instances and remain fail-fast.
+      if (options.signal.aborted || !(error instanceof TypeError)) {
+        throw error;
+      }
+      await waitForLoopbackRetry(options.signal);
+    }
+  }
+}
+
 async function requestCatalogFromTransientServer(
   command: string,
   cwd: string,
@@ -118,14 +172,10 @@ async function requestCatalogFromTransientServer(
       const url = new URL(`http://127.0.0.1:${port}/command`);
       url.searchParams.set('directory', cwd);
       const authorization = buildAuthorizationHeader();
-      const response = await fetch(url, {
-        headers: authorization ? { Authorization: authorization } : undefined,
+      return fetchOpenCodeCommandCatalog(url, {
+        authorization,
         signal: abortController.signal,
       });
-      if (!response.ok) {
-        throw new Error(`OpenCode command discovery failed with HTTP ${response.status}.`);
-      }
-      return response.json();
     };
     const onStdout = (chunk: Buffer | string) => {
       stdout = `${stdout}${chunk.toString()}`.slice(-4_000);

--- a/tests/opencode-command-discovery-client.test.ts
+++ b/tests/opencode-command-discovery-client.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
+import { createServer as createHttpServer } from 'node:http';
+import { createServer as createNetServer } from 'node:net';
 import test from 'node:test';
 
 import {
+  fetchOpenCodeCommandCatalog,
   listOpenCodeCommands,
   setOpenCodeCommandDiscoveryExecutorForTests,
 } from '@/lib/cli/providers/opencode/command-discovery-client';
@@ -50,4 +53,44 @@ test('OpenCode discovery preserves a provider-reported compact command without d
   }), [
     { name: 'compact', description: 'Configured compact command' },
   ]);
+});
+
+test('OpenCode discovery waits for bridged WSL localhost forwarding to become reachable', async (t) => {
+  const reservation = createNetServer();
+  await new Promise<void>((resolve, reject) => {
+    reservation.once('error', reject);
+    reservation.listen(0, '127.0.0.1', resolve);
+  });
+  const address = reservation.address();
+  assert.ok(address && typeof address !== 'string');
+  const port = address.port;
+  await new Promise<void>((resolve, reject) => {
+    reservation.close((error) => error ? reject(error) : resolve());
+  });
+
+  const catalog = [{ name: 'diagnosing-bugs', description: 'Diagnose hard bugs' }];
+  const delayedServer = createHttpServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify(catalog));
+  });
+  const startTimer = setTimeout(() => {
+    delayedServer.listen(port, '127.0.0.1');
+  }, 150);
+  t.after(async () => {
+    clearTimeout(startTimer);
+    if (!delayedServer.listening) return;
+    await new Promise<void>((resolve) => delayedServer.close(() => resolve()));
+  });
+
+  const abortController = new AbortController();
+  const abortTimer = setTimeout(() => abortController.abort(), 2_000);
+  try {
+    const url = new URL(`http://127.0.0.1:${port}/command`);
+    url.searchParams.set('directory', '/repo');
+    assert.deepEqual(await fetchOpenCodeCommandCatalog(url, {
+      signal: abortController.signal,
+    }), catalog);
+  } finally {
+    clearTimeout(abortTimer);
+  }
 });


### PR DESCRIPTION
## What changed

- Retry transient loopback fetch failures while discovering OpenCode commands.
- Keep HTTP/auth/payload failures fail-fast.
- Add a regression test where the command server becomes reachable shortly after the first connection attempt.

## Root cause

In the packaged Windows Electron app, Tessera's server runs on Windows while OpenCode runs in WSL. OpenCode prints its listening banner before WSL's localhost forwarding is reachable from Windows, so the first fetch failed with `ECONNREFUSED` and Tessera cached an empty slash-command list. The browser dev server did not reproduce this because both sides run inside WSL.

## Validation

- `npx tsx --test tests/opencode-command-discovery-client.test.ts`
- `node --test tests/pre-conversation-skill-discovery.test.mjs`
- targeted ESLint
- `npx tsc --noEmit --pretty false`
- Windows Electron package + WSL OpenCode: `/skills` changed from 0 to 47 commands; slash picker confirmed in the packaged UI.
