### PR TITLE
fix: restore linked session drag reorder

### DIFF
--- a/src/app/api/sessions/reorder/route.ts
+++ b/src/app/api/sessions/reorder/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
-import { reorderSessionsByIds } from '@/lib/db/sessions';
+import { getSession, reorderSessionsByIds } from '@/lib/db/sessions';
+import { getTaskProjectViewIds } from '@/lib/projects/project-view-projection';
 import { broadcastSessionMutation, getOriginClientIdFromRequest } from '@/lib/ws/mutation-broadcast';
 import logger from '@/lib/logger';
 
@@ -22,11 +23,23 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ error: 'orderedIds must be a non-empty array' }, { status: 400 });
     }
 
+    const firstSession = typeof orderedIds[0] === 'string'
+      ? getSession(orderedIds[0])
+      : undefined;
+    const taskId = firstSession?.task_id ?? undefined;
+    const affectedProjectIds = taskId
+      ? getTaskProjectViewIds(taskId)
+      : firstSession?.project_id ? [firstSession.project_id] : [];
+
     reorderSessionsByIds(orderedIds);
     logger.info({ count: orderedIds.length }, 'Sessions reordered by canonical IDs');
 
     broadcastSessionMutation(auth.userId, {
       kind: 'reordered',
+      projectId: firstSession?.project_id,
+      sessionId: firstSession?.id,
+      taskId,
+      affectedProjectIds,
       originClientId: getOriginClientIdFromRequest(req),
     });
 

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -1633,6 +1633,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   // Session reorder by IDs only (collection view)
   reorderSessionsByIds: (orderedIds) => {
     const orderMap = new Map(orderedIds.map((id, idx) => [id, idx]));
+    const affectedTaskProjectIds = useTaskStore.getState().reorderLinkedSessions(orderedIds);
     set((state) => ({
       projects: state.projects.map((p) => ({
         ...p,
@@ -1649,12 +1650,21 @@ export const useSessionStore = create<SessionState>((set, get) => ({
           : session,
       ),
     }));
-    fetchWithClientId('/api/sessions/reorder', {
+    void fetchWithClientId('/api/sessions/reorder', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ orderedIds }),
+    }).then((response) => {
+      if (!response.ok) throw new Error(`Session reorder failed: ${response.status}`);
     }).catch(() => {
-      get().loadProjects();
+      void Promise.all([
+        get().loadProjects(),
+        ...affectedTaskProjectIds.map((projectId) =>
+          useTaskStore.getState().loadTasks(projectId, {
+            setCurrent: useTaskStore.getState().currentProjectId === projectId,
+          })
+        ),
+      ]);
     });
   },
 

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -84,6 +84,8 @@ interface TaskState {
   setLinkedSessionRunning: (sessionId: string, running: boolean) => void;
   /** Mirror canonical unread state into every loaded Worktree Task summary. */
   setLinkedSessionUnreadCount: (sessionId: string, unreadCount: number) => void;
+  /** Reorder child Sessions across every loaded appearance of their Worktree Task. */
+  reorderLinkedSessions: (orderedIds: string[]) => string[];
   /**
    * Update a linked session title in local task cache.
    * Single-session tasks also mirror the parent task title.
@@ -212,6 +214,40 @@ function setLinkedSessionUnreadCountInList(
         candidate.id === sessionId ? { ...candidate, unreadCount } : candidate
       ),
     };
+  });
+
+  return changed ? nextTasks : tasks;
+}
+
+function reorderLinkedSessionsInList(
+  tasks: TaskEntity[],
+  orderedIds: readonly string[],
+): TaskEntity[] {
+  const orderMap = new Map(orderedIds.map((id, index) => [id, index]));
+  let changed = false;
+  const nextTasks = tasks.map((task) => {
+    if (!task.sessions.some((session) => orderMap.has(session.id))) return task;
+
+    const orderedSessions = orderedIds.flatMap((id, index) => {
+      const session = task.sessions.find((candidate) => candidate.id === id);
+      return session ? [{ ...session, sortOrder: index }] : [];
+    });
+    const remainingSessions = task.sessions
+      .filter((session) => !orderMap.has(session.id))
+      .map((session, index) => ({
+        ...session,
+        sortOrder: orderedSessions.length + index,
+      }));
+    const sessions = [...orderedSessions, ...remainingSessions];
+    const isUnchanged = sessions.length === task.sessions.length
+      && sessions.every((session, index) => (
+        session.id === task.sessions[index]?.id
+        && session.sortOrder === task.sessions[index]?.sortOrder
+      ));
+    if (isUnchanged) return task;
+
+    changed = true;
+    return { ...task, sessions };
   });
 
   return changed ? nextTasks : tasks;
@@ -702,6 +738,37 @@ export const useTaskStore = create<TaskState>((set, get) => ({
         ? state
         : { tasks, tasksByProject };
     }),
+
+  reorderLinkedSessions: (orderedIds) => {
+    if (orderedIds.length === 0) return [];
+
+    const orderedIdSet = new Set(orderedIds);
+    const state = get();
+    const affectedProjectIds = Object.entries(state.tasksByProject)
+      .filter(([, tasks]) => tasks.some((task) =>
+        task.sessions.some((session) => orderedIdSet.has(session.id))
+      ))
+      .map(([projectId]) => projectId);
+
+    set((current) => {
+      const tasks = reorderLinkedSessionsInList(current.tasks, orderedIds);
+      let tasksByProject = current.tasksByProject;
+      for (const [projectId, projectTasks] of Object.entries(current.tasksByProject)) {
+        const reorderedTasks = reorderLinkedSessionsInList(projectTasks, orderedIds);
+        if (reorderedTasks === projectTasks) continue;
+        if (tasksByProject === current.tasksByProject) {
+          tasksByProject = { ...current.tasksByProject };
+        }
+        tasksByProject[projectId] = reorderedTasks;
+      }
+
+      return tasks === current.tasks && tasksByProject === current.tasksByProject
+        ? current
+        : { tasks, tasksByProject };
+    });
+
+    return affectedProjectIds;
+  },
 
   syncLinkedTaskTitle: (sessionId, title) =>
     set((state) => ({

--- a/tests/sub-session-reorder.e2e.mjs
+++ b/tests/sub-session-reorder.e2e.mjs
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import { execFile, spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { chromium } from '@playwright/test';
+
+const run = promisify(execFile);
+const port = Number(process.env.TESSERA_E2E_PORT ?? 34322);
+const origin = `http://127.0.0.1:${port}`;
+const tempRoot = path.join(os.homedir(), 'tmp');
+await fs.mkdir(tempRoot, { recursive: true });
+const dataDir = await fs.mkdtemp(path.join(tempRoot, 'tessera-subsession-reorder-'));
+const descriptor = path.join(dataDir, 'control.json');
+const evidenceDir = process.env.TESSERA_EVIDENCE_DIR
+  ?? path.join(process.cwd(), '.tmp', 'sub-session-reorder-evidence');
+const suffix = path.basename(dataDir).toLowerCase();
+const serverOutput = [];
+let server;
+let browser;
+let createdWorktree;
+let authCookie = '';
+
+function cleanEnv() {
+  const env = { ...process.env };
+  for (const key of [
+    'ELECTRON_RUN_AS_NODE', 'ELECTRON_CHILD', 'TESSERA_APP_ROOT',
+    'TESSERA_ELECTRON_SERVER', 'TESSERA_PRODUCTION_DB', 'TESSERA_HOOK_PORT',
+    'TESSERA_PANE_TOKEN', 'TESSERA_SESSION_ID',
+  ]) delete env[key];
+  return env;
+}
+
+async function startServer() {
+  server = spawn(process.execPath, ['./node_modules/.bin/tsx', 'server.ts'], {
+    cwd: process.cwd(),
+    detached: true,
+    env: {
+      ...cleanEnv(),
+      NODE_ENV: 'development',
+      PORT: String(port),
+      TESSERA_DATA_DIR: dataDir,
+      TESSERA_CONTROL_DESCRIPTOR_PATH: descriptor,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  for (const stream of [server.stdout, server.stderr]) {
+    stream.on('data', (chunk) => serverOutput.push(chunk.toString()));
+  }
+  for (let attempt = 0; attempt < 480; attempt += 1) {
+    if (server.exitCode !== null) throw new Error(serverOutput.join(''));
+    try {
+      if ((await fetch(`${origin}/api/auth/setup`)).ok && await fs.stat(descriptor)) return;
+    } catch { /* still starting */ }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`server timeout:\n${serverOutput.join('')}`);
+}
+
+async function api(url, body, method = 'POST') {
+  const headers = { 'content-type': 'application/json', origin };
+  if (authCookie) headers.cookie = authCookie;
+  const response = await fetch(
+    `${origin}${url}`,
+    body ? { method, headers, body: JSON.stringify(body) } : { headers },
+  );
+  const setCookie = response.headers.get('set-cookie');
+  if (setCookie) authCookie = setCookie.split(';', 1)[0];
+  const text = await response.text();
+  assert.equal(response.ok, true, `${url}: ${text}`);
+  return JSON.parse(text);
+}
+
+async function cli(args) {
+  const result = await run(
+    process.execPath,
+    ['bin/tessera.mjs', ...args, '--json', '--control-descriptor', descriptor],
+    { cwd: process.cwd(), env: cleanEnv(), maxBuffer: 2 ** 20 },
+  );
+  const envelope = JSON.parse(result.stdout);
+  assert.equal(envelope.ok, true, result.stdout || result.stderr);
+  return envelope.data;
+}
+
+async function stopServer() {
+  if (!server || server.exitCode !== null) return;
+  let exited = false;
+  const exit = new Promise((resolve) => server.once('exit', () => { exited = true; resolve(); }));
+  try { process.kill(-server.pid, 'SIGTERM'); } catch { server.kill('SIGTERM'); }
+  await Promise.race([exit, new Promise((resolve) => setTimeout(resolve, 5_000))]);
+  if (!exited && server.exitCode === null) {
+    try { process.kill(-server.pid, 'SIGKILL'); } catch { server.kill('SIGKILL'); }
+    await Promise.race([exit, new Promise((resolve) => setTimeout(resolve, 5_000))]);
+  }
+}
+
+try {
+  await fs.mkdir(evidenceDir, { recursive: true });
+  await startServer();
+  await api('/api/auth/setup', { username: 'subsession-reorder', password: 'subsession-reorder' });
+  const projects = await api('/api/sessions/projects');
+  const project = projects.projects.find((item) => item.decodedPath === process.cwd());
+  assert.ok(project?.projectWorktree?.id, 'current Project Worktree was not registered');
+  await api('/api/settings', {
+    agentEnvironment: 'wsl',
+    showProviderIcons: false,
+    showRecentWork: false,
+  }, 'PUT');
+
+  const branch = `subsession-reorder-${suffix}`;
+  createdWorktree = await cli([
+    'worktree', 'create', '--project', project.encodedDir,
+    '-b', branch, 'HEAD', '--title', 'Sub-session reorder',
+  ]);
+  const taskProjection = await api(`/api/tasks?projectId=${encodeURIComponent(project.encodedDir)}`);
+  const task = taskProjection.tasks.find((candidate) =>
+    candidate.worktreeId === createdWorktree.worktreeId
+  );
+  assert.ok(task, 'created Worktree must be projected into the current Project');
+
+  const createdSessions = [];
+  for (const title of ['First Session', 'Second Session']) {
+    createdSessions.push(await api('/api/sessions', {
+      workDir: createdWorktree.path,
+      parentProjectId: project.encodedDir,
+      taskId: task.id,
+      worktreeBranch: createdWorktree.branch,
+      providerId: 'codex',
+      executionMode: 'gui',
+      title,
+      hasCustomTitle: true,
+    }));
+  }
+
+  browser = await chromium.launch({ headless: process.env.TESSERA_HEADFUL !== '1' });
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  const [cookieName, cookieValue] = authCookie.split('=', 2);
+  await page.context().addCookies([{ name: cookieName, value: cookieValue, url: origin }]);
+  await page.goto(`${origin}/chat`, { waitUntil: 'networkidle' });
+
+  const taskRow = page.locator(`[data-worktree-id="${createdWorktree.worktreeId}"]`);
+  await taskRow.waitFor({ timeout: 30_000 });
+  const observerPage = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await observerPage.context().addCookies([{ name: cookieName, value: cookieValue, url: origin }]);
+  await observerPage.goto(`${origin}/chat`, { waitUntil: 'networkidle' });
+  await observerPage.locator(
+    `[data-worktree-id="${createdWorktree.worktreeId}"]`,
+  ).waitFor({ timeout: 30_000 });
+  assert.equal(await taskRow.getAttribute('data-linked-worktree-density'), 'expanded');
+  const rows = page.locator(
+    '[data-testid^="collection-subsession-"][data-session-id][draggable="true"]',
+  );
+  await rows.first().waitFor();
+  const initialOrder = await rows.evaluateAll((items) =>
+    items.map((item) => item.getAttribute('data-session-id')),
+  );
+  assert.deepEqual(new Set(initialOrder), new Set(createdSessions.map((session) => session.sessionId)));
+  await page.screenshot({ path: path.join(evidenceDir, '01-before-drag.png'), fullPage: true });
+
+  const reorderResponse = page.waitForResponse((response) =>
+    response.url().endsWith('/api/sessions/reorder') && response.request().method() === 'PATCH',
+  );
+  const firstRow = rows.nth(0);
+  const firstBox = await firstRow.boundingBox();
+  assert.ok(firstBox, 'first Session row must have a drag target');
+  await rows.nth(1).dragTo(firstRow, {
+    targetPosition: { x: firstBox.width / 2, y: 1 },
+  });
+  assert.equal((await reorderResponse).ok(), true);
+  const expectedOrder = [initialOrder[1], initialOrder[0]];
+  await page.waitForFunction(
+    (expected) => JSON.stringify(
+      [...document.querySelectorAll(
+        '[data-testid^="collection-subsession-"][data-session-id][draggable="true"]',
+      )].map((row) => row.getAttribute('data-session-id')),
+    ) === JSON.stringify(expected),
+    expectedOrder,
+  );
+  await observerPage.waitForFunction(
+    (expected) => JSON.stringify(
+      [...document.querySelectorAll(
+        '[data-testid^="collection-subsession-"][data-session-id][draggable="true"]',
+      )].map((row) => row.getAttribute('data-session-id')),
+    ) === JSON.stringify(expected),
+    expectedOrder,
+  );
+  await page.screenshot({ path: path.join(evidenceDir, '02-after-drag.png'), fullPage: true });
+  await observerPage.screenshot({
+    path: path.join(evidenceDir, '03-observer-window-synced.png'),
+    fullPage: true,
+  });
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await page.locator(`[data-worktree-id="${createdWorktree.worktreeId}"]`).waitFor();
+  assert.deepEqual(
+    await page.locator(
+      '[data-testid^="collection-subsession-"][data-session-id][draggable="true"]',
+    ).evaluateAll((items) => items.map((item) => item.getAttribute('data-session-id'))),
+    expectedOrder,
+  );
+  await page.screenshot({ path: path.join(evidenceDir, '04-after-reload.png'), fullPage: true });
+  console.log(`Sub-session reorder passed; evidence: ${evidenceDir}`);
+} finally {
+  await browser?.close();
+  await stopServer();
+  if (createdWorktree) {
+    await run('git', ['worktree', 'remove', '--force', createdWorktree.path]).catch(() => undefined);
+    await run('git', ['branch', '-D', createdWorktree.branch]).catch(() => undefined);
+  }
+  await fs.rm(dataDir, { recursive: true, force: true });
+}

--- a/tests/sub-session-reorder.test.ts
+++ b/tests/sub-session-reorder.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { useSessionStore } from '@/stores/session-store';
+import { useTaskStore } from '@/stores/task-store';
+import type { ProjectGroup } from '@/types/chat';
+import type { TaskEntity, TaskSession } from '@/types/task-entity';
+
+const originalFetch = globalThis.fetch;
+
+function taskSession(id: string, sortOrder: number): TaskSession {
+  return {
+    id,
+    originProjectId: 'project-a',
+    title: id,
+    lastModified: '2026-09-01T00:00:00.000Z',
+    isRunning: false,
+    sortOrder,
+  };
+}
+
+function task(projectViewId: string): TaskEntity {
+  return {
+    id: 'shared-worktree',
+    worktreeId: 'wt-shared',
+    projectId: 'project-a',
+    projectViewId,
+    title: 'Shared Worktree',
+    workflowStatus: 'todo',
+    sortOrder: 0,
+    sessions: [taskSession('session-a', 0), taskSession('session-b', 1)],
+    createdAt: '2026-09-01T00:00:00.000Z',
+    updatedAt: '2026-09-01T00:00:00.000Z',
+  };
+}
+
+function project(projectId: string): ProjectGroup {
+  return {
+    encodedDir: projectId,
+    displayName: projectId,
+    decodedPath: `/${projectId}`,
+    isCurrent: projectId === 'project-a',
+    // Linked Worktree Sessions deliberately live only in the Task projection.
+    // This is the Project View shape that exposed the reorder regression.
+    sessions: [],
+    totalSessions: 0,
+    allLoaded: true,
+    loadedCount: 0,
+    nextCursor: null,
+    loadBatchIndex: 0,
+  };
+}
+
+function taskSessionIds(tasks: TaskEntity[]): string[] {
+  return tasks[0]?.sessions.map((session) => session.id) ?? [];
+}
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+  useTaskStore.setState(useTaskStore.getInitialState(), true);
+  useSessionStore.setState(useSessionStore.getInitialState(), true);
+});
+
+test('reordering linked Sessions updates every loaded Task appearance immediately', () => {
+  globalThis.fetch = async () => Response.json({ success: true });
+  const inA = task('project-a');
+  const inC = task('project-c');
+  useTaskStore.setState({
+    ...useTaskStore.getInitialState(),
+    tasks: [inC],
+    tasksByProject: { 'project-a': [inA], 'project-c': [inC] },
+    currentProjectId: 'project-c',
+    loaded: true,
+    loadedProjects: { 'project-a': true, 'project-c': true },
+  }, true);
+  useSessionStore.setState({
+    ...useSessionStore.getInitialState(),
+    projects: [project('project-a'), project('project-c')],
+  }, true);
+
+  useSessionStore.getState().reorderSessionsByIds(['session-b', 'session-a']);
+
+  assert.deepEqual(taskSessionIds(useTaskStore.getState().tasks), ['session-b', 'session-a']);
+  assert.deepEqual(
+    Object.values(useTaskStore.getState().tasksByProject).map(taskSessionIds),
+    [
+      ['session-b', 'session-a'],
+      ['session-b', 'session-a'],
+    ],
+  );
+  assert.deepEqual(
+    useTaskStore.getState().tasksByProject['project-a'][0]?.sessions.map((session) => session.sortOrder),
+    [0, 1],
+  );
+});


### PR DESCRIPTION
## Summary
- update linked Worktree Task projections immediately when child Sessions are reordered
- reload affected projections on failure and broadcast enough identity for cross-window refresh
- add unit and browser regression coverage for immediate, cross-window, and persisted ordering

## Verification
- `npx tsx --test tests/sub-session-reorder.test.ts tests/project-view-task-mutation.test.ts tests/project-view-workspace-state.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx eslint src/app/api/sessions/reorder/route.ts src/stores/session-store.ts src/stores/task-store.ts tests/sub-session-reorder.test.ts tests/sub-session-reorder.e2e.mjs`
- `TESSERA_EVIDENCE_DIR="$PWD/.tmp/subsession-dnd-pr-qa" TESSERA_E2E_PORT=34327 node tests/sub-session-reorder.e2e.mjs`