### PR TITLE
fix(tabs): preserve tab order across project switches

### DIFF
--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -211,6 +211,21 @@ function normalizeLruForTabs(lruTabIds: string[] | undefined, tabs: Tab[], activ
   return normalized.slice(0, LRU_LIMIT);
 }
 
+function normalizeTabOrderIdsByScope(value: unknown): Record<string, string[]> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([scope, tabIds]) => {
+      if (!Array.isArray(tabIds)) return [];
+      const normalized = tabIds.filter(
+        (tabId, index): tabId is string => (
+          typeof tabId === 'string' && tabIds.indexOf(tabId) === index
+        ),
+      );
+      return [[scope, normalized]];
+    }),
+  );
+}
+
 function getStateTabs(projectState: ProjectTabState | null | undefined): Tab[] {
   return projectState?.tabs ?? [];
 }
@@ -219,18 +234,25 @@ function getVisibleTabs(
   projectStates: Record<string, ProjectTabState>,
   globalState: ProjectTabState | null,
   projectDir: string | null,
+  tabOrderIdsByScope: Record<string, string[]> = {},
 ): Tab[] {
   const globalTabs = getStateTabs(globalState);
-  if (isAllProjectsScope(projectDir)) {
-    return [
+  const visibleTabs = isAllProjectsScope(projectDir)
+    ? [
       ...globalTabs,
       ...Object.values(projectStates).flatMap((projectState) => projectState.tabs),
+    ]
+    : [
+      ...globalTabs,
+      ...(projectDir ? getStateTabs(projectStates[projectDir]) : []),
     ];
-  }
-  return [
-    ...globalTabs,
-    ...(projectDir ? getStateTabs(projectStates[projectDir]) : []),
-  ];
+  if (!projectDir) return visibleTabs;
+
+  const tabsById = new Map(visibleTabs.map((tab) => [tab.id, tab]));
+  const orderedTabs = (tabOrderIdsByScope[projectDir] ?? [])
+    .flatMap((tabId) => tabsById.get(tabId) ?? []);
+  const orderedIds = new Set(orderedTabs.map((tab) => tab.id));
+  return [...orderedTabs, ...visibleTabs.filter((tab) => !orderedIds.has(tab.id))];
 }
 
 function getVisibleLruTabIds(
@@ -495,6 +517,7 @@ function saveVisibleTabsToScopedStates(
 ): {
   projectTabStates: Record<string, ProjectTabState>;
   globalTabState: ProjectTabState | null;
+  tabOrderIdsByScope: Record<string, string[]>;
 } {
   const projectTabs = new Map<string, Tab[]>();
   const globalTabs: Tab[] = [];
@@ -536,6 +559,12 @@ function saveVisibleTabsToScopedStates(
   return {
     projectTabStates,
     globalTabState,
+    tabOrderIdsByScope: state.currentProjectDir
+      ? {
+          ...state.tabOrderIdsByScope,
+          [state.currentProjectDir]: state.tabs.map((tab) => tab.id),
+        }
+      : state.tabOrderIdsByScope,
   };
 }
 
@@ -627,6 +656,7 @@ export const useTabStore = create<TabStore>()((set, get) => ({
   lruTabIds: [initialTabId],
   projectTabStates: {},
   globalTabState: null,
+  tabOrderIdsByScope: {},
   currentProjectDir: null,
 
   // --- 액션 ---
@@ -1318,6 +1348,7 @@ export const useTabStore = create<TabStore>()((set, get) => ({
       activeTabId: state.activeTabId,
       projects,
       global,
+      tabOrderIdsByScope: scopedStates.tabOrderIdsByScope,
     };
 
     // Step 3: 직렬화 및 저장
@@ -1338,6 +1369,7 @@ export const useTabStore = create<TabStore>()((set, get) => ({
         lruTabIds: [tab.id],
         projectTabStates: {},
         globalTabState: null,
+        tabOrderIdsByScope: {},
         currentProjectDir: null,
       });
       const panelStore = usePanelStore.getState();
@@ -1350,6 +1382,7 @@ export const useTabStore = create<TabStore>()((set, get) => ({
       globalTabState: ProjectTabState | null,
       currentProjectDir: string | null,
       preferredActiveTabId: string | null,
+      tabOrderIdsByScope: Record<string, string[]> = {},
     ) => {
       const panelStore = usePanelStore.getState();
       for (const oldTabId of Object.keys(panelStore.tabPanels)) {
@@ -1358,7 +1391,12 @@ export const useTabStore = create<TabStore>()((set, get) => ({
 
       let nextProjectTabStates = projectTabStates;
       let nextGlobalTabState = globalTabState;
-      let visibleTabs = getVisibleTabs(nextProjectTabStates, nextGlobalTabState, currentProjectDir);
+      let visibleTabs = getVisibleTabs(
+        nextProjectTabStates,
+        nextGlobalTabState,
+        currentProjectDir,
+        tabOrderIdsByScope,
+      );
 
       if (visibleTabs.length === 0) {
         const projectDir =
@@ -1402,6 +1440,7 @@ export const useTabStore = create<TabStore>()((set, get) => ({
         ),
         projectTabStates: nextProjectTabStates,
         globalTabState: nextGlobalTabState,
+        tabOrderIdsByScope,
         currentProjectDir,
       });
 
@@ -1480,7 +1519,13 @@ export const useTabStore = create<TabStore>()((set, get) => ({
           };
         }
 
-        applyRestoredScope(projectTabStates, globalTabState, v3.currentProjectDir, v3.activeTabId);
+        applyRestoredScope(
+          projectTabStates,
+          globalTabState,
+          v3.currentProjectDir,
+          v3.activeTabId,
+          normalizeTabOrderIdsByScope(v3.tabOrderIdsByScope),
+        );
         return;
       }
 
@@ -1600,11 +1645,18 @@ export const useTabStore = create<TabStore>()((set, get) => ({
       : {
           projectTabStates: state.projectTabStates,
           globalTabState: state.globalTabState,
+          tabOrderIdsByScope: state.tabOrderIdsByScope,
         };
 
     let projectTabStates = scopedStates.projectTabStates;
     let globalTabState = scopedStates.globalTabState;
-    let visibleTabs = getVisibleTabs(projectTabStates, globalTabState, projectDir);
+    const tabOrderIdsByScope = scopedStates.tabOrderIdsByScope;
+    let visibleTabs = getVisibleTabs(
+      projectTabStates,
+      globalTabState,
+      projectDir,
+      tabOrderIdsByScope,
+    );
 
     if (visibleTabs.length === 0) {
       const emptyProjectDir = isAllProjectsScope(projectDir) ? null : projectDir;
@@ -1642,6 +1694,7 @@ export const useTabStore = create<TabStore>()((set, get) => ({
       lruTabIds: normalizeLruForTabs([activeTabId], visibleTabs, activeTabId),
       projectTabStates,
       globalTabState,
+      tabOrderIdsByScope,
       currentProjectDir: projectDir,
     });
 
@@ -1668,12 +1721,19 @@ export const useTabStore = create<TabStore>()((set, get) => ({
       : {
           projectTabStates: state.projectTabStates,
           globalTabState: state.globalTabState,
+          tabOrderIdsByScope: state.tabOrderIdsByScope,
         };
 
     const { [projectDir]: _, ...restProjectStates } = scopedStates.projectTabStates;
+    const { [projectDir]: __, ...restTabOrderIdsByScope } = scopedStates.tabOrderIdsByScope;
     const currentProjectDir = state.currentProjectDir === projectDir ? null : state.currentProjectDir;
 
-    let visibleTabs = getVisibleTabs(restProjectStates, scopedStates.globalTabState, currentProjectDir);
+    let visibleTabs = getVisibleTabs(
+      restProjectStates,
+      scopedStates.globalTabState,
+      currentProjectDir,
+      restTabOrderIdsByScope,
+    );
     let globalTabState = scopedStates.globalTabState;
     if (visibleTabs.length === 0) {
       const { tab, panelData } = createEmptyTab(null);
@@ -1701,6 +1761,7 @@ export const useTabStore = create<TabStore>()((set, get) => ({
       lruTabIds: normalizeLruForTabs([activeTabId], visibleTabs, activeTabId),
       projectTabStates: restProjectStates,
       globalTabState,
+      tabOrderIdsByScope: restTabOrderIdsByScope,
       currentProjectDir,
     });
 

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -91,6 +91,8 @@ export interface TabStoreState {
   projectTabStates: Record<string, ProjectTabState>;
   /** 모든 프로젝트에서 항상 보이는 전역 탭 상태. */
   globalTabState: ProjectTabState | null;
+  /** 프로젝트별 화면에서 전역/프로젝트 탭이 합쳐져 보이는 순서. */
+  tabOrderIdsByScope: Record<string, string[]>;
   /** 현재 활성 프로젝트 디렉토리. null이면 아직 프로젝트 미결정 상태. */
   currentProjectDir: string | null;
 }
@@ -312,6 +314,8 @@ export interface PersistedTabStoreV3 {
   projects: Record<string, { tabs: PersistedTab[]; activeTabId: string; lruTabIds?: string[] }>;
   /** 전역 탭 상태. 전역 탭이 없으면 null. */
   global: { tabs: PersistedTab[]; activeTabId: string; lruTabIds?: string[] } | null;
+  /** 프로젝트별 화면에서 전역/프로젝트 탭이 합쳐져 보이는 순서. */
+  tabOrderIdsByScope?: Record<string, string[]>;
 }
 
 /** localStorage에 저장되는 탭 스토어 DTO (v1 | v2 | v3) */

--- a/tests/mobile-tab-list.e2e.mjs
+++ b/tests/mobile-tab-list.e2e.mjs
@@ -51,6 +51,10 @@ const repoRoot = path.resolve(new URL('..', import.meta.url).pathname);
 const tempRoot = path.join(os.homedir(), 'tmp');
 await fs.mkdir(tempRoot, { recursive: true });
 const dataDir = await fs.mkdtemp(path.join(tempRoot, 'tessera-mobile-tab-list-'));
+const projectARoot = await fs.mkdtemp(path.join(tempRoot, 'tessera-mobile-tab-order-a-'));
+const projectBRoot = await fs.mkdtemp(path.join(tempRoot, 'tessera-mobile-tab-order-b-'));
+const screenshotDir = process.env.TESSERA_E2E_SCREENSHOT_DIR ?? null;
+if (screenshotDir) await fs.mkdir(screenshotDir, { recursive: true });
 const port = await reservePort();
 const appOrigin = `http://127.0.0.1:${port}`;
 let serverOutput = '';
@@ -95,6 +99,7 @@ try {
   if (shouldRun(3)) await testChoosingATabActivatesIt(browser, appOrigin);
   if (shouldRun(4)) await testATabCanBeClosedFromTheList(browser, appOrigin);
   if (shouldRun(5)) await testDesktopStripIsUnchanged(browser, appOrigin);
+  if (shouldRun(6)) await testProjectSwitchPreservesTabOrder(browser, appOrigin);
   console.log('mobile-tab-list: all phases passed');
 } catch (error) {
   if (serverOutput) process.stderr.write(`\n--- isolated server output ---\n${serverOutput}\n`);
@@ -110,6 +115,8 @@ try {
   }
   await waitForExit(server, 5_000);
   await fs.rm(dataDir, { recursive: true, force: true });
+  await fs.rm(projectARoot, { recursive: true, force: true });
+  await fs.rm(projectBRoot, { recursive: true, force: true });
 }
 
 async function testPhoneReplacesTheStripWithOneControl(browserInstance, origin) {
@@ -346,6 +353,40 @@ async function testDesktopStripIsUnchanged(browserInstance, origin) {
   }
 }
 
+async function testProjectSwitchPreservesTabOrder(browserInstance, origin) {
+  await fs.writeFile(path.join(projectARoot, '.gitkeep'), '');
+  await fs.writeFile(path.join(projectBRoot, '.gitkeep'), '');
+  await api('/api/settings', { method: 'PUT', body: { agentEnvironment: 'wsl' } });
+  await api('/api/projects', { method: 'POST', body: { folderPath: projectARoot } });
+  await api('/api/projects', { method: 'POST', body: { folderPath: projectBRoot } });
+
+  const { context, page } = await createSeededPage(
+    browserInstance,
+    createPhoneContext,
+    seedProjectTabOrderStore(),
+  );
+  try {
+    await openChat(page, origin);
+    await openTabList(page);
+    await assertTabListTitles(page, ['A first', 'Global middle', 'A last']);
+    await capture(page, '01-project-a-initial-interleaved-order.png');
+
+    await closeTabList(page);
+    await page.getByTestId(`project-strip-${projectBRoot}`).tap();
+    await openTabList(page);
+    await assertTabListTitles(page, ['B only', 'Global middle']);
+    await capture(page, '02-project-b-own-order.png');
+
+    await closeTabList(page);
+    await page.getByTestId(`project-strip-${projectARoot}`).tap();
+    await openTabList(page);
+    await assertTabListTitles(page, ['A first', 'Global middle', 'A last']);
+    await capture(page, '03-project-a-restored-interleaved-order.png');
+  } finally {
+    await context.close();
+  }
+}
+
 /**
  * A window with tabs already open.
  *
@@ -377,7 +418,43 @@ function seedTabStore() {
   };
 }
 
-async function createSeededPage(browserInstance, makeContext) {
+function seedProjectTabOrderStore() {
+  const makeTab = (id, title, projectDir) => {
+    const panelId = `${id}-panel`;
+    return {
+      id,
+      projectDir,
+      title,
+      isPreview: false,
+      snapshot: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: null } },
+        activePanelId: panelId,
+      },
+    };
+  };
+  const aFirst = makeTab('a-first', 'A first', projectARoot);
+  const globalMiddle = makeTab('global-middle', 'Global middle', null);
+  const aLast = makeTab('a-last', 'A last', projectARoot);
+  const bOnly = makeTab('b-only', 'B only', projectBRoot);
+
+  return {
+    version: 3,
+    currentProjectDir: projectARoot,
+    activeTabId: aFirst.id,
+    projects: {
+      [projectARoot]: { tabs: [aFirst, aLast], activeTabId: aFirst.id },
+      [projectBRoot]: { tabs: [bOnly], activeTabId: bOnly.id },
+    },
+    global: { tabs: [globalMiddle], activeTabId: globalMiddle.id },
+    tabOrderIdsByScope: {
+      [projectARoot]: [aFirst.id, globalMiddle.id, aLast.id],
+      [projectBRoot]: [bOnly.id, globalMiddle.id],
+    },
+  };
+}
+
+async function createSeededPage(browserInstance, makeContext, tabStore = seedTabStore()) {
   const context = await makeContext(browserInstance, {
     extraHTTPHeaders: { 'x-tessera-app-secret': appSecret },
   });
@@ -385,10 +462,50 @@ async function createSeededPage(browserInstance, makeContext) {
     ([key, value]) => {
       window.localStorage.setItem(key, value);
     },
-    ['tessera-tab-store', JSON.stringify(seedTabStore())],
+    ['tessera-tab-store', JSON.stringify(tabStore)],
   );
   const page = await context.newPage();
   return { context, page };
+}
+
+async function api(pathname, { method, body }) {
+  const response = await fetch(`${appOrigin}${pathname}`, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      'x-tessera-app-secret': appSecret,
+      origin: appOrigin,
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  assert.ok(response.ok, `${method} ${pathname} failed (${response.status}): ${text}`);
+}
+
+async function openTabList(page) {
+  const popover = page.getByTestId('tab-list-popover');
+  if (await popover.isVisible().catch(() => false)) return;
+  await page.getByTestId('tab-list-trigger').tap();
+  await popover.waitFor({ timeout: 5_000 });
+}
+
+async function closeTabList(page) {
+  const popover = page.getByTestId('tab-list-popover');
+  if (!(await popover.isVisible().catch(() => false))) return;
+  await page.getByTestId('tab-list-trigger').tap();
+  await popover.waitFor({ state: 'detached', timeout: 5_000 });
+}
+
+async function assertTabListTitles(page, expected) {
+  assert.deepEqual(
+    (await page.getByTestId('tab-list-item').allInnerTexts()).map((text) => text.trim()),
+    expected,
+  );
+}
+
+async function capture(page, filename) {
+  if (!screenshotDir) return;
+  await page.screenshot({ path: path.join(screenshotDir, filename), fullPage: true });
 }
 
 async function openChat(page, origin) {

--- a/tests/project-view-tab-state.test.ts
+++ b/tests/project-view-tab-state.test.ts
@@ -110,6 +110,66 @@ test('the same canonical Session has independent tabs and active targets in A an
   assert.equal(usePanelStore.getState().activeTabId, tabC);
 });
 
+test('Project switching preserves the visible order of interleaved global and Project tabs', () => {
+  resetWorkspace();
+
+  const tabs = [
+    { id: 'project-a-first', projectDir: 'project-a', title: 'A first', isPreview: false },
+    { id: 'global-middle', projectDir: null, title: 'Global middle', isPreview: false },
+    { id: 'project-a-last', projectDir: 'project-a', title: 'A last', isPreview: false },
+  ];
+  const panelData = (tabId: string) => ({
+    layout: { type: 'leaf' as const, panelId: `${tabId}-panel` },
+    panels: { [`${tabId}-panel`]: { id: `${tabId}-panel`, sessionId: null } },
+    activePanelId: `${tabId}-panel`,
+  });
+  const projectCTab = {
+    id: 'project-c-only',
+    projectDir: 'project-c',
+    title: 'C only',
+    isPreview: false,
+  };
+
+  useTabStore.setState({
+    ...useTabStore.getInitialState(),
+    tabs,
+    activeTabId: 'project-a-first',
+    lruTabIds: tabs.map((tab) => tab.id),
+    currentProjectDir: 'project-a',
+    projectTabStates: {
+      'project-c': {
+        tabs: [projectCTab],
+        activeTabId: projectCTab.id,
+        lruTabIds: [projectCTab.id],
+        tabPanelSnapshots: { [projectCTab.id]: panelData(projectCTab.id) },
+      },
+    },
+    globalTabState: null,
+  });
+  usePanelStore.setState({
+    activeTabId: 'project-a-first',
+    tabPanels: Object.fromEntries(tabs.map((tab) => [tab.id, panelData(tab.id)])),
+  });
+
+  const originalOrder = tabs.map((tab) => tab.id);
+  useTabStore.getState().switchProject('project-c');
+  useTabStore.getState().switchProject('project-a');
+
+  assert.deepEqual(
+    useTabStore.getState().tabs.map((tab) => tab.id),
+    originalOrder,
+  );
+
+  useTabStore.getState().persistToLocalStorage();
+  resetWorkspace(false);
+  useTabStore.getState().restoreFromLocalStorage();
+  assert.deepEqual(
+    useTabStore.getState().tabs.map((tab) => tab.id),
+    originalOrder,
+    'reload must preserve the same visible order',
+  );
+});
+
 test('reload restores each tab through its selected Project projection', () => {
   resetWorkspace();
   const tabA = openSharedSession('project-a');


### PR DESCRIPTION
## Summary
- preserve each Project scope’s combined global/Project tab order
- persist and validate the per-scope order across reloads
- add unit and phone-width E2E regression coverage for A → B → A switching

## Root cause
The tab store saved global tabs and Project-local tabs separately, then rebuilt the visible list as global tabs followed by Project tabs. An interleaved list such as `[A first, Global middle, A last]` therefore became `[Global middle, A first, A last]` after a Project switch.

## Verification
- `node --import tsx --test --test-reporter=spec tests/project-view-tab-state.test.ts`
- `TESSERA_E2E_PHASES=6 node tests/mobile-tab-list.e2e.mjs`
- full `tests/mobile-tab-list.e2e.mjs` (all 6 phases)
- `npx tsc --noEmit`
- `npm run test:contracts` (414/414)
- `npm run lint -- --max-warnings=20` (0 errors, 3 existing warnings)

## Existing unrelated failure
`npm run test:unit` has one existing failure in `tests/git-action-failure-report.test.ts`: the test expects five unique failure headings while the current `GIT_FAILURE_TITLE_KEY` contains six. The same isolated failure remains on the latest `dev` code and is unrelated to the four files changed here.