### PR TITLE
fix(sidebar): retain revealed sub-sessions across projects

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -623,7 +623,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
   const sessionCount = task.sessions.length;
   const isMultiSession = sessionCount > 1;
   const expanded = isMultiSession;
-  const { visibleSessions, hiddenCount, showToggle, revealed, toggle } = useSubSessionCap(task.sessions);
+  const { visibleSessions, hiddenCount, showToggle, revealed, toggle } = useSubSessionCap(task.id, task.sessions);
   const subSessionReorder = useSubSessionReorder(task.id, task.sessions);
   const isActive = task.sessions.some((s) => s.id === activeSessionId);
   const primarySessionId = task.sessions[0]?.id;

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -841,7 +841,7 @@ export function TaskItemRow({
   const showProviderIcons = useSettingsStore((state) => state.settings.showProviderIcons);
   const density = getLinkedWorktreeDensity(task.sessions);
   const isExpanded = density === 'expanded';
-  const { visibleSessions, hiddenCount, showToggle, revealed, toggle } = useSubSessionCap(task.sessions);
+  const { visibleSessions, hiddenCount, showToggle, revealed, toggle } = useSubSessionCap(task.id, task.sessions);
   const subSessionReorder = useSubSessionReorder(task.id, task.sessions);
   const activeTabId = useTabStore((state) => state.activeTabId);
   const activePanelSessionId = usePanelStore((state) => {

--- a/src/hooks/use-sub-session-cap.ts
+++ b/src/hooks/use-sub-session-cap.ts
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useSubSessionCapStateStore } from '@/stores/sub-session-cap-state-store';
 import type { TaskSession } from '@/types/task-entity';
 
 /** Sub-session rows a task shows before the rest collapse behind "show more". */
@@ -6,11 +7,12 @@ export const SUB_SESSION_VISIBLE_LIMIT = 5;
 
 /**
  * Caps a task's sub-session list so long-running worktrees don't stretch the
- * card down the whole column. Deliberately unpersisted: the cap comes back on
- * remount, which is what keeps the list from creeping back to full height.
+ * card down the whole column. Expansion is keyed by task so a Project change
+ * does not reset a list that the user already revealed.
  */
-export function useSubSessionCap(sessions: TaskSession[]) {
-  const [revealed, setRevealed] = useState(false);
+export function useSubSessionCap(taskId: string, sessions: TaskSession[]) {
+  const revealed = useSubSessionCapStateStore((state) => state.revealedTaskIds[taskId] ?? false);
+  const toggle = useSubSessionCapStateStore((state) => state.toggleRevealed);
   const isCapped = sessions.length > SUB_SESSION_VISIBLE_LIMIT;
 
   const visibleSessions = useMemo(
@@ -25,6 +27,6 @@ export function useSubSessionCap(sessions: TaskSession[]) {
     // limit would otherwise show a "show less" that collapses nothing.
     showToggle: isCapped,
     revealed,
-    toggle: () => setRevealed((current) => !current),
+    toggle: () => toggle(taskId),
   };
 }

--- a/src/stores/sub-session-cap-state-store.ts
+++ b/src/stores/sub-session-cap-state-store.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+interface SubSessionCapState {
+  revealedTaskIds: Record<string, boolean>;
+  isRevealed: (taskId: string) => boolean;
+  toggleRevealed: (taskId: string) => void;
+}
+
+/**
+ * UI-only sub-session expansion state. It intentionally outlives an individual
+ * task row so switching away from and back to a Project restores its list.
+ */
+export const useSubSessionCapStateStore = create<SubSessionCapState>()((set, get) => ({
+  revealedTaskIds: {},
+  isRevealed: (taskId) => get().revealedTaskIds[taskId] ?? false,
+  toggleRevealed: (taskId) => set((state) => ({
+    revealedTaskIds: {
+      ...state.revealedTaskIds,
+      [taskId]: !(state.revealedTaskIds[taskId] ?? false),
+    },
+  })),
+}));

--- a/tests/sub-session-cap-state.test.ts
+++ b/tests/sub-session-cap-state.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { useSubSessionCapStateStore } from '@/stores/sub-session-cap-state-store';
+
+test.afterEach(() => {
+  useSubSessionCapStateStore.setState(
+    useSubSessionCapStateStore.getInitialState(),
+    true,
+  );
+});
+
+test('a task keeps its revealed sub-session state while its project view is unmounted', () => {
+  const taskId = 'task-in-project-a';
+
+  useSubSessionCapStateStore.getState().toggleRevealed(taskId);
+
+  // Project changes unmount this task row. The UI state must belong to the
+  // task, rather than to that short-lived component instance.
+  assert.equal(useSubSessionCapStateStore.getState().isRevealed(taskId), true);
+  assert.equal(useSubSessionCapStateStore.getState().isRevealed('task-in-project-b'), false);
+});


### PR DESCRIPTION
## Summary
- keep Show more/less state keyed by task across Project view remounts
- apply the shared state to list and Kanban task cards
- add a regression test for retained revealed state

## Verification
- `npx tsx --test tests/sub-session-cap-state.test.ts tests/sidebar-project-task-selection.test.ts`
- `npx eslint src/hooks/use-sub-session-cap.ts src/stores/sub-session-cap-state-store.ts src/components/chat/collection-group-sections.tsx src/components/board/kanban-card.tsx tests/sub-session-cap-state.test.ts`
- `npx tsc --noEmit --incremental`