### PR TITLE
fix(files): add find shortcut to file viewer

### DIFF
--- a/src/components/workspace/workspace-code-view.tsx
+++ b/src/components/workspace/workspace-code-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { AlertCircle, Binary, Code2, Copy, ExternalLink, Eye, FileCode2, FileText, GitCompare, Image as ImageIcon, LoaderCircle, RefreshCw, Save, X } from "lucide-react";
-import { useCallback, useState, useSyncExternalStore, type ReactNode } from "react";
+import { AlertCircle, Binary, ChevronDown, ChevronUp, Code2, Copy, ExternalLink, Eye, FileCode2, FileText, GitCompare, Image as ImageIcon, LoaderCircle, RefreshCw, Save, Search, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { PreviewMarkdown } from "@/components/chat/preview-markdown";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
@@ -90,6 +90,107 @@ function useCanUseElectronFileActions(): boolean {
     subscribeToStaticClientValue,
     canUseElectronFileActions,
     getNoElectronFileActions,
+  );
+}
+
+function WorkspaceFileFind({
+  contentRef,
+  onClose,
+}: {
+  contentRef: React.RefObject<HTMLDivElement | null>;
+  onClose: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const matchesRef = useRef<Range[]>([]);
+  const [query, setQuery] = useState("");
+  const [matchIndex, setMatchIndex] = useState(-1);
+  const [matchCount, setMatchCount] = useState(0);
+
+  const selectMatch = useCallback((index: number) => {
+    const match = matchesRef.current[index];
+    if (!match) return;
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(match);
+    const element = match.startContainer.parentElement;
+    element?.scrollIntoView({ block: "center", behavior: "smooth" });
+    setMatchIndex(index);
+  }, []);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const updateQuery = useCallback((nextQuery: string) => {
+    setQuery(nextQuery);
+    const container = contentRef.current;
+    const normalizedQuery = nextQuery.toLocaleLowerCase();
+    if (!container || !normalizedQuery) {
+      matchesRef.current = [];
+      setMatchCount(0);
+      setMatchIndex(-1);
+      return;
+    }
+
+    const matches: Range[] = [];
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+      const text = node.textContent ?? "";
+      const normalizedText = text.toLocaleLowerCase();
+      let offset = normalizedText.indexOf(normalizedQuery);
+      while (offset >= 0) {
+        const range = document.createRange();
+        range.setStart(node, offset);
+        range.setEnd(node, offset + nextQuery.length);
+        matches.push(range);
+        offset = normalizedText.indexOf(normalizedQuery, offset + normalizedQuery.length);
+      }
+      node = walker.nextNode();
+    }
+    matchesRef.current = matches;
+    setMatchCount(matches.length);
+    if (matches.length > 0) selectMatch(0);
+    else setMatchIndex(-1);
+  }, [contentRef, selectMatch]);
+
+  const move = useCallback((direction: 1 | -1) => {
+    const count = matchesRef.current.length;
+    if (count === 0) return;
+    selectMatch((matchIndex + direction + count) % count);
+  }, [matchIndex, selectMatch]);
+
+  return (
+    <div className="absolute right-4 top-4 z-10 flex items-center gap-1 rounded-md border border-(--divider) bg-(--chat-bg) p-1 shadow-lg">
+      <Search className="ml-1 h-3.5 w-3.5 text-(--text-muted)" />
+      <input
+        ref={inputRef}
+        value={query}
+        onChange={(event) => updateQuery(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") onClose();
+          if (event.key === "Enter") {
+            event.preventDefault();
+            move(event.shiftKey ? -1 : 1);
+          }
+        }}
+        className="h-7 w-44 bg-transparent px-1 text-xs text-(--text-primary) outline-none"
+        placeholder="Find in file"
+        aria-label="Find in file"
+      />
+      <span className="min-w-12 text-center text-[11px] text-(--text-muted)">
+        {query ? `${matchCount ? matchIndex + 1 : 0}/${matchCount}` : ""}
+      </span>
+      <Button type="button" variant="ghost" size="icon" className="h-7 w-7" onClick={() => move(-1)} disabled={!matchCount} aria-label="Previous match">
+        <ChevronUp className="h-3.5 w-3.5" />
+      </Button>
+      <Button type="button" variant="ghost" size="icon" className="h-7 w-7" onClick={() => move(1)} disabled={!matchCount} aria-label="Next match">
+        <ChevronDown className="h-3.5 w-3.5" />
+      </Button>
+      <Button type="button" variant="ghost" size="icon" className="h-7 w-7" onClick={onClose} aria-label="Close find">
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
   );
 }
 
@@ -253,6 +354,9 @@ export function WorkspaceCodeView({
     mode: "preview",
     path: "",
   });
+  const [isFindOpen, setIsFindOpen] = useState(false);
+  const [monacoFindRequest, setMonacoFindRequest] = useState(0);
+  const markdownContentRef = useRef<HTMLDivElement>(null);
   const loadedContent =
     mode === "diff"
       ? (data as GitDiffData | null)?.diff ?? ""
@@ -285,7 +389,21 @@ export function WorkspaceCodeView({
   }, [path, sourceTarget]);
   const handleMarkdownViewModeChange = useCallback((nextMode: MarkdownViewMode) => {
     setMarkdownModeState({ mode: nextMode, path });
+    setIsFindOpen(false);
   }, [path]);
+  const handleMonacoFind = useCallback(() => {
+    // Monaco owns source/diff searching, including its match navigation UI.
+    setMonacoFindRequest((request) => request + 1);
+  }, []);
+  const handleFindShortcut = useCallback((event: React.KeyboardEvent) => {
+    if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "f") return;
+    event.preventDefault();
+    if (shouldRenderMarkdownPreview) {
+      setIsFindOpen(true);
+      return;
+    }
+    handleMonacoFind();
+  }, [handleMonacoFind, shouldRenderMarkdownPreview]);
   // Bound to this view's root rather than window: with two split panels open,
   // only the panel the keystroke happened in must save.
   const handleSaveShortcut = useCallback((event: React.KeyboardEvent) => {
@@ -297,6 +415,10 @@ export function WorkspaceCodeView({
       onSave?.();
     }
   }, [dirty, editable, onSave, saving]);
+  const handleViewKeyDown = useCallback((event: React.KeyboardEvent) => {
+    handleSaveShortcut(event);
+    handleFindShortcut(event);
+  }, [handleFindShortcut, handleSaveShortcut]);
 
   async function copyContent() {
     try {
@@ -374,7 +496,7 @@ export function WorkspaceCodeView({
 
   return (
     <>
-    <div className="flex h-full min-h-0 flex-col bg-(--chat-bg)" onKeyDown={handleSaveShortcut}>
+    <div className="flex h-full min-h-0 flex-col bg-(--chat-bg)" tabIndex={-1} onMouseDown={(event) => event.currentTarget.focus({ preventScroll: true })} onKeyDown={handleViewKeyDown}>
       <div className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-(--chat-header-border) px-4">
         <div className="flex min-w-0 items-center gap-2">
           {mode === "diff" ? (
@@ -545,7 +667,7 @@ export function WorkspaceCodeView({
           </div>
         </div>
       ) : null}
-      <div className={shouldRenderMarkdownPreview ? "min-h-0 flex-1 overflow-auto" : "min-h-0 flex-1 overflow-hidden"}>
+      <div className={shouldRenderMarkdownPreview ? "relative min-h-0 flex-1 overflow-auto" : "min-h-0 flex-1 overflow-hidden"}>
         {imageRawUrl && fileData ? (
           <WorkspaceImageViewer
             key={imageRawUrl}
@@ -554,7 +676,7 @@ export function WorkspaceCodeView({
             size={fileData.size}
           />
         ) : shouldRenderMarkdownPreview ? (
-          <div className="mx-auto w-full max-w-5xl px-6 py-8 text-base">
+          <div ref={markdownContentRef} className="mx-auto w-full max-w-5xl px-6 py-8 text-base">
             <PreviewMarkdown content={content} resolveImageSrc={resolveMarkdownImageSrc} variant="document" />
           </div>
         ) : (
@@ -566,8 +688,12 @@ export function WorkspaceCodeView({
             path={path}
             readOnly={!editable}
             onChange={editable ? onDraftChange : undefined}
+            findRequest={monacoFindRequest}
           />
         )}
+        {shouldRenderMarkdownPreview && isFindOpen ? (
+          <WorkspaceFileFind contentRef={markdownContentRef} onClose={() => setIsFindOpen(false)} />
+        ) : null}
       </div>
     </div>
     {contextMenu && absolutePath ? (

--- a/src/components/workspace/workspace-monaco-editor.tsx
+++ b/src/components/workspace/workspace-monaco-editor.tsx
@@ -12,6 +12,8 @@ interface WorkspaceMonacoEditorProps {
   mode: "file" | "diff";
   /** Unique editor instance identity; required when the same path can be open in multiple tabs. */
   modelKey?: string;
+  /** Opens Monaco's built-in Find widget when this counter changes. */
+  findRequest?: number;
   path: string;
   readOnly?: boolean;
   /**
@@ -211,6 +213,7 @@ export function WorkspaceMonacoEditor({
   language,
   mode,
   modelKey,
+  findRequest = 0,
   path,
   readOnly = true,
   onChange,
@@ -347,6 +350,13 @@ export function WorkspaceMonacoEditor({
       readOnly,
     });
   }, [readOnly]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor || findRequest === 0) return;
+    editor.focus();
+    editor.trigger("workspace", "actions.find", null);
+  }, [findRequest]);
 
   return (
     <div className={cn("relative h-full min-h-0 w-full", className)}>

--- a/tests/workspace-file-editing-contract.test.mjs
+++ b/tests/workspace-file-editing-contract.test.mjs
@@ -139,10 +139,18 @@ test('only a whole, textual buffer is editable', () => {
   assert.match(codeViewSource, /onChange=\{editable \? onDraftChange : undefined\}/);
 });
 
-test('the save shortcut is bound to this view, not to the window', () => {
-  assert.match(codeViewSource, /onKeyDown=\{handleSaveShortcut\}/);
+test('file shortcuts are bound to this view, not to the window', () => {
+  assert.match(codeViewSource, /onKeyDown=\{handleViewKeyDown\}/);
   assert.doesNotMatch(codeViewSource, /window\.addEventListener\("keydown"/);
   assert.match(codeViewSource, /event\.metaKey \|\| event\.ctrlKey/);
+});
+
+test('file viewers open an in-view search for both Monaco source and Markdown previews', () => {
+  assert.match(codeViewSource, /WorkspaceFileFind/);
+  assert.match(codeViewSource, /event\.key\.toLowerCase\(\) !== "f"/);
+  assert.match(codeViewSource, /findRequest=\{monacoFindRequest\}/);
+  assert.match(monacoEditorSource, /findRequest\?: number/);
+  assert.match(monacoEditorSource, /editor\.trigger\("workspace", "actions\.find", null\)/);
 });
 
 test('a dirty preview tab is pinned so it cannot be replaced out from under the draft', () => {


### PR DESCRIPTION
## Summary
- add Ctrl/Cmd+F search to Markdown file previews
- open Monaco Find for source, code, and diff viewers
- cover the shortcut paths with a workspace file-viewer contract test

## Verification
- npx tsc --noEmit --pretty false --incremental false
- npx eslint src/components/workspace/workspace-code-view.tsx src/components/workspace/workspace-monaco-editor.tsx tests/workspace-file-editing-contract.test.mjs
- npx tsx --test tests/workspace-file-editing-contract.test.mjs