### PR TITLE
Verify npm package rendering before publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,12 +42,14 @@ jobs:
         env:
           NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN }}
 
-      - name: Verify package installs and boots
+      - name: Verify package installs and renders
         if: ${{ github.event.inputs.dist_tag_version == '' }}
         env:
           SMOKE_PORT: '32123'
         run: |
           set -euo pipefail
+
+          npx playwright install --with-deps chromium
 
           # Pack the real tarball — prepack already ran in the Build step.
           tarball="$(npm pack --ignore-scripts | tail -1)"
@@ -76,15 +78,16 @@ jobs:
               cat "$RUNNER_TEMP/server.log"
               exit 1
             fi
-            # An auth redirect is fine, but a rendered 5xx response is not.
+            # Wait until the server accepts HTTP requests, then use a real
+            # browser so redirects, Next.js loading, and React runtime errors
+            # are all exercised before publication.
             status="$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$SMOKE_PORT/" || true)"
             if [ -n "$status" ] && [ "$status" != "000" ]; then
-              if [ "$status" -ge 500 ]; then
-                echo "::error::tessera responded with HTTP $status"
+              if ! node scripts/verify-npm-render.mjs "http://127.0.0.1:$SMOKE_PORT/"; then
+                echo "::error::installed Tessera package did not render successfully"
                 cat "$RUNNER_TEMP/server.log"
                 exit 1
               fi
-              echo "Server responded with HTTP $status"
               exit 0
             fi
             sleep 1

--- a/scripts/verify-npm-render.mjs
+++ b/scripts/verify-npm-render.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { chromium } from '@playwright/test';
+
+const targetUrl = process.argv[2];
+
+if (!targetUrl) {
+  throw new Error('Usage: node scripts/verify-npm-render.mjs <url>');
+}
+
+const browser = await chromium.launch({ headless: true });
+
+try {
+  const page = await browser.newPage();
+  const runtimeErrors = [];
+
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') runtimeErrors.push(message.text());
+  });
+
+  const response = await page.goto(targetUrl, {
+    waitUntil: 'load',
+    timeout: 120_000,
+  });
+
+  assert.ok(response, 'the browser did not receive a document response');
+  assert.equal(response.status(), 200, `rendered page returned HTTP ${response.status()}`);
+
+  await page.locator('body').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.waitForTimeout(1_000);
+
+  const rendered = await page.evaluate(() => ({
+    bodyTextLength: document.body.innerText.trim().length,
+    hasNextRuntime: Boolean(document.querySelector('script[src*="/_next/static/"]')),
+  }));
+
+  assert.ok(rendered.bodyTextLength > 0, 'rendered page body is empty');
+  assert.ok(rendered.hasNextRuntime, 'rendered page did not load the Next.js runtime');
+  assert.deepEqual(runtimeErrors, [], `browser runtime errors:\n${runtimeErrors.join('\n')}`);
+
+  console.log(
+    `Rendered ${page.url()} successfully (${rendered.bodyTextLength} visible characters)`,
+  );
+} finally {
+  await browser.close();
+}

--- a/scripts/verify-npm-render.mjs
+++ b/scripts/verify-npm-render.mjs
@@ -25,9 +25,11 @@ try {
 
   assert.ok(response, 'the browser did not receive a document response');
   assert.equal(response.status(), 200, `rendered page returned HTTP ${response.status()}`);
+  assert.equal(new URL(page.url()).pathname, '/setup', 'fresh install did not reach setup');
 
   await page.locator('body').waitFor({ state: 'visible', timeout: 30_000 });
-  await page.waitForTimeout(1_000);
+  const accountForm = page.getByTestId('setup-account-form');
+  await accountForm.waitFor({ state: 'visible', timeout: 30_000 });
 
   const rendered = await page.evaluate(() => ({
     bodyTextLength: document.body.innerText.trim().length,
@@ -36,6 +38,36 @@ try {
 
   assert.ok(rendered.bodyTextLength > 0, 'rendered page body is empty');
   assert.ok(rendered.hasNextRuntime, 'rendered page did not load the Next.js runtime');
+
+  const expectedAccount = {
+    username: 'npm-render-smoke',
+    password: 'not-created',
+  };
+  const expectedError = 'npm-render-smoke-hydrated';
+
+  await page.evaluate((errorDetail) => {
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = (input, init) => {
+      if (String(input).endsWith('/api/auth/setup') && init?.method === 'POST') {
+        window.__npmRenderSmokeRequest = init.body;
+        return Promise.resolve(new Response(
+          JSON.stringify({ detail: errorDetail }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        ));
+      }
+      return originalFetch(input, init);
+    };
+  }, expectedError);
+
+  await accountForm.locator('input[name="username"]').fill(expectedAccount.username);
+  await accountForm.locator('input[name="password"]').fill(expectedAccount.password);
+  await accountForm.locator('button[type="submit"]').click();
+  await page.getByRole('alert').filter({ hasText: expectedError }).waitFor();
+
+  const submittedAccount = await page.evaluate(
+    () => JSON.parse(window.__npmRenderSmokeRequest),
+  );
+  assert.deepEqual(submittedAccount, expectedAccount, 'hydrated form submitted wrong state');
   assert.deepEqual(runtimeErrors, [], `browser runtime errors:\n${runtimeErrors.join('\n')}`);
 
   console.log(

--- a/tests/linux-npm-package-contract.test.mjs
+++ b/tests/linux-npm-package-contract.test.mjs
@@ -9,6 +9,10 @@ const npmCliSource = fs.readFileSync(
   new URL('../bin/tessera.mjs', import.meta.url),
   'utf8',
 );
+const npmPublishWorkflowSource = fs.readFileSync(
+  new URL('../.github/workflows/npm-publish.yml', import.meta.url),
+  'utf8',
+);
 
 test('npm CLI package keeps Linux-friendly runtime dependencies and executable bin', () => {
   const binPath = new URL('../bin/tessera.mjs', import.meta.url);
@@ -37,4 +41,15 @@ test('npm CLI uses the requested port without scanning for a fallback', () => {
   assert.doesNotMatch(npmCliSource, /PORT_SCAN_LIMIT/);
   assert.doesNotMatch(npmCliSource, /findPort/);
   assert.doesNotMatch(npmCliSource, /isPortAvailable/);
+});
+
+test('npm publish smoke test renders the installed package in a real browser', () => {
+  assert.match(
+    npmPublishWorkflowSource,
+    /npx playwright install --with-deps chromium/,
+  );
+  assert.match(
+    npmPublishWorkflowSource,
+    /node scripts\/verify-npm-render\.mjs/,
+  );
 });

--- a/tests/linux-npm-package-contract.test.mjs
+++ b/tests/linux-npm-package-contract.test.mjs
@@ -13,6 +13,10 @@ const npmPublishWorkflowSource = fs.readFileSync(
   new URL('../.github/workflows/npm-publish.yml', import.meta.url),
   'utf8',
 );
+const npmRenderSmokeSource = fs.readFileSync(
+  new URL('../scripts/verify-npm-render.mjs', import.meta.url),
+  'utf8',
+);
 
 test('npm CLI package keeps Linux-friendly runtime dependencies and executable bin', () => {
   const binPath = new URL('../bin/tessera.mjs', import.meta.url);
@@ -52,4 +56,6 @@ test('npm publish smoke test renders the installed package in a real browser', (
     npmPublishWorkflowSource,
     /node scripts\/verify-npm-render\.mjs/,
   );
+  assert.match(npmRenderSmokeSource, /getByTestId\('setup-account-form'\)/);
+  assert.match(npmRenderSmokeSource, /hydrated form submitted wrong state/);
 });


### PR DESCRIPTION
## Summary

- install and launch the packed npm artifact during publication
- render the fresh-install setup page in Chromium
- verify Next.js loading and React hydration without mutating server data

## Validation

- npm run lint
- npm run test:non-e2e
- published package browser smoke: `/` → `/setup`, hydrated form interaction passed