### PR TITLE
fix(selection): synchronize bulk session actions

### DIFF
--- a/src/stores/selection-store.ts
+++ b/src/stores/selection-store.ts
@@ -107,23 +107,35 @@ export const useSelectionStore = create<SelectionState>((set, get) => ({
     const { selectedIds } = get();
     if (selectedIds.size === 0) return;
 
-    const sessionStore = useSessionStore.getState();
-    const taskIds = new Set<string>();
-    const sessionIds: string[] = [];
+    const targets = new Map<string, {
+      ids: string[];
+      target: ReturnType<typeof resolveSessionWorktreeLifecycleTarget>;
+    }>();
     for (const id of selectedIds) {
       const task = projectViewWorkspaceState.resolveTaskBySessionId(id);
       const target = resolveSessionWorktreeLifecycleTarget(id, task);
-      if (target.kind === 'worktree') taskIds.add(target.taskId);
-      else sessionIds.push(target.sessionId);
+      const key = target.kind === 'worktree' ? `worktree:${target.taskId}` : `session:${id}`;
+      const existing = targets.get(key);
+      if (existing) existing.ids.push(id);
+      else targets.set(key, { ids: [id], target });
     }
-    for (const taskId of taskIds) {
-      void useTaskStore.getState().toggleTaskArchive(taskId, true);
-    }
-    for (const id of sessionIds) {
-      sessionStore.toggleArchive(id, true);
+
+    const results = await Promise.all([...targets.values()].map(async ({ ids, target }) => ({
+      ids,
+      success: target.kind === 'worktree'
+        ? await useTaskStore.getState().toggleTaskArchive(target.taskId, true)
+        : await useSessionStore.getState().toggleArchive(target.sessionId, true),
+    })));
+    const failedIds = results.flatMap(({ ids, success }) => success ? [] : ids);
+    const successCount = selectedIds.size - failedIds.length;
+    if (failedIds.length > 0) {
+      set({ selectedIds: new Set(failedIds), lastClickedId: null, barAnchorId: null });
+      if (successCount > 0) toast.warning(`${successCount}개 아카이브 성공, ${failedIds.length}개 실패`);
+      else toast.error(`아카이브 실패: ${failedIds.length}개 항목을 처리할 수 없습니다`);
+      return;
     }
     set({ selectedIds: new Set(), lastClickedId: null, barAnchorId: null });
-    toast.success(`${taskIds.size + sessionIds.length}개 항목을 아카이브했습니다`);
+    toast.success(`${successCount}개 항목을 아카이브했습니다`);
   },
 
   bulkDelete: async () => {
@@ -132,29 +144,48 @@ export const useSelectionStore = create<SelectionState>((set, get) => ({
 
     const ids = [...selectedIds];
     const failedIds: string[] = [];
+    const targets = new Map<string, {
+      ids: string[];
+      target: ReturnType<typeof resolveSessionWorktreeLifecycleTarget>;
+    }>();
 
+    // A single-session Worktree is represented by its child Session in the
+    // list. Several selected appearances can therefore resolve to the same
+    // Worktree. Collapse those before issuing requests so one batch never
+    // races itself or leaves a stale optimistic cache behind.
     for (const id of ids) {
+      const task = projectViewWorkspaceState.resolveTaskBySessionId(id);
+      const target = resolveSessionWorktreeLifecycleTarget(id, task);
+      const key = target.kind === 'worktree' ? `worktree:${target.taskId}` : `session:${id}`;
+      const existing = targets.get(key);
+      if (existing) existing.ids.push(id);
+      else targets.set(key, { ids: [id], target });
+    }
+
+    await Promise.all([...targets.values()].map(async ({ ids: targetIds, target }) => {
       try {
-        const task = projectViewWorkspaceState.resolveTaskBySessionId(id);
-        const target = resolveSessionWorktreeLifecycleTarget(id, task);
         if (target.kind === 'worktree') {
           if (!await useTaskStore.getState().deleteWorktree(target.taskId)) {
-            failedIds.push(id);
+            failedIds.push(...targetIds);
           }
-          continue;
+          return;
         }
-        const res = await fetchWithClientId(`/api/sessions/${encodeURIComponent(id)}`, {
+        const res = await fetchWithClientId(`/api/sessions/${encodeURIComponent(target.sessionId)}`, {
           method: 'DELETE',
         });
         if (res.ok) {
-          useSessionStore.getState().removeSession(id);
+          // A child Session is rendered from the Task cache rather than the
+          // direct Project Session list. Both caches must change in the same
+          // tick or the menu continues to show a successfully deleted row.
+          useSessionStore.getState().removeSession(target.sessionId);
+          useTaskStore.getState().removeTaskSession(target.sessionId);
         } else {
-          failedIds.push(id);
+          failedIds.push(...targetIds);
         }
       } catch {
-        failedIds.push(id);
+        failedIds.push(...targetIds);
       }
-    }
+    }));
 
     const successCount = ids.length - failedIds.length;
     if (failedIds.length > 0) {

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -159,7 +159,7 @@ export interface SessionState {
   ) => void;
   syncTaskCollectionId: (taskId: string, collectionId: string | null) => void;
   replaceCollectionId: (fromCollectionId: string, toCollectionId: string | null) => void;
-  toggleArchive: (sessionId: string, archived: boolean) => void;
+  toggleArchive: (sessionId: string, archived: boolean) => Promise<boolean>;
 
   // Task selectors
   getSessionsByStatusGroup: (
@@ -831,10 +831,17 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 
   removeSession: (sessionId) => {
     set((state) => {
-      const updatedProjects = state.projects.map((project) => ({
-        ...project,
-        sessions: project.sessions.filter((s) => s.id !== sessionId),
-      }));
+      const updatedProjects = state.projects.map((project) => {
+        const sessions = project.sessions.filter((session) => session.id !== sessionId);
+        const removedCount = project.sessions.length - sessions.length;
+        if (removedCount === 0) return project;
+        return {
+          ...project,
+          sessions,
+          totalSessions: Math.max(0, project.totalSessions - removedCount),
+          loadedCount: Math.max(0, project.loadedCount - removedCount),
+        };
+      });
 
       // BR-DEL-006: 활성 세션 삭제 시 빈 상태 표시 (자동 전환 없음)
       // BR-DEL-007: 비활성 세션 삭제 시 현재 세션 유지
@@ -1502,7 +1509,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       ),
     }));
 
-    fetchWithClientId(`/api/sessions/${sessionId}/archive`, {
+    return fetchWithClientId(`/api/sessions/${sessionId}/archive`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ archived }),
@@ -1527,6 +1534,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         if (result.cleanupError) {
           console.warn(`[session-store] archive cleanup warning for ${sessionId}: ${result.cleanupError}`);
         }
+        return true;
       })
       .catch(() => {
         // Rollback on any network or server error
@@ -1561,6 +1569,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
           }));
           console.warn(`[session-store] toggleArchive rollback for session ${sessionId}`);
         }
+        return false;
       });
   },
 

--- a/tests/sidebar-project-task-selection.test.ts
+++ b/tests/sidebar-project-task-selection.test.ts
@@ -8,6 +8,8 @@ import {
 } from '../src/components/chat/sidebar-utils';
 import type { RecentWorkItem } from '../src/lib/chat/recent-work';
 import { useSelectionStore } from '../src/stores/selection-store';
+import { useSessionStore } from '../src/stores/session-store';
+import { useTaskStore } from '../src/stores/task-store';
 import type { ProjectGroup, UnifiedSession } from '../src/types/chat';
 import type { TaskEntity } from '../src/types/task-entity';
 
@@ -152,4 +154,47 @@ test('normal click replaces a stale Shift range anchor before session activation
   assert.deepEqual([...state.selectedIds], ['session-a', 'session-b']);
   assert.equal(state.lastClickedId, 'session-a');
   assert.equal(state.barAnchorId, 'session-b');
+});
+
+test('bulk delete removes selected child Sessions from both Project and Worktree caches', async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    useSelectionStore.getState().clearSelection();
+    useSessionStore.setState(useSessionStore.getInitialState(), true);
+    useTaskStore.setState(useTaskStore.getInitialState(), true);
+  });
+  globalThis.fetch = async () => new Response('{}', { status: 200 });
+
+  const sessions = ['child-a', 'child-b'].map((id, sortOrder) => ({
+    id,
+    title: id,
+    sortOrder,
+    isRunning: false,
+  }));
+  useTaskStore.setState({
+    ...useTaskStore.getInitialState(),
+    tasks: [{ id: 'worktree-a', projectViewId: 'project-a', sessions } as TaskEntity],
+    tasksByProject: {
+      'project-a': [{ id: 'worktree-a', projectViewId: 'project-a', sessions } as TaskEntity],
+    },
+    currentProjectId: 'project-a',
+  }, true);
+  useSessionStore.setState({
+    ...useSessionStore.getInitialState(),
+    projects: [{
+      encodedDir: 'project-a', displayName: 'project-a', decodedPath: '/project-a',
+      isCurrent: true, sessions: sessions.map((session) => ({
+        ...session, projectDir: 'project-a', archived: false, hasStarted: true,
+      })) as UnifiedSession[], totalSessions: 2, loadedCount: 2, allLoaded: true,
+      nextCursor: null, loadBatchIndex: 0,
+    }],
+  }, true);
+  useSelectionStore.setState({ selectedIds: new Set(['child-a', 'child-b']) });
+
+  await useSelectionStore.getState().bulkDelete();
+
+  assert.deepEqual(useTaskStore.getState().tasksByProject['project-a'][0]?.sessions, []);
+  assert.deepEqual(useSessionStore.getState().projects[0]?.sessions, []);
+  assert.equal(useSessionStore.getState().projects[0]?.totalSessions, 0);
 });


### PR DESCRIPTION
## Summary
- process selected archive/delete targets as awaited batches and retain failed selections
- remove deleted child Sessions from both Project and Worktree caches immediately
- keep direct Session project counters consistent after deletion

## Tests
- NODE_PATH=/home/work/Source/tessera-dev/node_modules /home/work/Source/tessera-dev/node_modules/.bin/tsx --test tests/sidebar-project-task-selection.test.ts tests/project-view-task-mutation.test.ts tests/project-view-session-lifetime.test.ts