### PR TITLE
fix(chat): handle Claude Code tool_progress stream messages

### DIFF
--- a/src/components/chat/tool-call-block-sections.tsx
+++ b/src/components/chat/tool-call-block-sections.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react';
 import type { ToolDisplayMetadata } from '@/types/tool-display';
 import type { ToolCallKind } from '@/types/tool-call-kind';
 import { ErrorBlock } from './shared/error-block';
-import { renderToolCallResult, TOOL_STATUS_TEXT } from './tool-call-block-utils';
+import { renderToolCallResult, TOOL_STATUS_TEXT, formatElapsedSeconds } from './tool-call-block-utils';
 
 export function ToolCallBlockHeader({
   toolName,
@@ -16,6 +16,7 @@ export function ToolCallBlockHeader({
   statusColor,
   isError,
   isRunning,
+  elapsedSeconds,
   onToggle,
 }: {
   toolName: string;
@@ -26,6 +27,7 @@ export function ToolCallBlockHeader({
   statusColor: string;
   isError: boolean;
   isRunning: boolean;
+  elapsedSeconds?: number;
   onToggle: () => void;
 }) {
   return (
@@ -41,10 +43,17 @@ export function ToolCallBlockHeader({
           <div className="truncate font-mono text-[11px] text-(--text-muted)">{summary}</div>
         )}
       </div>
-      <div className="ml-auto flex h-3 w-3 shrink-0 items-center justify-center">
-        {isRunning && <Loader2 className="h-3 w-3 animate-spin text-(--accent)" />}
-        {status === 'completed' && <CheckCircle className={`h-3 w-3 ${TOOL_STATUS_TEXT.completed}`} />}
-        {isError && <XCircle className={`h-3 w-3 ${TOOL_STATUS_TEXT.error}`} />}
+      <div className="ml-auto flex shrink-0 items-center gap-1.5">
+        {isRunning && elapsedSeconds != null && (
+          <span className="text-[10px] font-mono tabular-nums text-(--text-muted)">
+            {formatElapsedSeconds(elapsedSeconds)}
+          </span>
+        )}
+        <div className="flex h-3 w-3 items-center justify-center">
+          {isRunning && <Loader2 className="h-3 w-3 animate-spin text-(--accent)" />}
+          {status === 'completed' && <CheckCircle className={`h-3 w-3 ${TOOL_STATUS_TEXT.completed}`} />}
+          {isError && <XCircle className={`h-3 w-3 ${TOOL_STATUS_TEXT.error}`} />}
+        </div>
       </div>
     </button>
   );

--- a/src/components/chat/tool-call-block-utils.tsx
+++ b/src/components/chat/tool-call-block-utils.tsx
@@ -54,6 +54,14 @@ export function resolveToolUseId(id: string, explicitToolUseId?: string): string
   return historyMatch ? historyMatch[1] : null;
 }
 
+/** "42s" below a minute, "3m 05s" above — for live tool_progress elapsed ticks. */
+export function formatElapsedSeconds(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${String(s % 60).padStart(2, '0')}s`;
+}
+
 export function shortenToolName(name: string): string {
   if (name.startsWith('mcp__')) {
     const lastSeparator = name.lastIndexOf('__');

--- a/src/components/chat/tool-call-block.tsx
+++ b/src/components/chat/tool-call-block.tsx
@@ -13,7 +13,7 @@ import {
 } from './tool-call-block-utils';
 import { useToolCallOutput } from './use-tool-call-output';
 
-export { getToolIcon, getToolSummary, shortenToolName } from './tool-call-block-utils';
+export { getToolIcon, getToolSummary, shortenToolName, formatElapsedSeconds } from './tool-call-block-utils';
 
 interface ToolCallBlockProps extends Omit<ToolCallMessage, 'timestamp'> {
   defaultExpanded?: boolean;
@@ -33,6 +33,7 @@ export const ToolCallBlock = memo(function ToolCallBlock({
   hasOutput,
   sessionId,
   toolUseId: explicitToolUseId,
+  toolProgress,
   defaultExpanded,
   inGrid = false,
 }: ToolCallBlockProps) {
@@ -109,6 +110,7 @@ export const ToolCallBlock = memo(function ToolCallBlock({
           statusColor={statusColor}
           isError={isError}
           isRunning={isRunning}
+          elapsedSeconds={isRunning ? toolProgress?.elapsedTimeSeconds : undefined}
           onToggle={toggleExpand}
         />
       )}

--- a/src/components/chat/tool-call-grid.tsx
+++ b/src/components/chat/tool-call-grid.tsx
@@ -5,7 +5,7 @@ import { CheckCircle, XCircle, Loader2, ChevronDown, ChevronUp, Wrench } from 'l
 import type { ToolCallMessage } from '@/types/chat';
 import { useChatStore } from '@/stores/chat-store';
 import { cn } from '@/lib/utils';
-import { getToolIcon, getToolSummary, shortenToolName } from './tool-call-block';
+import { getToolIcon, getToolSummary, shortenToolName, formatElapsedSeconds } from './tool-call-block';
 import { TOOL_STATUS_TEXT } from './tool-call-block-utils';
 import { ToolCallDetailPanel } from './tool-call-detail-panel';
 import { MESSAGE_BODY_OFFSET_CLASS } from './message-layout';
@@ -192,7 +192,15 @@ function CompactRow({
       <span className="text-[11px] text-(--text-muted) truncate font-mono flex-1 min-w-0">
         {getToolSummary(toolName, toolParams, toolCall.toolKind, toolDisplay) || '\u00A0'}
       </span>
-      <div className="shrink-0">
+      <div className="shrink-0 flex items-center gap-1.5">
+        {isRunning && toolCall.toolProgress && (
+          <span
+            className="text-[10px] font-mono tabular-nums text-(--text-muted)"
+            data-testid="tool-call-elapsed"
+          >
+            {formatElapsedSeconds(toolCall.toolProgress.elapsedTimeSeconds)}
+          </span>
+        )}
         {isLoading && <Loader2 className="w-2.5 h-2.5 text-(--accent) animate-spin" />}
         {!isLoading && isRunning && <Loader2 className="w-2.5 h-2.5 text-(--accent) animate-spin" />}
         {!isLoading && status === 'completed' && <CheckCircle className={`w-2.5 h-2.5 ${TOOL_STATUS_TEXT.completed}`} />}

--- a/src/lib/cli/protocol-message-types.ts
+++ b/src/lib/cli/protocol-message-types.ts
@@ -58,7 +58,8 @@ export type CliMessage = {
     | 'tool_result'
     | 'control_request'
     | 'control_response'
-    | 'stream_event';
+    | 'stream_event'
+    | 'tool_progress';
   session_id: string;
   uuid: string;
   timestamp?: string;

--- a/src/lib/cli/providers/claude-code/protocol-parser.ts
+++ b/src/lib/cli/providers/claude-code/protocol-parser.ts
@@ -258,6 +258,9 @@ export class ClaudeCodeProtocolParser {
       case 'stream_event':
         results = this.handleStreamEvent(sessionId, msg);
         break;
+      case 'tool_progress':
+        results = this.handleToolProgress(sessionId, msg);
+        break;
       default: {
         if (KNOWN_IGNORED_MESSAGE_TYPES.has(msg.type)) {
           logger.debug('Ignoring known benign CLI message type', { sessionId, type: msg.type });
@@ -1233,6 +1236,55 @@ export class ClaudeCodeProtocolParser {
     }
 
     return results;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handler: tool_progress
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Handle top-level `tool_progress` messages (CLI >= 2.1.x).
+   *
+   * The CLI emits these while a tool call is in flight: `bash_progress` /
+   * `powershell_progress` output ticks, 30s `tool_heartbeat`s for any long
+   * tool, and REPL/subagent-retry variants. They carry no result content —
+   * only liveness (`elapsed_time_seconds`, optional `task_id` / `heartbeat`)
+   * — so they are forwarded as a lightweight live-only `tool_progress` server
+   * message that updates the running tool card without touching history.
+   */
+  private handleToolProgress(sessionId: string, msg: CliMessage): ParsedMessage[] {
+    const raw = msg as any;
+    const toolUseId = raw.tool_use_id;
+
+    if (typeof toolUseId !== 'string' || !toolUseId) {
+      logger.debug('tool_progress without tool_use_id', { sessionId });
+      return [];
+    }
+
+    const elapsedTimeSeconds = typeof raw.elapsed_time_seconds === 'number'
+      ? raw.elapsed_time_seconds
+      : 0;
+
+    logger.debug('Tool progress received', {
+      sessionId,
+      toolUseId,
+      toolName: raw.tool_name,
+      elapsedTimeSeconds,
+      heartbeat: raw.heartbeat === true,
+    });
+
+    return [{
+      serverMessage: {
+        type: 'tool_progress',
+        sessionId,
+        toolUseId,
+        ...(typeof raw.tool_name === 'string' ? { toolName: raw.tool_name } : {}),
+        elapsedTimeSeconds,
+        ...(raw.heartbeat === true ? { heartbeat: true } : {}),
+        ...(typeof raw.task_id === 'string' ? { taskId: raw.task_id } : {}),
+        timestamp: new Date().toISOString(),
+      },
+    }];
   }
 
   // ---------------------------------------------------------------------------

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -136,6 +136,16 @@ export function handleIncomingServerMessage({
       applySessionReplayEventsToStores(msg.sessionId, msg.events);
       return { wasReconnect };
 
+    case 'tool_progress':
+      // Live-only liveness tick for an in-flight tool card; not persisted,
+      // not a replay event — just patch the running card's progress.
+      chatStore.updateToolCallProgress(msg.sessionId, msg.toolUseId, {
+        elapsedTimeSeconds: msg.elapsedTimeSeconds,
+        ...(msg.heartbeat !== undefined ? { heartbeat: msg.heartbeat } : {}),
+        ...(msg.taskId !== undefined ? { taskId: msg.taskId } : {}),
+      });
+      return { wasReconnect };
+
     case 'notification':
       sessionStore.touchSessionActivity(msg.sessionId);
       handleNotificationMessage(msg, getVisibleWorkspaceSessionId(sessionStore.activeSessionId));

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -299,6 +299,25 @@ export type AppServerMessage =
       stateAt?: number;
     }
   | {
+      /**
+       * Live-only liveness tick for an in-flight tool call (Claude Code
+       * `tool_progress` stdout messages). Deliberately NOT replay-transported
+       * and NOT persisted to session history — heartbeats fire every 30s and
+       * would bloat the transcript; on replay the card just shows the final
+       * tool_call status.
+       */
+      type: 'tool_progress';
+      sessionId: string;
+      toolUseId: string;
+      toolName?: string;
+      elapsedTimeSeconds: number;
+      /** True for the 30s keep-alive heartbeat variant (vs output-driven ticks). */
+      heartbeat?: boolean;
+      /** Background task id, present on bash/powershell progress ticks. */
+      taskId?: string;
+      timestamp: string;
+    }
+  | {
       type: 'terminal_session_runtime';
       sessionId: string;
       terminalId: string;

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -220,6 +220,11 @@ export interface ChatState {
     agentContext?: AgentContextEvent[];
     hasOutput?: boolean;
   }) => void;
+  updateToolCallProgress: (sessionId: string, toolUseId: string, progress: {
+    elapsedTimeSeconds: number;
+    heartbeat?: boolean;
+    taskId?: string;
+  }) => void;
   attachMessageTranslation: (sessionId: string, targetMessageId: string, update: {
     translatedContent?: string;
     translationStatus?: 'pending' | 'completed' | 'error';
@@ -826,6 +831,31 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
         return msg;
       });
+      const messages = new Map(state.messages);
+      messages.set(sessionId, updatedMessages);
+      return { messages };
+    }),
+
+  updateToolCallProgress: (sessionId, toolUseId, progress) =>
+    set((state) => {
+      const sessionMessages = state.messages.get(sessionId) || [];
+      // Live tool cards carry the `hist-tool-<toolUseId>` id assigned by the
+      // replay reducer; match by toolUseId field as a fallback for safety.
+      const targetId = `hist-tool-${toolUseId}`;
+      let changed = false;
+      const updatedMessages = sessionMessages.map((msg) => {
+        if (
+          'type' in msg &&
+          msg.type === 'tool_call' &&
+          msg.status === 'running' &&
+          (msg.id === targetId || msg.toolUseId === toolUseId)
+        ) {
+          changed = true;
+          return { ...msg, toolProgress: progress };
+        }
+        return msg;
+      });
+      if (!changed) return state;
       const messages = new Map(state.messages);
       messages.set(sessionId, updatedMessages);
       return { messages };

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -851,7 +851,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
           (msg.id === targetId || msg.toolUseId === toolUseId)
         ) {
           changed = true;
-          return { ...msg, toolProgress: progress };
+          return { ...msg, toolProgress: { ...(msg.toolProgress ?? {}), ...progress } };
         }
         return msg;
       });

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -59,6 +59,12 @@ export interface ToolCallMessage extends BaseEnhancedMessage {
   agentContext?: AgentContextEvent[];
   /** True when output/toolUseResult were stripped for lazy loading (read-only sessions) */
   hasOutput?: boolean;
+  /** Latest live progress tick from the CLI (`tool_progress`) while running. */
+  toolProgress?: {
+    elapsedTimeSeconds: number;
+    heartbeat?: boolean;
+    taskId?: string;
+  };
 }
 
 // Thinking message (NEW)

--- a/tests/claude-code-tool-progress.test.ts
+++ b/tests/claude-code-tool-progress.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { claudeCodeProtocolParser } from '../src/lib/cli/providers/claude-code/protocol-parser';
+
+// The Claude Code CLI (>= 2.1.x) emits top-level `tool_progress` stdout
+// messages while a tool call is in flight — bash/powershell output ticks,
+// 30s `tool_heartbeat`s for any long tool, and REPL/subagent-retry variants.
+// They carry no result content, only liveness (elapsed_time_seconds, optional
+// task_id / heartbeat), so the parser must forward them as a lightweight
+// live-only `tool_progress` server message — never as the generic
+// "Unhandled Claude Code message type" chat warning.
+
+const SESSION = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+function systemWarnings(messages: ReturnType<typeof claudeCodeProtocolParser.parseStdout>) {
+  return messages.filter((m) => m.serverMessage && (m.serverMessage as any).type === 'system');
+}
+
+test('tool_progress (bash tick) is forwarded as a live tool_progress message', () => {
+  const line = JSON.stringify({
+    type: 'tool_progress',
+    tool_use_id: 'toolu_0123456789abcdef',
+    tool_name: 'Bash',
+    parent_tool_use_id: null,
+    elapsed_time_seconds: 42,
+    task_id: 'bash-0gf3v8wf',
+    session_id: SESSION,
+    uuid: '00000000-0000-0000-0000-000000000002',
+  });
+
+  const result = claudeCodeProtocolParser.parseStdout(SESSION, line);
+
+  assert.equal(systemWarnings(result).length, 0, 'tool_progress must not warn to the chat');
+  assert.equal(result.length, 1);
+
+  const sm = result[0].serverMessage as any;
+  assert.equal(sm.type, 'tool_progress');
+  assert.equal(sm.sessionId, SESSION);
+  assert.equal(sm.toolUseId, 'toolu_0123456789abcdef');
+  assert.equal(sm.toolName, 'Bash');
+  assert.equal(sm.elapsedTimeSeconds, 42);
+  assert.equal(sm.taskId, 'bash-0gf3v8wf');
+  assert.equal(sm.heartbeat, undefined);
+  assert.equal(typeof sm.timestamp, 'string');
+});
+
+test('tool_progress (heartbeat) propagates the heartbeat flag', () => {
+  const line = JSON.stringify({
+    type: 'tool_progress',
+    tool_use_id: 'toolu_0123456789abcdef',
+    tool_name: 'Bash',
+    parent_tool_use_id: null,
+    elapsed_time_seconds: 31,
+    heartbeat: true,
+    session_id: SESSION,
+    uuid: '00000000-0000-0000-0000-000000000003',
+  });
+
+  const result = claudeCodeProtocolParser.parseStdout(SESSION, line);
+
+  assert.equal(result.length, 1);
+  const sm = result[0].serverMessage as any;
+  assert.equal(sm.type, 'tool_progress');
+  assert.equal(sm.heartbeat, true);
+  assert.equal(sm.taskId, undefined);
+});
+
+test('tool_progress without tool_use_id is dropped silently', () => {
+  const line = JSON.stringify({
+    type: 'tool_progress',
+    tool_name: 'Bash',
+    elapsed_time_seconds: 5,
+    session_id: SESSION,
+    uuid: '00000000-0000-0000-0000-000000000004',
+  });
+
+  const result = claudeCodeProtocolParser.parseStdout(SESSION, line);
+
+  assert.equal(result.length, 0);
+  assert.equal(systemWarnings(result).length, 0);
+});


### PR DESCRIPTION
## What changed

- Parser: new `tool_progress` case that forwards a live-only `tool_progress` server message (`toolUseId`, `toolName`, `elapsedTimeSeconds`, `heartbeat`, `taskId`). Frames without a `tool_use_id` are dropped silently.
- Transport: new `AppServerMessage` variant, deliberately not replay-transported and not persisted to session history — 30s heartbeats would bloat it.
- Client: `chatStore.updateToolCallProgress` patches the running tool card; the compact row and the detail-panel header now show the elapsed time reported by the CLI.
- Regression test covering a bash output tick, a heartbeat, and the drop-silent case.

## Root cause

Newer Claude Code CLIs emit top-level `tool_progress` stdout messages — bash/powershell output ticks and 30s heartbeats for long-running tools. They fell through the protocol parser's default branch and flooded the transcript with `Unhandled Claude Code message type` warnings.

## User impact

- No more warning spam in the transcript when a Claude Code tool runs for a while.
- The running tool card shows live elapsed time reported by the CLI instead of staying static.

## Validation

- `npx tsx --test tests/claude-code-tool-progress.test.ts` (3 tests, red before / green after)
- `npx tsc --noEmit --pretty false`
- ESLint on all changed files
- `NODE_ENV=production npm run build`
- Real Claude Code session on Linux: long-running bash calls render elapsed time on the tool card; transcript stays free of `Unhandled Claude Code message type` warnings
- Not tested on Windows/macOS, but the change is platform-agnostic (stdout JSON parsing only)
