### PR TITLE
feat(git): open worktree folder from panel

### DIFF
--- a/src/components/git/git-panel-sections.tsx
+++ b/src/components/git/git-panel-sections.tsx
@@ -10,13 +10,14 @@ import {
   Copy,
   ExternalLink,
   FileText,
+  FolderOpen,
   GitCompare,
   GitCommitHorizontal,
   GitPullRequest,
   LoaderCircle,
   Undo2,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tooltip } from "@/components/ui/tooltip";
@@ -24,7 +25,11 @@ import { GitRevertConfirmDialog } from "@/components/git/git-revert-confirm-dial
 import { WorkspaceFileContextMenu } from "@/components/workspace/workspace-file-context-menu";
 import { setWorkspaceFileDragData } from "@/lib/dnd/panel-session-drag";
 import { useI18n } from "@/lib/i18n";
-import { toAbsoluteWorkspacePath } from "@/lib/workspace-tabs/file-path-actions";
+import {
+  canUseElectronFileActions,
+  openFilePathOnHost,
+  toAbsoluteWorkspacePath,
+} from "@/lib/workspace-tabs/file-path-actions";
 import { cn } from "@/lib/utils";
 import { deriveGitConflictRecovery } from "@/lib/git/git-conflict-recovery";
 import type { GitPrimaryAction } from "@/lib/git/primary-git-action";
@@ -61,6 +66,9 @@ function formatShortCount(value: number): string {
   if (value < 10000) return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}k`;
   return `${Math.round(value / 1000)}k`;
 }
+
+const subscribeToStaticClientValue = () => () => {};
+const getNoElectronFileActions = () => false;
 
 function formatDiffMetric(
   data: GitPanelData,
@@ -439,6 +447,11 @@ export function GitPanelSummarySection({
   const worktreeName = data ? getGitPanelWorktreeName(data) : "worktree";
   const branchName = data?.branch ?? "branch";
   const worktreeTooltip = data?.worktreePath ?? "Worktree path unavailable";
+  const canOpenWorktreeFolder = useSyncExternalStore(
+    subscribeToStaticClientValue,
+    canUseElectronFileActions,
+    getNoElectronFileActions,
+  );
   const prUrl = data?.prStatus?.url ?? data?.github.pullRequest?.url;
   const historicalPr = data?.prStatus ? !isCurrentTaskPr(data.prStatus) : false;
   const prLabel = data?.prStatus
@@ -492,12 +505,29 @@ export function GitPanelSummarySection({
                   </span>
                 </Tooltip>
                 {data ? (
-                  <GitSummaryCopyButton
-                    ariaLabel="Copy full worktree path"
-                    onClick={onCopyWorktreePath}
-                    telemetryControl="git.worktree_path.copy"
-                    tooltip="Copy full worktree path"
-                  />
+                  <>
+                    {canOpenWorktreeFolder ? (
+                      <Tooltip content="Open worktree folder" side="top">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 shrink-0 rounded text-(--text-muted) hover:text-(--text-primary)"
+                          onClick={() => openFilePathOnHost(data.worktreePath)}
+                          {...telemetryClickAttributes("git.worktree_folder.open", "git_panel")}
+                          aria-label="Open worktree folder"
+                        >
+                          <FolderOpen className="h-3.5 w-3.5" />
+                        </Button>
+                      </Tooltip>
+                    ) : null}
+                    <GitSummaryCopyButton
+                      ariaLabel="Copy full worktree path"
+                      onClick={onCopyWorktreePath}
+                      telemetryControl="git.worktree_path.copy"
+                      tooltip="Copy full worktree path"
+                    />
+                  </>
                 ) : null}
               </div>
             </div>

--- a/src/lib/telemetry/ui-click.ts
+++ b/src/lib/telemetry/ui-click.ts
@@ -123,6 +123,7 @@ export const TELEMETRY_UI_CONTROLS = [
   'git.generate_commit_message',
   'git.repository.open',
   'git.pull_request.open',
+  'git.worktree_folder.open',
   'git.worktree_path.copy',
   'git.branch.copy',
   'git.commit_file.toggle',

--- a/tests/git-worktree-folder-open-contract.test.mjs
+++ b/tests/git-worktree-folder-open-contract.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const sectionsSource = fs.readFileSync(
+  new URL('../src/components/git/git-panel-sections.tsx', import.meta.url),
+  'utf8',
+);
+const telemetrySource = fs.readFileSync(
+  new URL('../src/lib/telemetry/ui-click.ts', import.meta.url),
+  'utf8',
+);
+
+test('Git panel Worktree summary exposes an Electron folder-open action', () => {
+  assert.match(sectionsSource, /canUseElectronFileActions/);
+  assert.match(sectionsSource, /canOpenWorktreeFolder \? \(/);
+  assert.match(sectionsSource, /openFilePathOnHost\(data\.worktreePath\)/);
+  assert.match(sectionsSource, /aria-label="Open worktree folder"/);
+  assert.match(sectionsSource, /<FolderOpen className="h-3\.5 w-3\.5" \/>/);
+  assert.match(telemetrySource, /'git\.worktree_folder\.open'/);
+});


### PR DESCRIPTION
## Summary
- add a visible folder-open action beside the Git panel Worktree path
- reuse Electron shell path handling, including Windows/WSL conversion
- cover the action with a contract test

## Verification
- npm run test:contracts
- npm run lint -- --quiet
- npx tsc --noEmit
- npm run electron:compile