### PR TITLE
revert: remove worktree title width fix from main

### DIFF
--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -710,7 +710,7 @@ function SubSessionRow({
           className="min-w-0 flex-1 border-b border-(--accent) bg-transparent text-[0.75rem] text-(--sidebar-text-active) outline-none"
         />
       ) : (
-        <span className="min-w-0 flex-1 truncate">{sess.title}</span>
+        <span className="min-w-0 flex-1 truncate pr-8">{sess.title}</span>
       )}
 
       {!isRenaming && (
@@ -720,7 +720,7 @@ function SubSessionRow({
         // carries them via onContextMenu), and the kebab itself is always
         // visible. Hover on touch is unreliable and, when it does fire on tap,
         // races the row's own onClick that opens the session.
-        <div className="flex shrink-0 items-center gap-0.5 sm:absolute sm:inset-y-0 sm:right-2 sm:z-10">
+        <div className="flex shrink-0 items-center gap-0.5">
           {runtimePresentation.canStop && onStopProcess && (
             <StopProcessButton
               telemetryControl="task.stop"

--- a/tests/adaptive-linked-worktree-navigation.test.tsx
+++ b/tests/adaptive-linked-worktree-navigation.test.tsx
@@ -158,18 +158,6 @@ test('linked Worktree rows render standalone, composite, and expanded identities
   assert.match(expanded, /collection-subsession-two/);
 });
 
-test('expanded Worktree child session titles retain the desktop row width until actions appear', () => {
-  const markup = renderLinkedWorktree(['one', 'two']);
-
-  // The desktop quick actions are hover-only. They must overlay the row rather
-  // than reserve their full width, otherwise every child title is truncated
-  // while that space is visibly empty.
-  assert.match(
-    markup,
-    /data-testid="collection-subsession-one"[\s\S]*?class="[^"]*sm:absolute[^"]*"/,
-  );
-});
-
 test('selecting an expanded child Session does not also select its parent Worktree', () => {
   assert.equal(isLinkedWorktreeParentActive({
     density: 'expanded',


### PR DESCRIPTION
Reverts #391, which was merged to main by mistake; the intended target is dev via #393.