### PR TITLE
Fix image lightbox Escape handling in PTY ChatView

### DIFF
--- a/src/components/chat/image-lightbox.tsx
+++ b/src/components/chat/image-lightbox.tsx
@@ -4,6 +4,7 @@ import { telemetryClickAttributes } from '@/lib/telemetry/ui-click';
 
 import { useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
+import { useCloseOnEscape } from '@/hooks/use-close-on-escape';
 import { useElectronPlatform } from '@/hooks/use-electron-platform';
 import { useI18n } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
@@ -25,16 +26,9 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
   const avoidsWindowControls = electronPlatform === 'win32';
   const resolvedAlt = alt || t('chat.imageOriginalView');
 
-  // ESC key to close
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
+  // The PTY chat view handles Escape during React's capture phase. Claim it at
+  // document capture first so closing the lightbox cannot also interrupt the PTY.
+  useCloseOnEscape(onClose, { capture: true });
 
   // Scroll lock
   useEffect(() => {

--- a/tests/image-lightbox-escape-contract.test.mjs
+++ b/tests/image-lightbox-escape-contract.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const read = (relativePath) => fs.readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+
+test('image lightbox claims Escape before the PTY chat view capture handler', () => {
+  const chatAreaSource = read('../src/components/chat/chat-area.tsx');
+  const imageLightboxSource = read('../src/components/chat/image-lightbox.tsx');
+  const closeOnEscapeSource = read('../src/hooks/use-close-on-escape.ts');
+
+  assert.match(chatAreaSource, /onKeyDownCapture=\{handleTerminalChatKeyDown\}/);
+  assert.match(
+    imageLightboxSource,
+    /useCloseOnEscape\(onClose, \{ capture: true \}\)/,
+  );
+  assert.match(closeOnEscapeSource, /event\.preventDefault\(\)/);
+  assert.match(closeOnEscapeSource, /event\.stopPropagation\(\)/);
+  assert.match(
+    closeOnEscapeSource,
+    /document\.addEventListener\('keydown', handleEscape, capture\)/,
+  );
+});


### PR DESCRIPTION
## What changed

- Reuse the shared capture-phase Escape hook in `ImageLightbox`.
- Stop Escape before PTY ChatView interprets it as a terminal interrupt.
- Add a regression contract covering the lightbox/ChatView event-order relationship.

## Root cause

The lightbox listened for Escape during document bubbling. PTY ChatView handles Escape from a React capture handler, so the chat action could run before the modal claimed the key.

## Impact

Pressing Escape while viewing a chat image now closes only the image modal and does not trigger the PTY chat Escape action.

## Validation

- `npm run test:contracts` — 399 passed
- Focused PTY/lightbox tests — 4 passed
- `npx eslint src/components/chat/image-lightbox.tsx tests/image-lightbox-escape-contract.test.mjs`
- `npx tsc --noEmit`
- Browser harness: modal count became 0 while parent Escape count remained 0
