### PR TITLE
Restart session runtimes without closing views

### DIFF
--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -869,6 +869,11 @@ export const KanbanBoard = memo(function KanbanBoard() {
     projectViewWorkspaceState.markSessionRead(taskId);
   }, []);
 
+  const handleCardRestartProcess = useCallback((sessionId: string) => {
+    wsClient.restartSession(sessionId);
+    projectViewWorkspaceState.markSessionRead(sessionId);
+  }, []);
+
   // Card click handler
   const handleChatClick = useCallback((session: UnifiedSession, event?: React.MouseEvent) => {
     handleSessionClick(session, event);
@@ -1030,6 +1035,21 @@ export const KanbanBoard = memo(function KanbanBoard() {
     setTaskMenuAnchor(null);
   }, [taskMenuAnchor]);
 
+  const handleTaskRestartProcess = useCallback(() => {
+    if (!taskMenuAnchor) return;
+    for (const session of taskMenuAnchor.task.sessions) {
+      const liveSession = projectViewWorkspaceState.resolveSession(
+        session.id,
+        taskMenuAnchor.task.projectViewId,
+      );
+      if (resolveSessionRuntimePresentation(liveSession ?? session).canStop) {
+        wsClient.restartSession(session.id);
+        projectViewWorkspaceState.markSessionRead(session.id);
+      }
+    }
+    setTaskMenuAnchor(null);
+  }, [taskMenuAnchor]);
+
   const handleChatMoveToCollection = useCallback((sessionId: string, collectionId: string | null) => {
     useSessionStore.getState().updateSessionCollection(
       sessionId,
@@ -1155,6 +1175,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
                 onSessionOpenInNewTab={handleCardOpenInNewTab}
                 onSessionGenerateTitle={handleCardGenerateTitle}
                 onSessionStopProcess={handleCardStopProcess}
+                onSessionRestartProcess={handleCardRestartProcess}
                 renamingTaskId={renamingTaskId}
                 onTaskRenameComplete={handleTaskRenameComplete}
               />
@@ -1196,6 +1217,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
               onCardGenerateTitle={handleCardGenerateTitle}
               onCardMoveToCollection={handleChatMoveToCollection}
               onCardStopProcess={handleCardStopProcess}
+              onCardRestartProcess={handleCardRestartProcess}
             />
         </div>
       </div>
@@ -1219,6 +1241,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
           onGenerateTitle={handleTaskGenerateTitle}
           isRunning={taskMenuIsRunning}
           onStopProcess={taskMenuIsRunning ? handleTaskStopProcess : undefined}
+          onRestartProcess={taskMenuIsRunning ? handleTaskRestartProcess : undefined}
           onRunPreparation={
             canPrepareTask(taskMenuAnchor.task, taskMenuProjectHasScript)
               ? handleTaskRunPreparation

--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -142,6 +142,7 @@ interface KanbanChatCardProps {
   onGenerateTitle?: (taskId: string) => void;
   onMoveToCollection?: (taskId: string, collectionId: string | null) => void;
   onStopProcess?: (sessionId: string) => void;
+  onRestartProcess?: (sessionId: string) => void;
   collections?: Collection[];
 }
 
@@ -165,6 +166,7 @@ export const KanbanChatCard = memo(function KanbanChatCard({
   onGenerateTitle,
   onMoveToCollection,
   onStopProcess,
+  onRestartProcess,
   collections: scopedCollections,
 }: KanbanChatCardProps) {
   const { t } = useI18n();
@@ -255,6 +257,7 @@ export const KanbanChatCard = memo(function KanbanChatCard({
   const handleOpenInNewTab = useCallback(() => onOpenInNewTab?.(session.id), [session.id, onOpenInNewTab]);
 
   const handleStopProcess = useCallback(() => onStopProcess?.(session.id), [session.id, onStopProcess]);
+  const handleRestartProcess = useCallback(() => onRestartProcess?.(session.id), [session.id, onRestartProcess]);
   const {
     isConfirmingArchive,
     handleArchiveClick,
@@ -552,6 +555,7 @@ export const KanbanChatCard = memo(function KanbanChatCard({
           onGenerateTitle={onGenerateTitle ? () => onGenerateTitle(session.id) : undefined}
           isRunning={runtimePresentation.showRunning}
           onStopProcess={runtimePresentation.canStop ? handleStopProcess : undefined}
+          onRestartProcess={runtimePresentation.canStop ? handleRestartProcess : undefined}
           onClose={handleCloseMenu}
         />
       )}
@@ -588,6 +592,7 @@ interface KanbanTaskCardProps {
   onSessionOpenInNewTab?: (sessionId: string) => void;
   onSessionGenerateTitle?: (sessionId: string) => void;
   onSessionStopProcess?: (sessionId: string) => void;
+  onSessionRestartProcess?: (sessionId: string) => void;
   isRenameRequested?: boolean;
   onRenameComplete?: () => void;
 }
@@ -612,6 +617,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
   onSessionOpenInNewTab,
   onSessionGenerateTitle,
   onSessionStopProcess,
+  onSessionRestartProcess,
   isRenameRequested,
   onRenameComplete,
 }: KanbanTaskCardProps) {
@@ -1192,6 +1198,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
                 onOpenInNewTab={onSessionOpenInNewTab}
                 onGenerateTitle={onSessionGenerateTitle}
                 onStopProcess={onSessionStopProcess}
+                onRestartProcess={onSessionRestartProcess}
                 reorder={subSessionReorder}
               />
             ))}
@@ -1249,6 +1256,7 @@ function KanbanSubSessionItem({
   onOpenInNewTab,
   onGenerateTitle,
   onStopProcess,
+  onRestartProcess,
   reorder,
 }: {
   session: TaskSession;
@@ -1261,6 +1269,7 @@ function KanbanSubSessionItem({
   onOpenInNewTab?: (sessionId: string) => void;
   onGenerateTitle?: (sessionId: string) => void;
   onStopProcess?: (sessionId: string) => void;
+  onRestartProcess?: (sessionId: string) => void;
 }) {
   const [isHovered, setIsHovered] = useState(false);
   const [menuAnchorRect, setMenuAnchorRect] = useState<DOMRect | null>(null);
@@ -1285,7 +1294,7 @@ function KanbanSubSessionItem({
       onDelete ||
       onOpenInNewTab ||
       onGenerateTitle ||
-      (runtimePresentation.canStop && onStopProcess),
+      (runtimePresentation.canStop && (onStopProcess || onRestartProcess)),
   );
 
   const {
@@ -1326,6 +1335,7 @@ function KanbanSubSessionItem({
   const handleOpenInNewTab = useCallback(() => onOpenInNewTab?.(session.id), [onOpenInNewTab, session.id]);
   const handleGenerateTitle = useCallback(() => onGenerateTitle?.(session.id), [onGenerateTitle, session.id]);
   const handleStopProcess = useCallback(() => onStopProcess?.(session.id), [onStopProcess, session.id]);
+  const handleRestartProcess = useCallback(() => onRestartProcess?.(session.id), [onRestartProcess, session.id]);
   const handleDragStart = useCallback((e: React.DragEvent) => {
     if (isRenaming) {
       e.preventDefault();
@@ -1473,6 +1483,7 @@ function KanbanSubSessionItem({
           onGenerateTitle={onGenerateTitle ? handleGenerateTitle : undefined}
           isRunning={runtimePresentation.showRunning}
           onStopProcess={runtimePresentation.canStop && onStopProcess ? handleStopProcess : undefined}
+          onRestartProcess={runtimePresentation.canStop && onRestartProcess ? handleRestartProcess : undefined}
           onClose={handleCloseMenu}
         />
       )}

--- a/src/components/board/kanban-column.tsx
+++ b/src/components/board/kanban-column.tsx
@@ -200,6 +200,7 @@ interface KanbanChatColumnProps {
   onCardGenerateTitle?: (taskId: string) => void;
   onCardMoveToCollection?: (taskId: string, collectionId: string | null) => void;
   onCardStopProcess?: (taskId: string) => void;
+  onCardRestartProcess?: (taskId: string) => void;
 }
 
 export const KanbanChatColumn = memo(function KanbanChatColumn({
@@ -232,6 +233,7 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
   onCardGenerateTitle,
   onCardMoveToCollection,
   onCardStopProcess,
+  onCardRestartProcess,
 }: KanbanChatColumnProps) {
   const { t } = useI18n();
   const isEditable = interactionMode === 'editable';
@@ -341,6 +343,7 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
                     onGenerateTitle={onCardGenerateTitle}
                     onMoveToCollection={onCardMoveToCollection}
                     onStopProcess={onCardStopProcess}
+                    onRestartProcess={onCardRestartProcess}
                     collections={collectionsByProject[session.projectDir] ?? collections}
                   />
                 ))}
@@ -396,6 +399,7 @@ interface KanbanWorkflowColumnProps {
   onSessionOpenInNewTab?: (sessionId: string) => void;
   onSessionGenerateTitle?: (sessionId: string) => void;
   onSessionStopProcess?: (sessionId: string) => void;
+  onSessionRestartProcess?: (sessionId: string) => void;
   renamingTaskId?: string | null;
   onTaskRenameComplete?: (taskId: string) => void;
 }
@@ -432,6 +436,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
   onSessionOpenInNewTab,
   onSessionGenerateTitle,
   onSessionStopProcess,
+  onSessionRestartProcess,
   renamingTaskId,
   onTaskRenameComplete,
 }: KanbanWorkflowColumnProps) {
@@ -908,6 +913,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
                     onSessionOpenInNewTab={onSessionOpenInNewTab}
                     onSessionGenerateTitle={onSessionGenerateTitle}
                     onSessionStopProcess={onSessionStopProcess}
+                    onSessionRestartProcess={onSessionRestartProcess}
                     isRenameRequested={renamingTaskId === task.id}
                     onRenameComplete={() => onTaskRenameComplete?.(task.id)}
                   />
@@ -942,6 +948,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
                       )
                     }
                     onStopProcess={onSessionStopProcess}
+                    onRestartProcess={onSessionRestartProcess}
                     collections={collectionsByProject[session.projectDir]}
                   />
                 ))}

--- a/src/components/chat/all-projects-list.tsx
+++ b/src/components/chat/all-projects-list.tsx
@@ -46,6 +46,7 @@ interface AllProjectsListProps {
   onSessionOpenInNewTab: (sessionId: string) => void;
   onSessionGenerateTitle: (sessionId: string) => void;
   onSessionStopProcess: (sessionId: string) => void;
+  onSessionRestartProcess: (sessionId: string) => void;
   onChatStatusChange: (sessionId: string, status: string) => void;
 }
 
@@ -60,6 +61,7 @@ export function AllProjectsList({
   onSessionOpenInNewTab,
   onSessionGenerateTitle,
   onSessionStopProcess,
+  onSessionRestartProcess,
   onChatStatusChange,
 }: AllProjectsListProps) {
   const representation = useOriginProjectRepresentation();
@@ -95,6 +97,7 @@ export function AllProjectsList({
           onSessionOpenInNewTab={onSessionOpenInNewTab}
           onSessionGenerateTitle={onSessionGenerateTitle}
           onSessionStopProcess={onSessionStopProcess}
+          onSessionRestartProcess={onSessionRestartProcess}
           onChatStatusChange={onChatStatusChange}
         />
       ))}
@@ -122,6 +125,7 @@ function AllProjectSection({
   onSessionOpenInNewTab,
   onSessionGenerateTitle,
   onSessionStopProcess,
+  onSessionRestartProcess,
   onChatStatusChange,
 }: AllProjectSectionProps) {
   const { t } = useI18n();
@@ -362,6 +366,7 @@ function AllProjectSection({
               onSessionOpenInNewTab={onSessionOpenInNewTab}
               onSessionGenerateTitle={onSessionGenerateTitle}
               onSessionStopProcess={onSessionStopProcess}
+              onSessionRestartProcess={onSessionRestartProcess}
               disableDnd
               allowPanelSessionDnd
               hideHeader
@@ -414,6 +419,7 @@ function AllProjectSection({
                   onSessionOpenInNewTab={onSessionOpenInNewTab}
                   onSessionGenerateTitle={onSessionGenerateTitle}
                   onSessionStopProcess={onSessionStopProcess}
+                  onSessionRestartProcess={onSessionRestartProcess}
                 />
               );
             })

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -13,6 +13,7 @@ import {
   Pencil,
   Plus,
   RefreshCw,
+  RotateCcw,
   Sparkles,
   Trash2,
   type LucideIcon,
@@ -279,6 +280,7 @@ export function CollectionContextMenu({
   onOpenInNewTab,
   onGenerateTitle,
   onStopProcess,
+  onRestartProcess,
   onStatusChange,
   onRunPreparation,
 }: {
@@ -292,6 +294,7 @@ export function CollectionContextMenu({
   onOpenInNewTab?: () => void;
   onGenerateTitle?: () => void;
   onStopProcess?: () => void;
+  onRestartProcess?: () => void;
   onStatusChange?: (status: string) => void;
   /** Runs the project's preparation script again on this task's worktree. */
   onRunPreparation?: () => void;
@@ -382,17 +385,30 @@ export function CollectionContextMenu({
       className="animate-in fade-in-0 zoom-in-95 duration-100"
     >
       <div className="min-w-[180px] rounded-lg border border-(--divider) bg-(--sidebar-bg) py-1.5 shadow-[0_8px_32px_rgba(0,0,0,0.24),0_2px_8px_rgba(0,0,0,0.16)]">
-        {menu.isRunning && onStopProcess && (
+        {menu.isRunning && (onStopProcess || onRestartProcess) && (
           <>
-            <button
-              {...telemetryClickAttributes('task.stop', 'workspace_list')}
-              className={cn(menuItemClass, 'text-(--error)')}
-              onClick={() => { onStopProcess(); onClose(); }}
-              data-testid="ctx-stop-process"
-            >
-              <CircleStop className="h-3.5 w-3.5 shrink-0" />
-              <span>Stop Process</span>
-            </button>
+            {onStopProcess && (
+              <button
+                {...telemetryClickAttributes('task.stop', 'workspace_list')}
+                className={cn(menuItemClass, 'text-(--error)')}
+                onClick={() => { onStopProcess(); onClose(); }}
+                data-testid="ctx-stop-process"
+              >
+                <CircleStop className="h-3.5 w-3.5 shrink-0" />
+                <span>Stop Process</span>
+              </button>
+            )}
+            {onRestartProcess && (
+              <button
+                {...telemetryClickAttributes('task.restart', 'workspace_list')}
+                className={menuItemClass}
+                onClick={() => { onRestartProcess(); onClose(); }}
+                data-testid="ctx-restart-process"
+              >
+                <RotateCcw className="h-3.5 w-3.5 shrink-0 text-(--text-muted)" />
+                <span>{t('status.restartSession')}</span>
+              </button>
+            )}
             <div className="mx-2 my-1 h-px bg-(--divider) opacity-40" />
           </>
         )}
@@ -951,7 +967,6 @@ export function TaskItemRow({
       }
     }
   }, [onStopProcess, task.projectViewId, task.sessions]);
-
   const handleDragStart = useCallback((event: React.DragEvent) => {
     if (disableDnd) {
       event.stopPropagation();

--- a/src/components/chat/collection-group.tsx
+++ b/src/components/chat/collection-group.tsx
@@ -179,6 +179,7 @@ export interface CollectionGroupProps {
   onSessionOpenInNewTab?: (sessionId: string) => void;
   onSessionGenerateTitle?: (sessionId: string) => void;
   onSessionStopProcess?: (sessionId: string) => void;
+  onSessionRestartProcess?: (sessionId: string) => void;
   onTaskStatusChange?: (taskId: string, status: string) => void;
   onChatStatusChange?: (sessionId: string, status: string) => void;
   disableDnd?: boolean;
@@ -227,6 +228,7 @@ export const CollectionGroup = memo(function CollectionGroup({
   onSessionOpenInNewTab,
   onSessionGenerateTitle,
   onSessionStopProcess,
+  onSessionRestartProcess,
   onTaskStatusChange,
   onChatStatusChange,
   disableDnd = false,
@@ -448,6 +450,23 @@ export const CollectionGroup = memo(function CollectionGroup({
       }
     }
   }, [contextMenu, onSessionStopProcess, taskById]);
+
+  const handleContextMenuRestartProcess = useCallback(() => {
+    if (!contextMenu || !onSessionRestartProcess) return;
+
+    if (contextMenu.type === 'chat') {
+      onSessionRestartProcess(contextMenu.targetId);
+      return;
+    }
+
+    const task = useTaskStore.getState().getTask(contextMenu.targetId) ?? taskById.get(contextMenu.targetId);
+    for (const session of task?.sessions ?? []) {
+      const liveSession = projectViewWorkspaceState.resolveSession(session.id, task?.projectViewId);
+      if (resolveSessionRuntimePresentation(liveSession ?? session).canStop) {
+        onSessionRestartProcess(session.id);
+      }
+    }
+  }, [contextMenu, onSessionRestartProcess, taskById]);
 
   const renderTaskRow = (task: TaskEntity) => (
     <TaskItemRow
@@ -713,6 +732,7 @@ export const CollectionGroup = memo(function CollectionGroup({
           onOpenInNewTab={contextMenu.type === 'chat' ? () => onSessionOpenInNewTab?.(contextMenu.targetId) : undefined}
           onGenerateTitle={onSessionGenerateTitle ? handleContextMenuGenerateTitle : undefined}
           onStopProcess={contextMenu.isRunning ? handleContextMenuStopProcess : undefined}
+          onRestartProcess={contextMenu.isRunning ? handleContextMenuRestartProcess : undefined}
           onRunPreparation={
             contextMenuTask && canPrepareTask(contextMenuTask, projectHasPreparationScript)
               ? () => requestPreparation(contextMenuTask.id)

--- a/src/components/chat/header.tsx
+++ b/src/components/chat/header.tsx
@@ -217,6 +217,10 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
     wsClient.stopSession(sessionId);
   }, [sessionId]);
 
+  const handleRestartProcess = useCallback(() => {
+    wsClient.restartSession(sessionId);
+  }, [sessionId]);
+
   const branchPresentation = resolveSessionBranchPresentation({
     worktreeBranch: session?.worktreeBranch,
     scopeBranch: session?.scopeBranch,
@@ -516,6 +520,7 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
           onDelete={handleDelete}
           onGenerateTitle={() => generateTitle(sessionId)}
           onStopProcess={runtimePresentation.canStop ? handleStopProcess : undefined}
+          onRestartProcess={runtimePresentation.canStop ? handleRestartProcess : undefined}
           onClose={handleCloseMenu}
         />
       )}

--- a/src/components/chat/recent-work-section.tsx
+++ b/src/components/chat/recent-work-section.tsx
@@ -26,6 +26,7 @@ type RecentWorkSectionProps = Pick<
   | 'onSessionOpenInNewTab'
   | 'onSessionGenerateTitle'
   | 'onSessionStopProcess'
+  | 'onSessionRestartProcess'
 > & {
   items: RecentWorkItem[];
 };

--- a/src/components/chat/sidebar.tsx
+++ b/src/components/chat/sidebar.tsx
@@ -488,6 +488,11 @@ export function Sidebar() {
     projectViewWorkspaceState.markSessionRead(taskId);
   }, []);
 
+  const handleTaskRestartProcess = useCallback((sessionId: string) => {
+    wsClient.restartSession(sessionId);
+    projectViewWorkspaceState.markSessionRead(sessionId);
+  }, []);
+
   const prevActivePanelIdRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -793,6 +798,7 @@ export function Sidebar() {
                   onSessionOpenInNewTab={handleTaskOpenInNewTab}
                   onSessionGenerateTitle={handleTaskGenerateTitle}
                   onSessionStopProcess={handleTaskStopProcess}
+                  onSessionRestartProcess={handleTaskRestartProcess}
                 />
               )}
               <AllProjectsList
@@ -807,6 +813,7 @@ export function Sidebar() {
                 onSessionOpenInNewTab={handleTaskOpenInNewTab}
                 onSessionGenerateTitle={handleTaskGenerateTitle}
                 onSessionStopProcess={handleTaskStopProcess}
+                onSessionRestartProcess={handleTaskRestartProcess}
               />
             </>
           )
@@ -873,6 +880,7 @@ export function Sidebar() {
                 onSessionOpenInNewTab={handleTaskOpenInNewTab}
                 onSessionGenerateTitle={handleTaskGenerateTitle}
                 onSessionStopProcess={handleTaskStopProcess}
+                onSessionRestartProcess={handleTaskRestartProcess}
                 disableDnd
                 allowPanelSessionDnd
                 hideHeader
@@ -898,6 +906,7 @@ export function Sidebar() {
                     onSessionOpenInNewTab={handleTaskOpenInNewTab}
                     onSessionGenerateTitle={handleTaskGenerateTitle}
                     onSessionStopProcess={handleTaskStopProcess}
+                    onSessionRestartProcess={handleTaskRestartProcess}
                   />
                 )}
                 {visibleCollectionGroups.map((group, groupIdx) => {
@@ -956,6 +965,7 @@ export function Sidebar() {
                       onSessionOpenInNewTab={handleTaskOpenInNewTab}
                       onSessionGenerateTitle={handleTaskGenerateTitle}
                       onSessionStopProcess={handleTaskStopProcess}
+                      onSessionRestartProcess={handleTaskRestartProcess}
                       disableDnd={isRunningFilterActive}
                     />
                   );

--- a/src/components/chat/task-context-menu.tsx
+++ b/src/components/chat/task-context-menu.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useCallback, useMemo } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent, SyntheticEvent } from 'react';
 import { createPortal } from 'react-dom';
-import { Archive, ArchiveRestore, CircleStop, Pencil, RefreshCw, Trash2, ExternalLink, Sparkles } from 'lucide-react';
+import { Archive, ArchiveRestore, CircleStop, Pencil, RefreshCw, RotateCcw, Trash2, ExternalLink, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 import { SIDEBAR_STATUS_GROUP_CONFIG, SIDEBAR_STATUS_GROUP_ORDER } from '@/types/task';
@@ -30,6 +30,7 @@ export interface TaskContextMenuProps {
   onOpenInNewTab?: () => void;
   onGenerateTitle?: () => void;
   onStopProcess?: () => void;
+  onRestartProcess?: () => void;
   /** Runs the project's preparation script again on this task's worktree. */
   onRunPreparation?: () => void;
   onClose: () => void;
@@ -56,6 +57,7 @@ export function TaskContextMenu({
   onOpenInNewTab,
   onGenerateTitle,
   onStopProcess,
+  onRestartProcess,
   onRunPreparation,
   onClose,
 }: TaskContextMenuProps) {
@@ -76,11 +78,12 @@ export function TaskContextMenu({
       ? SIDEBAR_STATUS_GROUP_ORDER.filter((s) => (allowChatStatus || s !== 'chat') && s !== currentStatus).length
       : 0;
     const optionalItems = (isRunning && onStopProcess ? 1 : 0)
+      + (isRunning && onRestartProcess ? 1 : 0)
       + (onMoveToCollection ? 1 : 0)
       + (onGenerateTitle ? 1 : 0)
       + (onOpenInNewTab ? 1 : 0);
     const statusSectionHeight = statusCount > 0 ? 20 + statusCount * ITEM_HEIGHT + 8 : 0;
-    const stopProcessDividerHeight = isRunning && onStopProcess ? 8 : 0;
+    const stopProcessDividerHeight = isRunning && (onStopProcess || onRestartProcess) ? 8 : 0;
     const upperActionDividerHeight = onGenerateTitle || onMoveToCollection ? 8 : 0;
     const deleteDividerHeight = 8;
     const archiveItemCount = hasArchiveAction ? 1 : 0;
@@ -113,6 +116,7 @@ export function TaskContextMenu({
     onOpenInNewTab,
     onStatusChange,
     onStopProcess,
+    onRestartProcess,
     hasArchiveAction,
   ]);
 
@@ -211,6 +215,11 @@ export function TaskContextMenu({
     onClose();
   }, [onClose, onStopProcess]);
 
+  const handleRestartProcess = useCallback(() => {
+    onRestartProcess?.();
+    onClose();
+  }, [onClose, onRestartProcess]);
+
   if (typeof document === 'undefined' || !menuPos) return null;
 
   const otherStatuses = currentStatus && onStatusChange
@@ -236,24 +245,32 @@ export function TaskContextMenu({
       onContextMenu={stopEventPropagation}
       data-testid="task-context-menu"
     >
-      {isRunning && onStopProcess && (
+      {isRunning && (onStopProcess || onRestartProcess) && (
         <>
-          <button
-            role="menuitem"
-            className={cn(
-              'w-full flex items-center gap-2 px-3 h-8 text-[12px] text-left rounded-md',
-              'text-(--error) transition-colors',
-              'hover:bg-[color-mix(in_srgb,var(--error)_10%,transparent)]',
-              'focus:bg-[color-mix(in_srgb,var(--error)_10%,transparent)] focus:outline-none',
-              'cursor-default'
-            )}
-            onClick={handleStopProcess}
-            {...telemetryClickAttributes('task.stop', 'task_menu')}
-            data-testid="ctx-stop-process"
-          >
-            <CircleStop className="w-3.5 h-3.5 shrink-0" />
-            <span>Stop Process</span>
-          </button>
+          {onStopProcess && (
+            <button
+              role="menuitem"
+              className={cn(menuItemClass, 'text-(--error)')}
+              onClick={handleStopProcess}
+              {...telemetryClickAttributes('task.stop', 'task_menu')}
+              data-testid="ctx-stop-process"
+            >
+              <CircleStop className="w-3.5 h-3.5 shrink-0" />
+              <span>Stop Process</span>
+            </button>
+          )}
+          {onRestartProcess && (
+            <button
+              role="menuitem"
+              className={menuItemClass}
+              onClick={handleRestartProcess}
+              {...telemetryClickAttributes('task.restart', 'task_menu')}
+              data-testid="ctx-restart-process"
+            >
+              <RotateCcw className="w-3.5 h-3.5 shrink-0 text-(--text-muted)" />
+              <span>{t('status.restartSession')}</span>
+            </button>
+          )}
           <div className="my-1 h-px bg-(--divider) opacity-40" />
         </>
       )}

--- a/src/hooks/use-websocket.ts
+++ b/src/hooks/use-websocket.ts
@@ -59,6 +59,10 @@ export function useWebSocket() {
     wsClient.retrySession(sessionId);
   }, []);
 
+  const restartSession = useCallback((sessionId: string) => {
+    wsClient.restartSession(sessionId);
+  }, []);
+
   const sendInteractiveResponse = useCallback(
     (sessionId: string, toolUseId: string, response: string): boolean => {
       return wsClient.sendInteractiveResponse(sessionId, toolUseId, response);
@@ -102,6 +106,7 @@ export function useWebSocket() {
     closeSession,
     resumeSession,
     retrySession,
+    restartSession,
     sendInteractiveResponse,
     cancelGeneration,
     compactSession,

--- a/src/lib/cli/providers/opencode/adapter.ts
+++ b/src/lib/cli/providers/opencode/adapter.ts
@@ -80,6 +80,16 @@ type OpenCodePromptPart =
   | { type: 'image'; mimeType: string; data: string };
 
 export class OpenCodeAdapter implements CliProvider {
+  canResumeTerminalAfterRestart(providerState: string | null): boolean {
+    if (!providerState) return false;
+    try {
+      const resumeId = (JSON.parse(providerState) as Record<string, unknown>)
+        .opencodeTerminalSessionId;
+      return typeof resumeId === 'string' && resumeId.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
   private _nextRequestId = 3;
   private _processRuntimeConfig = new WeakMap<ChildProcess, OpenCodeRuntimeConfig>();
   private _initialConfigSent = new WeakSet<ChildProcess>();

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -977,6 +977,7 @@ export const en: I18nMessages = {
     error: 'Error',
     stopped: 'Stopped',
     stopProcess: 'Stop process',
+    restartSession: 'Restart session',
     processing: 'Processing',
     inputRequired: 'Input required',
     unreadNotification: 'Unread notification',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -977,6 +977,7 @@ export const ja: I18nMessages = {
     error: 'エラー',
     stopped: '停止済み',
     stopProcess: 'プロセスを停止',
+    restartSession: 'セッションを再起動',
     processing: '処理中',
     inputRequired: '入力待ち',
     unreadNotification: '未読通知',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -984,6 +984,7 @@ export const ko: I18nMessages = {
     error: '오류',
     stopped: '중지됨',
     stopProcess: '프로세스 정지',
+    restartSession: '세션 재시작',
     processing: '처리 중',
     inputRequired: '입력 필요',
     unreadNotification: '읽지 않은 알림',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -959,6 +959,7 @@ export interface I18nMessages {
     error: string;
     stopped: string;
     stopProcess: string;
+    restartSession: string;
     processing: string;
     inputRequired: string;
     unreadNotification: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -977,6 +977,7 @@ export const zh: I18nMessages = {
     error: '错误',
     stopped: '已停止',
     stopProcess: '停止进程',
+    restartSession: '重启会话',
     processing: '处理中',
     inputRequired: '等待输入',
     unreadNotification: '未读通知',

--- a/src/lib/session/session-restart-lifecycle.ts
+++ b/src/lib/session/session-restart-lifecycle.ts
@@ -1,0 +1,41 @@
+type SessionRestartListener = (succeeded: boolean, message?: string) => void;
+
+const restartingSessionIds = new Set<string>();
+const listenersBySessionId = new Map<string, Set<SessionRestartListener>>();
+
+export function beginSessionRestart(sessionId: string): void {
+  restartingSessionIds.add(sessionId);
+}
+
+export function isSessionRestarting(sessionId: string): boolean {
+  return restartingSessionIds.has(sessionId);
+}
+
+/** A disconnected client cannot rely on receiving the matching restart outcome. */
+export function resetSessionRestarts(): void {
+  restartingSessionIds.clear();
+}
+
+export function finishSessionRestart(
+  sessionId: string,
+  succeeded: boolean,
+  message?: string,
+): void {
+  restartingSessionIds.delete(sessionId);
+  for (const listener of listenersBySessionId.get(sessionId) ?? []) {
+    listener(succeeded, message);
+  }
+}
+
+export function subscribeSessionRestart(
+  sessionId: string,
+  listener: SessionRestartListener,
+): () => void {
+  const listeners = listenersBySessionId.get(sessionId) ?? new Set<SessionRestartListener>();
+  listeners.add(listener);
+  listenersBySessionId.set(sessionId, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) listenersBySessionId.delete(sessionId);
+  };
+}

--- a/src/lib/telemetry/ui-click.ts
+++ b/src/lib/telemetry/ui-click.ts
@@ -94,6 +94,7 @@ export const TELEMETRY_UI_CONTROLS = [
   'panel.split.down',
   'panel.close',
   'task.stop',
+  'task.restart',
   'task.menu.open',
   'task.status.change',
   'task.generate_title',

--- a/src/lib/terminal/provider-launch-module.ts
+++ b/src/lib/terminal/provider-launch-module.ts
@@ -134,6 +134,7 @@ export interface ProviderLaunchResult {
 
 export interface ProviderLaunchModule {
   supportsProvider(providerId: string): boolean;
+  canResumeSession(sessionId: string): Promise<boolean>;
   launch(request: ProviderLaunchRequest): Promise<ProviderLaunchResult>;
 }
 
@@ -973,6 +974,17 @@ export function createProviderLaunchModule(
   return {
     supportsProvider(providerId): boolean {
       return isSupportedTerminalProvider(providerId);
+    },
+    async canResumeSession(sessionId): Promise<boolean> {
+      const persisted = getPersistedProvider({ mode: 'detached', sessionId, userId: '' });
+      if (persisted.providerId === 'claude-code') {
+        const providerSession = resolveTerminalProviderSessionReference(
+          sessionId,
+          persisted.providerState,
+        );
+        return providerSession.nativeFork || sessionHistory.historyExists(sessionId);
+      }
+      return persisted.provider.canResumeTerminalAfterRestart?.(persisted.providerState) ?? false;
     },
     async launch(request): Promise<ProviderLaunchResult> {
       validateInitialPrompt(request.initialPrompt);

--- a/src/lib/terminal/shared-provider-launch-module.ts
+++ b/src/lib/terminal/shared-provider-launch-module.ts
@@ -38,5 +38,6 @@ function getSharedProviderLaunchModule(): ProviderLaunchModule {
 /** Production adapter that defers singleton wiring until the first launch. */
 export const providerLaunchModule: ProviderLaunchModule = {
   supportsProvider: (providerId) => getSharedProviderLaunchModule().supportsProvider(providerId),
+  canResumeSession: (sessionId) => getSharedProviderLaunchModule().canResumeSession(sessionId),
   launch: (request) => getSharedProviderLaunchModule().launch(request),
 };

--- a/src/lib/terminal/terminal-surface-registry.ts
+++ b/src/lib/terminal/terminal-surface-registry.ts
@@ -79,6 +79,7 @@ import {
   sanitizeXtermGeneratedData,
   type TerminalKeyboardOwner,
 } from './terminal-input-policy';
+import { subscribeSessionRestart } from '@/lib/session/session-restart-lifecycle';
 
 export type TerminalSurfaceStatus = 'starting' | 'running' | 'exited' | 'error';
 
@@ -370,6 +371,7 @@ export class TerminalSurface {
   private autoConnect = true;
   private sessionWasPresent = false;
   private readonly unsubscribeSessionStore: (() => void) | null;
+  private readonly unsubscribeSessionRestart: (() => void) | null;
 
   constructor(private readonly options: TerminalSurfaceOptions) {
     this.theme = { ...options.theme };
@@ -393,6 +395,16 @@ export class TerminalSurface {
             return;
           }
           if (present) this.sessionWasPresent = true;
+        })
+      : null;
+    this.unsubscribeSessionRestart = options.sessionId
+      ? subscribeSessionRestart(options.sessionId, (succeeded, message) => {
+          if (!succeeded) {
+            this.autoConnect = false;
+            this.updateState('error', message ?? 'Session restart failed');
+            return;
+          }
+          void this.restart();
         })
       : null;
   }
@@ -825,6 +837,7 @@ export class TerminalSurface {
     }
     this.unsubscribeMessages();
     this.unsubscribeSessionStore?.();
+    this.unsubscribeSessionRestart?.();
     this.releaseRenderResources();
     if (surfaces.get(this.options.registryKey) === this) {
       surfaces.delete(this.options.registryKey);

--- a/src/lib/ws/client-message-handlers.ts
+++ b/src/lib/ws/client-message-handlers.ts
@@ -49,6 +49,11 @@ import {
   retainPendingTerminalRebounds,
   takePendingTerminalReboundsForDestination,
 } from '@/lib/terminal/terminal-session-rebound-reservations';
+import {
+  beginSessionRestart,
+  finishSessionRestart,
+  isSessionRestarting,
+} from '@/lib/session/session-restart-lifecycle';
 
 interface HandleIncomingServerMessageOptions {
   msg: ServerTransportMessage;
@@ -149,11 +154,33 @@ export function handleIncomingServerMessage({
       // PTY surfaces retire on terminal_session_runtime so a provider session
       // rebound can transfer the existing panel first. GUI sessions have no
       // later runtime event, so stopping one must retire its surface here.
-      if (stoppedKind && stoppedKind !== 'terminal') {
+      if (stoppedKind && stoppedKind !== 'terminal' && !isSessionRestarting(msg.sessionId)) {
         retireProjectViewSessionSurfaces(msg.sessionId);
       }
       return { wasReconnect };
     }
+
+    case 'session_restarting':
+      beginSessionRestart(msg.sessionId);
+      finalizeInFlightTurn(msg.sessionId, { clearPrompt: true });
+      void captureTelemetryPromptTurnFinished(msg.sessionId, 'stopped');
+      chatStore.settleRunningWorkflows(msg.sessionId, 'failed');
+      chatStore.setTodoSnapshot(msg.sessionId, []);
+      chatStore.setCompacting(msg.sessionId, null);
+      sessionStore.setSessionWorkflowRunning(msg.sessionId, false);
+      useCommandStore.getState().clearSession(msg.sessionId);
+      return { wasReconnect };
+
+    case 'session_restarted':
+      finishSessionRestart(msg.sessionId, true);
+      return { wasReconnect };
+
+    case 'session_restart_failed':
+      finishSessionRestart(msg.sessionId, false, msg.message);
+      sessionStore.markSessionStopped(msg.sessionId);
+      useTaskStore.getState().setLinkedSessionRunning(msg.sessionId, false);
+      useNotificationStore.getState().showToast(msg.message, 'error');
+      return { wasReconnect };
 
     case 'replay_events':
       sessionStore.touchSessionActivity(msg.sessionId, getLatestReplayEventTimestamp(msg.events));
@@ -227,7 +254,9 @@ export function handleIncomingServerMessage({
       } else {
         useTerminalSessionStore.getState().markRuntimeStopped(msg.sessionId);
         cancelPendingTerminalReboundsForDestination(msg.sessionId);
-        retireStoppedTerminalSessionSurface(msg.sessionId);
+        if (!isSessionRestarting(msg.sessionId)) {
+          retireStoppedTerminalSessionSurface(msg.sessionId);
+        }
       }
       return { wasReconnect };
 
@@ -347,6 +376,7 @@ export function handleIncomingServerMessage({
     }
 
     case 'cli_down':
+      if (isSessionRestarting(msg.sessionId)) return { wasReconnect };
       applySessionReplayEventsToStores(msg.sessionId, serverMessageToReplayEvents(msg));
       finalizeInFlightTurn(msg.sessionId, { clearPrompt: true });
       void captureTelemetryPromptTurnFinished(msg.sessionId, 'failed');

--- a/src/lib/ws/client.ts
+++ b/src/lib/ws/client.ts
@@ -17,6 +17,10 @@ import { useProvidersStore } from '@/stores/providers-store';
 import { useSettingsStore } from '@/stores/settings-store';
 import { resolveStoredCanonicalSession } from '@/lib/projects/stored-session-resolution';
 import {
+  applyProviderSessionRuntimeOverrides,
+  getProviderSessionRuntimeConfig,
+} from '@/lib/settings/provider-defaults';
+import {
   applyLocalInteractiveResponseStart,
   finalizeInFlightTurn,
 } from '@/lib/chat/session-client-effects';
@@ -30,6 +34,7 @@ import {
   captureTelemetryPromptSubmitted,
   captureTelemetryPromptTurnFinished,
 } from '@/lib/telemetry/client';
+import { resetSessionRestarts } from '@/lib/session/session-restart-lifecycle';
 
 type ServerMessageListener = (msg: ServerTransportMessage) => void;
 
@@ -146,6 +151,7 @@ export class WebSocketClient {
       this.ws.onclose = (event) => {
         const closeMsg = this.formatCloseMessage(event);
         console.warn('WebSocket closed:', closeMsg);
+        resetSessionRestarts();
         this.failPendingRequestCallbacks();
         this.reconnect();
       };
@@ -292,6 +298,36 @@ export class WebSocketClient {
       ...(controls?.sandboxMode && { sandboxMode: controls.sandboxMode }),
       ...(controls?.serviceTier !== undefined && { serviceTier: controls.serviceTier }),
       ...(controls?.fastMode !== undefined && { fastMode: controls.fastMode }),
+    });
+  }
+
+  restartSession(
+    sessionId: string,
+    controls?: ({ permissionMode?: PermissionMode } & ProviderRuntimeControls),
+  ): boolean {
+    let resolvedControls = controls;
+    if (!resolvedControls) {
+      const { projects, retainedSessions } = useSessionStore.getState();
+      const session = resolveStoredCanonicalSession(projects, retainedSessions, sessionId);
+      const providerId = session?.provider?.trim();
+      if (providerId) {
+        resolvedControls = applyProviderSessionRuntimeOverrides(
+          getProviderSessionRuntimeConfig(useSettingsStore.getState().settings, providerId),
+          session,
+          providerId,
+        );
+      }
+    }
+    return this.sendRequest('restart_session', {
+      sessionId,
+      ...(resolvedControls?.permissionMode && { permissionMode: resolvedControls.permissionMode }),
+      ...(resolvedControls?.sessionMode && { sessionMode: resolvedControls.sessionMode }),
+      ...(resolvedControls?.accessMode && { accessMode: resolvedControls.accessMode }),
+      ...(resolvedControls?.collaborationMode && { collaborationMode: resolvedControls.collaborationMode }),
+      ...(resolvedControls?.approvalPolicy && { approvalPolicy: resolvedControls.approvalPolicy }),
+      ...(resolvedControls?.sandboxMode && { sandboxMode: resolvedControls.sandboxMode }),
+      ...(resolvedControls?.serviceTier !== undefined && { serviceTier: resolvedControls.serviceTier }),
+      ...(resolvedControls?.fastMode !== undefined && { fastMode: resolvedControls.fastMode }),
     });
   }
 

--- a/src/lib/ws/message-types.ts
+++ b/src/lib/ws/message-types.ts
@@ -76,6 +76,7 @@ export type ClientMessage =
   | { type: 'send_message'; requestId: string; sessionId: string; content: string | ContentBlock[]; skillName?: string; displayContent?: string | ContentBlock[]; spawnConfig?: SessionSpawnConfig; forceTranslateInput?: boolean; messageId?: string }
   | { type: 'translate_message'; requestId: string; sessionId: string; messageId: string }
   | ({ type: 'resume_session'; requestId: string; sessionId: string; permissionMode?: PermissionMode } & ProviderRuntimeControls)
+  | ({ type: 'restart_session'; requestId: string; sessionId: string; permissionMode?: PermissionMode } & ProviderRuntimeControls)
   | { type: 'retry_session'; requestId: string; sessionId: string }
   | { type: 'interactive_response'; requestId: string; sessionId: string; toolUseId: string; response: string }
   | { type: 'mark_as_read'; requestId: string; sessionId: string } // NEW - for FEAT-002
@@ -526,6 +527,9 @@ export type AppServerMessage =
       unreadCount: number;
     }
   | { type: 'session_stopped'; sessionId: string }
+  | { type: 'session_restarting'; sessionId: string; kind: 'chat' | 'terminal' }
+  | { type: 'session_restarted'; sessionId: string; kind: 'chat' | 'terminal' }
+  | { type: 'session_restart_failed'; sessionId: string; kind: 'chat' | 'terminal'; message: string }
   | { type: 'session_idle_closed'; sessionId: string }
   | ({ type: 'rate_limit_update' } & ProviderRateLimitsSnapshot)
   | { type: 'model_config_updated'; providerId: 'claude-code' }

--- a/src/lib/ws/server-message-routing.ts
+++ b/src/lib/ws/server-message-routing.ts
@@ -39,6 +39,7 @@ import {
   compactSessionFromWebSocket,
   createSessionFromWebSocket,
   resumeSessionFromWebSocket,
+  restartSessionFromWebSocket,
   retrySessionFromWebSocket,
   runProcessManagerControlAction,
   sendCommandsListToWebSocketUser,
@@ -166,6 +167,7 @@ export async function routeClientTransportMessage({
 }: RouteClientTransportMessageOptions): Promise<void> {
   const unguardedSessionMessage = message.type === 'terminal_create'
     || message.type === 'terminal_prompt'
+    || message.type === 'restart_session'
     || message.type === 'subscribe_workspace_files'
     || message.type === 'unsubscribe_workspace_files'
     || message.type === 'mark_as_read'
@@ -329,6 +331,22 @@ export async function routeClientTransportMessage({
         approvalPolicy: message.approvalPolicy,
         sandboxMode: message.sandboxMode,
         serviceTier: message.serviceTier,
+      });
+      return;
+
+    case 'restart_session':
+      await restartSessionFromWebSocket({
+        userId,
+        sendToUser,
+        sessionId: message.sessionId,
+        permissionMode: message.permissionMode,
+        sessionMode: message.sessionMode,
+        accessMode: message.accessMode,
+        collaborationMode: message.collaborationMode,
+        approvalPolicy: message.approvalPolicy,
+        sandboxMode: message.sandboxMode,
+        serviceTier: message.serviceTier,
+        fastMode: message.fastMode,
       });
       return;
 

--- a/src/lib/ws/server-session-actions.ts
+++ b/src/lib/ws/server-session-actions.ts
@@ -28,8 +28,10 @@ import {
   isSessionHandedOffToTerminal,
   isSessionOperationConflictError,
   isTerminalHandoffConflictError,
+  withExclusiveTesseraSessionOperation,
   withTesseraSessionOperation,
 } from '../terminal/terminal-handoff-lock';
+import { resumeSessionWithLifecycle } from '../session/session-orchestrator-lifecycle';
 import type {
   ClientMessage,
   ContentBlock,
@@ -38,6 +40,8 @@ import type {
   TextContentBlock,
 } from './message-types';
 import type { ProviderRuntimeControls } from '@/lib/session/session-control-types';
+import { terminalManager } from '@/lib/terminal/shared-terminal-manager';
+import { providerLaunchModule } from '@/lib/terminal/shared-provider-launch-module';
 
 type WsSendToUser = (userId: string, message: ServerTransportMessage) => void;
 type SessionHistoryMessage = Extract<ServerTransportMessage, { type: 'session_history' }>;
@@ -59,6 +63,7 @@ const CODEX_REQUEST_USER_INPUT_TOOL_NAME = 'CodexRequestUserInput';
 const CODEX_MCP_ELICITATION_TOOL_NAME = 'CodexMcpElicitation';
 const CODEX_PERMISSIONS_REQUEST_TOOL_NAME = 'CodexPermissionsRequest';
 const LIVE_EVENT_VERSION = 1;
+const restartingSessionIds = new Set<string>();
 
 type SessionControlRequest = Pick<
   Extract<ClientMessage, { sessionId: string }>,
@@ -104,6 +109,11 @@ interface ResumeSessionActionOptions extends SessionActionOptions, ProviderRunti
 }
 
 interface RetrySessionActionOptions extends SessionActionOptions {
+  sessionId: string;
+}
+
+interface RestartSessionActionOptions extends SessionActionOptions, ProviderRuntimeControls {
+  permissionMode?: string;
   sessionId: string;
 }
 
@@ -782,6 +792,106 @@ export async function resumeSessionFromWebSocket({
       sessionId,
       code: 'resume_failed',
       message: `Failed to resume session: ${(err as Error).message}`,
+    });
+  }
+}
+
+export async function restartSessionFromWebSocket({
+  accessMode,
+  approvalPolicy,
+  collaborationMode,
+  fastMode,
+  permissionMode,
+  sandboxMode,
+  sendToUser,
+  serviceTier,
+  sessionId,
+  sessionMode,
+  userId,
+}: RestartSessionActionOptions): Promise<void> {
+  let announcedKind: 'chat' | 'terminal' | null = null;
+  try {
+    await withExclusiveTesseraSessionOperation(sessionId, async () => {
+      const record = dbSessions.getSession(sessionId);
+      if (!record) throw new Error('Session does not exist.');
+
+      const kind = dbSessions.extractSessionKind(record.provider_state);
+      if (restartingSessionIds.has(sessionId)) {
+        throw new Error('This session is already restarting.');
+      }
+      restartingSessionIds.add(sessionId);
+      try {
+        if (kind === 'terminal' && !await providerLaunchModule.canResumeSession(sessionId)) {
+          throw new Error('The provider session is not ready to resume yet.');
+        }
+        sendToUser(userId, { type: 'session_restarting', sessionId, kind });
+        announcedKind = kind;
+
+        if (kind === 'terminal') {
+          await terminalManager.stopSessionRuntime(sessionId, userId);
+          await providerLaunchModule.launch({ mode: 'detached', sessionId, userId });
+        } else {
+          const sessionRecord = dbSessions.getSessionWorktreeContext(sessionId);
+          const result = await resumeSessionWithLifecycle({
+            options: {
+              workDir: sessionRecord?.workDir || undefined,
+              permissionMode,
+              sessionMode,
+              accessMode,
+              collaborationMode,
+              approvalPolicy,
+              sandboxMode,
+              serviceTier,
+              fastMode,
+            },
+            processManager,
+            sessionId,
+            userId,
+          });
+          if (result.status !== 'running') {
+            throw new Error('Session could not be resumed.');
+          }
+          sendToUser(userId, {
+            type: 'session_started',
+            sessionId,
+            workDir: sessionRecord?.workDir || process.cwd(),
+            provider: record.provider ?? undefined,
+            model: result.model,
+            reasoningEffort: result.reasoningEffort,
+            serviceTier: result.serviceTier,
+            fastMode: result.fastMode,
+            sessionMode: result.sessionMode,
+            accessMode: result.accessMode,
+          });
+        }
+        sendToUser(userId, { type: 'session_restarted', sessionId, kind });
+        logger.info({ userId, sessionId, kind }, 'Session restarted');
+      } finally {
+        restartingSessionIds.delete(sessionId);
+      }
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown restart error';
+    const kind = announcedKind ?? dbSessions.extractSessionKind(
+      dbSessions.getSession(sessionId)?.provider_state ?? null,
+    );
+    logger.error({ userId, sessionId, kind, error }, 'Failed to restart session');
+    if (!announcedKind) {
+      sendToUser(userId, {
+        type: 'error',
+        sessionId,
+        code: isSessionOperationConflictError(error)
+          ? 'session_restart_in_progress'
+          : 'session_restart_unavailable',
+        message: `Could not restart session: ${message}`,
+      });
+      return;
+    }
+    sendToUser(userId, {
+      type: 'session_restart_failed',
+      sessionId,
+      kind,
+      message: `Failed to restart session: ${message}`,
     });
   }
 }

--- a/tests/provider-launch-module.test.ts
+++ b/tests/provider-launch-module.test.ts
@@ -231,6 +231,25 @@ async function launchDetached(
   });
 }
 
+test('restart readiness requires a persisted provider resume identity', async () => {
+  const launcher = modules.createProviderLaunchModule({
+    terminalManager: createManager([]),
+  });
+  createTerminalSession('restart-not-ready', 'codex');
+  createTerminalSession('restart-ready-codex', 'codex', {
+    kind: 'terminal',
+    codexSessionId: 'codex-resume-id',
+  });
+  createTerminalSession('restart-ready-opencode', 'opencode', {
+    kind: 'terminal',
+    opencodeTerminalSessionId: 'opencode-resume-id',
+  });
+
+  assert.equal(await launcher.canResumeSession('restart-not-ready'), false);
+  assert.equal(await launcher.canResumeSession('restart-ready-codex'), true);
+  assert.equal(await launcher.canResumeSession('restart-ready-opencode'), true);
+});
+
 test('launch preparation finalizes provider argv before shell resolution', async () => {
   const captured: CapturedSpawn[] = [];
   const manager = createManager(captured);

--- a/tests/session-restart-ui-contract.test.mjs
+++ b/tests/session-restart-ui-contract.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const read = (path) => fs.readFileSync(path, 'utf8');
+
+test('restart session is exposed in header, sidebar, and kanban context menus only', () => {
+  const taskMenu = read('src/components/chat/task-context-menu.tsx');
+  const listMenu = read('src/components/chat/collection-group-sections.tsx');
+  const header = read('src/components/chat/header.tsx');
+  const kanban = read('src/components/board/kanban-card.tsx');
+  const primitives = read('src/components/chat/work-item-primitives.tsx');
+
+  assert.match(taskMenu, /data-testid="ctx-restart-process"/);
+  assert.match(listMenu, /data-testid="ctx-restart-process"/);
+  assert.match(header, /onRestartProcess=/);
+  assert.match(kanban, /onRestartProcess=/);
+  assert.doesNotMatch(kanban, /quick-restart-button/);
+  assert.doesNotMatch(listMenu, /quick-restart/);
+  assert.doesNotMatch(primitives, /RestartProcessButton/);
+});
+
+test('task restart snapshots only currently running child sessions', () => {
+  const board = read('src/components/board/kanban-board.tsx');
+  const list = read('src/components/chat/collection-group.tsx');
+
+  assert.match(board, /handleTaskRestartProcess[\s\S]*taskMenuAnchor\.task\.sessions/);
+  assert.match(board, /resolveSessionRuntimePresentation\(liveSession \?\? session\)\.canStop/);
+  assert.match(list, /handleContextMenuRestartProcess[\s\S]*resolveSessionRuntimePresentation\(liveSession \?\? session\)\.canStop/);
+});

--- a/tests/terminal-session-runtime-state.test.ts
+++ b/tests/terminal-session-runtime-state.test.ts
@@ -14,6 +14,7 @@ import { useTabStore } from '@/stores/tab-store';
 import type { ProjectGroup, UnifiedSession } from '@/types/chat';
 import type { TaskEntity } from '@/types/task-entity';
 import { projectViewWorkspaceState } from '@/lib/projects/project-view-workspace-state-client';
+import { resetSessionRestarts } from '@/lib/session/session-restart-lifecycle';
 
 const SESSION_ID = 'terminal-session-a';
 
@@ -115,6 +116,7 @@ function countSessionSurfaces(sessionId: string): number {
 }
 
 beforeEach(() => {
+  resetSessionRestarts();
   resetPendingTerminalReboundsForTests();
   useChatStore.setState({ turnInFlightBySession: {} });
   useBoardStore.setState({ selectedProjectDir: null, peekFileDirty: false });
@@ -390,6 +392,102 @@ test('PTY runtime exit closes a retained single-panel session tab', () => {
 
   assert.equal(useTabStore.getState().tabs.some((tab) => tab.id === tabId), false);
   assert.equal(useTabStore.getState().findSessionLocation(SESSION_ID), null);
+});
+
+test('planned PTY restart preserves its retained tab through the runtime gap', () => {
+  const tabId = 'restarting-terminal-tab';
+  const panelId = 'restarting-terminal-panel';
+  useSessionStore.setState({ projects: [project(terminalSession(SESSION_ID, true))] });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: SESSION_ID } },
+        activePanelId: panelId,
+      },
+    },
+  });
+  useBoardStore.setState({ peekSessionId: SESSION_ID });
+
+  receive({ type: 'session_restarting', sessionId: SESSION_ID, kind: 'terminal' });
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    running: false,
+  });
+
+  assert.equal(useTabStore.getState().activeTabId, tabId);
+  assert.ok(useTabStore.getState().findSessionLocation(SESSION_ID));
+  assert.equal(useBoardStore.getState().peekSessionId, SESSION_ID);
+
+  receive({ type: 'session_restarted', sessionId: SESSION_ID, kind: 'terminal' });
+  assert.ok(useTabStore.getState().findSessionLocation(SESSION_ID));
+});
+
+test('disconnect reset prevents a stale restart latch from retaining a later stopped PTY', () => {
+  const tabId = 'disconnected-restart-tab';
+  const panelId = 'disconnected-restart-panel';
+  useSessionStore.setState({ projects: [project(terminalSession(SESSION_ID, true))] });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId: SESSION_ID } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  receive({ type: 'session_restarting', sessionId: SESSION_ID, kind: 'terminal' });
+  resetSessionRestarts();
+  receive({
+    type: 'terminal_session_runtime',
+    sessionId: SESSION_ID,
+    terminalId: `session-${SESSION_ID}`,
+    running: false,
+  });
+
+  assert.equal(useTabStore.getState().findSessionLocation(SESSION_ID), null);
+});
+
+test('planned GUI restart suppresses a stale stopped event without retiring the tab', () => {
+  const sessionId = 'restarting-gui-session';
+  const tabId = 'restarting-gui-tab';
+  const panelId = 'restarting-gui-panel';
+  useSessionStore.setState({ projects: [project(guiSession(sessionId, true))] });
+  useTabStore.setState({
+    tabs: [{ id: tabId, projectDir: '/workspace', title: null, isPreview: false }],
+    activeTabId: tabId,
+    lruTabIds: [tabId],
+  });
+  usePanelStore.setState({
+    activeTabId: tabId,
+    tabPanels: {
+      [tabId]: {
+        layout: { type: 'leaf', panelId },
+        panels: { [panelId]: { id: panelId, sessionId } },
+        activePanelId: panelId,
+      },
+    },
+  });
+
+  receive({ type: 'session_restarting', sessionId, kind: 'chat' });
+  receive({ type: 'session_stopped', sessionId });
+  assert.ok(useTabStore.getState().findSessionLocation(sessionId));
+  receive({ type: 'session_restarted', sessionId, kind: 'chat' });
 });
 
 test('restoring a retained PTY runtime does not steal focus from the active tab', () => {


### PR DESCRIPTION
## Summary

- add a first-class session restart WebSocket lifecycle for GUI and PTY runtimes
- preserve tabs, panels, Peek, session IDs, and provider conversation identity while replacing only the runtime
- expose restart in header/sidebar/Kanban context menus; task actions restart every currently running child session
- reject unsafe PTY restarts until the provider resume identity is persisted, and serialize restart against other session mutations

## Testing

- [x] `npx tsc --noEmit --pretty false`
- [x] targeted ESLint on changed files
- [x] `npx tsx --test tests/provider-launch-module.test.ts tests/terminal-session-runtime-state.test.ts tests/session-restart-ui-contract.test.mjs`
- [x] `npm run server:compile`
- [x] `npm run build`
- [x] Manual test: isolated packaged Windows Electron backend + WSL Codex CLI; restart completed under the same session ID and the existing tab remained open

## Screenshots or Recordings

- QA screenshots captured locally in Windows Downloads: `restart-qa-07-hover-no-restart.png` through `restart-qa-10-kanban-menu-restart.png`

## Notes

- Restart is intentionally limited to context menus; hover quick actions remain unchanged.