### PR TITLE
Restore safe telemetry metadata

### DIFF
--- a/src/lib/telemetry/client.ts
+++ b/src/lib/telemetry/client.ts
@@ -60,6 +60,13 @@ export interface TelemetryRuntimeContext {
 
 const MAX_STRING_LENGTH = 100;
 const MAX_ARRAY_LENGTH = 20;
+const postHogEnvironmentPropertyNames = [
+  '$browser',
+  '$browser_language',
+  '$browser_language_prefix',
+  '$browser_version',
+  '$timezone',
+] as const;
 
 const projectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
 const apiHost = process.env.NEXT_PUBLIC_POSTHOG_API_HOST || '/ingest';
@@ -95,6 +102,7 @@ const allowedEvents = new Set<TelemetryEventName>([
 ]);
 
 const allowedProperties = new Set([
+  ...postHogEnvironmentPropertyNames,
   '$geoip_disable',
   '$process_person_profile',
   'active_seconds',
@@ -553,6 +561,19 @@ export function sanitizeTelemetryProperties(
   return sanitized;
 }
 
+function sanitizePostHogEnvironmentProperties(
+  properties: TelemetryEventProperties,
+): TelemetryEventProperties {
+  const sanitized = sanitizeTelemetryProperties(properties);
+  const environmentProperties: TelemetryEventProperties = {};
+
+  for (const key of postHogEnvironmentPropertyNames) {
+    if (sanitized[key] !== undefined) environmentProperties[key] = sanitized[key];
+  }
+
+  return environmentProperties;
+}
+
 export function prepareTelemetryCaptureForTransport(
   captureResult: CaptureResult | null,
   context: TelemetryRuntimeContext | null = telemetryContext,
@@ -571,6 +592,7 @@ export function prepareTelemetryCaptureForTransport(
       properties: {
         token: transportToken,
         ...baseProperties(context),
+        ...sanitizePostHogEnvironmentProperties(captureResult.properties ?? {}),
         ...clickProperties,
       },
     };

--- a/tests/telemetry-ui-click.test.ts
+++ b/tests/telemetry-ui-click.test.ts
@@ -190,6 +190,11 @@ test('PostHog transport keeps its public project token while dropping private SD
         token: 'sdk-token-that-must-not-be-trusted',
         control: 'composer.send',
         surface: 'composer',
+        '$browser': 'Chrome',
+        '$browser_version': 130,
+        '$browser_language': 'en-US',
+        '$browser_language_prefix': 'en',
+        '$timezone': 'Asia/Singapore',
         '$el_text': 'private prompt',
         '$current_url': 'http://localhost/private',
       },
@@ -211,7 +216,41 @@ test('PostHog transport keeps its public project token while dropping private SD
   assert.equal(result?.properties?.control, 'composer.send');
   assert.equal(result?.properties?.surface, 'composer');
   assert.equal(result?.properties?.client_form_factor, 'desktop');
+  assert.equal(result?.properties?.['$browser'], 'Chrome');
+  assert.equal(result?.properties?.['$browser_version'], 130);
+  assert.equal(result?.properties?.['$browser_language'], 'en-US');
+  assert.equal(result?.properties?.['$browser_language_prefix'], 'en');
+  assert.equal(result?.properties?.['$timezone'], 'Asia/Singapore');
   assert.doesNotMatch(JSON.stringify(result), /private prompt|localhost\/private|sdk-token/);
+});
+
+test('PostHog transport preserves safe browser locale and timezone properties', () => {
+  const result = prepareTelemetryCaptureForTransport(
+    {
+      event: 'app_started',
+      properties: {
+        '$browser': 'Chrome',
+        '$browser_version': 130,
+        '$browser_language': 'en-US',
+        '$browser_language_prefix': 'en',
+        '$timezone': 'Asia/Singapore',
+        '$current_url': 'http://localhost/private',
+        '$raw_user_agent': 'private raw agent',
+      },
+    },
+    null,
+    true,
+    'phc-public-project-token',
+  );
+
+  assert.deepEqual(result?.properties, {
+    token: 'phc-public-project-token',
+    '$browser': 'Chrome',
+    '$browser_version': 130,
+    '$browser_language': 'en-US',
+    '$browser_language_prefix': 'en',
+    '$timezone': 'Asia/Singapore',
+  });
 });
 
 test('prompt submission telemetry keeps only privacy-safe composition metadata', () => {


### PR DESCRIPTION
## Summary

Restore safe telemetry metadata while preserving existing privacy filtering.

## Validation

- Automated tests
- Type checking and linting