### PR TITLE
fix(workspace): remove file explorer delays

### DIFF
--- a/src/components/workspace/workspace-file-panel-refresh.ts
+++ b/src/components/workspace/workspace-file-panel-refresh.ts
@@ -1,0 +1,27 @@
+interface ReselectedWorktreeReloadInput {
+  currentTargetKey: string | null;
+  isWorktreeTarget: boolean;
+  peekChanged: boolean;
+  peekWorktreeId: string | null;
+  previousTargetKey: string | null;
+  targetId: string | null;
+}
+
+/**
+ * The file-list hook owns initial loads and target changes. This extra reload
+ * exists only for reselecting the Worktree already shown in Peek, because a
+ * Worktree panel has no Session watcher to refresh it while it is hidden.
+ */
+export function shouldReloadReselectedWorktree({
+  currentTargetKey,
+  isWorktreeTarget,
+  peekChanged,
+  peekWorktreeId,
+  previousTargetKey,
+  targetId,
+}: ReselectedWorktreeReloadInput): boolean {
+  return isWorktreeTarget
+    && currentTargetKey === previousTargetKey
+    && peekChanged
+    && peekWorktreeId === targetId;
+}

--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -50,12 +50,10 @@ import {
 import { WorkspaceInlineInputRow } from "@/components/workspace/workspace-inline-input-row";
 import { useWorkspaceInlineInput } from "@/components/workspace/use-workspace-inline-input";
 import {
-  DIR_TOGGLE_DOUBLE_CLICK_MS,
-  isRenameHotspotTarget,
-  RENAME_HOTSPOT_ATTR,
-  resolveDirToggleTiming,
   shouldOpenOnRowClick,
+  shouldToggleDirectoryOnClick,
 } from "@/components/workspace/workspace-inline-input-state";
+import { shouldReloadReselectedWorktree } from "@/components/workspace/workspace-file-panel-refresh";
 import {
   createWorkspaceDirectoryRequest,
   createWorkspaceFileRequest,
@@ -223,6 +221,8 @@ export function WorkspaceFilePanel({
   const canMutate = target !== null;
   const isDocumentVisible = useDocumentVisibility();
   const peekTarget = useWorkspacePeekStore((state) => state.target);
+  const previousPeekTargetRef = useRef(peekTarget);
+  const previousFileListTargetKeyRef = useRef(targetKey);
   const subscriberId = useStableWorkspaceFilesSubscriberId("workspace-file-panel");
   const [query, setQuery] = useState("");
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -255,15 +255,21 @@ export function WorkspaceFilePanel({
   // carrying a tree snapshot from before a file-tab mutation. Subscribe to the
   // target object, not just its ID: clicking the already-selected Worktree is
   // still a new open event and must refresh this panel.
-  useEffect(() => {
-    if (target?.kind !== 'worktree' || peekTarget?.worktreeId !== target.id) return;
+  useEffect(function reloadReselectedWorktree() {
+    const previousTargetKey = previousFileListTargetKeyRef.current;
+    const peekChanged = previousPeekTargetRef.current !== peekTarget;
+    previousFileListTargetKeyRef.current = targetKey;
+    previousPeekTargetRef.current = peekTarget;
+    if (!shouldReloadReselectedWorktree({
+      currentTargetKey: targetKey,
+      isWorktreeTarget: target?.kind === 'worktree',
+      peekChanged,
+      peekWorktreeId: peekTarget?.worktreeId ?? null,
+      previousTargetKey,
+      targetId: target?.id ?? null,
+    })) return;
     void loadFiles({ silent: true });
-  }, [loadFiles, peekTarget, target]);
-
-  const deferredToggleRef = useRef<number | null>(null);
-  useEffect(() => () => {
-    if (deferredToggleRef.current !== null) window.clearTimeout(deferredToggleRef.current);
-  }, []);
+  }, [loadFiles, peekTarget, target?.id, target?.kind, targetKey]);
 
   const expandPath = useCallback((path: string) => {
     if (!path) return;
@@ -479,42 +485,18 @@ export function WorkspaceFilePanel({
     });
   }
 
-  function clearDeferredToggle() {
-    if (deferredToggleRef.current === null) return;
-    window.clearTimeout(deferredToggleRef.current);
-    deferredToggleRef.current = null;
-  }
-
   /**
-   * A click on the folder's name may be the first half of a double-click that
-   * means rename, and toggling on both halves collapses and re-expands the row
-   * under the input. Clicks on the name wait the double-click window out.
-   */
+   * Toggle on the first click with no double-click delay. Chromium marks the
+   * second click with detail > 1, so it is dropped instead of toggling back.
+  */
   function handleDirectoryClick(event: MouseEvent, path: string) {
-    const timing = resolveDirToggleTiming({
-      clickCount: event.detail,
-      fromRenameHotspot: isRenameHotspotTarget(event.target),
-    });
-    clearDeferredToggle();
-    if (timing === "skip") return;
-    if (timing === "immediate") {
-      toggleDirectory(path);
-      return;
-    }
-    deferredToggleRef.current = window.setTimeout(() => {
-      deferredToggleRef.current = null;
-      toggleDirectory(path);
-    }, DIR_TOGGLE_DOUBLE_CLICK_MS);
+    if (!shouldToggleDirectoryOnClick(event.detail)) return;
+    toggleDirectory(path);
   }
 
-  /**
-   * Named apart from the hook's `startRename` because it does more: the first
-   * click of the gesture armed a deferred toggle, and it must not fire under
-   * the input that is about to open.
-   */
+  /** Named apart from the hook's `startRename` to keep row event handling local. */
   function beginRename(node: WorkspaceTreeNode) {
     if (!canMutate) return;
-    clearDeferredToggle();
     inlineInput.startRename({
       isDirectory: node.type === "directory",
       name: node.name,
@@ -577,14 +559,8 @@ export function WorkspaceFilePanel({
     return node.path.split("/").slice(0, -1).join("/");
   }
 
-  /**
-   * Like `beginRename`, this disarms a toggle left over from a click on a
-   * folder's name: it would fire under the placeholder and collapse the folder
-   * the row is sitting in, taking the half-typed name with it.
-   */
   function beginNewEntry(kind: "file" | "folder", parentPath: string) {
     if (!canMutate) return;
-    clearDeferredToggle();
     inlineInput.startNew(kind, parentPath);
   }
 
@@ -667,10 +643,7 @@ export function WorkspaceFilePanel({
             />
             <FolderIcon className="h-3.5 w-3.5 shrink-0 text-(--text-muted) group-hover:text-(--text-primary)" />
             <span
-              // The double-click-to-rename target is the name text alone, so the
-              // disclosure stays reachable on the chevron, the icon and the
-              // empty part of the row.
-              {...{ [RENAME_HOTSPOT_ATTR]: "" }}
+              // The double-click-to-rename target is the name text alone.
               onDoubleClick={(event) => {
                 if (!canMutate) return;
                 event.stopPropagation();
@@ -756,7 +729,6 @@ export function WorkspaceFilePanel({
           <span
             // Renaming is scoped to the name text, so the icon and the rest of
             // the row keep opening the file the way they always have.
-            {...{ [RENAME_HOTSPOT_ATTR]: "" }}
             onDoubleClick={(event) => {
               if (!canMutate) return;
               event.stopPropagation();

--- a/src/components/workspace/workspace-inline-input-state.ts
+++ b/src/components/workspace/workspace-inline-input-state.ts
@@ -17,45 +17,13 @@ export type WorkspaceInlineSubmitIntent =
   /** Nothing to ask the server for: close the input and touch no network. */
   | { kind: "cancel" };
 
-/** Marks the row's name text, which doubles as the double-click-to-rename hotspot. */
-export const RENAME_HOTSPOT_ATTR = "data-workspace-row-name";
-
 /**
- * Duck-typed on `closest` rather than `instanceof Element`: this module carries
- * the rules, and the rules are the same whether a real DOM is present or not.
+ * The first click toggles immediately. Chromium reports the second click of a
+ * double-click with detail > 1; dropping that duplicate prevents a folder from
+ * toggling straight back before the rename handler runs.
  */
-export function isRenameHotspotTarget(target: unknown): boolean {
-  const candidate = target as { closest?: (selector: string) => unknown } | null;
-  if (!candidate || typeof candidate.closest !== "function") return false;
-  return candidate.closest(`[${RENAME_HOTSPOT_ATTR}]`) != null;
-}
-
-/** Whether the folder's disclosure should run now, wait, or step aside. */
-export type WorkspaceDirToggleTiming = "immediate" | "deferred" | "skip";
-
-/**
- * Chromium's own double-click window, so a deferred toggle cannot fire before
- * the second click of a slow double-click arrives and turns the gesture into a
- * rename.
- */
-export const DIR_TOGGLE_DOUBLE_CLICK_MS = 500;
-
-/**
- * A double-click on a folder's name means rename, but each of its two clicks
- * also reaches the row and toggles the disclosure, so the folder collapses and
- * re-expands before the input appears. A click that starts on the name waits
- * out the double-click window; the second click drops the toggle and lets the
- * rename take over. Ported from Orca's `resolveDirToggleTiming`.
- */
-export function resolveDirToggleTiming({
-  clickCount,
-  fromRenameHotspot,
-}: {
-  clickCount: number;
-  fromRenameHotspot: boolean;
-}): WorkspaceDirToggleTiming {
-  if (!fromRenameHotspot) return "immediate";
-  return clickCount > 1 ? "skip" : "deferred";
+export function shouldToggleDirectoryOnClick(clickCount: number): boolean {
+  return clickCount <= 1;
 }
 
 /**

--- a/tests/workspace-file-editing-contract.test.mjs
+++ b/tests/workspace-file-editing-contract.test.mjs
@@ -175,7 +175,8 @@ test('creating a file posts and opens what it created', () => {
   assert.match(fileListHookSource, /MUTATION_LIST_ATTEMPTS = 5/);
   assert.match(filePanelSource, /mutation: \{ kind: "file", path: created\.path, type: "create" \}/);
   assert.match(filePanelSource, /useWorkspacePeekStore\(\(state\) => state\.target\)/);
-  assert.match(filePanelSource, /peekTarget\?\.worktreeId !== target\.id/);
+  assert.match(filePanelSource, /shouldReloadReselectedWorktree\(\{/);
+  assert.match(filePanelSource, /previousFileListTargetKeyRef\.current = targetKey/);
   assert.match(
     filePanelSource,
     /openWorkspaceTargetFileTab\(target, "file", created\.path, \{[\s\S]*projectDir: sessionProjectDir/,

--- a/tests/workspace-file-panel-refresh.test.ts
+++ b/tests/workspace-file-panel-refresh.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldReloadReselectedWorktree } from "../src/components/workspace/workspace-file-panel-refresh";
+
+test("the initial Worktree panel mount relies on the file-list hook's own load", () => {
+  assert.equal(shouldReloadReselectedWorktree({
+    currentTargetKey: "worktree:wt-1",
+    isWorktreeTarget: true,
+    peekChanged: false,
+    peekWorktreeId: "wt-1",
+    previousTargetKey: "worktree:wt-1",
+    targetId: "wt-1",
+  }), false);
+});
+
+test("switching Worktrees does not duplicate the file-list hook's target load", () => {
+  assert.equal(shouldReloadReselectedWorktree({
+    currentTargetKey: "worktree:wt-2",
+    isWorktreeTarget: true,
+    peekChanged: true,
+    peekWorktreeId: "wt-2",
+    previousTargetKey: "worktree:wt-1",
+    targetId: "wt-2",
+  }), false);
+});
+
+test("reselecting the current Worktree refreshes its otherwise unwatched file list", () => {
+  assert.equal(shouldReloadReselectedWorktree({
+    currentTargetKey: "worktree:wt-1",
+    isWorktreeTarget: true,
+    peekChanged: true,
+    peekWorktreeId: "wt-1",
+    previousTargetKey: "worktree:wt-1",
+    targetId: "wt-1",
+  }), true);
+});
+
+test("a peek change for another Worktree does not refresh this panel", () => {
+  assert.equal(shouldReloadReselectedWorktree({
+    currentTargetKey: "worktree:wt-1",
+    isWorktreeTarget: true,
+    peekChanged: true,
+    peekWorktreeId: "wt-2",
+    previousTargetKey: "worktree:wt-1",
+    targetId: "wt-1",
+  }), false);
+});

--- a/tests/workspace-inline-input-state.test.ts
+++ b/tests/workspace-inline-input-state.test.ts
@@ -1,11 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  resolveDirToggleTiming,
-  isRenameHotspotTarget,
-  RENAME_HOTSPOT_ATTR,
   resolveInlineSubmitIntent,
   shouldOpenOnRowClick,
+  shouldToggleDirectoryOnClick,
   selectBaseNameRange,
 } from "../src/components/workspace/workspace-inline-input-state";
 
@@ -58,35 +56,9 @@ test("a rename back to the name it already has issues no request", () => {
   );
 });
 
-test("a click away from the name toggles the folder straight away", () => {
-  assert.equal(
-    resolveDirToggleTiming({ fromRenameHotspot: false, clickCount: 1 }),
-    "immediate",
-  );
-});
-
-test("a first click on the name holds the toggle back for the double-click window", () => {
-  // Without this the folder visibly collapses and re-expands before the rename
-  // input appears, because both clicks of the gesture toggle it on the way past.
-  assert.equal(
-    resolveDirToggleTiming({ fromRenameHotspot: true, clickCount: 1 }),
-    "deferred",
-  );
-});
-
-test("the second click on the name drops the toggle entirely", () => {
-  assert.equal(
-    resolveDirToggleTiming({ fromRenameHotspot: true, clickCount: 2 }),
-    "skip",
-  );
-});
-
-test("the hotspot is recognised through a nested element, and only there", () => {
-  const inside = { closest: (selector: string) => (selector === `[${RENAME_HOTSPOT_ATTR}]` ? {} : null) };
-  const outside = { closest: () => null };
-  assert.equal(isRenameHotspotTarget(inside), true);
-  assert.equal(isRenameHotspotTarget(outside), false);
-  assert.equal(isRenameHotspotTarget(null), false);
+test("a folder toggles on the first click and drops a double-click's second click", () => {
+  assert.equal(shouldToggleDirectoryOnClick(1), true);
+  assert.equal(shouldToggleDirectoryOnClick(2), false);
 });
 
 test("a rename preselects the name without its extension", () => {

--- a/tests/workspace-tree-operations-contract.test.mjs
+++ b/tests/workspace-tree-operations-contract.test.mjs
@@ -159,13 +159,9 @@ test('a double-click gesture creates only one file tab', () => {
   assert.match(filePanelSource, /if \(!canMutate \|\| event\.key !== "F2"\) return;/);
 });
 
-test('a deferred folder toggle cannot fire under an input that just opened', () => {
-  // Clicking a folder's name arms a toggle for the double-click window. Opening
-  // any input before it fires would let it collapse the folder the row sits in,
-  // taking the half-typed name with it — so both entry points disarm it.
-  assert.match(filePanelSource, /function beginRename\(node: WorkspaceTreeNode\) \{\s*if \(!canMutate\) return;\s*clearDeferredToggle\(\);/);
-  assert.match(filePanelSource, /function beginNewEntry\(kind: "file" \| "folder", parentPath: string\) \{\s*if \(!canMutate\) return;\s*clearDeferredToggle\(\);/);
-  // And nothing reaches the hook's startNew around that guard.
+test('folder toggles have no delayed timer that can fire under an input', () => {
+  assert.doesNotMatch(filePanelSource, /DIR_TOGGLE_DOUBLE_CLICK_MS/);
+  assert.doesNotMatch(filePanelSource, /deferredToggleRef/);
   const rawStartNew = filePanelSource.match(/inlineInput\.startNew\(/g) ?? [];
   assert.equal(rawStartNew.length, 1, 'startNew is only called from beginNewEntry');
 });
@@ -179,12 +175,11 @@ test('a watch reconcile cannot take the row being edited', () => {
 });
 
 test('double-clicking the name renames without fighting the row click', () => {
-  // The hotspot is the name text alone, and a folder holds its toggle back for
-  // the double-click window so the row does not collapse under the input.
-  assert.match(filePanelSource, /\[RENAME_HOTSPOT_ATTR\]: ""/);
+  // The first click toggles immediately and the second click is ignored before
+  // the double-click handler opens rename, so no timer delays ordinary clicks.
   assert.match(filePanelSource, /onDoubleClick=\{\(event\) => \{\s*if \(!canMutate\) return;\s*event\.stopPropagation\(\);\s*beginRename\(node\);/);
-  assert.match(filePanelSource, /resolveDirToggleTiming\(\{/);
-  assert.match(inlineStateSource, /return clickCount > 1 \? "skip" : "deferred"/);
+  assert.match(filePanelSource, /if \(!shouldToggleDirectoryOnClick\(event\.detail\)\) return;/);
+  assert.match(inlineStateSource, /return clickCount <= 1;/);
 });
 
 test('the delete confirmation survives the move to inline entry', () => {


### PR DESCRIPTION
## What changed

- remove the 500ms deferred folder-toggle timer so folders open on the first click
- drop the second click of a double-click to preserve inline rename behavior
- let the file-list hook own initial and target-change loads
- refresh separately only when the currently displayed Worktree is explicitly reselected

## Root cause

Folder name clicks intentionally waited for a double-click window, and the Worktree panel effect requested the same file list already loaded by the file-list hook.

## Impact

Folder navigation responds immediately and opening or switching Worktrees no longer sends duplicate file-list requests.

## Validation

- `npx tsc --noEmit`
- targeted ESLint
- `npm run test:non-e2e` (1,397 unit tests and 398 contract tests)