### PR TITLE
fix(workspace): keep file tab open when source session is a preview

### DIFF
--- a/src/app/api/sessions/[id]/file/route.ts
+++ b/src/app/api/sessions/[id]/file/route.ts
@@ -19,6 +19,10 @@ import {
 
 function toErrorResponse(error: unknown, sessionId: string, action: string): NextResponse {
   if (error instanceof WorkspaceFileError) {
+    logger.error(
+      { error, sessionId, code: error.code, status: error.status },
+      `Failed to ${action} workspace file`,
+    );
     return jsonError(error.code, error.message, error.status);
   }
   logger.error({ error, sessionId }, `Failed to ${action} workspace file`);

--- a/src/app/api/worktrees/[id]/file/route.ts
+++ b/src/app/api/worktrees/[id]/file/route.ts
@@ -65,6 +65,10 @@ async function authenticateAndResolveRoot(
 
 function toErrorResponse(error: unknown, worktreeId: string, action: string): NextResponse {
   if (error instanceof WorkspaceFileError) {
+    logger.error(
+      { error, worktreeId, code: error.code, status: error.status },
+      `Failed to ${action} Worktree file`,
+    );
     return jsonError(error.code, error.message, error.status);
   }
   logger.error({ error, worktreeId }, `Failed to ${action} Worktree file`);

--- a/src/lib/workspace-tabs/open-workspace-tab.ts
+++ b/src/lib/workspace-tabs/open-workspace-tab.ts
@@ -129,6 +129,23 @@ function focusOrCreateSpecialTab(
   return tabId;
 }
 
+/**
+ * A file tab belongs to its source Session. If that Session is open in a
+ * preview tab, opening a file would switch the active tab away from it; the
+ * preview-terminal audit then closes that tab and kills the Session's PTY,
+ * which retires the Session — and with it the just-opened file tab.
+ * Promote the Session's own tab to a retained tab before the file tab is
+ * created so the preview terminal survives.
+ */
+function promoteSourceSessionTab(sourceSessionId: string): void {
+  const tabStore = useTabStore.getState();
+  const location = tabStore.findSessionLocation(sourceSessionId);
+  if (!location) return;
+  const tab = tabStore.tabs.find((candidate) => candidate.id === location.tabId);
+  if (!tab?.isPreview) return;
+  tabStore.pinTab(location.tabId);
+}
+
 export function openWorkspaceFileTab(
   sourceSessionId: string,
   kind: WorkspaceFileTabKind,
@@ -140,6 +157,7 @@ export function openWorkspaceFileTab(
     options.preferKanbanPeek
     && tryOpenWorkspaceFileInKanbanPeek(sourceSessionId, kind, filePath)
   ) return;
+  promoteSourceSessionTab(sourceSessionId);
   const tabId = focusOrCreateSpecialTab(
     buildWorkspaceFileSessionId(sourceSessionId, kind, filePath, options.worktreeId),
     {


### PR DESCRIPTION
## 문제
파일 트리에서 특정 세션의 파일을 열면 파일 탭이 열리자마자 닫히는 버그.

## 근본 원인
파일을 여는 세션이 **preview 터미널 탭**(보드에서 카드를 미리보기로 연 상태)으로 열려 있으면:
1. 파일 탭이 생성되고 active 탭이 옮겨감
2. `terminal-preview-surface-lifecycle` audit이 그 preview 터미널 탭을 "버려진 미리보기"로 판단해 닫고 PTY를 release (`terminal_release_preview` → `terminal_exit`)
3. 세션이 retire되면서 (`retireSessionSurface`) 방금 만든 파일 탭까지 같이 닫힘

isolate debug 로그로 사건 순서를 확정했습니다:
```
21.241 file tab created → 21.345 terminal_release_preview → 21.357 terminal_detach
→ 21.368 running:false → 21.370 retireSessionSurface → 21.370 closeTab(file tab) → 21.409 terminal_exit
```

## 수정
- `openWorkspaceFileTab`이 파일 탭을 만들기 전에 `promoteSourceSessionTab(sourceSessionId)` 호출
- 원본 세션 탭이 preview면 retained로 승격(pin)시켜 preview 터미널이 죽지 않게 함
- 추가로 worktree/session 파일 라우트의 `WorkspaceFileError`도 서버 로그에 남기도록 보강 (기존엔 무시되어 파일 읽기 실패가 로그에 안 남던 문제)

## 검증
- 수정 빌드를 일렉트론 격리 인스턴스로 띄워 재현 → 파일 탭이 열린 채 유지됨을 확인
- `tests/project-worktree-target.test.tsx` (12개) 및 파일 편집/트리 계약 테스트 (41개) 통과