### PR TITLE
fix(files): preserve Monaco editor focus

### DIFF
--- a/src/components/workspace/workspace-code-view.tsx
+++ b/src/components/workspace/workspace-code-view.tsx
@@ -419,6 +419,13 @@ export function WorkspaceCodeView({
     handleSaveShortcut(event);
     handleFindShortcut(event);
   }, [handleFindShortcut, handleSaveShortcut]);
+  const handleViewMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    // Monaco focuses its hidden textarea during this same event. Taking focus
+    // back on the parent after it bubbles makes a file look read-only.
+    const target = event.target;
+    if (target instanceof Element && target.closest(".monaco-editor")) return;
+    event.currentTarget.focus({ preventScroll: true });
+  }, []);
 
   async function copyContent() {
     try {
@@ -496,7 +503,7 @@ export function WorkspaceCodeView({
 
   return (
     <>
-    <div className="flex h-full min-h-0 flex-col bg-(--chat-bg)" tabIndex={-1} onMouseDown={(event) => event.currentTarget.focus({ preventScroll: true })} onKeyDown={handleViewKeyDown}>
+    <div className="flex h-full min-h-0 flex-col bg-(--chat-bg)" tabIndex={-1} onMouseDown={handleViewMouseDown} onKeyDown={handleViewKeyDown}>
       <div className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-(--chat-header-border) px-4">
         <div className="flex min-w-0 items-center gap-2">
           {mode === "diff" ? (

--- a/tests/workspace-file-editing-contract.test.mjs
+++ b/tests/workspace-file-editing-contract.test.mjs
@@ -145,6 +145,12 @@ test('file shortcuts are bound to this view, not to the window', () => {
   assert.match(codeViewSource, /event\.metaKey \|\| event\.ctrlKey/);
 });
 
+test('clicking Monaco never moves focus to the surrounding file view', () => {
+  assert.match(codeViewSource, /const handleViewMouseDown/);
+  assert.match(codeViewSource, /target\.closest\("\.monaco-editor"\)/);
+  assert.match(codeViewSource, /onMouseDown=\{handleViewMouseDown\}/);
+});
+
 test('file viewers open an in-view search for both Monaco source and Markdown previews', () => {
   assert.match(codeViewSource, /WorkspaceFileFind/);
   assert.match(codeViewSource, /event\.key\.toLowerCase\(\) !== "f"/);


### PR DESCRIPTION
## Summary
- keep Monaco's textarea focused after clicking a file editor
- add regression coverage for the file-view focus boundary

## Verification
- `node --test tests/workspace-file-editing-contract.test.mjs`
- `npx eslint src/components/workspace/workspace-code-view.tsx`
- `npx tsc --noEmit`