### PR TITLE
Prevent nested Codex hooks from forking sessions

### DIFF
--- a/src/lib/cli/hook-receiver.ts
+++ b/src/lib/cli/hook-receiver.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import { resolvePaneToken } from '@/lib/terminal/pane-token-registry';
 import { wsServer } from '@/lib/ws/server';
 import {
+  getSession,
   markCodexTerminalSession,
   markOpenCodeTerminalSession,
 } from '@/lib/db/sessions';
@@ -17,11 +18,15 @@ import {
   mapClaudeHookLifecycle,
 } from '@/lib/cli/providers/claude-code/terminal-hook-lifecycle';
 import { classifyAskUserQuestionEvent } from '@/lib/cli/providers/claude-code/ask-user-question-status';
-import { extractTerminalProviderSessionIdentity } from '@/lib/terminal/provider-session-identity';
+import {
+  extractTerminalProviderSessionIdentity,
+  readPersistedTerminalProviderSessionId,
+} from '@/lib/terminal/provider-session-identity';
 import { getTerminalProviderSessionForTesseraSession } from '@/lib/db/terminal-provider-sessions';
 import { cliProviderRegistry } from '@/lib/cli/providers/registry';
 import { observeTerminalProviderSession } from '@/lib/terminal/provider-session-observation';
 import { classifyPermissionRequestEvent } from './permission-request-status';
+import { shouldIgnoreForeignCodexHookIdentity } from './providers/codex/terminal-hook-identity';
 
 const MAX_BODY_BYTES = 1_000_000;
 
@@ -200,12 +205,34 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
     let sessionId = activeSessionId ?? entry.sessionId;
     const providerIdentity = extractTerminalProviderSessionIdentity(entry.providerId, payload);
     if (activeSessionId && providerIdentity) {
-      const currentProviderSessionId = getTerminalProviderSessionForTesseraSession(activeSessionId)
+      const boundProviderSessionId = getTerminalProviderSessionForTesseraSession(activeSessionId)
         ?.provider_session_id;
-      const backgroundFork = currentProviderSessionId
+      let expectedCodexProviderSessionId = boundProviderSessionId;
+      if (isCodex && !expectedCodexProviderSessionId) {
+        const activeSession = getSession(activeSessionId);
+        expectedCodexProviderSessionId = activeSession
+          ? readPersistedTerminalProviderSessionId(activeSession)
+          : undefined;
+      }
+      if (isCodex && shouldIgnoreForeignCodexHookIdentity({
+        expectedProviderSessionId: expectedCodexProviderSessionId,
+        observedProviderSessionId: providerIdentity.providerSessionId,
+        event,
+        source: readString(payload.source),
+      })) {
+        logger.debug({
+          providerId: entry.providerId,
+          expectedProviderSessionId: expectedCodexProviderSessionId,
+          observedProviderSessionId: providerIdentity.providerSessionId,
+          terminalId: entry.terminalId,
+          event,
+        }, 'Foreign Codex hook identity ignored');
+        return send(204);
+      }
+      const backgroundFork = boundProviderSessionId
         ? await cliProviderRegistry.getProvider(entry.providerId)
           .resolveBackgroundTerminalSessionFork?.({
-            currentProviderSessionId,
+            currentProviderSessionId: boundProviderSessionId,
             observedProviderSessionId: providerIdentity.providerSessionId,
             userId: entry.userId,
           }) ?? null

--- a/src/lib/cli/providers/codex/terminal-hook-identity.ts
+++ b/src/lib/cli/providers/codex/terminal-hook-identity.ts
@@ -1,0 +1,30 @@
+export interface CodexTerminalHookIdentityInput {
+  expectedProviderSessionId?: string;
+  observedProviderSessionId: string;
+  event: string;
+  source?: string;
+}
+
+/**
+ * A pane token identifies the owning Tessera terminal, not every Codex process
+ * that inherits its environment. Nested `codex exec` processes therefore send
+ * validly authenticated hooks with an unrelated rollout id.
+ *
+ * Real Codex forks are discovered authoritatively from rollout metadata
+ * (`forked_from_id`). The only hook-driven identity transition is `/clear`,
+ * whose SessionStart payload explicitly reports `source=clear`.
+ */
+export function shouldIgnoreForeignCodexHookIdentity(
+  input: CodexTerminalHookIdentityInput,
+): boolean {
+  const {
+    expectedProviderSessionId,
+    observedProviderSessionId,
+    event,
+    source,
+  } = input;
+  if (!expectedProviderSessionId || expectedProviderSessionId === observedProviderSessionId) {
+    return false;
+  }
+  return event !== 'SessionStart' || source !== 'clear';
+}

--- a/tests/codex-terminal-hook-identity.test.ts
+++ b/tests/codex-terminal-hook-identity.test.ts
@@ -1,0 +1,245 @@
+import assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
+import { mkdtempSync } from 'node:fs';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test, { before } from 'node:test';
+
+process.env.TESSERA_DATA_DIR = mkdtempSync(path.join(tmpdir(), 'tessera-codex-hook-identity-'));
+process.env.NODE_ENV = 'test';
+
+let getDb: typeof import('@/lib/db/database').getDb;
+let dbSessions: typeof import('@/lib/db/sessions');
+let bindTerminalProviderSession: typeof import('@/lib/db/terminal-provider-sessions').bindTerminalProviderSession;
+let getTerminalProviderSession: typeof import('@/lib/db/terminal-provider-sessions').getTerminalProviderSession;
+let handleHookRequest: typeof import('@/lib/cli/hook-receiver').handleHookRequest;
+let mintPaneToken: typeof import('@/lib/terminal/pane-token-registry').mintPaneToken;
+let revokePaneToken: typeof import('@/lib/terminal/pane-token-registry').revokePaneToken;
+let terminalManager: typeof import('@/lib/terminal/shared-terminal-manager').terminalManager;
+let sessionHistory: typeof import('@/lib/session-history').sessionHistory;
+let shouldIgnoreForeignCodexHookIdentity: typeof import(
+  '@/lib/cli/providers/codex/terminal-hook-identity'
+).shouldIgnoreForeignCodexHookIdentity;
+
+before(async () => {
+  await import('@/lib/cli/providers/bootstrap');
+  const [
+    database,
+    projects,
+    sessions,
+    providerSessions,
+    hookReceiver,
+    paneTokens,
+    sharedManager,
+    hookIdentity,
+    history,
+  ] = await Promise.all([
+    import('@/lib/db/database'),
+    import('@/lib/db/projects'),
+    import('@/lib/db/sessions'),
+    import('@/lib/db/terminal-provider-sessions'),
+    import('@/lib/cli/hook-receiver'),
+    import('@/lib/terminal/pane-token-registry'),
+    import('@/lib/terminal/shared-terminal-manager'),
+    import('@/lib/cli/providers/codex/terminal-hook-identity'),
+    import('@/lib/session-history'),
+  ]);
+  await database.initDatabase();
+  projects.registerProject('project-1', '/tmp/project-1', 'Project 1');
+  getDb = database.getDb;
+  dbSessions = sessions;
+  bindTerminalProviderSession = providerSessions.bindTerminalProviderSession;
+  getTerminalProviderSession = providerSessions.getTerminalProviderSession;
+  handleHookRequest = hookReceiver.handleHookRequest;
+  mintPaneToken = paneTokens.mintPaneToken;
+  revokePaneToken = paneTokens.revokePaneToken;
+  terminalManager = sharedManager.terminalManager;
+  shouldIgnoreForeignCodexHookIdentity = hookIdentity.shouldIgnoreForeignCodexHookIdentity;
+  sessionHistory = history.sessionHistory;
+});
+
+async function postHook(token: string, payload: Record<string, unknown>): Promise<number> {
+  const req = Readable.from([Buffer.from(JSON.stringify(payload))]) as unknown as IncomingMessage;
+  Object.defineProperty(req, 'headers', {
+    configurable: true,
+    value: { 'x-tessera-pane-token': token },
+  });
+  let ended = false;
+  const res = {
+    statusCode: 0,
+    end: () => { ended = true; },
+  } as unknown as ServerResponse;
+
+  await handleHookRequest(req, res);
+  assert.equal(ended, true);
+  return res.statusCode;
+}
+
+test('a nested codex exec that inherits the pane token cannot fork or rebind the parent PTY', async (t) => {
+  const tesseraSessionId = 'codex-hook-parent';
+  const parentProviderSessionId = 'codex-parent-provider';
+  const nestedProviderSessionId = 'codex-nested-exec-provider';
+  const terminalId = `session-${tesseraSessionId}`;
+  const userId = 'codex-hook-user';
+
+  dbSessions.createSession(tesseraSessionId, 'project-1', 'Parent conversation', 'codex', {
+    providerState: JSON.stringify({
+      kind: 'terminal',
+      launched: true,
+      codexSessionId: parentProviderSessionId,
+    }),
+  });
+  bindTerminalProviderSession({
+    providerId: 'codex',
+    providerSessionId: parentProviderSessionId,
+    tesseraSessionId,
+  });
+
+  const token = mintPaneToken({ terminalId, userId, sessionId: tesseraSessionId, providerId: 'codex' });
+  t.after(() => revokePaneToken(token));
+  t.mock.method(terminalManager, 'getSessionIdForTerminal', () => tesseraSessionId);
+  const rebind = t.mock.method(terminalManager, 'rebindSession', () => true);
+  const recordState = t.mock.method(terminalManager, 'recordSessionState', () => true);
+  const sessionsBefore = (getDb().prepare('SELECT COUNT(*) AS count FROM sessions').get() as { count: number }).count;
+
+  const status = await postHook(token, {
+    hook_event_name: 'SessionStart',
+    session_id: nestedProviderSessionId,
+    source: 'startup',
+  });
+  const promptStatus = await postHook(token, {
+    hook_event_name: 'UserPromptSubmit',
+    session_id: nestedProviderSessionId,
+    prompt: 'nested process prompt must not rename the parent',
+  });
+
+  const sessionsAfter = (getDb().prepare('SELECT COUNT(*) AS count FROM sessions').get() as { count: number }).count;
+  assert.equal(status, 204);
+  assert.equal(promptStatus, 204);
+  assert.equal(sessionsAfter, sessionsBefore, 'foreign hook must not create a Tessera child session');
+  assert.equal(getTerminalProviderSession('codex', nestedProviderSessionId), undefined);
+  assert.equal(rebind.mock.callCount(), 0, 'foreign hook must not move the parent PTY');
+  assert.equal(recordState.mock.callCount(), 0, 'foreign hooks must not update the parent runtime state');
+  assert.equal(await sessionHistory.historyExists(tesseraSessionId), false);
+  assert.equal(dbSessions.getSession(tesseraSessionId)?.title, 'Parent conversation');
+  assert.equal(
+    JSON.parse(dbSessions.getSession(tesseraSessionId)?.provider_state ?? '{}').codexSessionId,
+    parentProviderSessionId,
+  );
+});
+
+test('a persisted Codex identity guards cold-resumed panes before the binding table is rebuilt', async (t) => {
+  const tesseraSessionId = 'codex-hook-persisted-parent';
+  const parentProviderSessionId = 'codex-persisted-parent-provider';
+  const nestedProviderSessionId = 'codex-persisted-nested-provider';
+  const terminalId = `session-${tesseraSessionId}`;
+  const userId = 'codex-hook-persisted-user';
+
+  dbSessions.createSession(tesseraSessionId, 'project-1', 'Cold-resumed conversation', 'codex', {
+    providerState: JSON.stringify({
+      kind: 'terminal',
+      launched: true,
+      codexSessionId: parentProviderSessionId,
+    }),
+  });
+
+  const token = mintPaneToken({ terminalId, userId, sessionId: tesseraSessionId, providerId: 'codex' });
+  t.after(() => revokePaneToken(token));
+  t.mock.method(terminalManager, 'getSessionIdForTerminal', () => tesseraSessionId);
+  const rebind = t.mock.method(terminalManager, 'rebindSession', () => true);
+  const sessionsBefore = (getDb().prepare('SELECT COUNT(*) AS count FROM sessions').get() as { count: number }).count;
+
+  const status = await postHook(token, {
+    hook_event_name: 'SessionStart',
+    session_id: nestedProviderSessionId,
+    source: 'startup',
+  });
+
+  const sessionsAfter = (getDb().prepare('SELECT COUNT(*) AS count FROM sessions').get() as { count: number }).count;
+  assert.equal(status, 204);
+  assert.equal(sessionsAfter, sessionsBefore);
+  assert.equal(getTerminalProviderSession('codex', nestedProviderSessionId), undefined);
+  assert.equal(rebind.mock.callCount(), 0);
+});
+
+test('Codex /clear remains an allowed hook-driven identity transition', async (t) => {
+  const tesseraSessionId = 'codex-hook-clear-parent';
+  const parentProviderSessionId = 'codex-clear-parent-provider';
+  const clearedProviderSessionId = 'codex-clear-child-provider';
+  const terminalId = `session-${tesseraSessionId}`;
+  const userId = 'codex-hook-clear-user';
+
+  dbSessions.createSession(tesseraSessionId, 'project-1', 'Conversation to clear', 'codex', {
+    providerState: JSON.stringify({
+      kind: 'terminal',
+      launched: true,
+      codexSessionId: parentProviderSessionId,
+    }),
+  });
+  bindTerminalProviderSession({
+    providerId: 'codex',
+    providerSessionId: parentProviderSessionId,
+    tesseraSessionId,
+  });
+
+  const token = mintPaneToken({ terminalId, userId, sessionId: tesseraSessionId, providerId: 'codex' });
+  t.after(() => revokePaneToken(token));
+  t.mock.method(terminalManager, 'getSessionIdForTerminal', () => tesseraSessionId);
+  const rebind = t.mock.method(terminalManager, 'rebindSession', () => true);
+  const sessionsBefore = (getDb().prepare('SELECT COUNT(*) AS count FROM sessions').get() as { count: number }).count;
+
+  const status = await postHook(token, {
+    hook_event_name: 'SessionStart',
+    session_id: clearedProviderSessionId,
+    source: 'clear',
+  });
+
+  const childBinding = getTerminalProviderSession('codex', clearedProviderSessionId);
+  const child = childBinding ? dbSessions.getSession(childBinding.tessera_session_id) : undefined;
+  const sessionsAfter = (getDb().prepare('SELECT COUNT(*) AS count FROM sessions').get() as { count: number }).count;
+  assert.equal(status, 204);
+  assert.equal(sessionsAfter, sessionsBefore + 1);
+  assert.equal(rebind.mock.callCount(), 1);
+  assert.ok(child);
+  assert.doesNotMatch(child.title, /\(Fork\)$/);
+});
+
+test('Codex hook identity classifier preserves legitimate ownership cases', () => {
+  assert.equal(shouldIgnoreForeignCodexHookIdentity({
+    observedProviderSessionId: 'first-provider-id',
+    event: 'SessionStart',
+    source: 'startup',
+  }), false, 'an unbound pane may adopt its first provider identity');
+  assert.equal(shouldIgnoreForeignCodexHookIdentity({
+    expectedProviderSessionId: 'same-provider-id',
+    observedProviderSessionId: 'same-provider-id',
+    event: 'PostToolUse',
+  }), false, 'the owning provider identity remains accepted');
+  assert.equal(shouldIgnoreForeignCodexHookIdentity({
+    expectedProviderSessionId: 'old-provider-id',
+    observedProviderSessionId: 'cleared-provider-id',
+    event: 'SessionStart',
+    source: 'clear',
+  }), false, '/clear may replace the owning identity');
+  for (const event of [
+    'SessionStart',
+    'UserPromptSubmit',
+    'PreToolUse',
+    'PostToolUse',
+    'PermissionRequest',
+    'Stop',
+  ]) {
+    assert.equal(shouldIgnoreForeignCodexHookIdentity({
+      expectedProviderSessionId: 'parent-provider-id',
+      observedProviderSessionId: 'foreign-provider-id',
+      event,
+    }), true, `${event} from a mismatched Codex identity is foreign`);
+  }
+  assert.equal(shouldIgnoreForeignCodexHookIdentity({
+    expectedProviderSessionId: 'parent-provider-id',
+    observedProviderSessionId: 'foreign-provider-id',
+    event: 'UserPromptSubmit',
+    source: 'clear',
+  }), true, 'source=clear is only trusted on SessionStart');
+});


### PR DESCRIPTION
## What changed

- Reject Codex lifecycle hooks whose rollout ID does not own the active Tessera terminal.
- Fall back to the persisted Codex session ID when a cold-resumed session has not rebuilt its binding row yet.
- Preserve legitimate first binding and `SessionStart(source=clear)` reset transitions.
- Add hook-boundary regression coverage for session creation, PTY rebind, title, history, and runtime-state side effects.

## Why

A nested `codex exec --ephemeral` inherits Tessera's pane token and hook environment. Its independently minted rollout ID was therefore treated as a fork of the outer Codex conversation. Tessera created a false `(Fork)` session and rebound the original PTY to it, so clicking either sidebar row could open the same terminal.

The pane token authenticates the terminal, but it does not prove that every inherited Codex process owns the active conversation. Real Codex forks continue to use the authoritative rollout `forked_from_id` observer.

## Impact

Nested Codex processes can no longer manufacture Tessera child sessions or move the parent PTY. Normal first launch, cold resume, and `/clear` behavior remain supported. Claude Code and OpenCode admission paths are unchanged.

## Validation

- `npm run test:unit` — 1,772 passed, 2 skipped, 0 failed
- focused Codex hook/fork/reset suite — passed
- changed-file ESLint — passed
- `npm run server:compile` — passed
- isolated packaged Windows Electron server + WSL Codex CLI reproduction:
  - nested `SessionStart`, `UserPromptSubmit`, and `Stop` hooks were rejected
  - no `(Fork)` session was created
  - no `terminal_session_rebound` event occurred
  - reopening the original session returned to the original PTY
