### PR TITLE
fix(files): load workspace tree lazily

### DIFF
--- a/src/app/api/sessions/[id]/files/route.ts
+++ b/src/app/api/sessions/[id]/files/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import { resolveSessionWorkspaceFilesystemRoot } from '@/lib/session/session-workspace-root';
-import { readWorkspaceRootFiles } from '@/lib/workspace-files/read-workspace-root';
+import {
+  readWorkspaceDirectoryFiles,
+  readWorkspaceRootFiles,
+} from '@/lib/workspace-files/read-workspace-root';
 import { getAgentEnvironment } from '@/lib/cli/spawn-cli';
 import { getProjectViewReferenceSessions } from '@/lib/projects/project-view-projection';
 
@@ -44,8 +47,15 @@ export async function GET(
     });
   }
 
+  const requestedDirectory = request.nextUrl.searchParams.has('directory')
+    ? request.nextUrl.searchParams.get('directory') ?? ''
+    : null;
+  const listing = requestedDirectory === null
+    ? await readWorkspaceRootFiles(root)
+    : await readWorkspaceDirectoryFiles(root, requestedDirectory);
+
   return NextResponse.json({
-    ...await readWorkspaceRootFiles(root),
+    ...listing,
     chats: refs.chats,
     tasks: refs.tasks,
   });

--- a/src/app/api/worktrees/[id]/files/route.ts
+++ b/src/app/api/worktrees/[id]/files/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
 import { getWorktree } from '@/lib/db/worktrees';
-import { readWorkspaceRootFiles } from '@/lib/workspace-files/read-workspace-root';
+import {
+  readWorkspaceDirectoryFiles,
+  readWorkspaceRootFiles,
+} from '@/lib/workspace-files/read-workspace-root';
 
 export async function GET(
   request: NextRequest,
@@ -19,6 +22,7 @@ export async function GET(
   }
   if (!worktree.filesystemPath) {
     return NextResponse.json({
+      directories: [],
       files: [],
       symlinks: [],
       truncated: false,
@@ -26,5 +30,10 @@ export async function GET(
       workDir: null,
     });
   }
-  return NextResponse.json(await readWorkspaceRootFiles(worktree.filesystemPath));
+  const requestedDirectory = request.nextUrl.searchParams.has('directory')
+    ? request.nextUrl.searchParams.get('directory') ?? ''
+    : null;
+  return NextResponse.json(requestedDirectory === null
+    ? await readWorkspaceRootFiles(worktree.filesystemPath)
+    : await readWorkspaceDirectoryFiles(worktree.filesystemPath, requestedDirectory));
 }

--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -90,7 +90,6 @@ interface WorkspaceDirectoryNode {
   name: string;
   path: string;
   children: WorkspaceTreeNode[];
-  fileCount: number;
 }
 
 type WorkspaceTreeNode = WorkspaceDirectoryNode | WorkspaceFileNode;
@@ -123,17 +122,12 @@ function finalizeDirectory(node: MutableDirectoryNode): WorkspaceDirectoryNode {
     .sort((a, b) => compareNodeNames(a.name, b.name));
   const files = [...node.files].sort((a, b) => compareNodeNames(a.name, b.name));
   const children: WorkspaceTreeNode[] = [...directories, ...files];
-  const fileCount = children.reduce((count, child) => {
-    if (child.type === "file") return count + 1;
-    return count + child.fileCount;
-  }, 0);
 
   return {
     type: "directory",
     name: node.name,
     path: node.path,
     children,
-    fileCount,
   };
 }
 
@@ -248,9 +242,14 @@ export function WorkspaceFilePanel({
     directories,
     error,
     files,
+    loadedDirectories,
+    loadDirectory,
     loadFiles,
     loading,
+    loadingDirectories,
     refreshFiles,
+    searchFiles,
+    searchResult,
     symlinks,
     truncated,
     workDir,
@@ -293,21 +292,90 @@ export function WorkspaceFilePanel({
     onRename: renameEntry,
     workspaceKey: targetKey,
   });
+  const handleExternalRefresh = inlineInput.handleExternalRefresh;
+  const skipInitialLiveRefreshRef = useRef(true);
+  useEffect(() => {
+    skipInitialLiveRefreshRef.current = true;
+  }, [targetKey]);
+  const handleLiveRefresh = useCallback(() => {
+    // The root listing just came from disk before the subscription was allowed
+    // to start. Its subscribe-time refresh would duplicate that same shallow
+    // request; later reconnects and actual tree changes still refresh normally.
+    if (skipInitialLiveRefreshRef.current) {
+      skipInitialLiveRefreshRef.current = false;
+      return;
+    }
+    handleExternalRefresh();
+  }, [handleExternalRefresh]);
 
   useWorkspaceFilesLiveSync({
-    enabled: Boolean(sessionId) && isDocumentVisible,
+    // Let the shallow root request win the first paint before starting the
+    // recursive background watch index on bridged Windows/WSL workspaces.
+    enabled: Boolean(sessionId) && isDocumentVisible && !loading,
     // Gated, not passed straight through: a reconcile landing while a name is
     // being typed would take the row it is being typed into.
-    onRefresh: inlineInput.handleExternalRefresh,
+    onRefresh: handleLiveRefresh,
     sessionId,
     subscriberId,
   });
 
+  const isSearching = query.trim().length > 0;
+  useEffect(function loadGlobalSearchResults() {
+    const trimmed = query.trim();
+    const abortController = new AbortController();
+    if (!trimmed) {
+      void searchFiles("", { signal: abortController.signal });
+      return () => abortController.abort();
+    }
+    const timer = window.setTimeout(() => {
+      void searchFiles(trimmed, { signal: abortController.signal });
+    }, 250);
+    return () => {
+      window.clearTimeout(timer);
+      abortController.abort();
+    };
+  }, [query, searchFiles]);
+
+  const loadedDirectorySet = useMemo(() => new Set(loadedDirectories), [loadedDirectories]);
+  const loadingDirectorySet = useMemo(() => new Set(loadingDirectories), [loadingDirectories]);
+
+  // Expansion state is persisted. Restore it one level at a time after the
+  // root is visible, never by turning tab entry back into a recursive scan.
+  useEffect(function restoreExpandedDirectories() {
+    if (loading || isSearching) return;
+    const knownDirectories = new Set(directories);
+    for (const path of [...storedExpandedPaths].sort((left, right) =>
+      left.split("/").length - right.split("/").length)) {
+      const parent = path.split("/").slice(0, -1).join("/");
+      if (
+        knownDirectories.has(path)
+        && loadedDirectorySet.has(parent)
+        && !loadedDirectorySet.has(path)
+        && !loadingDirectorySet.has(path)
+      ) {
+        void loadDirectory(path, { silent: true });
+      }
+    }
+  }, [
+    directories,
+    isSearching,
+    loadDirectory,
+    loadedDirectorySet,
+    loading,
+    loadingDirectorySet,
+    storedExpandedPaths,
+  ]);
+
+  const listedFiles = isSearching ? searchResult.files : files;
+  const listedDirectories = isSearching ? searchResult.directories : directories;
+  const listedSymlinks = isSearching ? searchResult.symlinks : symlinks;
+  const listedTruncated = isSearching ? searchResult.truncated : truncated;
+
   const baseFiles = useMemo(
     () => (showHiddenFiles
-      ? files
-      : files.filter((filePath) => !isHiddenWorkspaceRelativePath(filePath))),
-    [files, showHiddenFiles],
+      ? listedFiles
+      : listedFiles.filter((filePath) => !isHiddenWorkspaceRelativePath(filePath))),
+    [listedFiles, showHiddenFiles],
   );
   const visibleFiles = useMemo(() => {
     const trimmed = query.trim().toLowerCase();
@@ -317,9 +385,9 @@ export function WorkspaceFilePanel({
   }, [baseFiles, query]);
   const baseDirectories = useMemo(
     () => (showHiddenFiles
-      ? directories
-      : directories.filter((dirPath) => !isHiddenWorkspaceRelativePath(dirPath))),
-    [directories, showHiddenFiles],
+      ? listedDirectories
+      : listedDirectories.filter((dirPath) => !isHiddenWorkspaceRelativePath(dirPath))),
+    [listedDirectories, showHiddenFiles],
   );
   const visibleDirectories = useMemo(() => {
     const trimmed = query.trim().toLowerCase();
@@ -341,12 +409,11 @@ export function WorkspaceFilePanel({
     return baseDirectories.filter((dirPath) =>
       dirPath.toLowerCase().includes(trimmed) || ancestors.has(dirPath));
   }, [baseDirectories, query, visibleFiles]);
-  const symlinkPaths = useMemo(() => new Set(symlinks), [symlinks]);
+  const symlinkPaths = useMemo(() => new Set(listedSymlinks), [listedSymlinks]);
   const fileTree = useMemo(
     () => buildFileTree(visibleFiles, symlinkPaths, visibleDirectories),
     [symlinkPaths, visibleDirectories, visibleFiles],
   );
-  const isSearching = query.trim().length > 0;
 
   // Expand the ancestors, or an entry created inside a collapsed folder appears
   // to have done nothing.
@@ -359,7 +426,7 @@ export function WorkspaceFilePanel({
     try {
       const created = await createWorkspaceDirectoryRequest(target, path);
       expandParentOf(created.path);
-      await loadFiles({
+      await loadDirectory(created.path.split("/").slice(0, -1).join("/"), {
         silent: true,
         mutation: { kind: "directory", path: created.path, type: "create" },
       });
@@ -386,7 +453,7 @@ export function WorkspaceFilePanel({
       // Creation immediately navigates away to the new file tab. Finish the
       // list reload first so a Worktree panel without a Session watcher does not
       // show a stale tree when the user comes back.
-      await loadFiles({
+      await loadDirectory(created.path.split("/").slice(0, -1).join("/"), {
         silent: true,
         mutation: { kind: "file", path: created.path, type: "create" },
       });
@@ -418,7 +485,7 @@ export function WorkspaceFilePanel({
       if (selectedPath && isPathUnderMutation(selectedPath, renamed.previousPath)) {
         setSelectedPath(renamed.path + selectedPath.slice(renamed.previousPath.length));
       }
-      await loadFiles({
+      await loadDirectory(renamed.previousPath.split("/").slice(0, -1).join("/"), {
         silent: true,
         mutation: {
           kind,
@@ -454,7 +521,7 @@ export function WorkspaceFilePanel({
       if (selectedPath && isPathUnderMutation(selectedPath, request.path)) {
         setSelectedPath(null);
       }
-      await loadFiles({
+      await loadDirectory(request.path.split("/").slice(0, -1).join("/"), {
         silent: true,
         mutation: { kind: request.kind, path: request.path, type: "delete" },
       });
@@ -475,6 +542,14 @@ export function WorkspaceFilePanel({
 
   function toggleDirectory(path: string) {
     if (!targetKey) return;
+    if (
+      !isSearching
+      && !expandedPaths.has(path)
+      && !loadedDirectorySet.has(path)
+      && !loadingDirectorySet.has(path)
+    ) {
+      void loadDirectory(path);
+    }
     toggleStoredPath(targetKey, path);
   }
 
@@ -584,6 +659,7 @@ export function WorkspaceFilePanel({
 
     if (node.type === "directory") {
       const expanded = isSearching || expandedPaths.has(node.path);
+      const directoryLoading = loadingDirectorySet.has(node.path);
       const FolderIcon = expanded ? FolderOpen : Folder;
       const absolutePath = toAbsoluteWorkspacePath(workDir, node.path);
       const children = (
@@ -646,9 +722,9 @@ export function WorkspaceFilePanel({
             >
               {node.name}
             </span>
-            <span className="shrink-0 font-mono text-[10px] text-(--text-muted) tabular-nums">
-              {node.fileCount}
-            </span>
+            {directoryLoading ? (
+              <LoaderCircle className="h-3 w-3 shrink-0 animate-spin text-(--text-muted)" />
+            ) : null}
           </button>
           </div>
           {expanded ? children : null}
@@ -754,8 +830,10 @@ export function WorkspaceFilePanel({
                 Files
               </p>
               <p className="truncate text-[11px] text-(--text-muted)">
-                {baseFiles.length.toLocaleString()} files
-                {truncated ? " · truncated" : ""}
+                {isSearching
+                  ? `${visibleFiles.length.toLocaleString()} matches`
+                  : `${baseFiles.length.toLocaleString()} files loaded`}
+                {listedTruncated ? " · truncated" : ""}
               </p>
             </div>
           </div>
@@ -824,6 +902,12 @@ export function WorkspaceFilePanel({
         <div className="flex h-full items-center justify-center">
           <LoaderCircle className="h-5 w-5 animate-spin text-(--text-muted)" />
         </div>
+      ) : isSearching && searchResult.loading ? (
+        <div className="flex h-full items-center justify-center">
+          <LoaderCircle className="h-5 w-5 animate-spin text-(--text-muted)" />
+        </div>
+      ) : isSearching && searchResult.error ? (
+        <EmptyState title="Search unavailable" body={searchResult.error} icon="error" />
       ) : error ? (
         <EmptyState title="Files unavailable" body={error} icon="error" />
       ) : fileTree.length === 0 && !inlineInput.input ? (

--- a/src/hooks/use-workspace-file-list.ts
+++ b/src/hooks/use-workspace-file-list.ts
@@ -1,50 +1,69 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { fetchWithTimeout, isTimeoutError } from "@/lib/api/fetch-with-timeout";
-import { workspaceTargetApiPath, type WorkspaceTarget } from "@/types/worktree";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { fetchJsonWithTimeout, isTimeoutError } from "@/lib/api/fetch-with-timeout";
+import { workspaceTargetApiPath, workspaceTargetKey, type WorkspaceTarget } from "@/types/worktree";
 
 interface WorkspaceFilesResponse {
+  directory?: string;
   directories?: string[];
   files?: string[];
+  missing?: boolean;
   symlinks?: string[];
   truncated?: boolean;
   workDir?: string | null;
 }
 
+interface WorkspaceDirectoryListing {
+  directories: string[];
+  files: string[];
+  symlinks: string[];
+  truncated: boolean;
+}
+
+interface WorkspaceSearchResult extends WorkspaceDirectoryListing {
+  error: string | null;
+  loading: boolean;
+}
+
 interface WorkspaceFileListState {
-  /**
-   * Folders as the server saw them, not inferred from the file paths: an empty
-   * one appears in no file path at all.
-   */
+  /** Entries from the root and the directories the user has actually opened. */
   directories: string[];
   error: string | null;
   files: string[];
+  loadedDirectories: string[];
   loading: boolean;
+  loadingDirectories: string[];
+  searchResult: WorkspaceSearchResult;
   /** Subset of `files` that are symbolic links, in the same order. */
   symlinks: string[];
   truncated: boolean;
   workDir: string | null;
 }
 
-interface WorkspaceFileListMutation {
+export interface WorkspaceFileListMutation {
   kind: "directory" | "file";
   path: string;
   previousPath?: string;
   type: "create" | "delete" | "rename";
 }
 
-interface WorkspaceFileListLoadOptions {
+interface WorkspaceDirectoryLoadOptions {
   signal?: AbortSignal;
   silent?: boolean;
-  /**
-   * A successful mutation that the bridged Windows -> WSL file index may not
-   * expose on its first pass even though the filesystem operation completed.
-   */
   mutation?: WorkspaceFileListMutation;
 }
 
 const MUTATION_LIST_ATTEMPTS = 5;
+const FILE_LIST_LOAD_TIMEOUT_MS = 15_000;
+
+function normalizeWorkspaceRelativePath(filePath: string): string {
+  return filePath
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter((part) => part && part !== ".")
+    .join("/");
+}
 
 function sameStringArray(a: string[], b: string[]): boolean {
   if (a.length !== b.length) return false;
@@ -91,131 +110,249 @@ function payloadReflectsMutation(
     && sameStringArray(directories, reconcileEntries(directories, "directories", mutation));
 }
 
+function toListing(
+  payload: WorkspaceFilesResponse | null,
+  mutation?: WorkspaceFileListMutation,
+): WorkspaceDirectoryListing {
+  let files = Array.isArray(payload?.files) ? payload.files : [];
+  let symlinks = Array.isArray(payload?.symlinks) ? payload.symlinks : [];
+  let directories = Array.isArray(payload?.directories) ? payload.directories : [];
+  if (mutation) {
+    files = reconcileEntries(files, "files", mutation);
+    directories = reconcileEntries(directories, "directories", mutation);
+    symlinks = reconcileEntries(symlinks, "symlinks", mutation);
+  }
+  return { directories, files, symlinks, truncated: Boolean(payload?.truncated) };
+}
+
+function flattenListings(
+  listings: Record<string, WorkspaceDirectoryListing>,
+): WorkspaceDirectoryListing {
+  const directories = new Set<string>();
+  const files = new Set<string>();
+  const symlinks = new Set<string>();
+  let truncated = false;
+  for (const listing of Object.values(listings)) {
+    listing.directories.forEach((entry) => directories.add(entry));
+    listing.files.forEach((entry) => files.add(entry));
+    listing.symlinks.forEach((entry) => symlinks.add(entry));
+    truncated ||= listing.truncated;
+  }
+  return {
+    directories: [...directories].sort(compareWorkspacePaths),
+    files: [...files].sort(compareWorkspacePaths),
+    symlinks: [...symlinks].sort(compareWorkspacePaths),
+    truncated,
+  };
+}
+
+function workspaceFileListUrl(
+  target: WorkspaceTarget,
+  projectId: string | null | undefined,
+  directory?: string,
+): string {
+  const params = new URLSearchParams();
+  if (target.kind === "session" && projectId) params.set("projectId", projectId);
+  if (directory !== undefined) params.set("directory", directory);
+  const query = params.toString();
+  return `${workspaceFileListPath(target)}${query ? `?${query}` : ""}`;
+}
+
 export function useWorkspaceFileList(
   selected: string | WorkspaceTarget | null,
   projectId?: string | null,
 ): WorkspaceFileListState & {
-  loadFiles: (options?: WorkspaceFileListLoadOptions) => Promise<void>;
+  loadDirectory: (directory: string, options?: WorkspaceDirectoryLoadOptions) => Promise<void>;
+  loadFiles: (options?: WorkspaceDirectoryLoadOptions) => Promise<void>;
   refreshFiles: () => void;
+  searchFiles: (query: string, options?: { signal?: AbortSignal }) => Promise<void>;
 } {
   const targetKind = typeof selected === "string" ? "session" : selected?.kind;
   const targetId = typeof selected === "string" ? selected : selected?.id;
-  const [state, setState] = useState<WorkspaceFileListState>(() => ({
-    directories: [],
-    error: null,
-    files: [],
-    loading: Boolean(targetId),
-    symlinks: [],
-    truncated: false,
-    workDir: null,
-  }));
-  const requestSeqRef = useRef(0);
+  const target = useMemo<WorkspaceTarget | null>(() => targetKind && targetId
+    ? { kind: targetKind, id: targetId }
+    : null, [targetId, targetKind]);
+  const targetKey = target ? workspaceTargetKey(target) : null;
+  const targetReady = Boolean(target && (target.kind === "worktree" || projectId));
+  const [listings, setListings] = useState<Record<string, WorkspaceDirectoryListing>>({});
+  const [listingTargetKey, setListingTargetKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(Boolean(targetId));
+  const [loadingDirectories, setLoadingDirectories] = useState<string[]>([]);
+  const [workDir, setWorkDir] = useState<string | null>(null);
+  const [searchResult, setSearchResult] = useState<WorkspaceSearchResult>({
+    directories: [], error: null, files: [], loading: false, symlinks: [], truncated: false,
+  });
+  const generationRef = useRef(0);
+  const requestSeqByDirectoryRef = useRef(new Map<string, number>());
+  const listingsRef = useRef(listings);
+  listingsRef.current = listings;
 
-  const loadFiles = useCallback(async (options?: WorkspaceFileListLoadOptions) => {
-      if (!targetKind || !targetId) {
-        setState({
-          directories: [],
-          error: null,
-          files: [],
-          loading: false,
-          symlinks: [],
-          truncated: false,
-          workDir: null,
-        });
-        return;
+  const loadDirectory = useCallback(async (
+    rawDirectory: string,
+    options?: WorkspaceDirectoryLoadOptions,
+  ) => {
+    if (!target || !targetReady) return;
+    const directory = normalizeWorkspaceRelativePath(rawDirectory);
+    const generation = generationRef.current;
+    const requestSeq = (requestSeqByDirectoryRef.current.get(directory) ?? 0) + 1;
+    requestSeqByDirectoryRef.current.set(directory, requestSeq);
+
+    if (!options?.silent && directory === "") {
+      setError(null);
+      setLoading(true);
+    }
+    setLoadingDirectories((current) => current.includes(directory)
+      ? current
+      : [...current, directory]);
+
+    try {
+      let payload: WorkspaceFilesResponse | null = null;
+      const attempts = options?.mutation ? MUTATION_LIST_ATTEMPTS : 1;
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        const result = await fetchJsonWithTimeout<WorkspaceFilesResponse>(
+          workspaceFileListUrl(target, projectId, directory),
+          {
+            cache: "no-store",
+            signal: options?.signal,
+            timeoutMs: FILE_LIST_LOAD_TIMEOUT_MS,
+            retries: 1,
+          },
+        );
+        payload = result.payload;
+        if (!result.response.ok) throw new Error("Failed to load files.");
+        if (!options?.mutation || payloadReflectsMutation(payload, options.mutation)) break;
       }
 
-      const requestSeq = requestSeqRef.current + 1;
-      requestSeqRef.current = requestSeq;
+      if (
+        generationRef.current !== generation
+        || requestSeqByDirectoryRef.current.get(directory) !== requestSeq
+      ) return;
 
-      if (!options?.silent) {
-        setState((current) => ({
-          ...current,
-          error: null,
-          loading: true,
-          truncated: false,
-          workDir: null,
-        }));
+      const nextListing = toListing(payload, options?.mutation);
+      setListings((current) => {
+        const next = { ...current, [directory]: nextListing };
+        const previousChildren = current[directory]?.directories ?? [];
+        const nextChildren = new Set(nextListing.directories);
+        for (const removedDirectory of previousChildren) {
+          if (nextChildren.has(removedDirectory)) continue;
+          for (const loadedDirectory of Object.keys(next)) {
+            if (isPathAtOrBelow(loadedDirectory, removedDirectory)) delete next[loadedDirectory];
+          }
+        }
+        return next;
+      });
+      setWorkDir(payload?.workDir ?? null);
+      if (directory === "") {
+        setError(null);
+        setListingTargetKey(targetKey);
+        setLoading(false);
       }
-
-      try {
-        const target: WorkspaceTarget = { kind: targetKind, id: targetId };
-        // The sessions/[id]/files route requires projectId to scope Project View
-        // reference sessions; skip the query param for worktree targets.
-        const url = target.kind === "session" && projectId
-          ? `${workspaceFileListPath(target)}?projectId=${encodeURIComponent(projectId)}`
-          : workspaceFileListPath(target);
-        let payload: WorkspaceFilesResponse | null = null;
-        const attempts = options?.mutation ? MUTATION_LIST_ATTEMPTS : 1;
-        for (let attempt = 0; attempt < attempts; attempt += 1) {
-          const response = await fetchWithTimeout(
-            url,
-            { cache: 'no-store', signal: options?.signal, retries: 1 },
-          );
-          payload = (await response.json().catch(() => null)) as WorkspaceFilesResponse | null;
-          if (!response.ok) throw new Error("Failed to load files.");
-          if (!options?.mutation || payloadReflectsMutation(payload, options.mutation)) break;
-        }
-
-        if (requestSeqRef.current !== requestSeq) return;
-        let nextFiles = Array.isArray(payload?.files) ? payload.files : [];
-        let nextSymlinks = Array.isArray(payload?.symlinks) ? payload.symlinks : [];
-        let nextDirectories = Array.isArray(payload?.directories) ? payload.directories : [];
-        // The mutation response is authoritative. If the bridge index is still
-        // serving an old WSL directory snapshot after the bounded retry,
-        // reconcile the successful operation locally until the next refresh.
-        if (options?.mutation) {
-          nextFiles = reconcileEntries(nextFiles, "files", options.mutation);
-          nextDirectories = reconcileEntries(nextDirectories, "directories", options.mutation);
-          nextSymlinks = reconcileEntries(nextSymlinks, "symlinks", options.mutation);
-        }
-        setState((current) => ({
-          directories: sameStringArray(current.directories, nextDirectories)
-            ? current.directories
-            : nextDirectories,
-          error: null,
-          files: sameStringArray(current.files, nextFiles) ? current.files : nextFiles,
-          loading: false,
-          symlinks: sameStringArray(current.symlinks, nextSymlinks) ? current.symlinks : nextSymlinks,
-          truncated: Boolean(payload?.truncated),
-          workDir: payload?.workDir ?? null,
-        }));
-      } catch (error) {
-        if (options?.signal?.aborted || requestSeqRef.current !== requestSeq) return;
-        const message = isTimeoutError(error)
+    } catch (caught) {
+      if (
+        options?.signal?.aborted
+        || generationRef.current !== generation
+        || requestSeqByDirectoryRef.current.get(directory) !== requestSeq
+      ) return;
+      if (directory === "" && !options?.silent) {
+        setError(isTimeoutError(caught)
           ? "The file list did not load in time."
-          : error instanceof Error ? error.message : "Failed to load files.";
-        setState((current) => options?.silent
-          ? {
-              ...current,
-              loading: false,
-            }
-          : {
-              directories: [],
-              error: message,
-              files: [],
-              loading: false,
-              symlinks: [],
-              truncated: false,
-              workDir: null,
-            });
+          : caught instanceof Error ? caught.message : "Failed to load files.");
+        setLoading(false);
+        setListingTargetKey(targetKey);
       }
-  }, [targetId, targetKind, projectId]);
+    } finally {
+      if (
+        generationRef.current === generation
+        && requestSeqByDirectoryRef.current.get(directory) === requestSeq
+      ) {
+        setLoadingDirectories((current) => current.filter((entry) => entry !== directory));
+      }
+    }
+  }, [projectId, target, targetKey, targetReady]);
 
-  useEffect(() => {
-    const abortController = new AbortController();
-    void loadFiles({ signal: abortController.signal });
-    return () => abortController.abort();
-  }, [loadFiles]);
+  const loadFiles = useCallback((options?: WorkspaceDirectoryLoadOptions) =>
+    loadDirectory("", options), [loadDirectory]);
 
   const refreshFiles = useCallback(() => {
-    void loadFiles({ silent: true });
-  }, [loadFiles]);
+    const loaded = Object.keys(listingsRef.current);
+    void Promise.all((loaded.length ? loaded : [""]).map((directory) =>
+      loadDirectory(directory, { silent: true })));
+  }, [loadDirectory]);
 
+  const searchFiles = useCallback(async (
+    query: string,
+    options?: { signal?: AbortSignal },
+  ) => {
+    if (!target || !targetReady || !query.trim()) {
+      setSearchResult({
+        directories: [], error: null, files: [], loading: false, symlinks: [], truncated: false,
+      });
+      return;
+    }
+    const generation = generationRef.current;
+    setSearchResult((current) => ({ ...current, error: null, loading: true }));
+    try {
+      // The legacy recursive listing remains available for global search and
+      // the @ reference picker, but it is no longer on the tab-open path.
+      const result = await fetchJsonWithTimeout<WorkspaceFilesResponse>(
+        workspaceFileListUrl(target, projectId),
+        {
+          cache: "no-store",
+          signal: options?.signal,
+          timeoutMs: FILE_LIST_LOAD_TIMEOUT_MS,
+          retries: 1,
+        },
+      );
+      if (!result.response.ok) throw new Error("Failed to search files.");
+      if (generationRef.current !== generation || options?.signal?.aborted) return;
+      setSearchResult({ ...toListing(result.payload), error: null, loading: false });
+    } catch (caught) {
+      if (generationRef.current !== generation || options?.signal?.aborted) return;
+      setSearchResult({
+        directories: [],
+        error: isTimeoutError(caught)
+          ? "The file search did not finish in time."
+          : caught instanceof Error ? caught.message : "Failed to search files.",
+        files: [],
+        loading: false,
+        symlinks: [],
+        truncated: false,
+      });
+    }
+  }, [projectId, target, targetReady]);
+
+  useEffect(() => {
+    generationRef.current += 1;
+    requestSeqByDirectoryRef.current.clear();
+    setListings({});
+    setListingTargetKey(null);
+    setError(null);
+    setLoading(Boolean(target));
+    setLoadingDirectories([]);
+    setWorkDir(null);
+    setSearchResult({
+      directories: [], error: null, files: [], loading: false, symlinks: [], truncated: false,
+    });
+    if (!target || !targetReady) return;
+    const abortController = new AbortController();
+    void loadDirectory("", { signal: abortController.signal });
+    return () => abortController.abort();
+  }, [loadDirectory, target, targetKey, targetReady]);
+
+  const flattened = useMemo(() => flattenListings(listings), [listings]);
   return {
-    ...state,
+    ...flattened,
+    error,
+    loadedDirectories: Object.keys(listings),
+    loading: Boolean(target) && listingTargetKey !== targetKey ? true : loading,
+    loadingDirectories,
+    loadDirectory,
     loadFiles,
     refreshFiles,
+    searchFiles,
+    searchResult,
+    workDir,
   };
 }
 

--- a/src/lib/api/fetch-with-timeout.ts
+++ b/src/lib/api/fetch-with-timeout.ts
@@ -1,7 +1,13 @@
 const DEFAULT_TIMEOUT_MS = 3_000;
 
-export function isTimeoutError(error: unknown): boolean {
+export function isTimeoutError(error: unknown): error is DOMException {
   return error instanceof DOMException && error.name === 'TimeoutError';
+}
+
+function timeoutError(timeoutSignal: AbortSignal, error: unknown): DOMException {
+  if (isTimeoutError(timeoutSignal.reason)) return timeoutSignal.reason;
+  if (isTimeoutError(error)) return error;
+  return new DOMException("The operation timed out.", "TimeoutError");
 }
 
 export interface FetchWithTimeoutInit extends RequestInit {
@@ -26,6 +32,43 @@ export async function fetchWithTimeout(
     } catch (error) {
       lastError = error;
       if (signal?.aborted || !isTimeoutError(error)) throw error;
+    }
+  }
+  throw lastError;
+}
+
+export interface FetchJsonWithTimeoutResult<T> {
+  payload: T | null;
+  response: Response;
+}
+
+/**
+ * Keep the deadline active until the JSON body has arrived. `fetch()` resolves
+ * after response headers, so wrapping only that promise leaves a slow body
+ * outside the retry boundary.
+ */
+export async function fetchJsonWithTimeout<T>(
+  input: RequestInfo | URL,
+  init?: FetchWithTimeoutInit,
+): Promise<FetchJsonWithTimeoutResult<T>> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, retries = 0, signal, ...rest } = init ?? {};
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    try {
+      const response = await fetch(input, {
+        ...rest,
+        signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+      });
+      const payload = await response.json().catch((error: unknown) => {
+        if (signal?.aborted || timeoutSignal.aborted) throw error;
+        return null;
+      }) as T | null;
+      return { payload, response };
+    } catch (error) {
+      if (signal?.aborted || !timeoutSignal.aborted) throw error;
+      lastError = timeoutError(timeoutSignal, error);
     }
   }
   throw lastError;

--- a/src/lib/workspace-files/read-workspace-root.ts
+++ b/src/lib/workspace-files/read-workspace-root.ts
@@ -1,6 +1,12 @@
 import * as fs from 'node:fs/promises';
+import { getFilesystemPathModule, isAbsoluteFilesystemPath } from '@/lib/filesystem/host-path';
 import { workspaceFileWatchManager } from './workspace-file-watch-manager';
-import { walkWorkspaceFiles } from './workspace-file-scan';
+import { isInsideWorkspacePath } from './workspace-file-read-target';
+import {
+  normalizeWorkspaceRelativePath,
+  scanWorkspaceDirectory,
+  walkWorkspaceFiles,
+} from './workspace-file-scan';
 
 export interface WorkspaceRootFiles {
   directories: string[];
@@ -9,6 +15,86 @@ export interface WorkspaceRootFiles {
   truncated: boolean;
   reason?: 'not-a-directory' | 'unreadable' | 'walk-failed';
   workDir: string;
+}
+
+export interface WorkspaceDirectoryFiles extends WorkspaceRootFiles {
+  /** Workspace-relative directory whose immediate children were read. */
+  directory: string;
+  missing: boolean;
+}
+
+function parseWorkspaceDirectoryPath(rawPath: string): string | null {
+  if (rawPath.includes('\0') || isAbsoluteFilesystemPath(rawPath)) return null;
+  const parts = rawPath.replace(/\\/g, '/').split('/');
+  if (parts.some((part) => part === '..')) return null;
+  return normalizeWorkspaceRelativePath(rawPath);
+}
+
+/**
+ * Read exactly one level for the explorer. This deliberately bypasses the
+ * recursive watch snapshot: rendering the root of the Files tab must not wait
+ * for an index of every descendant on a bridged Windows/WSL filesystem.
+ */
+export async function readWorkspaceDirectoryFiles(
+  root: string,
+  requestedDirectory: string,
+): Promise<WorkspaceDirectoryFiles> {
+  const directory = parseWorkspaceDirectoryPath(requestedDirectory);
+  if (directory === null) {
+    return {
+      directory: '',
+      directories: [],
+      files: [],
+      symlinks: [],
+      truncated: false,
+      missing: true,
+      reason: 'unreadable',
+      workDir: root,
+    };
+  }
+
+  const pathModule = getFilesystemPathModule(root);
+  try {
+    const rootRealPath = await fs.realpath(root);
+    const candidatePath = directory
+      ? pathModule.join(rootRealPath, ...directory.split('/'))
+      : rootRealPath;
+    const candidateStat = await fs.lstat(candidatePath);
+    // Directory links are intentionally absent from the explorer scan. Do not
+    // let a hand-crafted request use one to traverse outside the workspace.
+    if (candidateStat.isSymbolicLink()) throw new Error('linked directory');
+    const targetRealPath = await fs.realpath(candidatePath);
+    if (
+      !candidateStat.isDirectory()
+      || !isInsideWorkspacePath(rootRealPath, targetRealPath, pathModule)
+    ) {
+      throw new Error('not a workspace directory');
+    }
+
+    const result = await scanWorkspaceDirectory(rootRealPath, directory, {
+      recursive: false,
+    });
+    return {
+      directory,
+      directories: result.directories,
+      files: result.files,
+      symlinks: result.symlinks,
+      truncated: result.truncated,
+      missing: result.missing,
+      workDir: root,
+    };
+  } catch {
+    return {
+      directory,
+      directories: [],
+      files: [],
+      symlinks: [],
+      truncated: false,
+      missing: true,
+      reason: 'unreadable',
+      workDir: root,
+    };
+  }
 }
 
 export async function readWorkspaceRootFiles(root: string): Promise<WorkspaceRootFiles> {

--- a/tests/fetch-with-timeout.test.ts
+++ b/tests/fetch-with-timeout.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  fetchJsonWithTimeout,
+  isTimeoutError,
+} from "../src/lib/api/fetch-with-timeout";
+
+function rejectWhenAborted(signal: AbortSignal | null | undefined): Promise<Response> {
+  return new Promise((_resolve, reject) => {
+    const rejectAbort = () => reject(new DOMException("The operation was aborted.", "AbortError"));
+    if (signal?.aborted) {
+      rejectAbort();
+      return;
+    }
+    signal?.addEventListener("abort", rejectAbort, { once: true });
+  });
+}
+
+test("fetchJsonWithTimeout never retries an external abort", async () => {
+  const originalFetch = globalThis.fetch;
+  const keepAlive = setInterval(() => undefined, 100);
+  const controller = new AbortController();
+  let calls = 0;
+  globalThis.fetch = (async (_input, init) => {
+    calls += 1;
+    return rejectWhenAborted(init?.signal);
+  }) as typeof fetch;
+
+  try {
+    const request = fetchJsonWithTimeout("https://example.invalid", {
+      signal: controller.signal,
+      timeoutMs: 1_000,
+      retries: 2,
+    });
+    controller.abort();
+    await assert.rejects(request, (error: unknown) => (
+      error instanceof DOMException && error.name === "AbortError"
+    ));
+    assert.equal(calls, 1);
+  } finally {
+    clearInterval(keepAlive);
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("fetchJsonWithTimeout retries when the response body misses the deadline", async () => {
+  const originalFetch = globalThis.fetch;
+  const keepAlive = setInterval(() => undefined, 100);
+  let calls = 0;
+  globalThis.fetch = (async (_input, init) => {
+    calls += 1;
+    return new Response(new ReadableStream({
+      start(controller) {
+        const abort = () => controller.error(
+          new DOMException("The operation was aborted.", "AbortError"),
+        );
+        if (init?.signal?.aborted) abort();
+        else init?.signal?.addEventListener("abort", abort, { once: true });
+      },
+    }), {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    });
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(
+      fetchJsonWithTimeout("https://example.invalid", { timeoutMs: 5, retries: 1 }),
+      (error: unknown) => isTimeoutError(error),
+    );
+    assert.equal(calls, 2);
+  } finally {
+    clearInterval(keepAlive);
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/file-read-timeout-contract.test.mjs
+++ b/tests/file-read-timeout-contract.test.mjs
@@ -11,6 +11,7 @@ const gitPanelSource = fs.readFileSync(new URL('../src/lib/git/git-panel.ts', im
 const gitRunnerSource = fs.readFileSync(new URL('../src/lib/worktrees/git-runner.ts', import.meta.url), 'utf8');
 const filePanelSource = fs.readFileSync(new URL('../src/components/workspace/workspace-file-panel.tsx', import.meta.url), 'utf8');
 const fileListHookSource = fs.readFileSync(new URL('../src/hooks/use-workspace-file-list.ts', import.meta.url), 'utf8');
+const liveSyncHookSource = fs.readFileSync(new URL('../src/hooks/use-workspace-files-live-sync.ts', import.meta.url), 'utf8');
 
 test('fetchWithTimeout enforces a deadline and retries only on timeout', () => {
   assert.match(fetchWithTimeoutSource, /AbortSignal\.timeout\(timeoutMs\)/);
@@ -82,6 +83,18 @@ test('worktree diff stats git runner opts into the kill timer', () => {
 
 test('file list flows use the timeout-aware fetch', () => {
   assert.match(filePanelSource, /useWorkspaceFileList/);
-  assert.match(fileListHookSource, /fetchWithTimeout\(/);
+  assert.match(fileListHookSource, /fetchJsonWithTimeout(?:<[^>]+>)?\(/);
+  assert.match(fileListHookSource, /FILE_LIST_LOAD_TIMEOUT_MS = 15_000/);
+  assert.match(fileListHookSource, /timeoutMs:\s*FILE_LIST_LOAD_TIMEOUT_MS,[\s\S]*?retries:\s*1/);
   assert.match(fileListHookSource, /isTimeoutError/);
+});
+
+test('the Files tab paints a shallow root before starting recursive live sync', () => {
+  assert.match(liveSyncHookSource, /onRefreshRef\.current\(\)/);
+  assert.match(fileListHookSource, /params\.set\("directory", directory\)/);
+  assert.match(filePanelSource, /enabled: Boolean\(sessionId\) && isDocumentVisible && !loading/);
+  assert.match(filePanelSource, /void loadDirectory\(path\)/);
+  assert.match(filePanelSource, /skipInitialLiveRefreshRef/);
+  assert.match(fileListHookSource, /target\.kind === "worktree" \|\| projectId/);
+  assert.match(fileListHookSource, /if \(!target \|\| !targetReady\) return;/);
 });

--- a/tests/workspace-file-editing-contract.test.mjs
+++ b/tests/workspace-file-editing-contract.test.mjs
@@ -170,8 +170,9 @@ test('creating a file posts and opens what it created', () => {
   // POST, now issued straight from the inline input.
   assert.match(mutationClientSource, /createWorkspaceFileRequest/);
   assert.match(mutationClientSource, /body: JSON\.stringify\(\{ path, content: "" \}\)/);
-  assert.match(filePanelSource, /await loadFiles\(\{[\s\S]*silent: true,[\s\S]*mutation:/);
-  assert.match(fileListHookSource, /cache: 'no-store'/);
+  // Lazy trees reconcile only the created entry's parent directory.
+  assert.match(filePanelSource, /await loadDirectory\(created\.path\.split\([\s\S]*silent: true,[\s\S]*mutation:/);
+  assert.match(fileListHookSource, /cache: ["']no-store["']/);
   assert.match(fileListHookSource, /MUTATION_LIST_ATTEMPTS = 5/);
   assert.match(filePanelSource, /mutation: \{ kind: "file", path: created\.path, type: "create" \}/);
   assert.match(filePanelSource, /useWorkspacePeekStore\(\(state\) => state\.target\)/);

--- a/tests/workspace-file-scan.test.ts
+++ b/tests/workspace-file-scan.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { readWorkspaceDirectoryFiles } from "../src/lib/workspace-files/read-workspace-root";
 import {
   applyMaxFiles,
   isIgnoredWorkspacePath,
@@ -116,6 +117,35 @@ test("directory scan reads one level or the whole subtree", async () => {
     // top-level entry invalidates.
     const rootShallow = await scanWorkspaceDirectory(root, "", { recursive: false });
     assert.deepEqual(rootShallow.files, ["top.ts"]);
+  });
+});
+
+test("Files tab directory reads return only immediate children", async () => {
+  await withTempWorkspace(async (root) => {
+    await mkdir(path.join(root, "src/nested"), { recursive: true });
+    await mkdir(path.join(root, "empty"), { recursive: true });
+    await writeFile(path.join(root, "root.ts"), "");
+    await writeFile(path.join(root, "src/index.ts"), "");
+    await writeFile(path.join(root, "src/nested/deep.ts"), "");
+
+    const rootListing = await readWorkspaceDirectoryFiles(root, "");
+    assert.equal(rootListing.missing, false);
+    assert.deepEqual(rootListing.directories, ["empty", "src"]);
+    assert.deepEqual(rootListing.files, ["root.ts"]);
+
+    const srcListing = await readWorkspaceDirectoryFiles(root, "src");
+    assert.equal(srcListing.missing, false);
+    assert.deepEqual(srcListing.directories, ["src/nested"]);
+    assert.deepEqual(srcListing.files, ["src/index.ts"]);
+  });
+});
+
+test("Files tab directory reads reject paths outside the workspace", async () => {
+  await withTempWorkspace(async (root) => {
+    const result = await readWorkspaceDirectoryFiles(root, "../outside");
+    assert.equal(result.missing, true);
+    assert.deepEqual(result.directories, []);
+    assert.deepEqual(result.files, []);
   });
 });
 

--- a/tests/workspace-tree-operations-contract.test.mjs
+++ b/tests/workspace-tree-operations-contract.test.mjs
@@ -201,7 +201,8 @@ test('folder toggles have no delayed timer that can fire under an input', () => 
 test('a watch reconcile cannot take the row being edited', () => {
   // The panel's live sync goes through the hook: while an input is open the
   // reload is held back and applied once, when the input closes.
-  assert.match(filePanelSource, /onRefresh: inlineInput\.handleExternalRefresh/);
+  assert.match(filePanelSource, /onRefresh: handleLiveRefresh/);
+  assert.match(filePanelSource, /handleExternalRefresh\(\)/);
   assert.match(inlineHookSource, /pendingRefreshRef\.current = true/);
   assert.match(inlineHookSource, /handlersRef\.current\.onRefreshFiles\(\)/);
 });


### PR DESCRIPTION
## Summary

- render the Files tab after loading only the workspace root children
- fetch each directory only when expanded, while preserving full scans for explicit global search and reference lookup
- wait for project context and suppress duplicate initial live-refresh requests
- keep filesystem reads and JSON body parsing bounded by timeouts

## Verification

- npm run build
- focused unit tests: 14 passed
- contract tests: 415 passed
- Windows backend + WSL filesystem E2E: root 26 ms, expanded directories 63-65 ms, global search 73 ms; no project-less 400 or duplicate root request
- full unit suite before rebase: 1,848 passed, 2 skipped, 1 pre-existing unrelated localization-contract failure in git-action-failure-report.test.ts

QA screenshots: C:\\Users\\work\\Downloads\\Tessera-files-lazy-qa-20260831