### PR TITLE
feat(settings): add default CLI provider

### DIFF
--- a/src/components/chat/cli-provider-chip-selector.tsx
+++ b/src/components/chat/cli-provider-chip-selector.tsx
@@ -23,6 +23,7 @@ type ProviderCreationSurface = Extract<TelemetryUiSurface, 'new_session' | 'coll
 interface CliProviderChipSelectorProps {
   value: string;
   onChange: (providerId: string) => void;
+  preferredProviderId?: string;
   className?: string;
   chipClassName?: string;
   executionMode?: AgentExecutionMode;
@@ -38,6 +39,7 @@ export function CliProviderChipSelector({
   executionMode,
   showRefresh = true,
   telemetrySurface = 'new_session',
+  preferredProviderId,
 }: CliProviderChipSelectorProps) {
   const { t } = useI18n();
   const providers = useProvidersStore((s) => s.providers);
@@ -48,6 +50,7 @@ export function CliProviderChipSelector({
   const defaultExecutionMode = useSettingsStore((s) => s.settings.agentExecutionMode);
   const agentExecutionMode = executionMode ?? defaultExecutionMode;
   const reportedIssueKeysRef = useRef<Set<string>>(new Set());
+  const selectionTouchedRef = useRef(false);
 
   useEffect(() => {
     // Populate on first mount if the WS onopen hook hasn't fired yet
@@ -71,9 +74,22 @@ export function CliProviderChipSelector({
 
   useEffect(() => {
     if (selectable.length === 0) return;
-    if (selectable.some((p) => p.id === value)) return;
-    onChange(selectable[0].id);
-  }, [selectable, onChange, value]);
+    const selectableProviderIds = selectable.map((provider) => provider.id);
+    if (
+      selectionTouchedRef.current
+      && value
+      && !selectableProviderIds.includes(value)
+    ) {
+      selectionTouchedRef.current = false;
+    }
+    const nextProviderId = resolveCliProviderSelection({
+      selectableProviderIds,
+      currentProviderId: value,
+      preferredProviderId,
+      selectionTouched: selectionTouchedRef.current,
+    });
+    if (nextProviderId && nextProviderId !== value) onChange(nextProviderId);
+  }, [selectable, onChange, preferredProviderId, value]);
 
   useEffect(() => {
     if (providers === null || loading || !initialized || !isEmpty) return;
@@ -138,7 +154,11 @@ export function CliProviderChipSelector({
             provider={provider}
             isSelected={provider.id === value}
             isSingle={selectable.length === 1}
-            onClick={() => selectable.length > 1 && onChange(provider.id)}
+            onClick={() => {
+              if (selectable.length <= 1) return;
+              selectionTouchedRef.current = true;
+              onChange(provider.id);
+            }}
             chipClassName={chipClassName}
             preferredExecutionMode={agentExecutionMode}
             telemetrySurface={telemetrySurface}
@@ -175,6 +195,30 @@ export function CliProviderChipSelector({
       )}
     </div>
   );
+}
+
+interface ResolveCliProviderSelectionInput {
+  selectableProviderIds: readonly string[];
+  currentProviderId: string;
+  preferredProviderId?: string;
+  selectionTouched: boolean;
+}
+
+/** Resolve automatic provider selection without overwriting a valid manual choice. */
+export function resolveCliProviderSelection({
+  selectableProviderIds,
+  currentProviderId,
+  preferredProviderId,
+  selectionTouched,
+}: ResolveCliProviderSelectionInput): string {
+  if (selectableProviderIds.length === 0) return currentProviderId;
+  const currentIsSelectable = selectableProviderIds.includes(currentProviderId);
+  if (selectionTouched && currentIsSelectable) return currentProviderId;
+  if (preferredProviderId && selectableProviderIds.includes(preferredProviderId)) {
+    return preferredProviderId;
+  }
+  if (currentIsSelectable) return currentProviderId;
+  return selectableProviderIds[0] ?? currentProviderId;
 }
 
 function ProviderChip({

--- a/src/components/chat/collection-quick-create-sheet.tsx
+++ b/src/components/chat/collection-quick-create-sheet.tsx
@@ -136,6 +136,7 @@ export function CollectionQuickCreateSheet({
   const pathTemplate = useSettingsStore((state) => state.settings.managedWorktreePathTemplate);
   const defaultExecutionMode = useSettingsStore((state) => state.settings.agentExecutionMode);
   const defaultNewSessionKind = useSettingsStore((state) => state.settings.defaultNewSessionKind);
+  const defaultCliProvider = useSettingsStore((state) => state.settings.defaultCliProvider);
   const resolvedInitialMode = resolveQuickCreateInitialMode({
     initialMode,
     defaultNewSessionKind,
@@ -524,6 +525,7 @@ export function CollectionQuickCreateSheet({
               telemetrySurface="collection_create"
               value={selectedProvider}
               onChange={setSelectedProvider}
+              preferredProviderId={defaultCliProvider}
               executionMode={executionMode}
               showRefresh={false}
               className="gap-1"

--- a/src/components/panel/empty-panel-state.tsx
+++ b/src/components/panel/empty-panel-state.tsx
@@ -152,6 +152,7 @@ export function EmptyPanelState({ panelId }: EmptyPanelStateProps) {
   const pathTemplate = useSettingsStore((state) => state.settings.managedWorktreePathTemplate);
   const defaultExecutionMode = useSettingsStore((state) => state.settings.agentExecutionMode);
   const defaultNewSessionKind = useSettingsStore((state) => state.settings.defaultNewSessionKind);
+  const defaultCliProvider = useSettingsStore((state) => state.settings.defaultCliProvider);
   const requestedCreationMode = usePanelStore(
     (state) => state.tabPanels[tabId]?.panels[panelId]?.creationMode ?? null,
   );
@@ -562,6 +563,7 @@ export function EmptyPanelState({ panelId }: EmptyPanelStateProps) {
               <CliProviderChipSelector
                 value={selectedProvider}
                 onChange={setSelectedProvider}
+                preferredProviderId={defaultCliProvider}
                 executionMode={executionMode}
                 className="gap-1.5"
                 chipClassName="px-2.5 py-1 text-[10px]"

--- a/src/components/settings/default-cli-provider-settings.tsx
+++ b/src/components/settings/default-cli-provider-settings.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useId } from 'react';
+import { getProviderBrand, ProviderLogoMark } from '@/components/chat/provider-brand';
+import { useI18n } from '@/lib/i18n';
+import { DEFAULT_CLI_PROVIDER_IDS } from '@/lib/settings/default-cli-provider';
+import { settingsTelemetryClickAttributes } from '@/lib/telemetry/ui-click';
+import { cn } from '@/lib/utils';
+import { useSettingsStore } from '@/stores/settings-store';
+
+export default function DefaultCliProviderSettings() {
+  const { t } = useI18n();
+  const value = useSettingsStore((state) => state.settings.defaultCliProvider);
+  const isSaving = useSettingsStore((state) => state.pendingSaveCount > 0);
+  const updateSettings = useSettingsStore((state) => state.updateSettings);
+  const groupId = useId();
+  const descriptionId = `${groupId}-description`;
+  const noteId = `${groupId}-note`;
+
+  return (
+    <fieldset
+      className="space-y-3"
+      disabled={isSaving}
+      aria-describedby={`${descriptionId} ${noteId}`}
+    >
+      <legend className="font-medium text-(--text-primary)">
+        {t('settings.defaultCliProvider.title')}
+      </legend>
+      <p id={descriptionId} className="-mt-2 text-xs leading-5 text-(--text-muted)">
+        {t('settings.defaultCliProvider.description')}
+      </p>
+
+      <div className="grid gap-2 sm:grid-cols-3">
+        {DEFAULT_CLI_PROVIDER_IDS.map((providerId) => {
+          const selected = value === providerId;
+          const inputId = `${groupId}-${providerId}`;
+
+          return (
+            <label
+              key={providerId}
+              {...settingsTelemetryClickAttributes('settings.general.default_cli_provider')}
+              htmlFor={inputId}
+              className={cn(
+                'relative flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-3 transition-colors',
+                'has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-(--accent)',
+                selected
+                  ? 'border-[color-mix(in_srgb,var(--accent)_35%,transparent)] bg-[color-mix(in_srgb,var(--accent)_10%,transparent)]'
+                  : 'border-(--divider) bg-(--sidebar-bg) hover:border-(--accent)/25',
+                isSaving && 'cursor-wait opacity-70',
+              )}
+            >
+              <ProviderLogoMark
+                providerId={providerId}
+                className="h-7 w-7 rounded-lg"
+                iconClassName="h-4 w-4"
+              />
+              <span className="min-w-0 flex-1 text-sm font-medium text-(--text-primary)">
+                {getProviderBrand(providerId).displayName}
+              </span>
+              <input
+                {...settingsTelemetryClickAttributes('settings.general.default_cli_provider')}
+                type="radio"
+                id={inputId}
+                name={groupId}
+                value={providerId}
+                checked={selected}
+                onChange={() => {
+                  if (selected) return;
+                  void updateSettings({ defaultCliProvider: providerId });
+                }}
+                className="h-4 w-4 shrink-0 accent-(--accent)"
+                data-testid={`default-cli-provider-${providerId}`}
+              />
+            </label>
+          );
+        })}
+      </div>
+
+      <p id={noteId} className="text-xs leading-5 text-(--text-muted)">
+        {t('settings.defaultCliProvider.note')}
+      </p>
+    </fieldset>
+  );
+}

--- a/src/components/settings/settings-panel.tsx
+++ b/src/components/settings/settings-panel.tsx
@@ -27,6 +27,7 @@ import AgentExecutionModeSettings from './agent-execution-mode-settings';
 import TesseraCliSettings from './tessera-cli-settings';
 import TerminalViewDefaultSettings from './terminal-view-default-settings';
 import NewSessionKindSettings from './new-session-kind-settings';
+import DefaultCliProviderSettings from './default-cli-provider-settings';
 import CustomModelSettings from './custom-model-settings';
 import ProjectPreparationSettings from './project-preparation-settings';
 import RemoteAccessSection from './remote-access-section';
@@ -236,6 +237,9 @@ export default function SettingsPanel() {
       default:
         return (
           <>
+            <SettingsCard testId="settings-section-general-default-cli-provider">
+              <DefaultCliProviderSettings />
+            </SettingsCard>
             <SettingsCard testId="settings-section-general-execution-mode">
               <AgentExecutionModeSettings />
             </SettingsCard>

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -47,6 +47,11 @@ export const en: I18nMessages = {
         description: 'Start a session with its own managed branch and worktree.',
       },
     },
+    defaultCliProvider: {
+      title: 'Default CLI provider',
+      description: 'Choose the provider preselected when you create a session or worktree.',
+      note: 'If it is unavailable, Tessera temporarily selects another connected provider.',
+    },
     executionMode: {
       title: 'Agent execution mode',
       description: 'Choose how new chats and worktree sessions open.',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -47,6 +47,11 @@ export const ja: I18nMessages = {
         description: '専用ブランチとワークツリーを作ってセッションを開始します。',
       },
     },
+    defaultCliProvider: {
+      title: 'デフォルト CLI プロバイダー',
+      description: '新しいセッションやワークツリーを作成するときに最初に選ぶプロバイダーです。',
+      note: '利用できない場合は、接続済みの別のプロバイダーを一時的に選択します。',
+    },
     executionMode: {
       title: 'エージェント実行モード',
       description: '新しいチャットとワークツリーセッションの開き方を選択します。',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -47,6 +47,11 @@ export const ko: I18nMessages = {
         description: '전용 브랜치와 워크트리를 만들고 세션을 시작합니다.',
       },
     },
+    defaultCliProvider: {
+      title: '기본 CLI 프로바이더',
+      description: '새 세션이나 워크트리를 만들 때 처음 선택할 프로바이더입니다.',
+      note: '사용할 수 없으면 연결된 다른 프로바이더를 임시로 선택합니다.',
+    },
     executionMode: {
       title: '에이전트 실행 모드',
       description: '새 채팅과 워크트리 세션을 여는 방식을 선택합니다.',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -34,6 +34,11 @@ export interface I18nMessages {
       chat: { label: string; description: string };
       task: { label: string; description: string };
     };
+    defaultCliProvider: {
+      title: string;
+      description: string;
+      note: string;
+    };
     executionMode: {
       title: string;
       description: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -47,6 +47,11 @@ export const zh: I18nMessages = {
         description: '创建专属分支和工作树后启动会话。',
       },
     },
+    defaultCliProvider: {
+      title: '默认 CLI 提供方',
+      description: '选择新建会话或工作树时默认选中的提供方。',
+      note: '如果该提供方不可用，Tessera 会临时选择其他已连接的提供方。',
+    },
     executionMode: {
       title: '智能体运行模式',
       description: '选择新聊天和工作树会话的打开方式。',

--- a/src/lib/settings/default-cli-provider.ts
+++ b/src/lib/settings/default-cli-provider.ts
@@ -1,0 +1,12 @@
+export const DEFAULT_CLI_PROVIDER_IDS = [
+  'claude-code',
+  'codex',
+  'opencode',
+] as const;
+
+export type DefaultCliProvider = (typeof DEFAULT_CLI_PROVIDER_IDS)[number];
+
+export function isDefaultCliProvider(value: unknown): value is DefaultCliProvider {
+  return typeof value === 'string'
+    && DEFAULT_CLI_PROVIDER_IDS.some((providerId) => providerId === value);
+}

--- a/src/lib/settings/provider-defaults.ts
+++ b/src/lib/settings/provider-defaults.ts
@@ -17,6 +17,7 @@ import {
 } from '@/lib/cli/providers/opencode/session-config';
 import type { UserSettings, ProviderSessionDefaults } from './types';
 import { normalizeCliCommandOverrides } from './cli-command-overrides';
+import { DEFAULT_CLI_PROVIDER_IDS, isDefaultCliProvider } from './default-cli-provider';
 import {
   DEFAULT_PROFILE_AVATAR_DATA_URL,
   DEFAULT_PROFILE_DISPLAY_NAME,
@@ -547,6 +548,7 @@ export function normalizeUserSettings(raw: Partial<UserSettings> | null | undefi
     agentExecutionMode: 'pty',
     terminalSessionDefaultView: 'terminal',
     defaultNewSessionKind: 'task',
+    defaultCliProvider: DEFAULT_CLI_PROVIDER_IDS[0],
     profile: {
       displayName: DEFAULT_PROFILE_DISPLAY_NAME,
       avatarDataUrl: DEFAULT_PROFILE_AVATAR_DATA_URL,
@@ -663,6 +665,9 @@ export function normalizeUserSettings(raw: Partial<UserSettings> | null | undefi
     agentExecutionMode: raw?.agentExecutionMode === 'gui' ? 'gui' : 'pty',
     terminalSessionDefaultView: raw?.terminalSessionDefaultView === 'chat' ? 'chat' : 'terminal',
     defaultNewSessionKind: raw?.defaultNewSessionKind === 'chat' ? 'chat' : 'task',
+    defaultCliProvider: isDefaultCliProvider(raw?.defaultCliProvider)
+      ? raw.defaultCliProvider
+      : DEFAULT_CLI_PROVIDER_IDS[0],
     defaultModel: normalizedClaudeModel,
     terminalThemeLightPreset: normalizeTerminalThemePresetId(
       'light',

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -2,16 +2,17 @@ import type { PermissionMode } from '@/lib/ws/message-types';
 import type { ShortcutId } from '@/lib/keyboard/registry';
 import type { ProviderSessionAccessMode, ProviderSessionMode } from '@/lib/session/session-control-types';
 import type { AgentExecutionMode } from '@/lib/session/agent-execution-mode';
+import type { DefaultCliProvider } from './default-cli-provider';
+import type {
+  TerminalDarkThemePresetId,
+  TerminalLightThemePresetId,
+} from '@/lib/terminal/terminal-theme';
 
 /** Surface a PTY session opens on: its terminal, or the read-only chat view. */
 export type TerminalSessionDefaultView = 'terminal' | 'chat';
 
 /** Which kind of session the creation UIs preselect: a plain chat, or a worktree task. */
 export type NewSessionDefaultKind = 'chat' | 'task';
-import type {
-  TerminalDarkThemePresetId,
-  TerminalLightThemePresetId,
-} from '@/lib/terminal/terminal-theme';
 
 export type Language = 'en' | 'ko' | 'zh' | 'ja';
 export type Theme = 'light' | 'dark' | 'auto';
@@ -75,6 +76,8 @@ export interface UserSettings {
    * Kanban board's per-column create button — keep overriding it.
    */
   defaultNewSessionKind: NewSessionDefaultKind;
+  /** CLI provider new-session creation surfaces prefer when it is available. */
+  defaultCliProvider: DefaultCliProvider;
   profile: UserProfileSettings;
   notifications: {
     soundEnabled: boolean;

--- a/src/lib/telemetry/client.ts
+++ b/src/lib/telemetry/client.ts
@@ -249,6 +249,7 @@ const allowedSettings = new Set([
   'agentExecutionMode',
   'terminalSessionDefaultView',
   'defaultNewSessionKind',
+  'defaultCliProvider',
   'profile',
   'notifications',
   'translate',

--- a/src/lib/telemetry/ui-click.ts
+++ b/src/lib/telemetry/ui-click.ts
@@ -177,6 +177,7 @@ export const TELEMETRY_UI_CONTROLS = [
   'settings.section.git',
   'settings.general.language',
   'settings.general.execution_mode',
+  'settings.general.default_cli_provider',
   'settings.general.new_session_kind',
   'settings.general.terminal_view',
   'settings.profile.display_name',

--- a/tests/default-cli-provider.test.ts
+++ b/tests/default-cli-provider.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveCliProviderSelection } from '@/components/chat/cli-provider-chip-selector';
+import { normalizeUserSettings } from '@/lib/settings/provider-defaults';
+
+test('new and invalid settings use Claude Code as the default CLI provider', () => {
+  assert.equal(normalizeUserSettings({}).defaultCliProvider, 'claude-code');
+  assert.equal(
+    normalizeUserSettings({ defaultCliProvider: '' as never }).defaultCliProvider,
+    'claude-code',
+  );
+  assert.equal(
+    normalizeUserSettings({ defaultCliProvider: 'unknown' as never }).defaultCliProvider,
+    'claude-code',
+  );
+});
+
+test('persisted built-in CLI provider defaults survive normalization', () => {
+  assert.equal(
+    normalizeUserSettings({ defaultCliProvider: 'codex' }).defaultCliProvider,
+    'codex',
+  );
+  assert.equal(
+    normalizeUserSettings({ defaultCliProvider: 'opencode' }).defaultCliProvider,
+    'opencode',
+  );
+});
+
+test('an untouched creation surface prefers the configured connected provider', () => {
+  assert.equal(
+    resolveCliProviderSelection({
+      selectableProviderIds: ['claude-code', 'codex', 'opencode'],
+      currentProviderId: 'claude-code',
+      preferredProviderId: 'codex',
+      selectionTouched: false,
+    }),
+    'codex',
+  );
+});
+
+test('a valid manual selection outranks the configured provider', () => {
+  assert.equal(
+    resolveCliProviderSelection({
+      selectableProviderIds: ['claude-code', 'codex', 'opencode'],
+      currentProviderId: 'opencode',
+      preferredProviderId: 'codex',
+      selectionTouched: true,
+    }),
+    'opencode',
+  );
+});
+
+test('an unavailable configured provider falls back to the first connected provider', () => {
+  assert.equal(
+    resolveCliProviderSelection({
+      selectableProviderIds: ['claude-code', 'opencode'],
+      currentProviderId: '',
+      preferredProviderId: 'codex',
+      selectionTouched: false,
+    }),
+    'claude-code',
+  );
+});
+
+test('an empty provider refresh preserves the current selection', () => {
+  assert.equal(
+    resolveCliProviderSelection({
+      selectableProviderIds: [],
+      currentProviderId: 'codex',
+      preferredProviderId: 'claude-code',
+      selectionTouched: false,
+    }),
+    'codex',
+  );
+});

--- a/tests/telemetry-ui-click.test.ts
+++ b/tests/telemetry-ui-click.test.ts
@@ -152,6 +152,14 @@ test('semantic telemetry transport keeps only allowlisted safe properties', () =
   });
 });
 
+test('default CLI provider changes keep their allowlisted setting name', () => {
+  assert.deepEqual(sanitizeTelemetryProperties({
+    setting: 'defaultCliProvider',
+  }), {
+    setting: 'defaultCliProvider',
+  });
+});
+
 test('client form factor is reduced locally without transmitting raw device signals', () => {
   assert.equal(detectTelemetryClientFormFactor({
     userAgent: 'Mozilla/5.0 (Linux; Android 15; Pixel) AppleWebKit Mobile',


### PR DESCRIPTION
## Summary
- add a General setting for the default CLI provider
- apply the preference to full-page and quick-create session launchers
- preserve manual choices and fall back when the preferred provider is unavailable
- add localization, telemetry, and regression coverage

## Verification
- `npm exec -- tsx --test tests/default-cli-provider.test.ts tests/telemetry-ui-click.test.ts`
- `npm exec -- tsx --test tests/settings-telemetry-contract.test.mjs`
- `npm exec -- tsc --noEmit`
- `npm run lint -- --quiet`
- browser QA for Settings, full new-session, and quick-create surfaces