### PR TITLE
fix(chat): prevent mobile image lightbox zoom

### DIFF
--- a/src/components/chat/image-lightbox.tsx
+++ b/src/components/chat/image-lightbox.tsx
@@ -26,9 +26,19 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
   const avoidsWindowControls = electronPlatform === 'win32';
   const resolvedAlt = alt || t('chat.imageOriginalView');
 
+  // The opener is a button, so it remains focused behind this portal. Android
+  // Chrome can restore that focus when the portal is removed, which summons the
+  // software keyboard even though the user only dismissed an image.
+  const closeLightbox = useCallback(() => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+    onClose();
+  }, [onClose]);
+
   // The PTY chat view handles Escape during React's capture phase. Claim it at
   // document capture first so closing the lightbox cannot also interrupt the PTY.
-  useCloseOnEscape(onClose, { capture: true });
+  useCloseOnEscape(closeLightbox, { capture: true });
 
   // Scroll lock
   useEffect(() => {
@@ -40,8 +50,8 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
   }, []);
 
   const handleOverlayClick = useCallback(() => {
-    onClose();
-  }, [onClose]);
+    closeLightbox();
+  }, [closeLightbox]);
 
   if (typeof document === 'undefined') {
     return null;
@@ -52,6 +62,7 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
       {...telemetryClickAttributes('message.image.close', 'message')}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
       onClick={handleOverlayClick}
+      style={{ touchAction: 'none' }}
       role="dialog"
       aria-modal="true"
       aria-label={resolvedAlt}
@@ -59,7 +70,7 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
       <button
         {...telemetryClickAttributes('message.image.close', 'message')}
         type="button"
-        onClick={onClose}
+        onClick={closeLightbox}
         className={cn(
           'absolute right-4 w-10 h-10 flex items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors text-xl',
           avoidsWindowControls ? 'top-12' : 'top-4',

--- a/tests/image-lightbox-escape-contract.test.mjs
+++ b/tests/image-lightbox-escape-contract.test.mjs
@@ -12,12 +12,27 @@ test('image lightbox claims Escape before the PTY chat view capture handler', ()
   assert.match(chatAreaSource, /onKeyDownCapture=\{handleTerminalChatKeyDown\}/);
   assert.match(
     imageLightboxSource,
-    /useCloseOnEscape\(onClose, \{ capture: true \}\)/,
+    /useCloseOnEscape\(closeLightbox, \{ capture: true \}\)/,
   );
   assert.match(closeOnEscapeSource, /event\.preventDefault\(\)/);
   assert.match(closeOnEscapeSource, /event\.stopPropagation\(\)/);
   assert.match(
     closeOnEscapeSource,
     /document\.addEventListener\('keydown', handleEscape, capture\)/,
+  );
+});
+
+test('image lightbox owns mobile gestures and clears the image opener focus when it closes', () => {
+  const imageLightboxSource = read('../src/components/chat/image-lightbox.tsx');
+
+  assert.match(
+    imageLightboxSource,
+    /touchAction:\s*'none'/,
+    'the browser must not turn a pinch on the lightbox into page zoom',
+  );
+  assert.match(
+    imageLightboxSource,
+    /document\.activeElement instanceof HTMLElement[\s\S]*?\.blur\(\)/,
+    'closing must clear the focused image opener so Android does not restore its keyboard',
   );
 });


### PR DESCRIPTION
## Summary
- prevent pinch gestures in the image lightbox from zooming Android Chrome
- blur the image opener when closing so the mobile keyboard is not restored
- cover the mobile lightbox interaction contract

## Verification
- `node --test tests/image-lightbox-escape-contract.test.mjs`
- `git diff --check`

Lint was not runnable in this worktree because `eslint-config-next` is not installed.