### PR TITLE
Fix Codex overlay transcript resolution

### DIFF
--- a/src/lib/cli/providers/codex/terminal-hook-lifecycle.ts
+++ b/src/lib/cli/providers/codex/terminal-hook-lifecycle.ts
@@ -1,6 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { resolveAgentReportedPath } from '@/lib/filesystem/path-environment';
+import { resolveCodexAccountTranscriptPath } from '@/lib/codex-home';
+import {
+  isBridgedAgentEnvironment,
+  resolveAgentHomeFilesystemPath,
+  resolveAgentReportedPath,
+} from '@/lib/filesystem/path-environment';
 import type { AgentEnvironment } from '@/lib/settings/types';
 
 export type CodexHookOrigin = 'lead' | 'subagent' | 'unknown';
@@ -33,7 +38,16 @@ export async function classifyCodexHookOrigin(
   if (!reportedPath) return 'unknown';
 
   try {
-    const transcriptPath = await resolveAgentReportedPath(reportedPath, environment);
+    const serverPath = await resolveAgentReportedPath(reportedPath, environment);
+    const transcriptPath = resolveCodexAccountTranscriptPath(serverPath, isBridgedAgentEnvironment(environment)
+      ? {
+          // The overlay marker contains a CLI-side path that the host cannot
+          // interpret directly. Anchor fallback resolution at the CLI's real
+          // account home as a host-readable path instead.
+          env: { NODE_ENV: process.env.NODE_ENV },
+          homeDir: await resolveAgentHomeFilesystemPath(environment),
+        }
+      : undefined);
     if (path.extname(transcriptPath).toLowerCase() !== '.jsonl') return 'unknown';
     const cached = rolloutOriginByPath.get(transcriptPath);
     if (cached) return cached;

--- a/tests/codex-hook-lifecycle.test.ts
+++ b/tests/codex-hook-lifecycle.test.ts
@@ -24,6 +24,53 @@ function writeRollout(threadSource: 'user' | 'subagent'): { dir: string; filePat
   return { dir, filePath };
 }
 
+function writeAccountRolloutBehindMissingOverlay(
+  threadSource: 'user' | 'subagent',
+): { root: string; reportedPath: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tessera-codex-hook-overlay-'));
+  const relativePath = path.join(
+    'sessions',
+    '2026',
+    '08',
+    '17',
+    `rollout-${threadSource}.jsonl`,
+  );
+  const accountPath = path.join(root, '.codex', relativePath);
+  fs.mkdirSync(path.dirname(accountPath), { recursive: true });
+  fs.writeFileSync(accountPath, `${JSON.stringify({
+    type: 'session_meta',
+    payload: {
+      id: `${threadSource}-thread`,
+      session_id: 'lead-thread',
+      thread_source: threadSource,
+    },
+  })}\n`);
+  return {
+    root,
+    // Windows cannot traverse the overlay's Linux-only `sessions` symlink, so
+    // model that host view with a missing overlay spelling while the durable
+    // account rollout remains readable.
+    reportedPath: path.join(
+      root,
+      '.tessera',
+      'codex-overlay',
+      'session-terminal-1',
+      relativePath,
+    ),
+  };
+}
+
+test('Codex hook origin resolves an unreadable overlay path through the durable account home', async (t) => {
+  const lead = writeAccountRolloutBehindMissingOverlay('user');
+  t.after(() => fs.rmSync(lead.root, { recursive: true, force: true }));
+
+  assert.equal(fs.existsSync(lead.reportedPath), false);
+  assert.equal(await classifyCodexHookOrigin({
+    session_id: 'lead-thread',
+    transcript_path: lead.reportedPath,
+  }, 'native'), 'lead');
+});
+
 test('Codex hook origin follows rollout thread_source instead of shared session_id', async (t) => {
   const lead = writeRollout('user');
   const child = writeRollout('subagent');


### PR DESCRIPTION
## Summary

- canonicalize Codex overlay transcript paths to the durable account-home rollout before hook origin classification
- anchor bridged resolution at the WSL agent home instead of the Windows server home
- add a regression test for an unreadable overlay spelling with a readable account rollout

## Root cause

After #379, the Windows backend translated the WSL-reported rollout path to UNC and attempted to read it directly. The path crossed the overlay's Linux-only `sessions` symlink, which Windows cannot traverse, so normal lead hooks were classified as `unknown`. That discarded provider binding, prompt history, Stop lifecycle, PTY ChatView replay, and AI title side effects.

## Validation

- 81 related tests pass
- ESLint passes for changed files
- TypeScript `--noEmit` passes
- `git diff --check` passes
- packaged Windows Electron backend + WSL Codex PTY: SessionStart/UserPromptSubmit/Stop classified as `lead`
- ChatView replay returned the real `PATHFIX_OK` response
- AI title generation returned 200 and persisted `Investigate transcript path`
