### PR TITLE
fix(git): keep merged task archive after branch deletion

### DIFF
--- a/src/lib/git/primary-git-action.ts
+++ b/src/lib/git/primary-git-action.ts
@@ -71,6 +71,11 @@ export interface GitStateSnapshot {
   pullRequest: GitPullRequestReadiness;
   /** State of the PR for this exact revision; historical PRs are null. */
   currentPullRequestState?: TaskPrState | null;
+  /**
+   * Whether GitHub still advertises this branch. A merged PR commonly loses
+   * its remote branch before the local panel can count against its upstream.
+   */
+  remoteBranchExists?: boolean;
   /** True only when this panel can reversibly archive its owning Task. */
   canArchiveTask?: boolean;
   /**
@@ -184,6 +189,7 @@ export function gitStateSnapshotFromPanel(
       panel.prStatusKnown !== false && panel.prStatus && isCurrentTaskPr(panel.prStatus)
         ? panel.prStatus.state
         : null,
+    remoteBranchExists: panel.remoteBranchExists,
     canArchiveTask: capabilities.canArchiveTask ?? false,
     defaultBranch: panel.defaultBranch,
     // A payload from before this field existed — one held in the client store
@@ -237,6 +243,22 @@ export function derivePrimaryGitAction(
   // committing without a branch is ordinary, pushing without one is not.
   if (snapshot.changedFileCount > 0) return commitAction(true, null);
 
+  // GitHub normally deletes a merged PR's source branch. That also removes the
+  // remote-tracking ref, so the local ahead/behind probe below has no object to
+  // compare and correctly returns null. The current-revision PR probe is the
+  // authoritative answer in this one terminal state: it has already confirmed
+  // that this HEAD belongs to the merged PR, and the remote probe confirmed
+  // that there is no delivery destination left. Keep conflict and dirty work
+  // above this branch so neither can be hidden by the terminal PR action.
+  if (
+    isCurrentMergedPullRequest(snapshot)
+    && snapshot.remoteBranchExists === false
+  ) {
+    return snapshot.canArchiveTask
+      ? archiveWorktreeAction()
+      : viewPullRequestAction();
+  }
+
   const blocked = describeRemoteObstacle(snapshot);
   if (blocked) return publishAction(false, blocked);
 
@@ -256,7 +278,7 @@ export function derivePrimaryGitAction(
   // Committed, pushed and tracking: the only step of delivery left is the pull
   // request (§3). A branch that already has one points at that destination.
   if (snapshot.pullRequest === 'exists') {
-    if (snapshot.currentPullRequestState === 'merged' && snapshot.canArchiveTask) {
+    if (isMergedTaskReadyToArchive(snapshot)) {
       return archiveWorktreeAction();
     }
     return viewPullRequestAction();
@@ -270,6 +292,16 @@ export function derivePrimaryGitAction(
   }
 
   return createPullRequestAction(snapshot.pullRequest);
+}
+
+function isMergedTaskReadyToArchive(snapshot: GitStateSnapshot): boolean {
+  return isCurrentMergedPullRequest(snapshot)
+    && snapshot.canArchiveTask === true;
+}
+
+function isCurrentMergedPullRequest(snapshot: GitStateSnapshot): boolean {
+  return snapshot.pullRequest === 'exists'
+    && snapshot.currentPullRequestState === 'merged';
 }
 
 function loadingAction(): GitPrimaryAction {

--- a/tests/git-merged-task-archive.e2e.mjs
+++ b/tests/git-merged-task-archive.e2e.mjs
@@ -279,17 +279,24 @@ try {
     prState: reconciledOpenTask.prStatus.state,
   });
 
+  // GitHub commonly deletes the source branch as part of merging. Mirror both
+  // sides of that state: the server's ls-remote probe must see it gone, and the
+  // local panel must lose the tracking ref so ahead/behind become uncountable.
+  await git(['update-ref', '-d', 'refs/heads/feature/merged'], remote);
+  await git(['update-ref', '-d', 'refs/remotes/origin/feature/merged']);
   await writeGhState('MERGED', headRefOid);
   await api(`/api/sessions/${taskSessionId}/refresh-git`, { method: 'POST' });
   const mergedTask = await waitForTaskState(task.id, 'done', 'merged');
+  assert.equal(mergedTask.remoteBranchExists, false);
   const doneCard = page.locator(
     `[data-testid="kanban-column"][data-status="done"] [data-testid="kanban-card"][data-task-id="${task.id}"]`,
   );
   await doneCard.waitFor({ timeout: 30_000 });
-  await capture('merged-pr-moves-task-to-done', {
+  await capture('merged-pr-with-deleted-branch-moves-task-to-done', {
     workflowStatus: mergedTask.workflowStatus,
     prState: mergedTask.prStatus.state,
     relation: mergedTask.prStatus.relation,
+    remoteBranchExists: mergedTask.remoteBranchExists,
   });
 
   await page.getByTestId('view-mode-list').click();
@@ -392,6 +399,7 @@ try {
     openPrConvergedToInReview: true,
     unchangedOpenPrCorrectedManualMove: true,
     mergedPrConvergedToDone: true,
+    mergedRemoteBranchDeleted: true,
     mergedTaskPrimaryAction: 'archive_worktree',
     mergedTaskPrimaryBackground: mergedPrimaryColors.actual,
     openPrPrimaryBackground: openPrimaryBackground,

--- a/tests/git-primary-action.test.ts
+++ b/tests/git-primary-action.test.ts
@@ -176,6 +176,56 @@ test('a current merged PR on an archive-capable Task offers Archive Worktree', (
   assert.equal(action.labelKey, 'gitPanel.pr.archiveButton');
 });
 
+test('a merged Task stays archivable after GitHub deletes its remote branch', () => {
+  const snapshot = gitStateSnapshotFromPanel({
+    ...PANEL,
+    // Once GitHub deletes the merged branch, its remote-tracking ref is gone
+    // and the local panel can no longer calculate either side of the upstream.
+    ahead: null,
+    behind: null,
+    remoteBranchExists: false,
+    prStatusKnown: true,
+    prStatus: {
+      number: 376,
+      url: 'https://github.com/horang-labs/tessera/pull/376',
+      state: 'merged',
+      relation: 'current',
+      lastSynced: '2026-08-17T07:47:24.000Z',
+    },
+  }, { canArchiveTask: true });
+  const action = derivePrimaryGitAction(snapshot);
+
+  assert.equal(action.kind, 'archive_worktree');
+  assert.equal(action.action, 'archive_worktree');
+  assert.equal(action.enabled, true);
+});
+
+test('an uncounted merged Task with a surviving remote branch stays unknown', () => {
+  const action = derivePrimaryGitAction({
+    ...SYNCED,
+    ahead: null,
+    behind: null,
+    remoteBranchExists: true,
+    currentPullRequestState: 'merged',
+    canArchiveTask: true,
+  });
+
+  assert.equal(action.kind, 'loading');
+});
+
+test('a standalone merged PR with a deleted remote branch stays viewable', () => {
+  const action = derivePrimaryGitAction({
+    ...SYNCED,
+    ahead: null,
+    behind: null,
+    remoteBranchExists: false,
+    currentPullRequestState: 'merged',
+    canArchiveTask: false,
+  });
+
+  assert.equal(action.kind, 'view_pr');
+});
+
 test('open and non-Task pull requests keep View PR', () => {
   const openTask = derivePrimaryGitAction({
     ...SYNCED,


### PR DESCRIPTION
## What changed

- Carry the remote-branch existence probe into the primary Git action snapshot.
- Keep a current merged Task on the purple Archive Worktree action after GitHub deletes its source branch and local ahead/behind counts become unavailable.
- Keep dirty/conflicted work ahead of archive, keep genuinely unknown surviving branches fail-closed, and keep standalone merged PRs on View PR.
- Extend unit and browser E2E coverage to reproduce deletion of both the remote branch and local tracking ref.

## Why

After a PR was merged and its source branch deleted, the missing remote-tracking ref made `ahead` and `behind` resolve to `null`. The primary-action ladder returned its unknown Git state before reaching the merged-Task archive branch, leaving the desktop control as a blue disabled Git button.

## Impact

Merged Task worktrees now expose the intended recoverable Archive Worktree flow even when the merged branch has already been deleted from GitHub. Other ambiguous Git states retain the existing conservative behavior.

## Validation

- Full unit suite: 1,771 passed, 2 skipped
- Focused Git action tests: 60 passed
- TypeScript and changed-file ESLint
- Browser E2E with deleted remote branch: passed, including merged Task archive, confirmation timeout, soft archive/worktree preservation, and standalone View PR fallback
- No unexpected browser request failures or console errors
