### PR TITLE
fix(git): offer archive for merged PR whose remote branch survives

### DIFF
--- a/src/lib/git/primary-git-action.ts
+++ b/src/lib/git/primary-git-action.ts
@@ -262,7 +262,20 @@ export function derivePrimaryGitAction(
   const blocked = describeRemoteObstacle(snapshot);
   if (blocked) return publishAction(false, blocked);
 
-  if (!snapshot.upstream) return publishAction(true, null);
+  if (!snapshot.upstream) {
+    // A current merged PR is delivery-finished even when its remote branch
+    // survives the merge (GitHub's delete-on-merge toggle is not guaranteed to
+    // run). Without a tracking ref there is no ahead/behind to count, so the
+    // publish rung below would otherwise masquerade a merged branch as one that
+    // was never shared. End in the same terminal state the deleted-branch path
+    // above does — archive when the owning Task can, otherwise view the merge.
+    if (isCurrentMergedPullRequest(snapshot)) {
+      return snapshot.canArchiveTask
+        ? archiveWorktreeAction()
+        : viewPullRequestAction();
+    }
+    return publishAction(true, null);
+  }
 
   // A tracking branch whose comparison could not be counted has no safe next
   // rung: it may need Pull, Push, or neither. Hold the disabled unknown frame

--- a/tests/git-primary-action.test.ts
+++ b/tests/git-primary-action.test.ts
@@ -200,6 +200,46 @@ test('a merged Task stays archivable after GitHub deletes its remote branch', ()
   assert.equal(action.enabled, true);
 });
 
+test("a current merged Task whose remote branch survives still offers Archive, not Publish", () => {
+  // GitHub's delete-on-merge toggle does not always run, so a merged PR branch
+  // can remain on the remote. If that branch also lost its tracking ref (for
+  // example it was created without `--track`), the publish rung would otherwise
+  // masquerade a finished, merged branch as one that was never shared. A merged
+  // PR is delivery-finished regardless of the remote branch surviving.
+  const snapshot = gitStateSnapshotFromPanel({
+    ...PANEL,
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    remoteBranchExists: true,
+    prStatusKnown: true,
+    prStatus: {
+      number: 383,
+      url: 'https://github.com/horang-labs/tessera/pull/383',
+      state: 'merged',
+      relation: 'current',
+      lastSynced: '2026-08-19T08:27:16.000Z',
+    },
+  }, { canArchiveTask: true });
+  const action = derivePrimaryGitAction(snapshot);
+
+  assert.equal(action.kind, 'archive_worktree');
+  assert.equal(action.action, 'archive_worktree');
+  assert.equal(action.enabled, true);
+});
+
+test("a standalone merged PR with a surviving branch and no upstream stays viewable", () => {
+  const action = derivePrimaryGitAction({
+    ...SYNCED,
+    upstream: null,
+    ahead: 0,
+    currentPullRequestState: 'merged',
+    canArchiveTask: false,
+  });
+
+  assert.equal(action.kind, 'view_pr');
+});
+
 test('an uncounted merged Task with a surviving remote branch stays unknown', () => {
   const action = derivePrimaryGitAction({
     ...SYNCED,


### PR DESCRIPTION
## 문제
머지된 PR(#383)의 소스 브랜치가 GitHub delete-on-merge 옵션이 꺼져 있어 원격에 살아있고, 해당 워크트리의 로컬 브랜치가 `--track` 없이 생성되어 upstream 설정이 없는 경우, 래더가 Publish Branch(브랜치 게시)로 판정했습니다.

머지된 PR은 delivery가 끝난 상태이므로, upstream 유무나 원격 브랜치 생존 여부와 무관하게:
- 아카이브 가능한 Task면 **Archive Worktree**
- 아니면 **View PR**

로 끝나야 합니다.

## 변경
- `src/lib/git/primary-git-action.ts`: `!upstream` publish 분기에 머지 PR 판정을 추가
- `tests/git-primary-action.test.ts`: 회귀 테스트 2건 추가 (머지+생존브랜치+upstream 부재 → archive / view_pr)

## 검증
- `npx tsx --test tests/git-primary-action.test.ts` 로직 테스트 통과
- `npx tsc -p tsconfig.json` 타입 검사 이상 없음