### PR TITLE
fix(ui): compact worktree child session layout

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -59,6 +59,10 @@ import { toLinkedWorktreeSession } from '@/lib/worktrees/linked-worktree-present
 import { projectViewWorkspaceState } from '@/lib/projects/project-view-workspace-state-client';
 import { captureTelemetryUiControl } from '@/lib/telemetry/client';
 import { telemetryClickAttributes } from '@/lib/telemetry/ui-click';
+import {
+  SIDEBAR_TREE_WORKTREE_CARD_CHILD_BRANCH,
+  SIDEBAR_TREE_WORKTREE_CHILD_CONNECTOR_OFFSET,
+} from '@/components/chat/sidebar-tree-layout';
 
 // --- Helpers ---
 
@@ -1164,7 +1168,10 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
 
         {/* Expanded session list with tree connectors (matching list view SubSessionRow) */}
         {!isDragging && expanded && isMultiSession && (
-          <div className="relative ml-[22px] pl-3 mt-2 border-t border-(--divider) pt-1.5">
+          <div className={cn(
+            'relative mt-0.5 border-t border-(--divider) pt-0.5',
+            SIDEBAR_TREE_WORKTREE_CARD_CHILD_BRANCH,
+          )}>
             {/* Vertical tree line */}
             <div className="absolute left-0 top-[6px] bottom-2 w-px bg-(--divider)" />
             {visibleSessions.map((s) => (
@@ -1381,8 +1388,14 @@ function KanbanSubSessionItem({
           />
         )}
         {/* Tree connector line */}
-        <div className="absolute -left-3 top-1/2 w-[10px] h-px bg-(--divider)" />
-        {isActive && <div className="absolute -left-3 top-1/2 -translate-y-1/2 w-[3px] h-4 rounded-r-full bg-(--accent)" />}
+        <div className={cn(
+          'absolute top-1/2 h-px w-[10px] bg-(--divider)',
+          SIDEBAR_TREE_WORKTREE_CHILD_CONNECTOR_OFFSET,
+        )} />
+        {isActive && <div className={cn(
+          'absolute top-1/2 h-4 w-[3px] -translate-y-1/2 rounded-r-full bg-(--accent)',
+          SIDEBAR_TREE_WORKTREE_CHILD_CONNECTOR_OFFSET,
+        )} />}
 
         {showProviderIcons ? (
           <span className="relative flex shrink-0 items-center">

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -75,6 +75,8 @@ import { resolveSessionRuntimePresentation } from '@/lib/session/session-runtime
 import {
   SIDEBAR_TREE_LEADING_SLOT,
   SIDEBAR_TREE_ROW_GUTTER,
+  SIDEBAR_TREE_WORKTREE_CHILD_BRANCH,
+  SIDEBAR_TREE_WORKTREE_CHILD_CONNECTOR_OFFSET,
 } from './sidebar-tree-layout';
 import type { AgentExecutionMode } from '@/lib/session/agent-execution-mode';
 import { projectViewWorkspaceState } from '@/lib/projects/project-view-workspace-state-client';
@@ -663,9 +665,15 @@ function SubSessionRow({
           )}
         />
       )}
-      <div className="absolute -left-3 top-1/2 h-px w-[10px] bg-(--divider)" />
+      <div className={cn(
+        'absolute top-1/2 h-px w-[10px] bg-(--divider)',
+        SIDEBAR_TREE_WORKTREE_CHILD_CONNECTOR_OFFSET,
+      )} />
       {isActive && (
-        <div className="absolute -left-3 top-1/2 h-4 w-[3px] -translate-y-1/2 rounded-r-full bg-(--accent)" />
+        <div className={cn(
+          'absolute top-1/2 h-4 w-[3px] -translate-y-1/2 rounded-r-full bg-(--accent)',
+          SIDEBAR_TREE_WORKTREE_CHILD_CONNECTOR_OFFSET,
+        )} />
       )}
       {showProviderIcons ? (
         <span className="relative flex shrink-0 items-center">
@@ -1272,7 +1280,7 @@ export function TaskItemRow({
 
       {isExpanded && (
         <div
-          className="relative ml-[30px] pl-3"
+          className={cn('relative', SIDEBAR_TREE_WORKTREE_CHILD_BRANCH)}
           onDragOver={(event) => {
             if (!event.dataTransfer.types.includes(COLLECTION_ITEM_DND_MIME)) return;
 

--- a/src/components/chat/sidebar-tree-layout.ts
+++ b/src/components/chat/sidebar-tree-layout.ts
@@ -7,3 +7,6 @@
 export const SIDEBAR_TREE_ROW_GUTTER = 'mx-0 px-2';
 export const SIDEBAR_TREE_CHILD_INDENT = 'ml-3';
 export const SIDEBAR_TREE_LEADING_SLOT = 'flex h-3.5 w-3.5 shrink-0 items-center justify-center';
+export const SIDEBAR_TREE_WORKTREE_CHILD_BRANCH = 'ml-4';
+export const SIDEBAR_TREE_WORKTREE_CARD_CHILD_BRANCH = 'ml-2';
+export const SIDEBAR_TREE_WORKTREE_CHILD_CONNECTOR_OFFSET = 'left-0';

--- a/tests/sidebar-tree-alignment-contract.test.mjs
+++ b/tests/sidebar-tree-alignment-contract.test.mjs
@@ -10,6 +10,10 @@ const collectionRowsSource = readFileSync(
   new URL('../src/components/chat/collection-group-sections.tsx', import.meta.url),
   'utf8',
 );
+const kanbanCardSource = readFileSync(
+  new URL('../src/components/board/kanban-card.tsx', import.meta.url),
+  'utf8',
+);
 const allProjectsSource = readFileSync(
   new URL('../src/components/chat/all-projects-list.tsx', import.meta.url),
   'utf8',
@@ -31,6 +35,22 @@ test('collection, task, and chat rows all consume the shared grid exactly once',
   assert.equal((collectionGroupSource.match(/SIDEBAR_TREE_LEADING_SLOT/g) ?? []).length, 2);
   assert.equal((collectionRowsSource.match(/SIDEBAR_TREE_ROW_GUTTER/g) ?? []).length, 3);
   assert.equal((collectionRowsSource.match(/SIDEBAR_TREE_LEADING_SLOT/g) ?? []).length, 3);
+});
+
+test('list and board worktree children use surface-adjusted compact branch insets', () => {
+  assert.match(treeLayoutSource, /SIDEBAR_TREE_WORKTREE_CHILD_BRANCH = 'ml-4'/);
+  assert.match(treeLayoutSource, /SIDEBAR_TREE_WORKTREE_CARD_CHILD_BRANCH = 'ml-2'/);
+  assert.match(treeLayoutSource, /SIDEBAR_TREE_WORKTREE_CHILD_CONNECTOR_OFFSET = 'left-0'/);
+  assert.equal((collectionRowsSource.match(/SIDEBAR_TREE_WORKTREE_CHILD_BRANCH/g) ?? []).length, 2);
+  assert.equal((kanbanCardSource.match(/SIDEBAR_TREE_WORKTREE_CARD_CHILD_BRANCH/g) ?? []).length, 2);
+  assert.equal((collectionRowsSource.match(/SIDEBAR_TREE_WORKTREE_CHILD_CONNECTOR_OFFSET/g) ?? []).length, 3);
+  assert.equal((kanbanCardSource.match(/SIDEBAR_TREE_WORKTREE_CHILD_CONNECTOR_OFFSET/g) ?? []).length, 3);
+  assert.doesNotMatch(collectionRowsSource, /className="relative ml-\[30px\] pl-3"/);
+  assert.doesNotMatch(kanbanCardSource, /className="relative ml-\[22px\] pl-3/);
+  assert.doesNotMatch(collectionRowsSource, /className="absolute -left-3 top-1\/2/);
+  assert.doesNotMatch(kanbanCardSource, /className="absolute -left-3 top-1\/2/);
+  assert.match(kanbanCardSource, /'relative mt-0\.5 border-t border-\(--divider\) pt-0\.5'/);
+  assert.doesNotMatch(kanbanCardSource, /'relative mt-2 border-t border-\(--divider\) pt-1\.5'/);
 });
 
 test('all-projects header joins the same icon and label columns', () => {


### PR DESCRIPTION
## Summary
- reduce nested Worktree Session indentation in List and Board views
- align tree connectors so they extend rightward from the vertical trunk
- tighten the Board card gap between collection metadata and child Sessions
- add a shared layout contract covering both surfaces

## Verification
- `node --test tests/sidebar-tree-alignment-contract.test.mjs`
- `node --import tsx --test tests/adaptive-linked-worktree-navigation.test.tsx tests/kanban-project-projection-render.test.tsx`
- `npx eslint src/components/chat/sidebar-tree-layout.ts src/components/chat/collection-group-sections.tsx src/components/board/kanban-card.tsx tests/sidebar-tree-alignment-contract.test.mjs`

## Visual verification
Measured in the development browser with the same fixture:
- List parent-to-child icon delta: 19px
- Board parent-to-child icon delta: 19px
- Connector leftward protrusion: none