### PR TITLE
fix(worktrees): reuse externally created checkouts

### DIFF
--- a/src/app/api/worktrees/route.ts
+++ b/src/app/api/worktrees/route.ts
@@ -279,6 +279,7 @@ export async function POST(req: NextRequest) {
   logger.info({ branchName, projectDir, worktreePath, worktreeRoot }, 'Creating git worktree');
 
   // --- Run git worktree add ---
+  let reusedExistingCheckout = false;
   try {
     await createGitWorktree({
       projectDir,
@@ -300,7 +301,24 @@ export async function POST(req: NextRequest) {
         { status: 422 },
       );
     }
-    if (err instanceof WorktreeCreationError && err.code === 'branch_already_checked_out') {
+    if (
+      err instanceof WorktreeCreationError
+      && err.code === 'branch_already_checked_out'
+      && err.holderWorktreePath
+      && err.holderWorktreePath !== projectDir
+      && checkoutTarget
+    ) {
+      // A chat agent can create a Git Worktree directly, before Tessera has a
+      // chance to persist it. The branch may only be checked out once, so
+      // attach this task/session to that checkout instead of attempting a
+      // second `git worktree add` and leaving the user with an unusable error.
+      worktreePath = err.holderWorktreePath;
+      reusedExistingCheckout = true;
+      logger.info(
+        { branchName, projectDir, worktreePath },
+        'Reusing externally created git worktree already holding branch',
+      );
+    } else if (err instanceof WorktreeCreationError && err.code === 'branch_already_checked_out') {
       return NextResponse.json(
         {
           code: 'BRANCH_ALREADY_CHECKED_OUT',
@@ -310,20 +328,17 @@ export async function POST(req: NextRequest) {
         },
         { status: 409 },
       );
-    }
-    if (msg.includes('already exists')) {
+    } else if (msg.includes('already exists')) {
       return NextResponse.json(
         { error: `Worktree path already exists: ${worktreePath}` },
         { status: 409 }
       );
-    }
-    if (msg.includes('is not a git repository')) {
+    } else if (msg.includes('is not a git repository')) {
       return NextResponse.json(
         { error: 'The project directory is not a git repository.' },
         { status: 422 }
       );
-    }
-    if (msg.includes('already checked out') || msg.includes('already used by worktree')) {
+    } else if (msg.includes('already checked out') || msg.includes('already used by worktree')) {
       return NextResponse.json(
         {
           code: 'BRANCH_ALREADY_CHECKED_OUT',
@@ -331,12 +346,12 @@ export async function POST(req: NextRequest) {
         },
         { status: 409 }
       );
+    } else {
+      return NextResponse.json(
+        { error: `Failed to create worktree: ${msg}` },
+        { status: 500 }
+      );
     }
-
-    return NextResponse.json(
-      { error: `Failed to create worktree: ${msg}` },
-      { status: 500 }
-    );
   }
 
   // Git runs inside the configured agent environment and must receive its own
@@ -377,7 +392,9 @@ export async function POST(req: NextRequest) {
     // one has nowhere to report to and is left unprepared.
     logger.warn(
       { branchName, projectDir, worktreePath },
-      'Worktree created without a task; preparation was not started',
+      reusedExistingCheckout
+        ? 'Existing worktree reused without a task; preparation was not started'
+        : 'Worktree created without a task; preparation was not started',
     );
   }
 

--- a/tests/control-worktree-creation.test.ts
+++ b/tests/control-worktree-creation.test.ts
@@ -374,7 +374,7 @@ test('the Worktree API ignores naming inputs when opening an existing branch', a
     });
     assert.equal(persisted?.startPoint, 'feature/api-resume');
 
-    const refusal = await POST(new NextRequest('http://localhost:32123/api/worktrees', {
+    const rootRefusal = await POST(new NextRequest('http://localhost:32123/api/worktrees', {
       method: 'POST',
       headers: {
         [APP_SECRET_HEADER]: secret,
@@ -387,14 +387,48 @@ test('the Worktree API ignores naming inputs when opening an existing branch', a
         source: { mode: 'checkout-branch', branch: 'main' },
       }),
     }));
-    assert.equal(refusal.status, 409);
-    assert.deepEqual(await refusal.json(), {
+    assert.equal(rootRefusal.status, 409);
+    assert.deepEqual(await rootRefusal.json(), {
       code: 'BRANCH_ALREADY_CHECKED_OUT',
       error: `Branch 'main' is already checked out in Worktree '${repository.path}'.`,
       branchName: 'main',
       holderWorktreePath: repository.path,
     });
-    assert.equal(fs.existsSync(path.join(managedRoot, 'main')), false);
+
+    const existingCheckoutPath = path.join(testRoot, 'externally-created-main');
+    git(repository.path, ['worktree', 'add', existingCheckoutPath, '-b', 'feature/already-open', 'main']);
+    mods.tasks.createTask({
+      id: 'api-reuse-existing-checkout-task',
+      projectId: repository.path,
+      title: 'Reuse external checkout',
+    });
+    const reuse = await POST(new NextRequest('http://localhost:32123/api/worktrees', {
+      method: 'POST',
+      headers: {
+        [APP_SECRET_HEADER]: secret,
+        'content-type': 'application/json',
+        host: 'localhost:32123',
+        origin: 'http://localhost:32123',
+      },
+      body: JSON.stringify({
+        projectDir: repository.path,
+        source: { mode: 'checkout-branch', branch: 'feature/already-open' },
+        taskId: 'api-reuse-existing-checkout-task',
+      }),
+    }));
+    const reuseText = await reuse.text();
+    assert.equal(reuse.status, 200, reuseText);
+    assert.deepEqual(JSON.parse(reuseText), {
+      branchName: 'feature/already-open',
+      worktreePath: existingCheckoutPath,
+    });
+    const reusedTask = mods.tasks.getTask('api-reuse-existing-checkout-task');
+    assert.equal(reusedTask?.worktreeBranch, 'feature/already-open');
+    const persistedCheckout = mods.database.getDb().prepare(`
+      SELECT worktree_path FROM tasks WHERE id = ?
+    `).get('api-reuse-existing-checkout-task') as { worktree_path: string };
+    assert.equal(persistedCheckout.worktree_path, existingCheckoutPath);
+    assert.equal(fs.existsSync(path.join(managedRoot, 'feature/already-open')), false);
 
     mods.tasks.createTask({
       id: 'api-detached-origin-task',


### PR DESCRIPTION
## Summary
- reuse an existing non-project Git worktree when the selected branch is already checked out there
- persist the discovered checkout path to the Tessera task so session creation continues normally
- retain the existing refusal when the selected branch is checked out in the Project Worktree itself

## Verification
- `npx tsx --test tests/control-worktree-creation.test.ts` (6/6 passed)
- `npx eslint --quiet src/app/api/worktrees/route.ts tests/control-worktree-creation.test.ts`
- `git diff --check`