### PR TITLE
fix(tabs): keep the active tab's close button clear of the scroll arrow

### DIFF
--- a/src/components/tab/tab-bar.tsx
+++ b/src/components/tab/tab-bar.tsx
@@ -17,9 +17,13 @@ import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
 import { parsePanelNodeDragData, parsePanelTitleDragData } from '@/lib/dnd/panel-session-drag';
 import { ElectronWindowControls } from '@/components/layout/electron-window-controls';
 import { focusPanelControl } from '@/lib/session/focus-session-panel';
+import {
+  TAB_SCROLL_EDGE_EPSILON,
+  TAB_SCROLL_GUTTER,
+  resolveTabScrollReveal,
+} from '@/lib/tab/tab-scroll-reveal';
 
 const TAB_SCROLL_MIN_STEP = 180;
-const TAB_SCROLL_EDGE_EPSILON = 1;
 
 // ---------------------------------------------------------------------------
 // Component
@@ -70,6 +74,11 @@ export const TabBar = memo(function TabBar() {
   const prevTabCountRef = useRef(tabs.length);
   const prevActiveTabIdRef = useRef<string | null>(null);
 
+  // A reveal that could not finish because the end zone had not widened yet —
+  // retried once the overflow state (and with it the end zone) has been applied.
+  const pendingRevealRef = useRef<{ tabId: string; behavior: ScrollBehavior } | null>(null);
+  const prevHasOverflowRef = useRef(false);
+
   const updateScrollState = useCallback(function updateScrollState() {
     const container = containerRef.current;
     if (!container) {
@@ -99,6 +108,43 @@ export const TabBar = memo(function TabBar() {
         ? prev
         : next,
     );
+  }, []);
+
+  /**
+   * Scrolls the given tab clear of the overlaid scroll arrows.
+   *
+   * Returns false when the scroller ran out of room before the tab was clear —
+   * the caller retries after the end zone has widened.
+   */
+  const revealTab = useCallback(function revealTab(
+    tabId: string,
+    behavior: ScrollBehavior,
+  ): boolean {
+    const container = containerRef.current;
+    if (!container) return false;
+
+    const tabElement = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-tab-id]'),
+    ).find((element) => element.dataset.tabId === tabId);
+    if (!tabElement) return true;
+
+    const containerRect = container.getBoundingClientRect();
+    const tabRect = tabElement.getBoundingClientRect();
+    const tabStart = tabRect.left - containerRect.left + container.scrollLeft;
+
+    const { scrollLeft, settled } = resolveTabScrollReveal({
+      tabStart,
+      tabEnd: tabStart + tabRect.width,
+      scrollLeft: container.scrollLeft,
+      viewportWidth: container.clientWidth,
+      maxScrollLeft: Math.max(0, container.scrollWidth - container.clientWidth),
+      gutter: TAB_SCROLL_GUTTER,
+    });
+
+    if (Math.abs(scrollLeft - container.scrollLeft) > TAB_SCROLL_EDGE_EPSILON) {
+      container.scrollTo({ left: scrollLeft, behavior });
+    }
+    return settled;
   }, []);
 
   useEffect(
@@ -149,22 +195,33 @@ export const TabBar = memo(function TabBar() {
       prevActiveTabIdRef.current = activeTabId;
 
       if (tabAdded || activeTabChanged) {
-        const container = containerRef.current;
-        const tabElements = container
-          ? Array.from(container.querySelectorAll<HTMLElement>('[data-tab-id]'))
-          : [];
-        const activeTabElement = tabElements.find((element) => element.dataset.tabId === activeTabId);
-
-        activeTabElement?.scrollIntoView({
-          block: 'nearest',
-          inline: 'nearest',
-          behavior: isInitialSync ? 'instant' : 'smooth',
-        });
+        const behavior: ScrollBehavior = isInitialSync ? 'instant' : 'smooth';
+        // On the commit that first overflows the strip the end zone is still
+        // collapsed, so there is no room to push the last tab out from under
+        // the arrow. That case is finished off by retryPendingReveal.
+        pendingRevealRef.current = revealTab(activeTabId, behavior)
+          ? null
+          : { tabId: activeTabId, behavior };
       }
       const frameId = requestAnimationFrame(updateScrollState);
       return () => cancelAnimationFrame(frameId);
     },
-    [activeTabId, tabs.length, updateScrollState],
+    [activeTabId, revealTab, tabs.length, updateScrollState],
+  );
+
+  // The end zone's width follows scrollState.hasOverflow, so a reveal that ran
+  // out of room gets its scroll room exactly one commit later.
+  useEffect(
+    function retryPendingReveal() {
+      const overflowChanged = prevHasOverflowRef.current !== scrollState.hasOverflow;
+      prevHasOverflowRef.current = scrollState.hasOverflow;
+
+      const pending = pendingRevealRef.current;
+      if (!overflowChanged || !pending) return;
+      pendingRevealRef.current = null;
+      revealTab(pending.tabId, pending.behavior);
+    },
+    [revealTab, scrollState.hasOverflow],
   );
 
   // ---------------------------------------------------------------------------
@@ -451,9 +508,11 @@ export const TabBar = memo(function TabBar() {
       {/* Scrollable tab items container */}
       <div className="relative flex min-w-0 items-stretch">
         {/*
-          scroll-px-8 keeps scrollIntoView from parking a tab flush against an edge:
-          the scroll arrows are absolutely positioned over the strip (left-1/right-1, w-6)
-          and would otherwise cover the tab's close button (BR-UI-024).
+          The scroll arrows are absolutely positioned over the strip (left-1/right-1,
+          w-6), so a tab parked flush against an edge has its close button covered
+          (BR-UI-024). revealTab keeps the active tab clear of both gutters;
+          scroll-px-8 makes browser-initiated scrolls (focusing the rename input,
+          say) respect the same margin.
         */}
         <div
           ref={containerRef}

--- a/src/lib/tab/tab-scroll-reveal.ts
+++ b/src/lib/tab/tab-scroll-reveal.ts
@@ -1,0 +1,78 @@
+/**
+ * 탭 스트립의 스크롤 화살표는 스크롤 영역 위에 겹쳐 그려진다. 활성 탭이 그
+ * 아래에 깔리면 닫기 버튼을 누를 수 없으므로(BR-UI-024), 활성 탭을 드러낼
+ * 스크롤 위치는 양 끝 `gutter`를 "화살표가 덮는 영역"으로 빼고 계산한다.
+ */
+
+/** 스크롤 화살표가 덮는 폭 — 탭 스트립의 `scroll-px-8`과 같은 값. */
+export const TAB_SCROLL_GUTTER = 32;
+
+/** 스크롤 좌표 비교에 쓰는 허용 오차(서브픽셀 반올림 흡수). */
+export const TAB_SCROLL_EDGE_EPSILON = 1;
+
+export interface TabScrollRevealInput {
+  /** 스크롤 콘텐츠 좌표계에서 탭의 왼쪽 끝. */
+  tabStart: number;
+  /** 스크롤 콘텐츠 좌표계에서 탭의 오른쪽 끝. */
+  tabEnd: number;
+  /** 현재 스크롤 위치. */
+  scrollLeft: number;
+  /** 스크롤 뷰포트 폭(`clientWidth`). */
+  viewportWidth: number;
+  /** 도달 가능한 최대 스크롤 위치(`scrollWidth - clientWidth`). */
+  maxScrollLeft: number;
+  /** 화살표가 덮는 폭. */
+  gutter?: number;
+}
+
+export interface TabScrollRevealResult {
+  /** 적용할 스크롤 위치. */
+  scrollLeft: number;
+  /**
+   * 이 위치에서 탭이 실제로 보이는 화살표에 가려지지 않으면 true.
+   *
+   * false는 "스크롤 여유가 모자라 아직 못 드러냈다"는 뜻이다 — 오버플로가 막
+   * 시작된 커밋에서는 끝 여백이 아직 0이라 여기에 걸린다.
+   */
+  settled: boolean;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), Math.max(min, max));
+}
+
+/**
+ * 활성 탭을 좌우 화살표 밖으로 드러내는 스크롤 위치를 계산한다.
+ *
+ * 탭이 뷰포트보다 넓어 양끝을 동시에 만족할 수 없으면 왼쪽 정렬을 택한다 —
+ * 제목 앞부분이 잘리는 편보다 낫다.
+ */
+export function resolveTabScrollReveal({
+  tabStart,
+  tabEnd,
+  scrollLeft,
+  viewportWidth,
+  maxScrollLeft,
+  gutter = TAB_SCROLL_GUTTER,
+}: TabScrollRevealInput): TabScrollRevealResult {
+  let target = scrollLeft;
+
+  // 오른쪽이 덮이면 그만큼 더 스크롤하고, 그다음 왼쪽을 확인한다.
+  const minForRightEdge = tabEnd + gutter - viewportWidth;
+  if (target < minForRightEdge) target = minForRightEdge;
+  const maxForLeftEdge = tabStart - gutter;
+  if (target > maxForLeftEdge) target = maxForLeftEdge;
+
+  const next = clamp(target, 0, maxScrollLeft);
+
+  // 오른쪽이 잘렸다면 스크롤 여유가 모자란 것이다. 이 순간에는 스크롤 끝이라
+  // 화살표가 아직 안 보이지만, 끝 여백이 펼쳐지는 다음 커밋에 화살표가 나타나
+  // 그대로 탭을 덮는다 — 그러니 "아직 못 드러냈다"로 본다.
+  const shortOnRight = maxScrollLeft > 0 && target > maxScrollLeft + TAB_SCROLL_EDGE_EPSILON;
+  // 왼쪽은 반대다. 스크롤 0이면 왼쪽 화살표 자체가 없으므로 탭이 끝에 붙어도
+  // 가려지지 않고, 더 되돌릴 여유도 없다.
+  const coveredOnLeft =
+    next > TAB_SCROLL_EDGE_EPSILON && tabStart < next + gutter - TAB_SCROLL_EDGE_EPSILON;
+
+  return { scrollLeft: next, settled: !shortOnRight && !coveredOnLeft };
+}

--- a/tests/tab-scroll-reveal.test.ts
+++ b/tests/tab-scroll-reveal.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  TAB_SCROLL_GUTTER,
+  resolveTabScrollReveal,
+} from '@/lib/tab/tab-scroll-reveal';
+
+/**
+ * 재현 기준 치수 — 폭 900 스트립에서 탭 6개(각 160)가 처음 넘칠 때의 값이다.
+ * 오른쪽 화살표는 스크롤 영역 위 32px(`TAB_SCROLL_GUTTER`)을 덮는다.
+ */
+const VIEWPORT_WIDTH = 860;
+const TAB_WIDTH = 160;
+const LAST_TAB_START = TAB_WIDTH * 5;
+const LAST_TAB_END = TAB_WIDTH * 6;
+
+test('마지막 탭을 열면 오른쪽 화살표 밖까지 스크롤한다', () => {
+  const contentWidth = LAST_TAB_END + TAB_SCROLL_GUTTER; // 끝 여백이 반영된 상태
+  const result = resolveTabScrollReveal({
+    tabStart: LAST_TAB_START,
+    tabEnd: LAST_TAB_END,
+    scrollLeft: 0,
+    viewportWidth: VIEWPORT_WIDTH,
+    maxScrollLeft: contentWidth - VIEWPORT_WIDTH,
+  });
+
+  assert.equal(result.settled, true);
+  assert.equal(result.scrollLeft, LAST_TAB_END + TAB_SCROLL_GUTTER - VIEWPORT_WIDTH);
+  // 탭 오른쪽 끝이 화살표가 덮는 영역 밖에 있어야 닫기 버튼을 누를 수 있다.
+  assert.ok(LAST_TAB_END <= result.scrollLeft + VIEWPORT_WIDTH - TAB_SCROLL_GUTTER);
+});
+
+test('끝 여백이 아직 0이면 여백이 모자란다고 보고한다', () => {
+  // 오버플로가 막 시작된 커밋: 끝 여백(end zone)이 아직 펼쳐지지 않았다.
+  const contentWidth = LAST_TAB_END;
+  const result = resolveTabScrollReveal({
+    tabStart: LAST_TAB_START,
+    tabEnd: LAST_TAB_END,
+    scrollLeft: 0,
+    viewportWidth: VIEWPORT_WIDTH,
+    maxScrollLeft: contentWidth - VIEWPORT_WIDTH,
+  });
+
+  // 갈 수 있는 데까지는 가되, 아직 화살표에 32px 물려 있다고 알린다.
+  assert.equal(result.scrollLeft, contentWidth - VIEWPORT_WIDTH);
+  assert.equal(result.settled, false);
+});
+
+test('여백이 반영된 뒤 재시도하면 화살표 밖으로 빠져나온다', () => {
+  const withoutEndZone = resolveTabScrollReveal({
+    tabStart: LAST_TAB_START,
+    tabEnd: LAST_TAB_END,
+    scrollLeft: 0,
+    viewportWidth: VIEWPORT_WIDTH,
+    maxScrollLeft: LAST_TAB_END - VIEWPORT_WIDTH,
+  });
+  assert.equal(withoutEndZone.settled, false);
+
+  const retry = resolveTabScrollReveal({
+    tabStart: LAST_TAB_START,
+    tabEnd: LAST_TAB_END,
+    scrollLeft: withoutEndZone.scrollLeft,
+    viewportWidth: VIEWPORT_WIDTH,
+    maxScrollLeft: LAST_TAB_END + TAB_SCROLL_GUTTER - VIEWPORT_WIDTH,
+  });
+
+  assert.equal(retry.settled, true);
+  assert.equal(retry.scrollLeft, withoutEndZone.scrollLeft + TAB_SCROLL_GUTTER);
+});
+
+test('끝 여백까지 스크롤한 상태는 그대로 유지한다', () => {
+  const maxScrollLeft = LAST_TAB_END + TAB_SCROLL_GUTTER - VIEWPORT_WIDTH;
+  const result = resolveTabScrollReveal({
+    tabStart: LAST_TAB_START,
+    tabEnd: LAST_TAB_END,
+    scrollLeft: maxScrollLeft,
+    viewportWidth: VIEWPORT_WIDTH,
+    maxScrollLeft,
+  });
+
+  assert.equal(result.scrollLeft, maxScrollLeft);
+  assert.equal(result.settled, true);
+});
+
+test('왼쪽 화살표에 가린 탭은 오른쪽으로 되돌려 드러낸다', () => {
+  const contentWidth = TAB_WIDTH * 10;
+  const result = resolveTabScrollReveal({
+    tabStart: TAB_WIDTH * 3,
+    tabEnd: TAB_WIDTH * 4,
+    scrollLeft: TAB_WIDTH * 3 + 10, // 탭 왼쪽이 화살표 아래로 들어간 상태
+    viewportWidth: VIEWPORT_WIDTH,
+    maxScrollLeft: contentWidth - VIEWPORT_WIDTH,
+  });
+
+  assert.equal(result.settled, true);
+  assert.equal(result.scrollLeft, TAB_WIDTH * 3 - TAB_SCROLL_GUTTER);
+});
+
+test('첫 탭은 스크롤 0에서 왼쪽 화살표가 없으므로 그대로 둔다', () => {
+  const contentWidth = TAB_WIDTH * 10;
+  const result = resolveTabScrollReveal({
+    tabStart: 0,
+    tabEnd: TAB_WIDTH,
+    scrollLeft: 0,
+    viewportWidth: VIEWPORT_WIDTH,
+    maxScrollLeft: contentWidth - VIEWPORT_WIDTH,
+  });
+
+  assert.equal(result.scrollLeft, 0);
+  assert.equal(result.settled, true);
+});
+
+test('이미 양쪽 여백 안에 보이는 탭은 스크롤을 건드리지 않는다', () => {
+  const contentWidth = TAB_WIDTH * 10;
+  const result = resolveTabScrollReveal({
+    tabStart: TAB_WIDTH * 2,
+    tabEnd: TAB_WIDTH * 3,
+    scrollLeft: TAB_WIDTH,
+    viewportWidth: VIEWPORT_WIDTH,
+    maxScrollLeft: contentWidth - VIEWPORT_WIDTH,
+  });
+
+  assert.equal(result.scrollLeft, TAB_WIDTH);
+  assert.equal(result.settled, true);
+});
+
+test('뷰포트보다 넓은 탭은 왼쪽을 드러내는 쪽을 택한다', () => {
+  const narrowViewport = 200;
+  const contentWidth = 1000;
+  const result = resolveTabScrollReveal({
+    tabStart: 400,
+    tabEnd: 700,
+    scrollLeft: 0,
+    viewportWidth: narrowViewport,
+    maxScrollLeft: contentWidth - narrowViewport,
+  });
+
+  // 양끝을 동시에 만족할 수 없으므로 제목이 보이는 왼쪽 정렬을 택한다.
+  assert.equal(result.scrollLeft, 400 - TAB_SCROLL_GUTTER);
+});


### PR DESCRIPTION
## Summary

- The active tab's close button could sit underneath the tab strip's scroll arrow, so the tab you are currently looking at could not be closed without first scrolling right by hand.
- Cause: the end zone that gives the last tab its trailing 32px of scroll room only widens on the commit *after* overflow is detected, while the active tab is scrolled into view on the commit before that. When a newly opened tab is the one that first overflows the strip, the scroller is 32px short — `scrollIntoView` parks the tab flush against the edge and the arrow, drawn over the strip, lands exactly on its close button.
- Replaced `scrollIntoView` (which depended on the browser honouring `scroll-px-8`) with an explicit scroll target in `src/lib/tab/tab-scroll-reveal.ts` that treats both gutters as covered, and retry the reveal once the end zone has actually widened.

Measured in the running dev app — window 420px wide, opening the tab that first overflows the strip:

| | active tab | close button | right arrow | scrollLeft |
| --- | --- | --- | --- | --- |
| before | `New Tab` | `[315, 331]` | `[316, 340]` — overlaps | 56 / max 88 |
| after | `New Tab` | `[283, 299]` | not rendered | 88 / max 88 |

## Testing

- [ ] `npm run lint` — passes for the changed files; the full-repo run was cut off at a 5 min timeout, not by an error
- [x] `npx tsc --noEmit`
- [x] `NODE_ENV=production npm run build`
- [x] Manual test: reproduced the failure in the dev app with the fix stashed and confirmed it is gone with the fix applied, capturing the tab strip in the same state both times. Also switched to the first tab and back so neither gutter clips the active tab. `tests/tab-scroll-reveal.test.ts` (8 cases) plus the existing tab suites — `tab-new-tab`, `mounted-tab-order`, `tab-navigation-commands`, `tab-title-rename`, `tab-session-open` — all pass.
- [ ] Not tested: packaged Electron build. This is renderer-only layout code with no cross-process or path dependency, so the web dev path exercises the same code.

## Screenshots or Recordings

Tab strip with `New Tab` active, same state before and after:

```
before — the close button is under the › arrow
[ ‹ og r… ✕ ] [ New Tab    › ] [ + ]

after — the close button is reachable
[ ‹ .    ✕ ] [ New Tab    ✕ ] [ + ]
```

## Notes

Bug fix, no issue filed. Branched from `origin/dev` so it carries this change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
