### PR TITLE
Fix stale processing indicator after Codex Escape interrupt

### DIFF
--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -1550,15 +1550,23 @@ export class TerminalManager {
     const runtime = this.getOwnedTerminal(message.terminalId, userId);
     if (!runtime || runtime.sessionId !== message.sessionId || runtime.ended) return false;
     message.interruptInputPolicy = runtime.interruptInputPolicy;
-    this.clearInterruptInference(runtime);
+    // Codex can emit the interrupted tool's PostToolUse before the Escape
+    // settle timer fires. Keep that timer alive; otherwise the stale running
+    // hook cancels the only idle signal and leaves the UI spinning forever.
     if (
-      runtime.interruptInferredAt
-      && message.status === 'running'
+      message.status === 'running'
       && message.hookEvent !== 'UserPromptSubmit'
-      && Date.now() - runtime.interruptInferredAt <= INTERRUPTED_LATE_RUNNING_SUPPRESSION_MS
+      && (
+        runtime.interruptInferenceTimer !== undefined
+        || (
+          runtime.interruptInferredAt !== undefined
+          && Date.now() - runtime.interruptInferredAt <= INTERRUPTED_LATE_RUNNING_SUPPRESSION_MS
+        )
+      )
     ) {
       return false;
     }
+    this.clearInterruptInference(runtime);
     runtime.interruptInferredAt = undefined;
     runtime.lastSessionState = message;
     runtime.runtimeStateAt = message.stateAt ?? Date.now();

--- a/tests/terminal-manager-lifecycle.test.ts
+++ b/tests/terminal-manager-lifecycle.test.ts
@@ -904,6 +904,48 @@ test('a provider-declared single Escape settles a running turn when the stop hoo
   )), [['idle', 'InterruptFallback']]);
 });
 
+test('PTY Escape fallback ignores tool activity that arrives before the settle timer', async () => {
+  const spawned: FakePty[] = [];
+  const inferredStates: ServerTransportMessage[] = [];
+  const manager = new TerminalManager(
+    () => {},
+    async () => createFactory(spawned),
+    undefined,
+    {
+      interruptSettleMs: 10,
+      onSessionStateChange: ({ message }) => inferredStates.push(message),
+    },
+  );
+
+  await manager.create(createOptions({ interruptInputPolicy: 'single-escape' }));
+  manager.recordSessionState({
+    type: 'session_state',
+    sessionId: 'session-a',
+    terminalId: 'terminal-a',
+    status: 'running',
+    hookEvent: 'PreToolUse',
+  }, 'user-a');
+
+  manager.write('terminal-a', 'user-a', 'connection-a', 'surface-a', '\x1b');
+  const acceptedInterruptedTool = manager.recordSessionState({
+    type: 'session_state',
+    sessionId: 'session-a',
+    terminalId: 'terminal-a',
+    status: 'running',
+    hookEvent: 'PostToolUse',
+  }, 'user-a');
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  assert.equal(acceptedInterruptedTool, false);
+  assert.equal(
+    manager.getSessionStateForSession('session-a', 'user-a')?.status,
+    'idle',
+  );
+  assert.deepEqual(inferredStates.map((state) => (
+    state.type === 'session_state' ? [state.status, state.hookEvent] : [state.type]
+  )), [['idle', 'InterruptFallback']]);
+});
+
 test('a terminal without the single-Escape policy does not infer an interrupt', async () => {
   const spawned: FakePty[] = [];
   const inferredStates: ServerTransportMessage[] = [];


### PR DESCRIPTION
## What changed

- Keep the pending single-Escape interrupt fallback alive when an interrupted Codex tool emits a stale `PostToolUse` running hook.
- Reject that stale running state until the fallback settles the turn to `idle`.
- Add a deterministic regression test for `PreToolUse → Escape → PostToolUse before settle timer → InterruptFallback idle`.

## Root cause

`recordSessionState` cleared the Escape inference timer before checking whether a running hook was stale. When Codex emitted `PostToolUse` shortly after printing `Conversation interrupted`, that hook canceled the only remaining idle signal and left the UI processing indicator spinning indefinitely.

## User impact

After interrupting a Codex PTY turn with Escape, the sidebar, active tab, and chat header now leave the processing state and agree with the terminal log/runtime state.

## Validation

- `npm run test:non-e2e` — unit suite: 1,745 tests, 1,743 passed, 2 skipped; contract suite: 398 passed
- `npm run lint` — 0 errors (3 existing warnings)
- `tsc -p tsconfig.server.json --noEmit`
- Packaged Windows Electron server + WSL Codex PTY smoke test: `InterruptFallback idle` arrived 507 ms after Escape; processing spinners were absent from both sidebar representations, the active tab, and chat header
- `graphify update .`
- Independent standards and spec reviews: no findings
