### PR TITLE
feat(workspace): add image viewer zoom and pan gestures

### DIFF
--- a/src/components/workspace/workspace-image-viewer.tsx
+++ b/src/components/workspace/workspace-image-viewer.tsx
@@ -2,7 +2,8 @@
 "use client";
 
 import { Image as ImageIcon, RefreshCw, RotateCcw, ZoomIn, ZoomOut } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { flushSync } from 'react-dom';
+import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
 import { formatBytes } from '@/lib/format-bytes';
@@ -12,7 +13,10 @@ import {
   MIN_WORKSPACE_IMAGE_ZOOM,
   WORKSPACE_IMAGE_ZOOM_STEP,
   clampWorkspaceImageZoom,
+  getAnchoredWorkspaceImageScrollOffset,
   getWorkspaceImageLayoutSize,
+  getNextWorkspaceImageWheelZoom,
+  getWorkspaceImagePanScrollOffset,
   type WorkspaceImageSize,
 } from '@/lib/workspace-files/workspace-image-zoom';
 
@@ -25,6 +29,14 @@ function withRetryVersion(rawUrl: string, retryAttempt: number): string {
   return `${rawUrl}&retry=${retryAttempt}`;
 }
 
+interface ImagePanState {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  startScrollLeft: number;
+  startScrollTop: number;
+}
+
 export function WorkspaceImageViewer({
   path,
   rawUrl,
@@ -35,7 +47,11 @@ export function WorkspaceImageViewer({
   size: number;
 }) {
   const [surfaceElement, setSurfaceElement] = useState<HTMLDivElement | null>(null);
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const imageLayoutRef = useRef<HTMLDivElement | null>(null);
+  const panStateRef = useRef<ImagePanState | null>(null);
   const [zoom, setZoom] = useState(1);
+  const [isPanning, setIsPanning] = useState(false);
   const [surfaceSize, setSurfaceSize] = useState<WorkspaceImageSize | null>(null);
   const [imageSize, setImageSize] = useState<WorkspaceImageSize | null>(null);
   const [failedSrc, setFailedSrc] = useState<string | null>(null);
@@ -65,9 +81,130 @@ export function WorkspaceImageViewer({
     };
   }, [surfaceElement]);
 
-  function changeZoom(getNextZoom: (current: number) => number): void {
-    setZoom((current) => clampWorkspaceImageZoom(getNextZoom(current)));
-  }
+  const setSurfaceRef = useCallback((element: HTMLDivElement | null) => {
+    surfaceRef.current = element;
+    setSurfaceElement(element);
+  }, []);
+
+  const changeZoom = useCallback(
+    (getNextZoom: (current: number) => number, anchor?: { x: number; y: number } | null): void => {
+      const surface = surfaceRef.current;
+      const resolvedAnchor = surface
+        ? (anchor ?? { x: surface.clientWidth / 2, y: surface.clientHeight / 2 })
+        : null;
+      const scrollLeft = surface?.scrollLeft ?? 0;
+      const scrollTop = surface?.scrollTop ?? 0;
+      const surfaceRect = surface?.getBoundingClientRect();
+      const imageRect = imageLayoutRef.current?.getBoundingClientRect();
+      const contentOrigin = surfaceRect && imageRect
+        ? imageRect.left - surfaceRect.left + scrollLeft
+        : 0;
+      const contentOriginTop = surfaceRect && imageRect
+        ? imageRect.top - surfaceRect.top + scrollTop
+        : 0;
+      let currentZoom = 1;
+      let nextZoom = 1;
+
+      flushSync(() => {
+        setZoom((current) => {
+          currentZoom = current;
+          nextZoom = clampWorkspaceImageZoom(getNextZoom(current));
+          return nextZoom;
+        });
+      });
+
+      if (!surface || !resolvedAnchor || currentZoom === nextZoom) return;
+      const nextSurfaceRect = surface.getBoundingClientRect();
+      const nextImageRect = imageLayoutRef.current?.getBoundingClientRect();
+      const nextContentOrigin = nextSurfaceRect && nextImageRect
+        ? nextImageRect.left - nextSurfaceRect.left + surface.scrollLeft
+        : 0;
+      const nextContentOriginTop = nextSurfaceRect && nextImageRect
+        ? nextImageRect.top - nextSurfaceRect.top + surface.scrollTop
+        : 0;
+      surface.scrollLeft = getAnchoredWorkspaceImageScrollOffset({
+        scrollOffset: scrollLeft,
+        anchorOffset: resolvedAnchor.x,
+        currentZoom,
+        nextZoom,
+        contentOrigin,
+        nextContentOrigin,
+      });
+      surface.scrollTop = getAnchoredWorkspaceImageScrollOffset({
+        scrollOffset: scrollTop,
+        anchorOffset: resolvedAnchor.y,
+        currentZoom,
+        nextZoom,
+        contentOrigin: contentOriginTop,
+        nextContentOrigin: nextContentOriginTop,
+      });
+    },
+    [],
+  );
+
+  const handleImageSurfaceWheel = useCallback((event: WheelEvent) => {
+    if (event.deltaY === 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const surface = surfaceRef.current;
+    const rect = surface?.getBoundingClientRect();
+    changeZoom(
+      (current) => getNextWorkspaceImageWheelZoom(current, event.deltaY, event.deltaMode),
+      rect ? { x: event.clientX - rect.left, y: event.clientY - rect.top } : null,
+    );
+  }, [changeZoom]);
+
+  useEffect(function registerImageSurfaceWheel() {
+    const surface = surfaceElement;
+    if (!surface) return;
+    surface.addEventListener('wheel', handleImageSurfaceWheel, { passive: false });
+    return function unregisterImageSurfaceWheel() {
+      surface.removeEventListener('wheel', handleImageSurfaceWheel);
+    };
+  }, [handleImageSurfaceWheel, surfaceElement]);
+
+  const handlePanStart = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.pointerType !== 'mouse' || event.button !== 0) return;
+    const surface = event.currentTarget;
+    if (surface.scrollWidth <= surface.clientWidth && surface.scrollHeight <= surface.clientHeight) return;
+    event.preventDefault();
+    surface.setPointerCapture(event.pointerId);
+    panStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startScrollLeft: surface.scrollLeft,
+      startScrollTop: surface.scrollTop,
+    };
+    setIsPanning(true);
+  }, []);
+
+  const handlePanMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const pan = panStateRef.current;
+    if (!pan || pan.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    const surface = event.currentTarget;
+    surface.scrollLeft = getWorkspaceImagePanScrollOffset({
+      startScrollOffset: pan.startScrollLeft,
+      startPointerOffset: pan.startX,
+      currentPointerOffset: event.clientX,
+    });
+    surface.scrollTop = getWorkspaceImagePanScrollOffset({
+      startScrollOffset: pan.startScrollTop,
+      startPointerOffset: pan.startY,
+      currentPointerOffset: event.clientY,
+    });
+  }, []);
+
+  const handlePanEnd = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const pan = panStateRef.current;
+    if (!pan || pan.pointerId !== event.pointerId) return;
+    panStateRef.current = null;
+    setIsPanning(false);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  }, []);
 
   if (imageError) {
     return (
@@ -98,17 +235,25 @@ export function WorkspaceImageViewer({
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="workspace-image-viewer">
       <div
-        ref={setSurfaceElement}
-        className="min-h-0 flex-1 overflow-auto bg-(--sidebar-hover)"
+        ref={setSurfaceRef}
+        data-testid="workspace-image-surface"
+        className={`min-h-0 flex-1 select-none overflow-auto bg-(--sidebar-hover) ${isPanning ? 'cursor-grabbing' : 'cursor-grab'}`}
+        onPointerDown={handlePanStart}
+        onPointerMove={handlePanMove}
+        onPointerUp={handlePanEnd}
+        onPointerCancel={handlePanEnd}
+        onLostPointerCapture={handlePanEnd}
       >
         <div className="flex h-max min-h-full w-max min-w-full items-center justify-center p-4">
           <div
+            ref={imageLayoutRef}
             className="flex items-center justify-center"
             style={layoutSize ? { width: layoutSize.width, height: layoutSize.height } : undefined}
           >
             <img
               src={previewSrc}
               alt={filename}
+              draggable={false}
               className={layoutSize ? 'block h-full w-full object-contain' : 'block max-h-full max-w-full object-contain'}
               onLoad={(event) => {
                 const image = event.currentTarget;
@@ -143,7 +288,7 @@ export function WorkspaceImageViewer({
               variant="ghost"
               size="icon"
               className="h-7 w-7"
-              onClick={() => setZoom(1)}
+              onClick={() => changeZoom(() => 1)}
               disabled={zoom === 1}
               aria-label="Reset image zoom"
             >

--- a/src/lib/workspace-files/workspace-image-zoom.ts
+++ b/src/lib/workspace-files/workspace-image-zoom.ts
@@ -3,6 +3,13 @@ export const MAX_WORKSPACE_IMAGE_ZOOM = 8;
 export const WORKSPACE_IMAGE_ZOOM_STEP = 1.25;
 export const WORKSPACE_IMAGE_SURFACE_PADDING = 16;
 
+const DOM_DELTA_LINE = 1;
+const DOM_DELTA_PAGE = 2;
+const PIXELS_PER_LINE = 16;
+const PIXELS_PER_PAGE = 800;
+const MAX_NORMALIZED_WHEEL_DELTA = 200;
+const WHEEL_ZOOM_SENSITIVITY = 300;
+
 export interface WorkspaceImageSize {
   width: number;
   height: number;
@@ -10,6 +17,61 @@ export interface WorkspaceImageSize {
 
 export function clampWorkspaceImageZoom(zoom: number): number {
   return Math.min(MAX_WORKSPACE_IMAGE_ZOOM, Math.max(MIN_WORKSPACE_IMAGE_ZOOM, zoom));
+}
+
+export function getWorkspaceImageWheelZoomFactor(deltaY: number, deltaMode: number): number {
+  if (deltaY === 0) return 1;
+
+  const normalizedDeltaY = deltaMode === DOM_DELTA_LINE
+    ? deltaY * PIXELS_PER_LINE
+    : deltaMode === DOM_DELTA_PAGE ? deltaY * PIXELS_PER_PAGE : deltaY;
+  const boundedDeltaY = Math.max(
+    -MAX_NORMALIZED_WHEEL_DELTA,
+    Math.min(MAX_NORMALIZED_WHEEL_DELTA, normalizedDeltaY),
+  );
+  return Math.exp(-boundedDeltaY / WHEEL_ZOOM_SENSITIVITY);
+}
+
+export function getNextWorkspaceImageWheelZoom(
+  currentZoom: number,
+  deltaY: number,
+  deltaMode: number,
+): number {
+  return clampWorkspaceImageZoom(
+    currentZoom * getWorkspaceImageWheelZoomFactor(deltaY, deltaMode),
+  );
+}
+
+export function getAnchoredWorkspaceImageScrollOffset({
+  scrollOffset,
+  anchorOffset,
+  currentZoom,
+  nextZoom,
+  contentOrigin = 0,
+  nextContentOrigin = 0,
+}: {
+  scrollOffset: number;
+  anchorOffset: number;
+  currentZoom: number;
+  nextZoom: number;
+  contentOrigin?: number;
+  nextContentOrigin?: number;
+}): number {
+  if (currentZoom <= 0) return scrollOffset;
+  const contentOffset = scrollOffset + anchorOffset - contentOrigin;
+  return nextContentOrigin + contentOffset * (nextZoom / currentZoom) - anchorOffset;
+}
+
+export function getWorkspaceImagePanScrollOffset({
+  startScrollOffset,
+  startPointerOffset,
+  currentPointerOffset,
+}: {
+  startScrollOffset: number;
+  startPointerOffset: number;
+  currentPointerOffset: number;
+}): number {
+  return startScrollOffset - (currentPointerOffset - startPointerOffset);
 }
 
 export function getWorkspaceImageLayoutSize({

--- a/tests/workspace-image-zoom.test.ts
+++ b/tests/workspace-image-zoom.test.ts
@@ -4,7 +4,11 @@ import {
   MAX_WORKSPACE_IMAGE_ZOOM,
   MIN_WORKSPACE_IMAGE_ZOOM,
   clampWorkspaceImageZoom,
+  getAnchoredWorkspaceImageScrollOffset,
   getWorkspaceImageLayoutSize,
+  getNextWorkspaceImageWheelZoom,
+  getWorkspaceImagePanScrollOffset,
+  getWorkspaceImageWheelZoomFactor,
 } from '../src/lib/workspace-files/workspace-image-zoom';
 
 test('clamps workspace image zoom to the Orca-compatible range', () => {
@@ -44,5 +48,64 @@ test('uses layout dimensions for zoom so the full image remains scrollable', () 
   assert.equal(
     getWorkspaceImageLayoutSize({ imageSize: null, surfaceSize: null, zoom: 1 }),
     null,
+  );
+});
+
+test('zooms ordinary wheel input in the expected direction and clamps it', () => {
+  assert.equal(getNextWorkspaceImageWheelZoom(1, -30, 0) > 1, true);
+  assert.equal(getNextWorkspaceImageWheelZoom(1, 30, 0) < 1, true);
+  assert.equal(getNextWorkspaceImageWheelZoom(MIN_WORKSPACE_IMAGE_ZOOM, 1000, 0), MIN_WORKSPACE_IMAGE_ZOOM);
+  assert.equal(getNextWorkspaceImageWheelZoom(MAX_WORKSPACE_IMAGE_ZOOM, -1000, 0), MAX_WORKSPACE_IMAGE_ZOOM);
+});
+
+test('normalizes wheel delta modes and limits extreme events', () => {
+  const pixelFactor = getWorkspaceImageWheelZoomFactor(1, 0);
+  const lineFactor = getWorkspaceImageWheelZoomFactor(1, 1);
+  const pageFactor = getWorkspaceImageWheelZoomFactor(1, 2);
+  assert.equal(lineFactor < pixelFactor, true);
+  assert.equal(pageFactor < lineFactor, true);
+  assert.equal(
+    getWorkspaceImageWheelZoomFactor(-10_000, 0),
+    getWorkspaceImageWheelZoomFactor(-200, 0),
+  );
+  assert.equal(getWorkspaceImageWheelZoomFactor(0, 0), 1);
+});
+
+test('keeps the zoom anchor stable while panning in either direction', () => {
+  assert.equal(
+    getAnchoredWorkspaceImageScrollOffset({
+      scrollOffset: 100,
+      anchorOffset: 200,
+      currentZoom: 1,
+      nextZoom: 2,
+    }),
+    400,
+  );
+  assert.equal(
+    getAnchoredWorkspaceImageScrollOffset({
+      scrollOffset: 0,
+      anchorOffset: 500,
+      currentZoom: 1,
+      nextZoom: 2,
+      contentOrigin: 250,
+      nextContentOrigin: 16,
+    }),
+    16,
+  );
+  assert.equal(
+    getWorkspaceImagePanScrollOffset({
+      startScrollOffset: 100,
+      startPointerOffset: 300,
+      currentPointerOffset: 250,
+    }),
+    150,
+  );
+  assert.equal(
+    getWorkspaceImagePanScrollOffset({
+      startScrollOffset: 100,
+      startPointerOffset: 300,
+      currentPointerOffset: 350,
+    }),
+    50,
   );
 });


### PR DESCRIPTION
## What changed

- Added ordinary mouse-wheel zooming to workspace image tabs.
- Kept zoom anchored to the pointer, including centered images and viewer padding.
- Added primary-button drag panning on both axes with pointer capture.
- Preserved toolbar zoom/reset controls and added pure gesture math coverage.

## User impact

Image files in the Files tab now behave like a standard image viewer: wheel to inspect details and drag to move around an enlarged image.

## Validation

- `npx tsx --test tests/workspace-image-zoom.test.ts`
- `npx eslint src/components/workspace/workspace-image-viewer.tsx src/lib/workspace-files/workspace-image-zoom.ts tests/workspace-image-zoom.test.ts`
- `npx tsc --noEmit --pretty false`
- Browser smoke QA confirmed 100% → 379% wheel zoom, two-axis drag panning, and reset to 100%.
