### PR TITLE
Preserve file tree expansion across session switches

### DIFF
--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -34,7 +34,10 @@ import {
 import { useWorkspaceFileList } from "@/hooks/use-workspace-file-list";
 import { useProjectViewSession } from "@/hooks/use-project-view-workspace-state";
 import { isHiddenWorkspaceRelativePath } from "@/lib/workspace-files/hidden-workspace-path";
-import { useWorkspaceFileViewStore } from "@/stores/workspace-file-view-store";
+import {
+  selectExpandedWorkspacePaths,
+  useWorkspaceFileViewStore,
+} from "@/stores/workspace-file-view-store";
 import { useWorkspacePeekStore } from '@/stores/workspace-peek-store';
 import {
   openWorkspaceTargetFileTab,
@@ -227,10 +230,15 @@ export function WorkspaceFilePanel({
   const [query, setQuery] = useState("");
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [deleteRequest, setDeleteRequest] = useState<WorkspaceDeleteRequest | null>(null);
-  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
   const [contextMenu, setContextMenu] = useState<PathContextMenuState | null>(null);
   const showHiddenFiles = useWorkspaceFileViewStore((state) => state.showHiddenFiles);
   const toggleShowHiddenFiles = useWorkspaceFileViewStore((state) => state.toggleShowHiddenFiles);
+  const storedExpandedPaths = useWorkspaceFileViewStore(
+    selectExpandedWorkspacePaths(targetKey),
+  );
+  const expandStoredPath = useWorkspaceFileViewStore((state) => state.expandPath);
+  const toggleStoredPath = useWorkspaceFileViewStore((state) => state.toggleExpandedPath);
+  const expandedPaths = useMemo(() => new Set(storedExpandedPaths), [storedExpandedPaths]);
   // The sessions/[id]/files route scopes Project View references by projectId;
   // resolve it from canonical workspace state so linked Task-only Sessions can
   // list files too.
@@ -272,18 +280,9 @@ export function WorkspaceFilePanel({
   }, [loadFiles, peekTarget, target?.id, target?.kind, targetKey]);
 
   const expandPath = useCallback((path: string) => {
-    if (!path) return;
-    setExpandedPaths((current) => {
-      if (current.has(path)) return current;
-      const next = new Set(current);
-      let walked = "";
-      for (const part of path.split("/")) {
-        walked = walked ? `${walked}/${part}` : part;
-        next.add(walked);
-      }
-      return next;
-    });
-  }, []);
+    if (!targetKey) return;
+    expandStoredPath(targetKey, path);
+  }, [expandStoredPath, targetKey]);
 
   const inlineInput = useWorkspaceInlineInput({
     onCreateFile: createFile,
@@ -474,15 +473,8 @@ export function WorkspaceFilePanel({
   }
 
   function toggleDirectory(path: string) {
-    setExpandedPaths((current) => {
-      const next = new Set(current);
-      if (next.has(path)) {
-        next.delete(path);
-      } else {
-        next.add(path);
-      }
-      return next;
-    });
+    if (!targetKey) return;
+    toggleStoredPath(targetKey, path);
   }
 
   /**

--- a/src/stores/workspace-file-view-store.ts
+++ b/src/stores/workspace-file-view-store.ts
@@ -6,21 +6,80 @@ interface WorkspaceFileViewState {
   /** Whether dotfiles/dotfolders (e.g. .github, .env, .claude) are shown in the
    * workspace file tree. Build/VCS output dirs stay hidden regardless. */
   showHiddenFiles: boolean;
+  /** Expanded directory paths, isolated by canonical Session/Worktree target. */
+  expandedPathsByWorkspace: Record<string, string[]>;
   toggleShowHiddenFiles: () => void;
   setShowHiddenFiles: (value: boolean) => void;
+  setExpandedPaths: (workspaceKey: string, paths: Iterable<string>) => void;
+  expandPath: (workspaceKey: string, path: string) => void;
+  toggleExpandedPath: (workspaceKey: string, path: string) => void;
 }
+
+type PersistedWorkspaceFileViewState = Pick<
+  WorkspaceFileViewState,
+  'showHiddenFiles' | 'expandedPathsByWorkspace'
+>;
+
+const EMPTY_EXPANDED_PATHS: string[] = [];
 
 export const useWorkspaceFileViewStore = create<WorkspaceFileViewState>()(
   persist(
     (set) => ({
       showHiddenFiles: false,
+      expandedPathsByWorkspace: {},
       toggleShowHiddenFiles: () =>
         set((state) => ({ showHiddenFiles: !state.showHiddenFiles })),
       setShowHiddenFiles: (value) => set({ showHiddenFiles: value }),
+      setExpandedPaths: (workspaceKey, paths) =>
+        set((state) => ({
+          expandedPathsByWorkspace: {
+            ...state.expandedPathsByWorkspace,
+            [workspaceKey]: Array.from(paths),
+          },
+        })),
+      expandPath: (workspaceKey, path) => {
+        if (!path) return;
+        set((state) => {
+          const next = new Set(state.expandedPathsByWorkspace[workspaceKey]);
+          let walked = '';
+          for (const part of path.split('/')) {
+            walked = walked ? `${walked}/${part}` : part;
+            next.add(walked);
+          }
+          return {
+            expandedPathsByWorkspace: {
+              ...state.expandedPathsByWorkspace,
+              [workspaceKey]: Array.from(next),
+            },
+          };
+        });
+      },
+      toggleExpandedPath: (workspaceKey, path) =>
+        set((state) => {
+          const next = new Set(state.expandedPathsByWorkspace[workspaceKey]);
+          if (next.has(path)) next.delete(path);
+          else next.add(path);
+          return {
+            expandedPathsByWorkspace: {
+              ...state.expandedPathsByWorkspace,
+              [workspaceKey]: Array.from(next),
+            },
+          };
+        }),
     }),
     {
       name: 'tessera:workspace-file-view',
-      storage: createUiJsonStorage<WorkspaceFileViewState>(),
+      storage: createUiJsonStorage<PersistedWorkspaceFileViewState>(),
+      partialize: (state) => ({
+        showHiddenFiles: state.showHiddenFiles,
+        expandedPathsByWorkspace: state.expandedPathsByWorkspace,
+      }),
     },
   ),
 );
+
+export const selectExpandedWorkspacePaths = (workspaceKey: string | null) =>
+  (state: WorkspaceFileViewState): string[] =>
+    workspaceKey
+      ? state.expandedPathsByWorkspace[workspaceKey] ?? EMPTY_EXPANDED_PATHS
+      : EMPTY_EXPANDED_PATHS;

--- a/tests/workspace-file-view-state.test.ts
+++ b/tests/workspace-file-view-state.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  selectExpandedWorkspacePaths,
+  useWorkspaceFileViewStore,
+} from '../src/stores/workspace-file-view-store';
+
+test('expanded folders survive switching to another workspace and back', () => {
+  useWorkspaceFileViewStore.setState({ expandedPathsByWorkspace: {} });
+
+  const store = useWorkspaceFileViewStore.getState();
+  store.setExpandedPaths('session:alpha', ['src', 'src/components']);
+  store.setExpandedPaths('session:beta', ['tests']);
+
+  assert.deepEqual(
+    selectExpandedWorkspacePaths('session:alpha')(useWorkspaceFileViewStore.getState()),
+    ['src', 'src/components'],
+  );
+  assert.deepEqual(
+    selectExpandedWorkspacePaths('session:beta')(useWorkspaceFileViewStore.getState()),
+    ['tests'],
+  );
+});

--- a/tests/workspace-tree-operations-contract.test.mjs
+++ b/tests/workspace-tree-operations-contract.test.mjs
@@ -6,6 +6,7 @@ const read = (relativePath) =>
   fs.readFileSync(new URL(relativePath, import.meta.url), 'utf8');
 
 const filePanelSource = read('../src/components/workspace/workspace-file-panel.tsx');
+const fileViewStoreSource = read('../src/stores/workspace-file-view-store.ts');
 const deleteDialogSource = read('../src/components/workspace/workspace-delete-dialog.tsx');
 const contextMenuSource = read('../src/components/workspace/workspace-file-context-menu.tsx');
 const inlineRowSource = read('../src/components/workspace/workspace-inline-input-row.tsx');
@@ -20,6 +21,14 @@ const worktreeDirectoryRouteSource = read('../src/app/api/worktrees/[id]/directo
 const filesRouteSource = read('../src/app/api/sessions/[id]/files/route.ts');
 const fileTabSource = read('../src/components/workspace/workspace-file-tab.tsx');
 const panelContainerSource = read('../src/components/panel/panel-container.tsx');
+
+test('folder expansion is restored per workspace after the file panel remounts', () => {
+  assert.match(filePanelSource, /selectExpandedWorkspacePaths\(targetKey\)/);
+  assert.match(filePanelSource, /toggleStoredPath\(targetKey, path\)/);
+  assert.doesNotMatch(filePanelSource, /useState<Set<string>>/);
+  assert.match(fileViewStoreSource, /expandedPathsByWorkspace/);
+  assert.match(fileViewStoreSource, /createUiJsonStorage<PersistedWorkspaceFileViewState>/);
+});
 
 test('every row action lives on the right-click menu, not on a hover strip', () => {
   // A file explorer is a list of names. Four icons appearing on whichever row


### PR DESCRIPTION
## Summary
- persist expanded file-tree folders per canonical Session/Worktree target
- restore expansion after the Files panel remounts on session navigation
- keep the state in Tessera UI storage so browser and Electron/mobile clients retain it locally
- add state and component contract regression coverage

## Tests
- `npx tsx --test tests/workspace-file-view-state.test.ts tests/workspace-tree-operations-contract.test.mjs`
- `npm run test:contracts`
- `npx eslint src/stores/workspace-file-view-store.ts src/components/workspace/workspace-file-panel.tsx tests/workspace-file-view-state.test.ts tests/workspace-tree-operations-contract.test.mjs`
- `npx tsc --noEmit --pretty false`

## Known unrelated test failure
- `npm run test:unit`: existing `git-action-failure-report.test.ts` locale-count assertion expects 5 locales but observes 6 (`6 !== 5`); 1,832 tests pass and 2 skip.