### PR TITLE
fix(files): preserve Markdown search input caret

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,15 @@
 @import "tailwindcss";
 
+::highlight(workspace-file-find-match) {
+  color: inherit;
+  background-color: color-mix(in srgb, var(--warning) 30%, transparent);
+}
+
+::highlight(workspace-file-find-active) {
+  color: inherit;
+  background-color: color-mix(in srgb, var(--warning) 72%, transparent);
+}
+
 /* Tailwind v4: Theme configuration */
 @theme {
   --color-primary: oklch(53% 0.19 27);

--- a/src/components/workspace/workspace-code-view.tsx
+++ b/src/components/workspace/workspace-code-view.tsx
@@ -29,6 +29,19 @@ type MarkdownViewMode = "preview" | "source";
 
 const subscribeToStaticClientValue = () => () => {};
 const getNoElectronFileActions = () => false;
+const WORKSPACE_FIND_MATCH_HIGHLIGHT = "workspace-file-find-match";
+const WORKSPACE_FIND_ACTIVE_HIGHLIGHT = "workspace-file-find-active";
+
+function getWorkspaceFindHighlightRegistry(): HighlightRegistry | null {
+  if (typeof CSS === "undefined" || typeof Highlight === "undefined" || !CSS.highlights) return null;
+  return CSS.highlights;
+}
+
+function clearWorkspaceFindHighlights(): void {
+  const registry = getWorkspaceFindHighlightRegistry();
+  registry?.delete(WORKSPACE_FIND_MATCH_HIGHLIGHT);
+  registry?.delete(WORKSPACE_FIND_ACTIVE_HIGHLIGHT);
+}
 
 function dirname(filePath: string): string {
   const slashIndex = filePath.lastIndexOf("/");
@@ -109,9 +122,10 @@ function WorkspaceFileFind({
   const selectMatch = useCallback((index: number) => {
     const match = matchesRef.current[index];
     if (!match) return;
-    const selection = window.getSelection();
-    selection?.removeAllRanges();
-    selection?.addRange(match);
+    getWorkspaceFindHighlightRegistry()?.set(
+      WORKSPACE_FIND_ACTIVE_HIGHLIGHT,
+      new Highlight(match),
+    );
     const element = match.startContainer.parentElement;
     element?.scrollIntoView({ block: "center", behavior: "smooth" });
     setMatchIndex(index);
@@ -119,6 +133,7 @@ function WorkspaceFileFind({
 
   useEffect(() => {
     inputRef.current?.focus();
+    return clearWorkspaceFindHighlights;
   }, []);
 
   const updateQuery = useCallback((nextQuery: string) => {
@@ -127,6 +142,7 @@ function WorkspaceFileFind({
     const normalizedQuery = nextQuery.toLocaleLowerCase();
     if (!container || !normalizedQuery) {
       matchesRef.current = [];
+      clearWorkspaceFindHighlights();
       setMatchCount(0);
       setMatchIndex(-1);
       return;
@@ -149,6 +165,9 @@ function WorkspaceFileFind({
       node = walker.nextNode();
     }
     matchesRef.current = matches;
+    const registry = getWorkspaceFindHighlightRegistry();
+    registry?.set(WORKSPACE_FIND_MATCH_HIGHLIGHT, new Highlight(...matches));
+    registry?.delete(WORKSPACE_FIND_ACTIVE_HIGHLIGHT);
     setMatchCount(matches.length);
     if (matches.length > 0) selectMatch(0);
     else setMatchIndex(-1);

--- a/tests/workspace-file-editing-contract.test.mjs
+++ b/tests/workspace-file-editing-contract.test.mjs
@@ -153,6 +153,13 @@ test('file viewers open an in-view search for both Monaco source and Markdown pr
   assert.match(monacoEditorSource, /editor\.trigger\("workspace", "actions\.find", null\)/);
 });
 
+test('Markdown preview search highlights matches without corrupting the input caret', () => {
+  assert.doesNotMatch(codeViewSource, /window\.getSelection\(\)/);
+  assert.match(codeViewSource, /return CSS\.highlights/);
+  assert.match(codeViewSource, /registry\?\.set\(/);
+  assert.match(codeViewSource, /registry\?\.delete\(/);
+});
+
 test('a dirty preview tab is pinned so it cannot be replaced out from under the draft', () => {
   assert.match(fileTabSource, /pinTab\(tabId\)/);
 });


### PR DESCRIPTION
## Summary
- replace document Selection-based Markdown search highlighting with CSS Highlight
- preserve the search input caret during continuous typing and IME composition
- clear search highlights when the query or find panel closes

## Root cause
Selecting each Markdown match with `window.getSelection().addRange()` corrupted the active input caret after the first character.

## Verification
- Chromium reproduction: continuous input remains `a → al → alp → alph → alpha`
- npx tsc --noEmit --pretty false --incremental false
- npx eslint src/components/workspace/workspace-code-view.tsx tests/workspace-file-editing-contract.test.mjs
- npx tsx --test tests/workspace-file-editing-contract.test.mjs (21/21)