### PR TITLE
Improve commit file selection

### DIFF
--- a/src/components/git/git-commit-selection.ts
+++ b/src/components/git/git-commit-selection.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+export interface CommitSelectionRange {
+  anchorPath: string;
+  paths: readonly string[];
+}
+
+export interface CommitSelectionAnchor {
+  path: string;
+  targetKey: string | null;
+}
+
+export function resolveCommitSelectionAnchorPath(
+  anchor: CommitSelectionAnchor | null,
+  targetKey: string | null,
+  visiblePaths: readonly string[],
+): string | null {
+  if (anchor?.targetKey !== targetKey) return null;
+  return visiblePaths.includes(anchor.path) ? anchor.path : null;
+}
+
+/**
+ * Resolve the paths affected by a commit checkbox interaction.
+ *
+ * A regular click establishes the range anchor. Shift-click keeps that anchor
+ * and applies the clicked checkbox's next state to every visible file between
+ * the two. If polling removed the anchor, the interaction safely falls back to
+ * the clicked file and starts a new range.
+ */
+export function resolveCommitSelectionRange(
+  visiblePaths: readonly string[],
+  anchorPath: string | null,
+  currentPath: string,
+  extendRange: boolean,
+): CommitSelectionRange {
+  if (!extendRange) {
+    return { anchorPath: currentPath, paths: [currentPath] };
+  }
+
+  if (anchorPath === null) {
+    return { anchorPath: currentPath, paths: [currentPath] };
+  }
+
+  const anchorIndex = visiblePaths.indexOf(anchorPath);
+  const currentIndex = visiblePaths.indexOf(currentPath);
+  if (anchorIndex === -1 || currentIndex === -1) {
+    return { anchorPath: currentPath, paths: [currentPath] };
+  }
+
+  const start = Math.min(anchorIndex, currentIndex);
+  const end = Math.max(anchorIndex, currentIndex);
+  return {
+    anchorPath,
+    paths: visiblePaths.slice(start, end + 1),
+  };
+}
+
+export function eventExtendsCommitSelection(event: Event): boolean {
+  return "shiftKey" in event && event.shiftKey === true;
+}
+
+export function useCommitFileSelection({
+  allSelected,
+  files,
+  onSetSelected,
+  someSelected,
+  targetKey,
+}: {
+  allSelected: boolean;
+  files: readonly { path: string }[] | undefined;
+  onSetSelected: (paths: readonly string[], selected: boolean) => void;
+  someSelected: boolean;
+  targetKey: string | null;
+}) {
+  const anchorRef = useRef<CommitSelectionAnchor | null>(null);
+  const visiblePaths = useMemo(
+    () => files?.map((file) => file.path) ?? [],
+    [files],
+  );
+  const mixed = someSelected && !allSelected;
+
+  useEffect(() => {
+    anchorRef.current = null;
+  }, [targetKey]);
+
+  useEffect(() => {
+    if (resolveCommitSelectionAnchorPath(anchorRef.current, targetKey, visiblePaths) === null) {
+      anchorRef.current = null;
+    }
+  }, [targetKey, visiblePaths]);
+
+  // `indeterminate` is a DOM property, not an HTML attribute. A callback ref
+  // applies it both on updates and when a conditional surface first mounts.
+  const selectAllCheckboxRef = useCallback((node: HTMLInputElement | null) => {
+    if (node) node.indeterminate = mixed;
+  }, [mixed]);
+
+  const setFileSelected = useCallback((
+    path: string,
+    selected: boolean,
+    nativeEvent: Event,
+  ) => {
+    const anchorPath = resolveCommitSelectionAnchorPath(
+      anchorRef.current,
+      targetKey,
+      visiblePaths,
+    );
+    const range = resolveCommitSelectionRange(
+      visiblePaths,
+      anchorPath,
+      path,
+      eventExtendsCommitSelection(nativeEvent),
+    );
+    anchorRef.current = { path: range.anchorPath, targetKey };
+    onSetSelected(range.paths, selected);
+  }, [onSetSelected, targetKey, visiblePaths]);
+
+  return { selectAllCheckboxRef, setFileSelected };
+}

--- a/src/components/git/git-desktop-commit-control.tsx
+++ b/src/components/git/git-desktop-commit-control.tsx
@@ -33,6 +33,9 @@ import {
   resolvePendingLabelKey,
 } from "./git-primary-action";
 import {
+  useCommitFileSelection,
+} from "./git-commit-selection";
+import {
   useSharedGitPanelController,
   type GitPanelController,
 } from "./git-panel-controller-context";
@@ -216,6 +219,14 @@ function GitDesktopCommitControlView({
   const allCommitFilesSelected = data !== null
     && data.changedFiles.length > 0
     && controller.commitTotals.files === data.changedFiles.length;
+  const someCommitFilesSelected = controller.commitTotals.files > 0;
+  const { selectAllCheckboxRef, setFileSelected } = useCommitFileSelection({
+    allSelected: allCommitFilesSelected,
+    files: data?.changedFiles,
+    onSetSelected: controller.setCommitFilesSelected,
+    someSelected: someCommitFilesSelected,
+    targetKey: controller.commitSelectionKey,
+  });
   const actionLabelKey = controller.pendingVerb
     ? resolvePendingLabelKey(controller.primaryAction, controller.pendingVerb)
     : controller.primaryAction.labelKey;
@@ -377,20 +388,24 @@ function GitDesktopCommitControlView({
               >
                 <div className="max-h-40 overflow-y-auto rounded-md border border-(--divider) bg-(--sidebar-bg)">
                   <div className="flex items-center justify-between gap-2 border-b border-(--divider) px-2 py-1">
-                    <p className="text-[10px] font-medium uppercase tracking-[0.14em] text-(--text-muted)">
-                      {t("gitPanel.commit.changedFiles")}
-                    </p>
-                    <button
-                      {...telemetryClickAttributes('git.commit_file.toggle_all', 'git_panel')}
-                      type="button"
-                      disabled={pending}
-                      onClick={() => controller.setAllCommitFilesSelected(!allCommitFilesSelected)}
-                      className="rounded px-1 py-0.5 text-[10px] font-medium text-(--text-secondary) transition-colors hover:bg-(--sidebar-hover) hover:text-(--text-primary) disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {t(allCommitFilesSelected
-                        ? "gitPanel.commit.deselectAll"
-                        : "gitPanel.commit.selectAll")}
-                    </button>
+                    <label className="flex min-w-0 items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-(--text-muted)">
+                      <input
+                        ref={selectAllCheckboxRef}
+                        {...telemetryClickAttributes('git.commit_file.toggle_all', 'git_panel')}
+                        type="checkbox"
+                        checked={allCommitFilesSelected}
+                        disabled={pending}
+                        onChange={() => controller.setAllCommitFilesSelected(!allCommitFilesSelected)}
+                        aria-label={t(allCommitFilesSelected
+                          ? "gitPanel.commit.deselectAll"
+                          : "gitPanel.commit.selectAll")}
+                        className="h-3.5 w-3.5 shrink-0 cursor-pointer accent-(--accent) disabled:cursor-not-allowed disabled:opacity-50"
+                      />
+                      <span className="truncate">{t("gitPanel.commit.changedFiles")}</span>
+                    </label>
+                    <span className="shrink-0 font-mono text-[10px] text-(--text-muted) tabular-nums">
+                      {controller.commitTotals.files}/{data?.changedFiles.length ?? 0}
+                    </span>
                   </div>
                   {(data?.changedFiles ?? []).map((file) => (
                     <label
@@ -402,7 +417,13 @@ function GitDesktopCommitControlView({
                         type="checkbox"
                         checked={controller.isSelectedForCommit(file.path)}
                         disabled={controller.pendingVerb !== null}
-                        onChange={() => controller.toggleCommitFile(file.path)}
+                        onChange={(event) => {
+                          setFileSelected(
+                            file.path,
+                            event.currentTarget.checked,
+                            event.nativeEvent,
+                          );
+                        }}
                         aria-label={t("gitPanel.commit.includeFile", { path: file.path })}
                         data-testid={`desktop-commit-file-checkbox-${file.path}`}
                         className="h-3.5 w-3.5 shrink-0 accent-(--accent)"

--- a/src/components/git/git-panel-sections.tsx
+++ b/src/components/git/git-panel-sections.tsx
@@ -49,6 +49,9 @@ import {
 import {
   FILE_STATE_META,
 } from "./git-panel-shared";
+import {
+  useCommitFileSelection,
+} from "./git-commit-selection";
 
 function formatShortCount(value: number): string {
   if (value < 1000) return String(value);
@@ -654,7 +657,8 @@ export function GitPanelContentSection({
     onGenerate: () => void;
     onMessageChange: (value: string) => void;
     onSetAllSelected: (selected: boolean) => void;
-    onToggleFile: (path: string) => void;
+    onSetSelected: (paths: readonly string[], selected: boolean) => void;
+    selectionKey: string | null;
     totals: { files: number; added: number; removed: number };
   };
   conflictHandoff: {
@@ -744,6 +748,14 @@ export function GitPanelContentSection({
   const hasTarget = targetSelected ?? Boolean(sessionId);
   const allCommitFilesSelected = changedFileCount > 0
     && commit.totals.files === changedFileCount;
+  const someCommitFilesSelected = commit.totals.files > 0;
+  const { selectAllCheckboxRef, setFileSelected } = useCommitFileSelection({
+    allSelected: allCommitFilesSelected,
+    files: data?.changedFiles,
+    onSetSelected: commit.onSetSelected,
+    someSelected: someCommitFilesSelected,
+    targetKey: commit.selectionKey,
+  });
 
   const contentBody = (
     <>
@@ -793,26 +805,25 @@ export function GitPanelContentSection({
             ) : (
               <>
                 <div className="flex items-center justify-between gap-2 px-1">
-                  <span className="text-[10px] uppercase tracking-[0.18em] text-(--text-muted)">
-                    {t("gitPanel.commit.changedFiles")}
-                  </span>
-                  <span className="flex shrink-0 items-center gap-2">
-                    <button
-                      type="button"
+                  <label className="flex min-w-0 items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-(--text-muted)">
+                    <input
+                      ref={selectAllCheckboxRef}
+                      type="checkbox"
                       disabled={primary.pendingVerb !== null}
-                      onClick={() => commit.onSetAllSelected(!allCommitFilesSelected)}
+                      checked={allCommitFilesSelected}
+                      onChange={() => commit.onSetAllSelected(!allCommitFilesSelected)}
                       {...telemetryClickAttributes("git.commit_file.toggle_all", "git_panel")}
-                      className="rounded px-1 py-0.5 text-[10px] font-medium text-(--text-secondary) transition-colors hover:bg-(--sidebar-hover) hover:text-(--text-primary) disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {t(allCommitFilesSelected
+                      aria-label={t(allCommitFilesSelected
                         ? "gitPanel.commit.deselectAll"
                         : "gitPanel.commit.selectAll")}
-                    </button>
-                    <span className="font-mono text-[11px] text-(--text-muted) tabular-nums">
-                      {data.changedFilesTruncated
-                        ? (data.changedFilesTotal ?? `${changedFileCount}+`)
-                        : changedFileCount}
-                    </span>
+                      className="h-3.5 w-3.5 shrink-0 cursor-pointer accent-(--accent) disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                    <span className="truncate">{t("gitPanel.commit.changedFiles")}</span>
+                  </label>
+                  <span className="shrink-0 font-mono text-[11px] text-(--text-muted) tabular-nums">
+                    {commit.totals.files}/{data.changedFilesTruncated
+                      ? (data.changedFilesTotal ?? `${changedFileCount}+`)
+                      : changedFileCount}
                   </span>
                 </div>
                 <ScrollArea className={cn(phoneScrollableContent ? "overflow-y-visible" : "flex-1")}>
@@ -857,7 +868,13 @@ export function GitPanelContentSection({
                               // locks with the rest of the form (§7) rather
                               // than only while a commit is what is running.
                               disabled={primary.pendingVerb !== null}
-                              onChange={() => commit.onToggleFile(file.path)}
+                              onChange={(event) => {
+                                setFileSelected(
+                                  file.path,
+                                  event.currentTarget.checked,
+                                  event.nativeEvent,
+                                );
+                              }}
                               {...telemetryClickAttributes("git.commit_file.toggle", "git_panel")}
                               aria-label={t("gitPanel.commit.includeFile", {
                                 path: file.path,

--- a/src/components/git/git-panel.tsx
+++ b/src/components/git/git-panel.tsx
@@ -388,7 +388,8 @@ export function GitPanel({
               onGenerate: () => void controller.generateCommitMessage(),
               onMessageChange: controller.setCommitMessage,
               onSetAllSelected: controller.setAllCommitFilesSelected,
-              onToggleFile: controller.toggleCommitFile,
+              onSetSelected: controller.setCommitFilesSelected,
+              selectionKey: controller.commitSelectionKey,
               totals: controller.commitTotals,
             }}
             primary={{

--- a/src/components/git/use-git-panel-controller.ts
+++ b/src/components/git/use-git-panel-controller.ts
@@ -179,9 +179,6 @@ export function useGitPanelController(
   const setWorktreeCommitMessage = useGitPanelStore(
     (state) => state.setCommitMessage,
   );
-  const toggleWorktreeCommitFile = useGitPanelStore(
-    (state) => state.toggleCommitFile,
-  );
   const setWorktreeCommitFilesSelected = useGitPanelStore(
     (state) => state.setCommitFilesSelected,
   );
@@ -617,10 +614,13 @@ export function useGitPanelController(
     [deselectedPaths],
   );
 
-  const toggleCommitFile = useCallback((path: string) => {
+  const setCommitFilesSelected = useCallback((
+    paths: readonly string[],
+    selected: boolean,
+  ) => {
     if (!worktreeKey) return;
-    toggleWorktreeCommitFile(worktreeKey, path);
-  }, [toggleWorktreeCommitFile, worktreeKey]);
+    setWorktreeCommitFilesSelected(worktreeKey, paths, selected);
+  }, [setWorktreeCommitFilesSelected, worktreeKey]);
 
   const setAllCommitFilesSelected = useCallback((selected: boolean) => {
     if (!worktreeKey) return;
@@ -1280,6 +1280,7 @@ export function useGitPanelController(
   return {
     hasActiveSession: Boolean(target),
     changedFileCount,
+    commitSelectionKey: worktreeKey,
     commitMessage,
     commitTotals,
     /**
@@ -1327,9 +1328,9 @@ export function useGitPanelController(
     selectedFileIndex,
     selectedPath,
     setAllCommitFilesSelected,
+    setCommitFilesSelected,
     setCommitMessage: changeCommitMessage,
     setSelectedPath,
-    toggleCommitFile,
   };
 }
 

--- a/src/stores/git-panel-store.ts
+++ b/src/stores/git-panel-store.ts
@@ -31,7 +31,6 @@ interface GitPanelStoreState {
   applyGitPanelData: (sessionId: string, data: GitPanelData) => void;
 
   setCommitMessage: (worktreeKey: string, message: string) => void;
-  toggleCommitFile: (worktreeKey: string, path: string) => void;
   setCommitFilesSelected: (
     worktreeKey: string,
     paths: readonly string[],
@@ -151,21 +150,6 @@ export const useGitPanelStore = create<GitPanelStoreState>((set) => ({
         },
       },
     }));
-  },
-
-  toggleCommitFile: (worktreeKey, path) => {
-    set((state) => {
-      const current = state.deliveryByWorktree[worktreeKey] ?? emptyDeliveryState();
-      const deselectedPaths = new Set(current.deselectedPaths);
-      if (deselectedPaths.has(path)) deselectedPaths.delete(path);
-      else deselectedPaths.add(path);
-      return {
-        deliveryByWorktree: {
-          ...state.deliveryByWorktree,
-          [worktreeKey]: { ...current, deselectedPaths },
-        },
-      };
-    });
   },
 
   setCommitFilesSelected: (worktreeKey, paths, selected) => {

--- a/tests/git-commit-selection.test.ts
+++ b/tests/git-commit-selection.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  resolveCommitSelectionAnchorPath,
+  resolveCommitSelectionRange,
+} from '../src/components/git/git-commit-selection';
+
+const paths = ['a.ts', 'b.ts', 'c.ts', 'd.ts'];
+
+test('a regular commit checkbox interaction selects only its file and sets the anchor', () => {
+  assert.deepEqual(
+    resolveCommitSelectionRange(paths, 'a.ts', 'c.ts', false),
+    { anchorPath: 'c.ts', paths: ['c.ts'] },
+  );
+});
+
+test('Shift commit checkbox interaction selects the inclusive visible range', () => {
+  assert.deepEqual(
+    resolveCommitSelectionRange(paths, 'b.ts', 'd.ts', true),
+    { anchorPath: 'b.ts', paths: ['b.ts', 'c.ts', 'd.ts'] },
+  );
+  assert.deepEqual(
+    resolveCommitSelectionRange(paths, 'd.ts', 'b.ts', true),
+    { anchorPath: 'd.ts', paths: ['b.ts', 'c.ts', 'd.ts'] },
+  );
+});
+
+test('Shift commit checkbox interaction replaces a missing polling anchor', () => {
+  assert.deepEqual(
+    resolveCommitSelectionRange(paths, 'removed.ts', 'c.ts', true),
+    { anchorPath: 'c.ts', paths: ['c.ts'] },
+  );
+});
+
+test('a commit selection anchor never crosses its canonical worktree target', () => {
+  const anchor = { path: 'b.ts', targetKey: '/repo-a' };
+
+  assert.equal(
+    resolveCommitSelectionAnchorPath(anchor, '/repo-a', paths),
+    'b.ts',
+  );
+  assert.equal(
+    resolveCommitSelectionAnchorPath(anchor, '/repo-b', paths),
+    null,
+  );
+  assert.equal(
+    resolveCommitSelectionAnchorPath(anchor, '/repo-a', ['a.ts', 'c.ts']),
+    null,
+  );
+});


### PR DESCRIPTION
## Summary

- replace the changed-file `Select all` action with a tri-state checkbox and selected/total count
- add Shift-click range selection shared by the side panel and compact desktop composer
- scope selection anchors to the canonical worktree and remove the obsolete single-file toggle API

## Why

Large agent-generated change sets required checking files one at a time. This brings the flow closer to standard Git clients while preserving Tessera's default-all selection model.

## Validation

- `npx eslint src/components/git/git-commit-selection.ts src/components/git/git-desktop-commit-control.tsx src/components/git/git-panel-sections.tsx src/components/git/git-panel.tsx src/components/git/use-git-panel-controller.ts src/stores/git-panel-store.ts tests/git-commit-selection.test.ts`
- `npx tsc --noEmit`
- `npm run test:unit` (1,767 passed, 2 skipped)
- authenticated isolated-browser QA covering all/none, Shift range, mixed tri-state, and compact composer mounting
