### PR TITLE
fix(paths): unify WSL and UNC worktree identity

### DIFF
--- a/src/lib/db/sessions.ts
+++ b/src/lib/db/sessions.ts
@@ -12,6 +12,7 @@ import {
 } from './worktree-identity';
 import type { ProjectViewMembership } from '@/lib/projects/project-view-membership';
 import { getWorktree, resolveCanonicalWorktree } from './worktrees';
+import { areCrossEnvironmentFilesystemPathsEquivalent } from '@/lib/filesystem/path-equivalence';
 
 export interface SessionRow {
   id: string;
@@ -323,10 +324,12 @@ export function deleteSession(id: string): void {
  * Used to decide whether to physically remove a managed worktree on session deletion.
  */
 export function countOtherSessionsByWorkDir(workDir: string, excludeSessionId: string): number {
-  const row = getDb()
-    .prepare('SELECT COUNT(*) AS cnt FROM sessions WHERE work_dir = ? AND id != ? AND deleted = 0')
-    .get(workDir, excludeSessionId) as { cnt: number } | undefined;
-  return row?.cnt ?? 0;
+  const rows = getDb()
+    .prepare('SELECT work_dir FROM sessions WHERE id != ? AND deleted = 0 AND work_dir IS NOT NULL')
+    .all(excludeSessionId) as Array<{ work_dir: string }>;
+  return rows.filter((row) =>
+    areCrossEnvironmentFilesystemPathsEquivalent(row.work_dir, workDir)
+  ).length;
 }
 
 /**
@@ -334,15 +337,17 @@ export function countOtherSessionsByWorkDir(workDir: string, excludeSessionId: s
  * Used to determine whether a managed worktree can be removed on archive.
  */
 export function countNonArchivedSessionsByWorkDir(workDir: string): number {
-  const row = getDb()
+  const rows = getDb()
     .prepare(`
-      SELECT COUNT(*) AS cnt
+      SELECT s.work_dir
       FROM sessions s
       LEFT JOIN tasks t ON t.id = s.task_id
-      WHERE s.work_dir = ? AND ${ACTIVE_SESSION_SCOPE_SQL}
+      WHERE s.work_dir IS NOT NULL AND ${ACTIVE_SESSION_SCOPE_SQL}
     `)
-    .get(workDir) as { cnt: number } | undefined;
-  return row?.cnt ?? 0;
+    .all() as Array<{ work_dir: string }>;
+  return rows.filter((row) =>
+    areCrossEnvironmentFilesystemPathsEquivalent(row.work_dir, workDir)
+  ).length;
 }
 
 /**
@@ -350,11 +355,15 @@ export function countNonArchivedSessionsByWorkDir(workDir: string): number {
  * Used to clear stale worktree metadata after the physical worktree is removed.
  */
 export function getSessionsByWorkDir(workDir: string): Array<Pick<SessionRow, 'id' | 'task_id' | 'worktree_branch'>> {
-  return getDb().prepare(`
-    SELECT id, task_id, worktree_branch
+  const rows = getDb().prepare(`
+    SELECT id, task_id, worktree_branch, work_dir
     FROM sessions
-    WHERE work_dir = ? AND deleted = 0
-  `).all(workDir) as Array<Pick<SessionRow, 'id' | 'task_id' | 'worktree_branch'>>;
+    WHERE work_dir IS NOT NULL AND deleted = 0
+  `).all() as Array<Pick<SessionRow, 'id' | 'task_id' | 'worktree_branch' | 'work_dir'>>;
+  return rows
+    .filter((row) => row.work_dir !== null
+      && areCrossEnvironmentFilesystemPathsEquivalent(row.work_dir, workDir))
+    .map(({ work_dir: _workDir, ...row }) => row);
 }
 
 /**
@@ -379,25 +388,26 @@ export function getSessionsByWorkDir(workDir: string): Array<Pick<SessionRow, 'i
 export function getActiveSessionIdsSharingWorkDir(workDir: string): string[] {
   const rows = getDb()
     .prepare(`
-      SELECT s.id AS id
-      FROM sessions s
-      LEFT JOIN tasks t ON t.id = s.task_id
-      WHERE (
-        s.work_dir = ?
-        OR (
-          s.task_id IS NOT NULL
-          AND (
+      SELECT
+        s.id AS id,
+        CASE
+          WHEN t.id IS NULL THEN s.work_dir
+          ELSE (
             SELECT ${PARENT_FIRST_WORKTREE_PATH_SQL}
             FROM tasks
             WHERE tasks.id = s.task_id
-          ) = ?
-        )
-      )
-      AND ${ACTIVE_SESSION_SCOPE_SQL}
+          )
+        END AS effective_work_dir
+      FROM sessions s
+      LEFT JOIN tasks t ON t.id = s.task_id
+      WHERE ${ACTIVE_SESSION_SCOPE_SQL}
       ORDER BY s.created_at ASC, s.id ASC
     `)
-    .all(workDir, workDir) as Array<{ id: string }>;
-  return rows.map((row) => row.id);
+    .all() as Array<{ id: string; effective_work_dir: string | null }>;
+  return rows
+    .filter((row) => row.effective_work_dir !== null
+      && areCrossEnvironmentFilesystemPathsEquivalent(row.effective_work_dir, workDir))
+    .map((row) => row.id);
 }
 
 export function getSessionsByTaskId(taskId: string): Array<Pick<SessionRow, 'id' | 'task_id' | 'worktree_branch'>> {
@@ -428,11 +438,20 @@ export function getSessionsEligibleForBareSessionPrSync(): Array<Pick<SessionRow
  * Clear worktree metadata for all sessions that reference the given work_dir.
  */
 export function clearWorktreeMetadataByWorkDir(workDir: string): void {
-  getDb().prepare(`
+  const db = getDb();
+  const rows = db.prepare(`
+    SELECT id, work_dir FROM sessions WHERE work_dir IS NOT NULL
+  `).all() as Array<{ id: string; work_dir: string }>;
+  const ids = rows
+    .filter((row) => areCrossEnvironmentFilesystemPathsEquivalent(row.work_dir, workDir))
+    .map((row) => row.id);
+  if (ids.length === 0) return;
+  const placeholders = ids.map(() => '?').join(', ');
+  db.prepare(`
     UPDATE sessions
     SET work_dir = NULL, worktree_branch = NULL, worktree_managed = 0, updated_at = ?
-    WHERE work_dir = ?
-  `).run(new Date().toISOString(), workDir);
+    WHERE id IN (${placeholders})
+  `).run(new Date().toISOString(), ...ids);
 }
 
 /**

--- a/src/lib/db/tasks.ts
+++ b/src/lib/db/tasks.ts
@@ -19,6 +19,7 @@ import {
   resolveEffectiveWorktreeCheckout,
 } from './worktree-identity';
 import type { ProjectViewMembership } from '@/lib/projects/project-view-membership';
+import { areCrossEnvironmentFilesystemPathsEquivalent } from '@/lib/filesystem/path-equivalence';
 
 export interface TaskRow {
   id: string;
@@ -865,13 +866,27 @@ export function getTaskBySessionId(
  * the directory names it unambiguously.
  */
 export function findTaskIdForWorktree(workDir: string): string | null {
-  const row = getDb().prepare(`
+  const db = getDb();
+  const row = db.prepare(`
     SELECT tasks.id AS task_id
     FROM tasks
     WHERE ${PARENT_FIRST_WORKTREE_PATH_SQL} = ?
     LIMIT 1
   `).get(workDir) as { task_id: string } | undefined;
-  return row?.task_id ?? null;
+  if (row) return row.task_id;
+
+  // A Windows server stores canonical Worktree roots as UNC while an existing
+  // WSL Session may still report `/home/...`. Exact SQL remains the hot path;
+  // the fallback only runs when the spellings differ.
+  const candidates = db.prepare(`
+    SELECT tasks.id AS task_id, ${PARENT_FIRST_WORKTREE_PATH_SQL} AS work_dir
+    FROM tasks
+    WHERE ${PARENT_FIRST_WORKTREE_PATH_SQL} IS NOT NULL
+    ORDER BY tasks.created_at, tasks.id
+  `).all() as Array<{ task_id: string; work_dir: string }>;
+  return candidates.find((candidate) =>
+    areCrossEnvironmentFilesystemPathsEquivalent(candidate.work_dir, workDir)
+  )?.task_id ?? null;
 }
 
 /**

--- a/src/lib/filesystem/path-equivalence.ts
+++ b/src/lib/filesystem/path-equivalence.ts
@@ -1,0 +1,62 @@
+/**
+ * Produce a browser-safe comparison key for paths that may cross the
+ * Windows-server / WSL-agent boundary. This module deliberately avoids Node
+ * path and filesystem APIs because Project state is also updated in the
+ * renderer.
+ */
+export function crossEnvironmentFilesystemPathKey(filesystemPath: string): string {
+  const slashPath = filesystemPath.trim().replace(/\\/g, '/');
+  const wslUncMatch = slashPath.match(
+    /^\/\/(?:wsl\.localhost|wsl\$)\/[^/]+(\/.*)?$/i,
+  );
+  if (wslUncMatch) {
+    return `wsl:${normalizeAbsolutePath(wslUncMatch[1] ?? '/')}`;
+  }
+
+  const windowsDriveMatch = slashPath.match(/^([a-zA-Z]):(?:\/(.*))?$/);
+  if (windowsDriveMatch) {
+    return windowsDriveKey(windowsDriveMatch[1], windowsDriveMatch[2] ?? '');
+  }
+
+  const wslDriveMountMatch = slashPath.match(/^\/mnt\/([a-zA-Z])(?:\/(.*))?$/);
+  if (wslDriveMountMatch) {
+    return windowsDriveKey(wslDriveMountMatch[1], wslDriveMountMatch[2] ?? '');
+  }
+
+  if (slashPath.startsWith('/')) {
+    return `wsl:${normalizeAbsolutePath(slashPath)}`;
+  }
+
+  return `relative:${slashPath}`;
+}
+
+export function areCrossEnvironmentFilesystemPathsEquivalent(
+  left: string,
+  right: string,
+): boolean {
+  return crossEnvironmentFilesystemPathKey(left)
+    === crossEnvironmentFilesystemPathKey(right);
+}
+
+function windowsDriveKey(drive: string, rest: string): string {
+  const normalizedRest = normalizePathSegments(rest).toLowerCase();
+  return `windows:${drive.toLowerCase()}:/${normalizedRest}`;
+}
+
+function normalizeAbsolutePath(value: string): string {
+  const normalized = normalizePathSegments(value);
+  return normalized ? `/${normalized}` : '/';
+}
+
+function normalizePathSegments(value: string): string {
+  const segments: string[] = [];
+  for (const segment of value.split('/')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments.join('/');
+}

--- a/src/lib/git/diff-stats-safety-sweep.ts
+++ b/src/lib/git/diff-stats-safety-sweep.ts
@@ -10,6 +10,8 @@
  * touching the push paths.
  */
 
+import { crossEnvironmentFilesystemPathKey } from '@/lib/filesystem/path-equivalence';
+
 export interface DiffStatsSafetySweepDependencies {
   /** Users with a live transport; nobody connected means nobody to broadcast to. */
   getConnectedUserIds(): Iterable<string>;
@@ -38,17 +40,19 @@ export function runDiffStatsSafetySweep(
   const refreshed: string[] = [];
   // First user seen for a workDir wins: a shared worktree only needs one
   // recompute, and the broadcast fans out to every session on that workDir.
-  const ownerByWorkDir = new Map<string, string>();
+  const ownerByWorkDir = new Map<string, { workDir: string; userId: string }>();
 
   for (const userId of dependencies.getConnectedUserIds()) {
     for (const sessionId of dependencies.getActiveSessionIds(userId)) {
       const workDir = dependencies.getSessionWorkDir(sessionId);
-      if (!workDir || ownerByWorkDir.has(workDir)) continue;
-      ownerByWorkDir.set(workDir, userId);
+      if (!workDir) continue;
+      const key = crossEnvironmentFilesystemPathKey(workDir);
+      if (ownerByWorkDir.has(key)) continue;
+      ownerByWorkDir.set(key, { workDir, userId });
     }
   }
 
-  for (const [workDir, userId] of ownerByWorkDir) {
+  for (const { workDir, userId } of ownerByWorkDir.values()) {
     if (!dependencies.needsRefresh(workDir)) continue;
     dependencies.recompute(workDir, userId);
     refreshed.push(workDir);

--- a/src/lib/git/git-actions.ts
+++ b/src/lib/git/git-actions.ts
@@ -28,6 +28,10 @@ import {
 } from "@/lib/github/gh-cli";
 import { normalizeGithubOwnerRepo } from "@/lib/github/pr-status-provider";
 import logger from "@/lib/logger";
+import {
+  getFilesystemPathModule,
+  resolvePathForHostFilesystem,
+} from "@/lib/filesystem/host-path";
 import type { AgentEnvironment } from "@/lib/settings/types";
 import type {
   GitActionFailure,
@@ -38,7 +42,6 @@ import type {
 } from "@/types/git";
 import { detectGitConflictOperation } from "./git-conflict-state";
 import { rm } from "node:fs/promises";
-import { join } from "node:path";
 import { parseGitStatus } from "./git-status";
 import { canRevertFile } from "./revert-eligibility";
 import {
@@ -180,6 +183,19 @@ export async function executeGitAction(
   return runCommit(target, action, runGit);
 }
 
+/** Resolve a repository-relative Git path into a path this Node process can open. */
+export async function resolveGitActionFilePath(
+  workDir: string,
+  relativePath: string,
+  resolveHostPath: (filesystemPath: string) => Promise<string> = resolvePathForHostFilesystem,
+): Promise<string> {
+  // Translate the root before joining. On Windows, node:path would otherwise
+  // turn a CLI-reported `/home/...` root into a drive-rooted `C:\\home\\...`
+  // path before the bridge resolver has a chance to see the POSIX spelling.
+  const hostWorkDir = await resolveHostPath(workDir);
+  return getFilesystemPathModule(hostWorkDir).join(hostWorkDir, relativePath);
+}
+
 async function runRevert(
   target: GitActionTarget,
   action: GitRevertAction,
@@ -220,7 +236,7 @@ async function runRevert(
       if (file.state === "untracked") {
         // No HEAD version to restore to; orca discards these by deleting.
         // `git rm` cannot remove an untracked path, so delete it directly.
-        await rm(join(target.workDir, filePath));
+        await rm(await resolveGitActionFilePath(target.workDir, filePath));
       } else {
         await runGit(["restore", "--source=HEAD", "--worktree", "--", filePath], {
           cwd: target.workDir,

--- a/src/lib/git/git-remote-refresh.ts
+++ b/src/lib/git/git-remote-refresh.ts
@@ -12,6 +12,7 @@
  */
 
 import logger from "@/lib/logger";
+import { crossEnvironmentFilesystemPathKey } from "@/lib/filesystem/path-equivalence";
 import { fetchGitRemote, getGitCommonDir } from "./git-panel";
 import { scheduleGitPanelRecompute } from "./git-panel-cache";
 
@@ -118,7 +119,8 @@ async function resolveRefsKeyCached(
   deps: GitRemoteRefreshDeps,
 ): Promise<string> {
   const state = getState();
-  const cached = state.refsKeyByWorkDir.get(workDir);
+  const workDirKey = crossEnvironmentFilesystemPathKey(workDir);
+  const cached = state.refsKeyByWorkDir.get(workDirKey);
   if (cached !== undefined) return cached;
 
   let resolved: string | null = null;
@@ -142,9 +144,9 @@ async function resolveRefsKeyCached(
   // the repository, which the interval already bounds. It is never a wrong
   // answer, only a less shared one. Not cached, so a momentary failure does not
   // decide the key for the rest of the process's life.
-  if (resolved === null) return workDir;
+  if (resolved === null) return workDirKey;
 
-  state.refsKeyByWorkDir.set(workDir, resolved);
+  state.refsKeyByWorkDir.set(workDirKey, resolved);
   return resolved;
 }
 

--- a/src/lib/git/worktree-diff-stats-bulk.ts
+++ b/src/lib/git/worktree-diff-stats-bulk.ts
@@ -4,6 +4,7 @@ import {
   scheduleRecompute,
 } from './worktree-diff-stats-cache';
 import type { WorktreeDiffStats } from '@/types/worktree-diff-stats';
+import { crossEnvironmentFilesystemPathKey } from '@/lib/filesystem/path-equivalence';
 
 interface BulkDiffStatsDependencies {
   readCached: typeof getCachedDiffStats;
@@ -30,8 +31,10 @@ export function getCachedBulk(
   const visited = new Set<string>();
 
   for (const workDir of workDirs) {
-    if (!workDir || visited.has(workDir)) continue;
-    visited.add(workDir);
+    if (!workDir) continue;
+    const key = crossEnvironmentFilesystemPathKey(workDir);
+    if (visited.has(key)) continue;
+    visited.add(key);
     const cached = readCached(workDir);
     if (cached !== undefined) result.set(workDir, cached);
   }
@@ -55,8 +58,9 @@ export function getCachedOrScheduleBulk(
 
   for (const wd of workDirs) {
     if (!wd) continue;
-    if (visited.has(wd)) continue;
-    visited.add(wd);
+    const key = crossEnvironmentFilesystemPathKey(wd);
+    if (visited.has(key)) continue;
+    visited.add(key);
 
     const cached = dependencies.readCached(wd);
     if (cached !== undefined) {

--- a/src/lib/memory/claude-memory.ts
+++ b/src/lib/memory/claude-memory.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as dbProjects from "@/lib/db/projects";
 import * as dbSessions from "@/lib/db/sessions";
 import { isAbsoluteFilesystemPath } from "@/lib/filesystem/host-path";
+import { areCrossEnvironmentFilesystemPathsEquivalent } from "@/lib/filesystem/path-equivalence";
 import { resolveClaudeConfigDirForEnvironment } from "@/lib/skill/skill-loader";
 import { normalizeCwdForCliEnvironment } from "@/lib/cli/spawn-cli";
 import { resolveSessionWorkspaceFilesystemRoot } from "@/lib/session/session-workspace-root";
@@ -181,7 +182,10 @@ export async function resolveSessionMemoryDir(
   const projectId = session.project_id?.trim();
   const projectRoot = projectPath
     || (projectId && isAbsoluteFilesystemPath(projectId) ? projectId : null);
-  if (projectRoot && projectRoot !== workDir) {
+  if (
+    projectRoot
+    && (!workDir || !areCrossEnvironmentFilesystemPathsEquivalent(projectRoot, workDir))
+  ) {
     candidates.push({ root: "project", workspaceRoot: projectRoot });
   }
   if (candidates.length === 0) return null;

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -34,6 +34,7 @@ import {
   type SessionRuntimeLiveness,
 } from '@/lib/session/session-runtime-liveness';
 import { resolveStoredSessionAppearance } from '@/lib/projects/stored-session-resolution';
+import { areCrossEnvironmentFilesystemPathsEquivalent } from '@/lib/filesystem/path-equivalence';
 
 const ACTIVE_SESSION_STORAGE_KEY = 'tessera:active-session';
 
@@ -1700,7 +1701,9 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         });
         const projectWorktree = project.projectWorktree;
         const isProjectWorktreeTarget = Boolean(
-          workDir && projectWorktree?.path === workDir,
+          workDir
+          && projectWorktree
+          && areCrossEnvironmentFilesystemPathsEquivalent(projectWorktree.path, workDir),
         );
         const nextProjectWorktree = isProjectWorktreeTarget
           && projectWorktree

--- a/tests/diff-stats-safety-sweep.test.ts
+++ b/tests/diff-stats-safety-sweep.test.ts
@@ -82,6 +82,22 @@ test('sessions sharing one workDir produce a single recompute', () => {
   assert.deepEqual(recomputed, [{ workDir: '/repo/shared', userId: 'user-a' }]);
 });
 
+test('WSL display and UNC spellings produce a single recompute', () => {
+  const recomputed: Array<{ workDir: string; userId: string }> = [];
+  const result = runDiffStatsSafetySweep({
+    getConnectedUserIds: () => ['user-a'],
+    getActiveSessionIds: () => ['session-posix', 'session-unc'],
+    getSessionWorkDir: (sessionId) => sessionId === 'session-posix'
+      ? '/home/work/Source/tessera-dev'
+      : '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\Source\\tessera-dev',
+    needsRefresh: () => true,
+    recompute: (workDir, userId) => recomputed.push({ workDir, userId }),
+  });
+
+  assert.equal(result.inspected, 1);
+  assert.equal(recomputed.length, 1);
+});
+
 test('a workDir shared across users is recomputed once, for the first owner seen', () => {
   const { dependencies, recomputed } = createDependencies({
     connectedUserIds: ['user-a', 'user-b'],

--- a/tests/filesystem-path-equivalence.test.ts
+++ b/tests/filesystem-path-equivalence.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  areCrossEnvironmentFilesystemPathsEquivalent,
+  crossEnvironmentFilesystemPathKey,
+} from '@/lib/filesystem/path-equivalence';
+
+test('Windows-hosted WSL UNC and agent POSIX paths share one comparison key', () => {
+  const unc = '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\Source\\tessera-dev';
+  const legacyUnc = '\\\\wsl$\\Ubuntu-24.04\\home\\work\\Source\\tessera-dev';
+  const agentPath = '/home/work/Source/tessera-dev';
+
+  assert.equal(crossEnvironmentFilesystemPathKey(unc), `wsl:${agentPath}`);
+  assert.equal(areCrossEnvironmentFilesystemPathsEquivalent(unc, agentPath), true);
+  assert.equal(areCrossEnvironmentFilesystemPathsEquivalent(legacyUnc, agentPath), true);
+});
+
+test('Windows drive and WSL mount spellings compare case-insensitively', () => {
+  assert.equal(
+    areCrossEnvironmentFilesystemPathsEquivalent(
+      'C:\\Users\\work\\Source\\tessera-dev',
+      '/mnt/c/users/WORK/source/tessera-dev',
+    ),
+    true,
+  );
+});
+
+test('distinct WSL paths remain distinct', () => {
+  assert.equal(
+    areCrossEnvironmentFilesystemPathsEquivalent(
+      '/home/work/Source/tessera-dev',
+      '/home/work/Source/tessera-main',
+    ),
+    false,
+  );
+});

--- a/tests/git-actions.test.ts
+++ b/tests/git-actions.test.ts
@@ -9,6 +9,7 @@ import {
   executeGitAction,
   GitActionRejection,
   promoteHookRejection,
+  resolveGitActionFilePath,
   type GitActionTarget,
 } from '@/lib/git/git-actions';
 import { GitCommandError } from '@/lib/worktrees/git-runner';
@@ -23,6 +24,25 @@ const execFileAsync = promisify(execFile);
  */
 const LOCAL_ENVIRONMENT: AgentEnvironment = 'wsl';
 const SKIP_ON_WINDOWS = process.platform === 'win32';
+
+test('untracked revert resolves a CLI-reported path for the host filesystem', async () => {
+  const reportedWorkDir = '/home/work/Source/tessera-dev';
+  const expectedHostRoot = '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\Source\\tessera-dev';
+  const expectedHostPath = '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\Source\\tessera-dev\\fresh.txt';
+  const inputs: string[] = [];
+
+  const resolved = await resolveGitActionFilePath(
+    reportedWorkDir,
+    'fresh.txt',
+    async (candidate) => {
+      inputs.push(candidate);
+      return expectedHostRoot;
+    },
+  );
+
+  assert.deepEqual(inputs, [reportedWorkDir]);
+  assert.equal(resolved, expectedHostPath);
+});
 
 async function withTempRepo(
   run: (target: GitActionTarget, repoDir: string) => Promise<void>,

--- a/tests/git-remote-refresh.test.ts
+++ b/tests/git-remote-refresh.test.ts
@@ -107,6 +107,29 @@ test('sessions sharing a working directory fetch once between them', async () =>
   assert.deepEqual(h.fetched, [workDir]);
 });
 
+test('WSL display and UNC spellings share the fallback refresh interval', async () => {
+  const posix = '/home/work/Source/tessera-dev';
+  const unc = '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\Source\\tessera-dev';
+  const fetched: string[] = [];
+  const deps: GitRemoteRefreshDeps = {
+    now: () => 1_000_000,
+    resolveRefsKey: async () => null,
+    runFetch: async (workDir) => { fetched.push(workDir); },
+    onFetched: () => undefined,
+  };
+
+  await scheduleGitRemoteRefresh(
+    { sessionId: 'alias-posix', workDir: posix, userId: 'user-1' },
+    deps,
+  );
+  await scheduleGitRemoteRefresh(
+    { sessionId: 'alias-unc', workDir: unc, userId: 'user-1' },
+    deps,
+  );
+
+  assert.deepEqual(fetched, [posix]);
+});
+
 test('reads that arrive together start one fetch, not two', async () => {
   // Two panels on the same checkout poll on their own clocks and do overlap.
   // Neither has resolved which refs it is asking about yet, so the guard has to

--- a/tests/parent-worktree-authority.test.ts
+++ b/tests/parent-worktree-authority.test.ts
@@ -111,6 +111,40 @@ test('preparation and reverse lookup use the parent path before the legacy child
   assert.equal(tasks.findTaskIdForWorktree(spacedPath), 'spaced-path-task');
 });
 
+test('workDir lookups match Windows-hosted WSL aliases', async () => {
+  const { sessions, tasks } = await modules();
+  const posix = '/home/work/Source/alias-worktree';
+  const unc = '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\Source\\alias-worktree';
+
+  tasks.createTask({ id: 'alias-task', projectId: dataDir, title: 'Alias task' });
+  tasks.setTaskWorktreeCheckout('alias-task', {
+    branch: 'feature/alias',
+    path: unc,
+  });
+  sessions.createSession('alias-posix-session', dataDir, 'Alias POSIX', 'codex', {
+    workDir: posix,
+  });
+  sessions.createSession('alias-unc-session', dataDir, 'Alias UNC', 'codex', {
+    workDir: unc,
+  });
+
+  assert.equal(tasks.findTaskIdForWorktree(posix), 'alias-task');
+  assert.deepEqual(
+    sessions.getSessionsByWorkDir(posix).map((session) => session.id).sort(),
+    ['alias-posix-session', 'alias-unc-session'],
+  );
+  assert.deepEqual(
+    sessions.getActiveSessionIdsSharingWorkDir(posix).sort(),
+    ['alias-posix-session', 'alias-unc-session'],
+  );
+  assert.equal(sessions.countOtherSessionsByWorkDir(posix, 'alias-posix-session'), 1);
+  assert.equal(sessions.countNonArchivedSessionsByWorkDir(posix), 2);
+
+  sessions.clearWorktreeMetadataByWorkDir(posix);
+  assert.equal(sessions.getSession('alias-posix-session')?.work_dir, null);
+  assert.equal(sessions.getSession('alias-unc-session')?.work_dir, null);
+});
+
 test('PR observation uses parent paths for zero-session Worktrees and legacy fallback only when needed', async () => {
   const { sessions, tasks } = await modules();
   const parentPath = path.join(dataDir, 'pr-parent-owned');

--- a/tests/project-view-open-session.test.ts
+++ b/tests/project-view-open-session.test.ts
@@ -107,7 +107,7 @@ test('a branch refresh hides a Session from projection but retains an open tab t
   });
 });
 
-test('a canonical Project checkout update reaches every direct chat despite path spelling', () => {
+test('a canonical Project checkout update reaches every direct chat across WSL path spellings', () => {
   const linuxChat = { ...scopedSession, id: 'linux-chat', workDir: '/home/work/repository' };
   const missingPathChat = { ...scopedSession, id: 'missing-path-chat', workDir: undefined };
   const stats = {
@@ -118,12 +118,19 @@ test('a canonical Project checkout update reaches every direct chat despite path
     deletedFiles: 0,
     computedAt: '2026-08-21T00:00:00.000Z',
   };
+  const projectView = project([linuxChat, missingPathChat], 'main');
   useSessionStore.setState({
     ...useSessionStore.getInitialState(),
-    projects: [project([linuxChat, missingPathChat], 'main')],
+    projects: [{
+      ...projectView,
+      projectWorktree: {
+        ...projectView.projectWorktree!,
+        path: '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\repository',
+      },
+    }],
   });
 
-  useSessionStore.getState().applyDiffStatsUpdate([], stats, '/repository');
+  useSessionStore.getState().applyDiffStatsUpdate([], stats, '/home/work/repository');
 
   const updated = useSessionStore.getState().projects[0];
   assert.deepEqual(updated.projectWorktree?.diffStats, stats);

--- a/tests/worktree-diff-stats-bulk.test.ts
+++ b/tests/worktree-diff-stats-bulk.test.ts
@@ -26,6 +26,19 @@ test('cold bulk reads deduplicate checkout paths without scheduling work', () =>
   assert.deepEqual(Array.from(result.entries()), [['/repo/project', cachedStats]]);
 });
 
+test('cold bulk reads deduplicate WSL display and UNC spellings', () => {
+  const reads: string[] = [];
+  const posix = '/home/work/Source/tessera-dev';
+  const unc = '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\Source\\tessera-dev';
+
+  getCachedBulk([posix, unc], (workDir) => {
+    reads.push(workDir);
+    return cachedStats;
+  });
+
+  assert.deepEqual(reads, [posix]);
+});
+
 test('bulk list reads return cached values and schedule every unique miss in list order', () => {
   const reads: string[] = [];
   const scheduled: Array<{ workDir: string; userId: string }> = [];
@@ -63,4 +76,18 @@ test('bulk list reads keep stale values visible while scheduling one refresh', (
 
   assert.deepEqual(Array.from(result.entries()), [['/repo/a', cachedStats]]);
   assert.deepEqual(scheduled, ['/repo/a']);
+});
+
+test('bulk list schedules one refresh for WSL display and UNC spellings', () => {
+  const scheduled: string[] = [];
+  const posix = '/home/work/Source/tessera-dev';
+  const unc = '\\\\wsl.localhost\\Ubuntu-24.04\\home\\work\\Source\\tessera-dev';
+
+  getCachedOrScheduleBulk([posix, unc], 'user-1', {
+    readCached: () => undefined,
+    isStale: () => false,
+    schedule: (workDir) => scheduled.push(workDir),
+  });
+
+  assert.deepEqual(scheduled, [posix]);
 });


### PR DESCRIPTION
## Summary
- treat WSL POSIX paths and their Windows UNC spellings as one worktree identity
- resolve untracked Revert targets for the Windows host filesystem before deletion
- deduplicate diff sweeps, bulk refreshes, remote refreshes, and memory candidates across path aliases
- make session/task lookups and project-view updates path-equivalence aware

## Verification
- `npx tsx --test tests/filesystem-path-equivalence.test.ts tests/project-view-open-session.test.ts tests/worktree-diff-stats-cache-key.test.ts tests/git-actions.test.ts tests/diff-stats-safety-sweep.test.ts tests/worktree-diff-stats-bulk.test.ts tests/git-remote-refresh.test.ts tests/parent-worktree-authority.test.ts` (61/61)
- `npx tsc --noEmit -p tsconfig.json`
- targeted ESLint and `git diff --check`
- isolated packaged Windows Electron backend + WSL CLI: UNC worktree detected an untracked file, Revert returned 200, and the next Git panel read returned `changedFilesTotal: 0`

## Note
- The full unit suite has one pre-existing failure in `git-action-failure-report.test.ts`: its verb list omits the already-supported `revert` action (expected 5 title keys, actual 6).