### PR TITLE
Prevent Codex child hooks from reviving completed turns

### DIFF
--- a/src/lib/cli/hook-receiver.ts
+++ b/src/lib/cli/hook-receiver.ts
@@ -22,6 +22,13 @@ import { getTerminalProviderSessionForTesseraSession } from '@/lib/db/terminal-p
 import { cliProviderRegistry } from '@/lib/cli/providers/registry';
 import { observeTerminalProviderSession } from '@/lib/terminal/provider-session-observation';
 import { classifyPermissionRequestEvent } from './permission-request-status';
+import { getAgentEnvironment } from '@/lib/cli/spawn-cli';
+import {
+  classifyCodexHookOrigin,
+  CODEX_LIFECYCLE_EVENTS,
+  mapCodexHookLifecycle,
+  type CodexHookOrigin,
+} from '@/lib/cli/providers/codex/terminal-hook-lifecycle';
 
 const MAX_BODY_BYTES = 1_000_000;
 
@@ -155,23 +162,23 @@ function mapClaudeEventToStatus(
  * PermissionRequest 훅은 결정을 반환하지 않으므로 codex 자체 승인 TUI가 xterm에 그대로 뜬다.
  */
 function mapCodexEventToStatus(
+  terminalId: string,
   event: string,
   payload: Record<string, unknown>,
+  origin: CodexHookOrigin,
 ): { status: TerminalSessionStatus; preview?: string } | null {
   const permissionRequest = classifyPermissionRequestEvent(event, payload);
-  if (permissionRequest) return permissionRequest;
-  switch (event) {
-    case 'SessionStart':
-      return { status: 'idle' };
-    case 'UserPromptSubmit':
-    case 'PreToolUse':
-    case 'PostToolUse':
-      return { status: 'running' };
-    case 'Stop':
-      return completedStatus(payload);
-    default:
-      return null;
+  const lifecycle = mapCodexHookLifecycle(terminalId, event, origin);
+  if (lifecycle) {
+    if (lifecycle.status === 'input_required') return permissionRequest;
+    if (event === 'Stop' && lifecycle.status === 'completed') return completedStatus(payload);
+    return lifecycle;
   }
+  // A null from a lifecycle-owned event is an intentional rejection (normally
+  // delayed child traffic after the lead Stop), not a reason to fall back to
+  // the old event→running mapping.
+  if (CODEX_LIFECYCLE_EVENTS.has(event)) return null;
+  return permissionRequest;
 }
 
 /**
@@ -198,7 +205,17 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
       ? terminalManager.getSessionIdForTerminal(entry.terminalId, entry.userId)
       : null;
     let sessionId = activeSessionId ?? entry.sessionId;
-    const providerIdentity = extractTerminalProviderSessionIdentity(entry.providerId, payload);
+    const codexOrigin = isCodex
+      ? await classifyCodexHookOrigin(payload, await getAgentEnvironment(entry.userId))
+      : 'lead';
+    if (isCodex) {
+      logger.debug({ terminalId: entry.terminalId, event, codexOrigin }, 'Classified Codex hook origin');
+    }
+    // A collaboration child inherits the lead's session_id. Observing that
+    // child payload as a root identity can replace the pane's resume binding.
+    const providerIdentity = isCodex && codexOrigin !== 'lead'
+      ? null
+      : extractTerminalProviderSessionIdentity(entry.providerId, payload);
     if (activeSessionId && providerIdentity) {
       const currentProviderSessionId = getTerminalProviderSessionForTesseraSession(activeSessionId)
         ?.provider_session_id;
@@ -229,11 +246,11 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
       sessionId = observation.sessionId;
     }
     const mapped = isCodex
-      ? mapCodexEventToStatus(event, payload)
+      ? mapCodexEventToStatus(entry.terminalId, event, payload, codexOrigin)
       : isOpenCode
         ? mapEventToStatus(event, payload)
         : mapClaudeEventToStatus(entry.terminalId, event, payload);
-    if (event === 'SessionStart' && sessionId) {
+    if (event === 'SessionStart' && sessionId && (!isCodex || codexOrigin === 'lead')) {
       if (isCodex) {
         // codex rollout id를 provider_state에 캡처(resume용) + launched 마커 + kind.
         markCodexTerminalSession(sessionId, readString(payload.session_id));
@@ -248,7 +265,7 @@ export async function handleHookRequest(req: IncomingMessage, res: ServerRespons
     }
     // 첫 프롬프트에서 동기 로컬 제목을 즉시 적용한다. 같은 프롬프트를 history에도
     // 기록해 사용자가 AI 개선을 켠 경우 Stop 시점의 선택적 생성 입력으로 활용한다.
-    if (event === 'UserPromptSubmit' && sessionId) {
+    if (event === 'UserPromptSubmit' && sessionId && (!isCodex || codexOrigin === 'lead')) {
       const prompt = readString(payload.prompt);
       if (prompt) {
         sessionHistory.recordUserMessage(sessionId, prompt);

--- a/src/lib/cli/providers/codex/terminal-hook-lifecycle.ts
+++ b/src/lib/cli/providers/codex/terminal-hook-lifecycle.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { resolveAgentReportedPath } from '@/lib/filesystem/path-environment';
+import type { AgentEnvironment } from '@/lib/settings/types';
+
+export type CodexHookOrigin = 'lead' | 'subagent' | 'unknown';
+export type CodexHookLifecycleStatus = 'running' | 'completed' | 'input_required' | 'idle';
+
+interface CodexTerminalLifecycle {
+  turnEnded: boolean;
+}
+
+const ROLLOUT_HEADER_MAX_BYTES = 64 * 1024;
+const ORIGIN_CACHE_MAX_ENTRIES = 512;
+const rolloutOriginByPath = new Map<string, Exclude<CodexHookOrigin, 'unknown'>>();
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+/**
+ * Codex collaboration children inherit the lead's session_id, so that field
+ * cannot identify hook ownership. Their own rollout header is authoritative:
+ * session_meta.payload.thread_source is `subagent` while the lead is `user`.
+ */
+export async function classifyCodexHookOrigin(
+  payload: Record<string, unknown>,
+  environment: AgentEnvironment,
+): Promise<CodexHookOrigin> {
+  if (readString(payload.agent_id) || readString(payload.agentId)) return 'subagent';
+
+  const reportedPath = readString(payload.transcript_path ?? payload.transcriptPath);
+  if (!reportedPath) return 'unknown';
+
+  try {
+    const transcriptPath = await resolveAgentReportedPath(reportedPath, environment);
+    if (path.extname(transcriptPath).toLowerCase() !== '.jsonl') return 'unknown';
+    const cached = rolloutOriginByPath.get(transcriptPath);
+    if (cached) return cached;
+    const descriptor = await fs.open(transcriptPath, 'r');
+    try {
+      const buffer = Buffer.alloc(ROLLOUT_HEADER_MAX_BYTES);
+      const { bytesRead } = await descriptor.read(buffer, 0, buffer.length, 0);
+      const firstLine = buffer.subarray(0, bytesRead).toString('utf8').split('\n', 1)[0];
+      if (!firstLine) return 'unknown';
+      const record = JSON.parse(firstLine) as {
+        type?: unknown;
+        payload?: Record<string, unknown>;
+      };
+      if (record.type !== 'session_meta') return 'unknown';
+      const threadSource = readString(record.payload?.thread_source);
+      const legacySource = readString(record.payload?.source);
+      if (threadSource !== 'user' && threadSource !== 'subagent' && !legacySource) {
+        return 'unknown';
+      }
+      // Codex <=0.146 lead rollouts predate thread_source and identify their
+      // creator through source (for example `vscode`). Collaboration rollouts
+      // carry the authoritative subagent thread_source in newer releases.
+      const origin = threadSource === 'subagent' ? 'subagent' : 'lead';
+      rolloutOriginByPath.set(transcriptPath, origin);
+      if (rolloutOriginByPath.size > ORIGIN_CACHE_MAX_ENTRIES) {
+        const oldestPath = rolloutOriginByPath.keys().next().value;
+        if (oldestPath) rolloutOriginByPath.delete(oldestPath);
+      }
+      return origin;
+    } finally {
+      await descriptor.close();
+    }
+  } catch {
+    // Keep ownership unknown so an unreadable child rollout cannot replace the
+    // lead identity or revive a completed turn. Later hooks retry the read.
+    return 'unknown';
+  }
+}
+
+/**
+ * Keeps the foreground Codex turn separate from collaboration-child traffic.
+ * A completed lead leaves a tombstone so delayed fire-and-forget child hooks
+ * cannot recreate a running turn that has no later Stop to close it.
+ */
+export class CodexHookLifecycleTracker {
+  private readonly terminals = new Map<string, CodexTerminalLifecycle>();
+
+  apply(
+    terminalId: string,
+    event: string,
+    origin: CodexHookOrigin,
+  ): { status: CodexHookLifecycleStatus } | null {
+    if (origin === 'unknown') {
+      // Ownership-sensitive status cannot be inferred safely. In particular,
+      // an unreadable child rollout must not open, close, or reset the lead.
+      return null;
+    }
+
+    if (origin === 'subagent') {
+      // Child hooks never own foreground state. The lead remains running until
+      // its own Stop, and a child must not overwrite a lead permission prompt.
+      return null;
+    }
+
+    if (event === 'SessionStart') {
+      this.terminals.delete(terminalId);
+      return { status: 'idle' };
+    }
+
+    if (event === 'UserPromptSubmit') {
+      this.terminals.set(terminalId, { turnEnded: false });
+      return { status: 'running' };
+    }
+
+    if (event === 'PermissionRequest') return { status: 'input_required' };
+
+    if (event === 'PreToolUse' || event === 'PostToolUse') {
+      const state = this.terminals.get(terminalId);
+      // Codex emits UserPromptSubmit as the explicit next-turn boundary. No
+      // tool delivery after Stop may clear the tombstone, regardless of delay.
+      if (state?.turnEnded) return null;
+      if (!state) {
+        this.terminals.set(terminalId, { turnEnded: false });
+      }
+      return { status: 'running' };
+    }
+
+    if (event === 'Stop') {
+      this.terminals.set(terminalId, { turnEnded: true });
+      return { status: 'completed' };
+    }
+
+    return null;
+  }
+}
+
+const terminalHookLifecycle = new CodexHookLifecycleTracker();
+
+export const CODEX_LIFECYCLE_EVENTS = new Set([
+  'SessionStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+  'PermissionRequest',
+  'Stop',
+]);
+
+export function mapCodexHookLifecycle(
+  terminalId: string,
+  event: string,
+  origin: CodexHookOrigin,
+): { status: CodexHookLifecycleStatus } | null {
+  return terminalHookLifecycle.apply(terminalId, event, origin);
+}

--- a/tests/codex-hook-lifecycle.test.ts
+++ b/tests/codex-hook-lifecycle.test.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  CodexHookLifecycleTracker,
+  classifyCodexHookOrigin,
+} from '@/lib/cli/providers/codex/terminal-hook-lifecycle';
+
+const ROLLOUT_TEST_OVERSIZE_BYTES = 70 * 1024;
+
+function writeRollout(threadSource: 'user' | 'subagent'): { dir: string; filePath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-codex-hook-'));
+  const filePath = path.join(dir, 'rollout.jsonl');
+  fs.writeFileSync(filePath, `${JSON.stringify({
+    type: 'session_meta',
+    payload: {
+      id: `${threadSource}-thread`,
+      session_id: 'lead-thread',
+      thread_source: threadSource,
+    },
+  })}\n`);
+  return { dir, filePath };
+}
+
+test('Codex hook origin follows rollout thread_source instead of shared session_id', async (t) => {
+  const lead = writeRollout('user');
+  const child = writeRollout('subagent');
+  t.after(() => {
+    fs.rmSync(lead.dir, { recursive: true, force: true });
+    fs.rmSync(child.dir, { recursive: true, force: true });
+  });
+
+  assert.equal(await classifyCodexHookOrigin({
+    session_id: 'lead-thread',
+    transcript_path: lead.filePath,
+  }, 'native'), 'lead');
+  assert.equal(await classifyCodexHookOrigin({
+    session_id: 'lead-thread',
+    transcript_path: child.filePath,
+  }, 'native'), 'subagent');
+
+  fs.rmSync(child.filePath);
+  assert.equal(await classifyCodexHookOrigin({
+    transcript_path: child.filePath,
+  }, 'native'), 'subagent');
+});
+
+test('legacy Codex session metadata with a source remains a lead rollout', async (t) => {
+  const legacy = writeRollout('user');
+  t.after(() => fs.rmSync(legacy.dir, { recursive: true, force: true }));
+  fs.writeFileSync(legacy.filePath, `${JSON.stringify({
+    type: 'session_meta',
+    payload: {
+      id: 'legacy-lead',
+      source: 'vscode',
+    },
+  })}\n`);
+
+  assert.equal(await classifyCodexHookOrigin({
+    transcript_path: legacy.filePath,
+  }, 'native'), 'lead');
+});
+
+test('unreadable or malformed Codex rollouts keep ownership unknown', async (t) => {
+  const malformed = writeRollout('user');
+  const truncated = writeRollout('user');
+  t.after(() => fs.rmSync(malformed.dir, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(truncated.dir, { recursive: true, force: true }));
+  fs.writeFileSync(malformed.filePath, '{not-json}\n');
+  fs.writeFileSync(truncated.filePath, JSON.stringify({
+    type: 'session_meta',
+    padding: 'x'.repeat(ROLLOUT_TEST_OVERSIZE_BYTES),
+    payload: { thread_source: 'subagent' },
+  }));
+
+  assert.equal(await classifyCodexHookOrigin({}, 'native'), 'unknown');
+  assert.equal(await classifyCodexHookOrigin({
+    transcript_path: path.join(malformed.dir, 'missing.jsonl'),
+  }, 'native'), 'unknown');
+  assert.equal(await classifyCodexHookOrigin({
+    transcript_path: malformed.filePath,
+  }, 'native'), 'unknown');
+  assert.equal(await classifyCodexHookOrigin({
+    transcript_path: truncated.filePath,
+  }, 'native'), 'unknown');
+});
+
+test('late Codex child hooks cannot resurrect a completed lead turn', () => {
+  const tracker = new CodexHookLifecycleTracker();
+  const terminalId = 'terminal-with-late-child';
+
+  assert.deepEqual(tracker.apply(terminalId, 'UserPromptSubmit', 'lead'), {
+    status: 'running',
+  });
+  assert.deepEqual(tracker.apply(terminalId, 'Stop', 'lead'), {
+    status: 'completed',
+  });
+  assert.equal(tracker.apply(terminalId, 'PreToolUse', 'subagent'), null);
+  assert.equal(tracker.apply(terminalId, 'PostToolUse', 'subagent'), null);
+  assert.equal(tracker.apply(terminalId, 'Stop', 'subagent'), null);
+
+  assert.deepEqual(tracker.apply(terminalId, 'UserPromptSubmit', 'lead'), {
+    status: 'running',
+  });
+});
+
+test('no Codex tool delivery reopens a completed turn without a prompt boundary', () => {
+  const tracker = new CodexHookLifecycleTracker();
+  const terminalId = 'terminal-with-reordered-hooks';
+
+  tracker.apply(terminalId, 'UserPromptSubmit', 'lead');
+  tracker.apply(terminalId, 'Stop', 'lead');
+
+  assert.equal(tracker.apply(terminalId, 'PostToolUse', 'lead'), null);
+  assert.equal(tracker.apply(terminalId, 'PreToolUse', 'lead'), null);
+  assert.equal(tracker.apply(terminalId, 'PreToolUse', 'unknown'), null);
+});
+
+test('Codex child activity never overwrites foreground lead state', () => {
+  const tracker = new CodexHookLifecycleTracker();
+  const terminalId = 'terminal-with-active-child';
+
+  tracker.apply(terminalId, 'UserPromptSubmit', 'lead');
+  assert.deepEqual(tracker.apply(terminalId, 'PermissionRequest', 'lead'), {
+    status: 'input_required',
+  });
+  assert.equal(tracker.apply(terminalId, 'PreToolUse', 'subagent'), null);
+  assert.equal(tracker.apply(terminalId, 'PostToolUse', 'subagent'), null);
+});
+
+test('unknown Codex ownership cannot open, close, or reset foreground state', () => {
+  const tracker = new CodexHookLifecycleTracker();
+  const terminalId = 'terminal-with-unknown-rollout';
+
+  assert.equal(tracker.apply(terminalId, 'SessionStart', 'unknown'), null);
+  assert.equal(tracker.apply(terminalId, 'UserPromptSubmit', 'unknown'), null);
+  assert.equal(tracker.apply(terminalId, 'PreToolUse', 'unknown'), null);
+  assert.equal(tracker.apply(terminalId, 'PermissionRequest', 'unknown'), null);
+  assert.equal(tracker.apply(terminalId, 'Stop', 'unknown'), null);
+
+  tracker.apply(terminalId, 'UserPromptSubmit', 'lead');
+  tracker.apply(terminalId, 'Stop', 'lead');
+  assert.equal(tracker.apply(terminalId, 'SessionStart', 'unknown'), null);
+  assert.equal(tracker.apply(terminalId, 'UserPromptSubmit', 'unknown'), null);
+  assert.equal(tracker.apply(terminalId, 'Stop', 'unknown'), null);
+  assert.equal(tracker.apply(terminalId, 'PreToolUse', 'lead'), null);
+  assert.deepEqual(tracker.apply(terminalId, 'UserPromptSubmit', 'lead'), {
+    status: 'running',
+  });
+});


### PR DESCRIPTION
## What changed

- Classify Codex hooks by rollout ownership and isolate collaboration child events from the foreground lifecycle.
- Keep a completed-turn tombstone until the next authoritative user prompt, preventing delayed tool hooks from restoring the processing indicator.
- Protect parent title, history, and provider identity from child or unknown hook traffic.
- Preserve legacy Codex rollout metadata and the explicit `/clear` identity transition.
- Cache successful rollout ownership reads with a bounded cache for Windows-server/WSL-agent performance.

## Validation

- `npm run test:non-e2e` — 1,786 unit tests passed, 2 skipped; 401 contract tests passed; 0 failed
- server TypeScript compile — passed
- changed-file ESLint — passed
- isolated packaged Windows Electron server + WSL Codex CLI QA — parent completed with `PARENT_DONE`; processing indicator settled to the idle runtime dot
- standards review — passed
- spec review — passed