### PR TITLE
Open workspace files in preview tabs

### DIFF
--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -696,6 +696,7 @@ export function WorkspaceFilePanel({
           onDoubleClick={() => {
             if (!target) return;
             openWorkspaceTargetFileTab(target, 'file', node.path, {
+              preferKanbanPeek: true,
               projectDir: sessionProjectDir,
             });
           }}

--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -41,6 +41,7 @@ import {
 import { useWorkspacePeekStore } from '@/stores/workspace-peek-store';
 import {
   openWorkspaceTargetFileTab,
+  previewWorkspaceTargetFileTab,
 } from "@/lib/workspace-tabs/open-workspace-tab";
 import { resolveWorkspaceTarget, workspaceTargetKey } from '@/types/worktree';
 import { setWorkspaceDirectoryDragData, setWorkspaceFileDragData } from "@/lib/dnd/panel-session-drag";
@@ -683,12 +684,18 @@ export function WorkspaceFilePanel({
           onClick={(event) => {
             setSelectedPath(node.path);
             if (!target) return;
-            // A browser double-click also dispatches two click events. Only the
-            // first creates a tab; the double-click itself may still rename the
-            // name hotspot without creating extra duplicate tabs.
+            // A browser double-click also dispatches two click events. The
+            // first click opens the replaceable file-preview tab; its paired
+            // double-click below promotes that preview to a retained tab.
             if (!shouldOpenOnRowClick(event.detail)) return;
-            openWorkspaceTargetFileTab(target, 'file', node.path, {
+            previewWorkspaceTargetFileTab(target, 'file', node.path, {
               preferKanbanPeek: true,
+              projectDir: sessionProjectDir,
+            });
+          }}
+          onDoubleClick={() => {
+            if (!target) return;
+            openWorkspaceTargetFileTab(target, 'file', node.path, {
               projectDir: sessionProjectDir,
             });
           }}
@@ -718,16 +725,7 @@ export function WorkspaceFilePanel({
           ) : (
             <FileText className="h-3.5 w-3.5 shrink-0 text-(--text-muted) group-hover:text-(--text-primary)" />
           )}
-          <span
-            // Renaming is scoped to the name text, so the icon and the rest of
-            // the row keep opening the file the way they always have.
-            onDoubleClick={(event) => {
-              if (!canMutate) return;
-              event.stopPropagation();
-              beginRename(node);
-            }}
-            className="min-w-0 flex-1 truncate font-mono text-[11px]"
-          >
+          <span className="min-w-0 flex-1 truncate font-mono text-[11px]">
             {node.name}
           </span>
         </button>

--- a/src/lib/workspace-tabs/open-workspace-tab.ts
+++ b/src/lib/workspace-tabs/open-workspace-tab.ts
@@ -180,6 +180,7 @@ export function previewWorkspaceFileTab(
     options.preferKanbanPeek
     && tryOpenWorkspaceFileInKanbanPeek(sourceSessionId, kind, filePath)
   ) return;
+  promoteSourceSessionTab(sourceSessionId);
   const tabId = previewSpecialFileTab(
     buildWorkspaceFileSessionId(sourceSessionId, kind, filePath, options.worktreeId),
     options.worktreeId,

--- a/tests/project-worktree-target.test.tsx
+++ b/tests/project-worktree-target.test.tsx
@@ -21,7 +21,9 @@ import {
 } from '../src/lib/workspace-tabs/special-session';
 import {
   openWorkspaceFileTab,
+  openWorkspaceTargetFileTab,
   openWorktreeFileTab,
+  previewWorkspaceFileTab,
   previewWorkspaceTargetFileTab,
   previewWorktreeFileTab,
 } from '../src/lib/workspace-tabs/open-workspace-tab';
@@ -194,6 +196,60 @@ test('opening a Worktree file dismisses Peek and targets a Worktree-scoped previ
   assert.equal(
     specialSessionId,
     buildWorktreeFileSessionId('wt_project_root', 'README.md'),
+  );
+});
+
+test('opening a previewed Worktree file again retains that same tab', () => {
+  const target = { kind: 'worktree', id: 'wt_preview_pin' } as const;
+  previewWorkspaceTargetFileTab(target, 'file', 'README.md', {
+    projectDir: 'project-a',
+  });
+
+  const previewTabId = useTabStore.getState().activeTabId;
+  assert.equal(
+    useTabStore.getState().tabs.find((tab) => tab.id === previewTabId)?.isPreview,
+    true,
+  );
+
+  openWorkspaceTargetFileTab(target, 'file', 'README.md', {
+    projectDir: 'project-a',
+  });
+
+  assert.equal(useTabStore.getState().activeTabId, previewTabId);
+  assert.equal(
+    useTabStore.getState().tabs.find((tab) => tab.id === previewTabId)?.isPreview,
+    false,
+  );
+});
+
+test('previewing a Session file retains its preview source Session', () => {
+  const sourceTabId = 'source-session-preview-tab';
+  const sourcePanelId = 'source-session-preview-panel';
+  const sourceSessionId = 'source-session-preview';
+  const panelStore = usePanelStore.getState();
+  panelStore.initTab(sourceTabId, {
+    layout: { type: 'leaf', panelId: sourcePanelId },
+    panels: {
+      [sourcePanelId]: { id: sourcePanelId, sessionId: sourceSessionId },
+    },
+    activePanelId: sourcePanelId,
+  });
+  panelStore.setActiveTabId(sourceTabId);
+  useTabStore.setState({
+    tabs: [{ id: sourceTabId, projectDir: 'project-a', title: null, isPreview: true }],
+    activeTabId: sourceTabId,
+    lruTabIds: [sourceTabId],
+    currentProjectDir: 'project-a',
+  });
+
+  previewWorkspaceFileTab(sourceSessionId, 'file', 'README.md');
+
+  const tabs = useTabStore.getState().tabs;
+  assert.equal(tabs.find((tab) => tab.id === sourceTabId)?.isPreview, false);
+  assert.notEqual(useTabStore.getState().activeTabId, sourceTabId);
+  assert.equal(
+    tabs.find((tab) => tab.id === useTabStore.getState().activeTabId)?.isPreview,
+    true,
   );
 });
 

--- a/tests/workspace-tree-operations-contract.test.mjs
+++ b/tests/workspace-tree-operations-contract.test.mjs
@@ -168,7 +168,7 @@ test('an input from another workspace cannot strand this panel', () => {
   assert.match(filePanelSource, /onRename: renameEntry,\s*\n\s*workspaceKey: targetKey,/);
 });
 
-test('a file click previews once and its double-click retains a real tab', () => {
+test('a file click previews once and its double-click respects Kanban Peek', () => {
   // Both clicks reach the row, but only the first is an independent preview.
   assert.match(fileRowSource, /if \(!shouldOpenOnRowClick\(event\.detail\)\) return;/);
   assert.match(inlineStateSource, /return clickCount === 1/);
@@ -182,10 +182,10 @@ test('a file click previews once and its double-click retains a real tab', () =>
   );
   assert.ok(doubleClick?.groups?.body, 'the file row owns a double-click handler');
   assert.match(doubleClick.groups.body, /openWorkspaceTargetFileTab\(target, 'file', node\.path/);
-  assert.doesNotMatch(
+  assert.match(
     doubleClick.groups.body,
-    /preferKanbanPeek/,
-    'double-click must bypass Kanban Peek and retain a tab',
+    /preferKanbanPeek: true/,
+    'double-click pins in List mode but must stay inside Kanban Peek mode',
   );
   // F2 renames; Enter still activates the row, so the keyboard can open a file.
   assert.match(fileRowSource, /if \(!canMutate \|\| event\.key !== "F2"\) return;/);

--- a/tests/workspace-tree-operations-contract.test.mjs
+++ b/tests/workspace-tree-operations-contract.test.mjs
@@ -21,6 +21,14 @@ const worktreeDirectoryRouteSource = read('../src/app/api/worktrees/[id]/directo
 const filesRouteSource = read('../src/app/api/sessions/[id]/files/route.ts');
 const fileTabSource = read('../src/components/workspace/workspace-file-tab.tsx');
 const panelContainerSource = read('../src/components/panel/panel-container.tsx');
+const directoryRowSource = filePanelSource.slice(
+  filePanelSource.indexOf('if (node.type === "directory")'),
+  filePanelSource.indexOf('const isSelected = node.path === selectedPath'),
+);
+const fileRowSource = filePanelSource.slice(
+  filePanelSource.indexOf('const isSelected = node.path === selectedPath'),
+  filePanelSource.indexOf('if (!sessionId && !worktreeId)'),
+);
 
 test('folder expansion is restored per workspace after the file panel remounts', () => {
   assert.match(filePanelSource, /selectExpandedWorkspacePaths\(targetKey\)/);
@@ -160,12 +168,27 @@ test('an input from another workspace cannot strand this panel', () => {
   assert.match(filePanelSource, /onRename: renameEntry,\s*\n\s*workspaceKey: targetKey,/);
 });
 
-test('a double-click gesture creates only one file tab', () => {
-  // Both clicks reach the row, but only the first is an independent open action.
-  assert.match(filePanelSource, /if \(!shouldOpenOnRowClick\(event\.detail\)\) return;/);
+test('a file click previews once and its double-click retains a real tab', () => {
+  // Both clicks reach the row, but only the first is an independent preview.
+  assert.match(fileRowSource, /if \(!shouldOpenOnRowClick\(event\.detail\)\) return;/);
   assert.match(inlineStateSource, /return clickCount === 1/);
+  assert.match(
+    fileRowSource,
+    /previewWorkspaceTargetFileTab\(target, 'file', node\.path, \{\s*preferKanbanPeek: true,/,
+  );
+
+  const doubleClick = fileRowSource.match(
+    /onDoubleClick=\{\(\) => \{(?<body>[\s\S]*?)\n\s*\}\}\s*onKeyDown/,
+  );
+  assert.ok(doubleClick?.groups?.body, 'the file row owns a double-click handler');
+  assert.match(doubleClick.groups.body, /openWorkspaceTargetFileTab\(target, 'file', node\.path/);
+  assert.doesNotMatch(
+    doubleClick.groups.body,
+    /preferKanbanPeek/,
+    'double-click must bypass Kanban Peek and retain a tab',
+  );
   // F2 renames; Enter still activates the row, so the keyboard can open a file.
-  assert.match(filePanelSource, /if \(!canMutate \|\| event\.key !== "F2"\) return;/);
+  assert.match(fileRowSource, /if \(!canMutate \|\| event\.key !== "F2"\) return;/);
 });
 
 test('folder toggles have no delayed timer that can fire under an input', () => {
@@ -183,10 +206,10 @@ test('a watch reconcile cannot take the row being edited', () => {
   assert.match(inlineHookSource, /handlersRef\.current\.onRefreshFiles\(\)/);
 });
 
-test('double-clicking the name renames without fighting the row click', () => {
+test('double-clicking a directory name renames without fighting its toggle', () => {
   // The first click toggles immediately and the second click is ignored before
   // the double-click handler opens rename, so no timer delays ordinary clicks.
-  assert.match(filePanelSource, /onDoubleClick=\{\(event\) => \{\s*if \(!canMutate\) return;\s*event\.stopPropagation\(\);\s*beginRename\(node\);/);
+  assert.match(directoryRowSource, /onDoubleClick=\{\(event\) => \{\s*if \(!canMutate\) return;\s*event\.stopPropagation\(\);\s*beginRename\(node\);/);
   assert.match(filePanelSource, /if \(!shouldToggleDirectoryOnClick\(event\.detail\)\) return;/);
   assert.match(inlineStateSource, /return clickCount <= 1;/);
 });


### PR DESCRIPTION
## Summary
- open files from the Files panel in a reusable preview tab on single click
- pin the previewed file on double click in List view
- keep all file opens inside the sidecar in Kanban Peek mode
- preserve the source Session when previewing a Session-backed file

## Verification
- `npx tsx --test tests/project-worktree-target.test.tsx tests/workspace-tree-operations-contract.test.mjs` (37 passed)
- `npm run test:contracts` (412 passed)
- `npx tsc --noEmit`
- `npm run lint`
- browser QA in List and Kanban Peek modes