### PR TITLE
fix(terminal): honor OSC 52 clipboard writes for TUI copy

### DIFF
--- a/src/lib/terminal/terminal-osc52.ts
+++ b/src/lib/terminal/terminal-osc52.ts
@@ -1,0 +1,102 @@
+import type { ElectronTerminalClipboardApi } from './terminal-clipboard-paste';
+
+/**
+ * OSC 52 clipboard write support for the live terminal surface.
+ *
+ * Terminal TUIs (OpenCode's Ink UI, tmux, etc.) copy text by emitting the OSC
+ * 52 escape sequence — `ESC ] 52 ; <selection> ; <base64> ST/BEL` — which the
+ * terminal emulator is expected to turn into a system clipboard write. WezTerm,
+ * Windows Terminal and others do this natively; xterm.js does not, so without
+ * this handler the TUI reports "copied to clipboard" while nothing reaches the
+ * desktop clipboard.
+ *
+ * Policy (mirrors WezTerm's `osc52 = "Clipboard"` write behaviour):
+ * - Only writes to the system clipboard selection (`c`) are honoured.
+ * - Read requests (payload `?`) are deliberately not answered, so a terminal
+ *   program cannot silently exfiltrate the user's clipboard.
+ * - Primary/secondary selections (`p`/`s`) have no Windows equivalent and are
+ *   ignored.
+ */
+
+const OSC52_MAX_DECODED_BYTES = 4 * 1024 * 1024;
+
+export interface TerminalOsc52Parser {
+  registerOscHandler(
+    ident: number,
+    callback: (data: string) => boolean | Promise<boolean>,
+  ): { dispose(): void };
+}
+
+export interface Osc52TerminalLike {
+  parser: TerminalOsc52Parser;
+}
+
+/**
+ * Installs an OSC 52 handler on the live xterm parser. Returns a disposable to
+ * unregister it when the surface tears down.
+ */
+export function installTerminalOsc52Handler(terminal: Osc52TerminalLike): { dispose(): void } {
+  return terminal.parser.registerOscHandler(52, (data) => {
+    const pending = handleOsc52Payload(data);
+    if (pending) {
+      pending.catch((error: unknown) => {
+        console.warn('[terminal] OSC 52 clipboard write failed', error);
+      });
+    }
+    return true;
+  });
+}
+
+function handleOsc52Payload(data: string): Promise<void> | null {
+  const text = parseOsc52Payload(data);
+  if (text === null) return null;
+  return writeToClipboard(text);
+}
+
+/**
+ * Parses an OSC 52 payload (`<selection>;<base64>` or `c;?` for a read
+ * request) into the text to copy. Returns null when the payload is a read
+ * request, targets a non-system selection, or is not valid base64.
+ */
+export function parseOsc52Payload(data: string): string | null {
+  const separatorIndex = data.indexOf(';');
+  if (separatorIndex === -1) return null;
+
+  const selection = data.slice(0, separatorIndex);
+  const payload = data.slice(separatorIndex + 1);
+
+  // Only the system clipboard is meaningful on the desktop. Ignore primary and
+  // secondary selections (and any other naming) rather than write garbage.
+  if (selection !== 'c') return null;
+
+  // A bare query requests clipboard contents — never answer it.
+  if (payload === '' || payload === '?') return null;
+
+  return decodeOsc52Base64(payload);
+}
+
+function decodeOsc52Base64(payload: string): string | null {
+  try {
+    const binary = atob(payload);
+    if (binary.length > OSC52_MAX_DECODED_BYTES) return null;
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+async function writeToClipboard(text: string): Promise<void> {
+  const electronClipboard = (
+    window as Window & { electronAPI?: Partial<ElectronTerminalClipboardApi> }
+  ).electronAPI;
+  if (typeof electronClipboard?.writeTerminalClipboardText === 'function') {
+    await electronClipboard.writeTerminalClipboardText(text);
+    return;
+  }
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  throw new Error('OSC 52 clipboard write: no clipboard backend available.');
+}

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -39,6 +39,10 @@ import {
   type ElectronTerminalClipboardApi,
 } from './terminal-clipboard-paste';
 import {
+  installTerminalOsc52Handler,
+  type TerminalOsc52Parser,
+} from './terminal-osc52';
+import {
   scheduleTerminalScrollIntentSync,
   TerminalScrollController,
   type TerminalScrollRestorePoint,
@@ -113,6 +117,7 @@ type XtermLike = TerminalScrollTarget & {
   options: { theme?: ITheme; fontSize?: number };
   unicode: IUnicodeHandling;
   modes: { sendFocusMode: boolean };
+  parser: TerminalOsc52Parser;
   textarea?: HTMLTextAreaElement;
   attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void;
   attachCustomWheelEventHandler(handler: (event: WheelEvent) => boolean): void;
@@ -326,6 +331,7 @@ export class TerminalSurface {
   private readonly scrollSyncSettler = new LayoutSettleRunner();
   private pasteListener: ((event: ClipboardEvent) => void) | null = null;
   private compositionEndListener: ((event: CompositionEvent) => void) | null = null;
+  private osc52Disposable: { dispose(): void } | null = null;
   private suppressNextNativePaste = false;
   private pasteSuppressionTimerId: number | null = null;
   private clipboardPasteQueue: Promise<void> = Promise.resolve();
@@ -876,6 +882,8 @@ export class TerminalSurface {
       this.root.removeEventListener('compositionend', this.compositionEndListener, true);
     }
     this.compositionEndListener = null;
+    this.osc52Disposable?.dispose();
+    this.osc52Disposable = null;
     this.suppressNextNativePaste = false;
     if (this.pasteSuppressionTimerId !== null) {
       window.clearTimeout(this.pasteSuppressionTimerId);
@@ -970,6 +978,9 @@ export class TerminalSurface {
       terminal.loadAddon(new WebLinksAddon(webLinkHandler));
       activateTesseraTerminalUnicodeProvider(terminal);
       attachTerminalMouseWheelMultiplier(terminal);
+      // TUI copy (OpenCode, tmux) arrives as OSC 52; xterm does not handle the
+      // sequence itself, so route it to the desktop clipboard here.
+      this.osc52Disposable = installTerminalOsc52Handler(terminal);
 
       // Renderer choice. WebGL everywhere by default — the postinstall patch
       // (scripts/patch-xterm-webgl-atlas.mjs) fixes the addon's atlas-wipe

--- a/tests/terminal-osc52.test.ts
+++ b/tests/terminal-osc52.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseOsc52Payload } from '../src/lib/terminal/terminal-osc52';
+
+const base64 = (text: string): string => Buffer.from(text, 'utf8').toString('base64');
+
+test('OSC 52 decodes a system-clipboard write payload', () => {
+  const text = 'hello opencode';
+  assert.equal(parseOsc52Payload(`c;${base64(text)}`), text);
+});
+
+test('OSC 52 decodes non-ASCII text as UTF-8', () => {
+  const text = '한글 복사 테스트';
+  assert.equal(parseOsc52Payload(`c;${base64(text)}`), text);
+});
+
+test('OSC 52 read requests are never answered', () => {
+  assert.equal(parseOsc52Payload('c;?'), null);
+  assert.equal(parseOsc52Payload('c;'), null);
+});
+
+test('OSC 52 ignores non-system selections', () => {
+  assert.equal(parseOsc52Payload(`p;${base64('primary')}`), null);
+  assert.equal(parseOsc52Payload(`s;${base64('secondary')}`), null);
+});
+
+test('OSC 52 rejects malformed payloads', () => {
+  assert.equal(parseOsc52Payload('no-separator'), null);
+  assert.equal(parseOsc52Payload('c;!!!not-base64!!!'), null);
+});


### PR DESCRIPTION
## Summary

- OpenCode's TUI (and tmux/other TUIs) copies text by emitting the **OSC 52** escape sequence (`ESC ] 52 ; c ; <base64> ST`) to the terminal emulator. WezTerm/Windows Terminal implement it natively; xterm.js ignores it.
- In Tessera the TUI showed "Copied to clipboard" but nothing reached the desktop clipboard — because the only reliable copy path for a WSL CLI (no X/Wayland) is OSC 52, and the renderer had no handler.
- Add `src/lib/terminal/terminal-osc52.ts`, installed on the live xterm parser in `terminal-surface-registry.ts`, that:
  - decodes system-clipboard (`c`) write payloads (UTF-8, 4 MB cap),
  - routes through the existing `electronAPI.writeTerminalClipboardText` IPC (Electron) with a `navigator.clipboard.writeText` fallback (web),
  - **refuses read requests** (`c;?`) so a terminal program cannot exfiltrate the user's clipboard,
  - ignores primary/secondary selections.
- Adds unit tests for the parser/decoder.

## Testing

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] Unit tests: `npx tsx --test tests/terminal-osc52.test.ts` (5/5 pass)
- [x] Manual test: packaged Windows Electron test instance (`feature/0818-8u` worktree, debug-logging build) — OpenCode PTY copy verified to reach the Windows clipboard, WezTerm-equivalent behavior. Original Tessera (PID 35668 on 32123) and DB hash unchanged.
- [ ] `NODE_ENV=production npm run build` (covered by `electron:prebuild` during the test build)
- [ ] Not tested:

## Notes

- Mirrors WezTerm's `osc52 = "Clipboard"` write policy. Windows has no primary/secondary selection, so `p`/`s` are ignored rather than mapped.