### PR TITLE
fix(archive): smooth restore transitions

### DIFF
--- a/src/components/archive/archive-dashboard.tsx
+++ b/src/components/archive/archive-dashboard.tsx
@@ -72,6 +72,40 @@ function emptyArchiveKindState(): ArchiveKindState {
   return { items: [], nextCursor: null, total: 0 };
 }
 
+function removeItemFromArchiveKindState(
+  current: ArchiveKindState,
+  itemId: string,
+): ArchiveKindState {
+  if (!current.items.some((item) => item.id === itemId)) return current;
+  return {
+    ...current,
+    items: current.items.filter((item) => item.id !== itemId),
+    total: Math.max(0, current.total - 1),
+  };
+}
+
+function removeItemFromArchiveSummary(
+  current: ArchiveResponse['summary'] | null,
+  item: ArchiveItem,
+): ArchiveResponse['summary'] | null {
+  if (!current) return current;
+  const worktreeKey = item.worktreeStatus === 'present'
+    ? 'worktreesPresent'
+    : item.worktreeStatus === 'deleted'
+      ? 'worktreesDeleted'
+      : item.worktreeStatus === 'missing'
+        ? 'worktreesMissing'
+        : null;
+
+  return {
+    ...current,
+    total: Math.max(0, current.total - 1),
+    chats: item.kind === 'chat' ? Math.max(0, current.chats - 1) : current.chats,
+    tasks: item.kind === 'task' ? Math.max(0, current.tasks - 1) : current.tasks,
+    ...(worktreeKey ? { [worktreeKey]: Math.max(0, current[worktreeKey] - 1) } : {}),
+  };
+}
+
 function formatRelativeTime(iso: string | undefined, t: TranslateFn): string {
   if (!iso) return '-';
   const date = new Date(iso);
@@ -203,6 +237,7 @@ export function ArchiveDashboard() {
   const [deleteTarget, setDeleteTarget] = useState<ArchiveItem | null>(null);
   const [worktreeDeleteTarget, setWorktreeDeleteTarget] = useState<ArchiveItem | null>(null);
   const [bulkWorktreeDeleteOpen, setBulkWorktreeDeleteOpen] = useState(false);
+  const [restoringItemIds, setRestoringItemIds] = useState<Set<string>>(() => new Set());
   const [error, setError] = useState<string | null>(null);
   const { handleSessionClick } = useSessionClickHandlers();
 
@@ -301,7 +336,27 @@ export function ArchiveDashboard() {
     await handleSessionClick(session);
   }, [handleSessionClick]);
 
+  const removeRestoredArchiveItem = useCallback((item: ArchiveItem) => {
+    if (item.kind === 'chat') {
+      setChatState((current) => removeItemFromArchiveKindState(current, item.id));
+    } else {
+      setTaskState((current) => removeItemFromArchiveKindState(current, item.id));
+    }
+    setSummary((current) => removeItemFromArchiveSummary(current, item));
+  }, []);
+
+  const finishRestoringItem = useCallback((itemId: string) => {
+    setRestoringItemIds((current) => {
+      const next = new Set(current);
+      next.delete(itemId);
+      return next;
+    });
+  }, []);
+
   const restoreItem = useCallback(async (item: ArchiveItem) => {
+    if (restoringItemIds.has(item.id)) return;
+    setRestoringItemIds((current) => new Set(current).add(item.id));
+    setError(null);
     const restoredSession = primarySessionFromItem(item);
     const rollbackWorkspace = item.kind === 'task'
       ? projectViewWorkspaceState.applyTaskRestoreMutation({
@@ -328,33 +383,31 @@ export function ArchiveDashboard() {
     } catch {
       rollbackWorkspace?.();
       setError(t('archive.errors.restoreFailed'));
+      finishRestoringItem(item.id);
       return;
     }
     if (!res.ok) {
       const body = await res.json().catch(() => ({})) as { error?: string };
       rollbackWorkspace?.();
       setError(body.error ?? t('archive.errors.restoreFailed'));
+      finishRestoringItem(item.id);
       return;
     }
     const result = await res.json().catch(() => ({})) as {
       taskId?: string;
       affectedProjectIds?: string[];
     };
-    try {
-      await Promise.all([
-        loadArchive(),
-        refreshProjectViewWorkspaceMutation({
-          projectId: item.projectId,
-          sessionId: item.kind === 'chat' ? item.id : undefined,
-          taskId: item.kind === 'task' ? item.id : result.taskId,
-          affectedProjectIds: result.affectedProjectIds ?? item.affectedProjectIds,
-        }),
-      ]);
-    } catch (error) {
+    removeRestoredArchiveItem(item);
+    finishRestoringItem(item.id);
+    void refreshProjectViewWorkspaceMutation({
+      projectId: item.projectId,
+      sessionId: item.kind === 'chat' ? item.id : undefined,
+      taskId: item.kind === 'task' ? item.id : result.taskId,
+      affectedProjectIds: result.affectedProjectIds ?? item.affectedProjectIds,
+    }).catch((error) => {
       console.error(error);
-      setError(t('archive.errors.loadFailed'));
-    }
-  }, [loadArchive, t]);
+    });
+  }, [finishRestoringItem, removeRestoredArchiveItem, restoringItemIds, t]);
 
   const deleteItem = useCallback(async (item: ArchiveItem) => {
     const endpoint = item.kind === 'task'
@@ -560,6 +613,7 @@ export function ArchiveDashboard() {
             <ArchiveSection title={t('archive.sections.tasks')} count={taskState.total}>
               <TaskArchiveTable
                 items={taskItems}
+                restoringItemIds={restoringItemIds}
                 onOpenSession={openItem}
                 onRestore={restoreItem}
                 onDelete={setDeleteTarget}
@@ -578,6 +632,7 @@ export function ArchiveDashboard() {
             <ArchiveSection title={t('archive.sections.chats')} count={chatState.total}>
               <ChatArchiveTable
                 items={chatItems}
+                restoringItemIds={restoringItemIds}
                 onOpen={openItem}
                 onRestore={restoreItem}
                 onDelete={setDeleteTarget}
@@ -818,12 +873,14 @@ function StackedField({
  */
 function ChatRowActions({
   item,
+  isRestoring,
   onRestore,
   onDelete,
   t,
   stacked = false,
 }: {
   item: ArchiveItem;
+  isRestoring: boolean;
   onRestore: (item: ArchiveItem) => void;
   onDelete: (item: ArchiveItem) => void;
   t: TranslateFn;
@@ -832,12 +889,18 @@ function ChatRowActions({
   return (
     <RowActions stacked={stacked}>
       {item.canRestore && (
-        <ActionButton telemetryControl="archive.item.restore" tone="primary" onClick={() => onRestore(item)}>
-          <RotateCcw className="h-3 w-3" />
+        <ActionButton
+          telemetryControl="archive.item.restore"
+          tone="primary"
+          onClick={() => onRestore(item)}
+          disabled={isRestoring}
+          ariaBusy={isRestoring}
+        >
+          <RotateCcw className={cn('h-3 w-3', isRestoring && 'animate-spin')} />
           {t('archive.actions.restore')}
         </ActionButton>
       )}
-      <ActionButton telemetryControl="archive.item.delete" tone="dangerOutline" onClick={() => onDelete(item)}>
+      <ActionButton telemetryControl="archive.item.delete" tone="dangerOutline" onClick={() => onDelete(item)} disabled={isRestoring}>
         <Trash2 className="h-3 w-3" />
         {t('archive.actions.delete')}
       </ActionButton>
@@ -852,6 +915,7 @@ function ChatRowActions({
  */
 function TaskRowActions({
   item,
+  isRestoring,
   onRestore,
   onDelete,
   onDeleteWorktree,
@@ -859,6 +923,7 @@ function TaskRowActions({
   stacked = false,
 }: {
   item: ArchiveItem;
+  isRestoring: boolean;
   onRestore: (item: ArchiveItem) => void;
   onDelete: (item: ArchiveItem) => void;
   onDeleteWorktree: (item: ArchiveItem) => void;
@@ -868,18 +933,24 @@ function TaskRowActions({
   return (
     <RowActions stacked={stacked}>
       {item.canRestore && (
-        <ActionButton telemetryControl="archive.item.restore" tone="primary" onClick={() => onRestore(item)}>
-          <RotateCcw className="h-3 w-3" />
+        <ActionButton
+          telemetryControl="archive.item.restore"
+          tone="primary"
+          onClick={() => onRestore(item)}
+          disabled={isRestoring}
+          ariaBusy={isRestoring}
+        >
+          <RotateCcw className={cn('h-3 w-3', isRestoring && 'animate-spin')} />
           {t('archive.actions.restore')}
         </ActionButton>
       )}
       {item.worktreeStatus === 'present' && item.worktreeManaged && !item.sharedWorktree && (
-        <ActionButton telemetryControl="archive.item.delete_worktree" tone="dangerOutline" onClick={() => onDeleteWorktree(item)} title={t('archive.actions.deleteWorktreeTooltip')}>
+        <ActionButton telemetryControl="archive.item.delete_worktree" tone="dangerOutline" onClick={() => onDeleteWorktree(item)} title={t('archive.actions.deleteWorktreeTooltip')} disabled={isRestoring}>
           <FolderX className="h-3 w-3" />
           {t('archive.actions.deleteWorktree')}
         </ActionButton>
       )}
-      <ActionButton telemetryControl="archive.item.delete" tone="dangerOutline" onClick={() => onDelete(item)}>
+      <ActionButton telemetryControl="archive.item.delete" tone="dangerOutline" onClick={() => onDelete(item)} disabled={isRestoring}>
         <Trash2 className="h-3 w-3" />
         {t('archive.actions.delete')}
       </ActionButton>
@@ -957,20 +1028,26 @@ function ActionButton({
   tone = 'neutral',
   onClick,
   title,
+  disabled = false,
+  ariaBusy = false,
 }: {
   children: React.ReactNode;
   telemetryControl: TelemetryUiControl;
   tone?: 'neutral' | 'primary' | 'danger' | 'dangerOutline';
   onClick: React.MouseEventHandler<HTMLButtonElement>;
   title?: string;
+  disabled?: boolean;
+  ariaBusy?: boolean;
 }) {
   return (
     <button
       {...telemetryClickAttributes(telemetryControl, 'archive')}
       onClick={onClick}
       title={title}
+      disabled={disabled}
+      aria-busy={ariaBusy}
       className={cn(
-        'inline-flex h-6 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors',
+        'inline-flex h-6 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors disabled:cursor-wait disabled:opacity-60',
         tone === 'primary'
           ? 'border-[color-mix(in_srgb,var(--accent)_28%,var(--divider))] bg-[color-mix(in_srgb,var(--accent)_10%,transparent)] text-(--accent) hover:bg-[color-mix(in_srgb,var(--accent)_16%,transparent)]'
           : tone === 'dangerOutline'
@@ -987,12 +1064,14 @@ function ActionButton({
 
 function ChatArchiveTable({
   items,
+  restoringItemIds,
   onOpen,
   onRestore,
   onDelete,
   t,
 }: {
   items: ArchiveItem[];
+  restoringItemIds: ReadonlySet<string>;
   onOpen: (item: ArchiveItem, sessionId?: string) => void;
   onRestore: (item: ArchiveItem) => void;
   onDelete: (item: ArchiveItem) => void;
@@ -1030,7 +1109,7 @@ function ChatArchiveTable({
                     label={t('archive.columns.archived')}
                     value={formatRelativeTime(item.archivedAt, t)}
                   />
-                  <ChatRowActions item={item} onRestore={onRestore} onDelete={onDelete} t={t} stacked />
+                  <ChatRowActions item={item} isRestoring={restoringItemIds.has(item.id)} onRestore={onRestore} onDelete={onDelete} t={t} stacked />
                 </td>
               </tr>
             ))}
@@ -1083,7 +1162,7 @@ function ChatArchiveTable({
                 {formatRelativeTime(item.archivedAt, t)}
               </td>
               <td className="h-10 px-3">
-                <ChatRowActions item={item} onRestore={onRestore} onDelete={onDelete} t={t} />
+                <ChatRowActions item={item} isRestoring={restoringItemIds.has(item.id)} onRestore={onRestore} onDelete={onDelete} t={t} />
               </td>
             </tr>
           ))}
@@ -1095,6 +1174,7 @@ function ChatArchiveTable({
 
 function TaskArchiveTable({
   items,
+  restoringItemIds,
   onOpenSession,
   onRestore,
   onDelete,
@@ -1102,6 +1182,7 @@ function TaskArchiveTable({
   t,
 }: {
   items: ArchiveItem[];
+  restoringItemIds: ReadonlySet<string>;
   onOpenSession: (item: ArchiveItem, sessionId: string) => void;
   onRestore: (item: ArchiveItem) => void;
   onDelete: (item: ArchiveItem) => void;
@@ -1140,6 +1221,7 @@ function TaskArchiveTable({
                   />
                   <TaskRowActions
                     item={item}
+                    isRestoring={restoringItemIds.has(item.id)}
                     onRestore={onRestore}
                     onDelete={onDelete}
                     onDeleteWorktree={onDeleteWorktree}
@@ -1198,6 +1280,7 @@ function TaskArchiveTable({
               <td className="px-3 py-2 align-top">
                 <TaskRowActions
                   item={item}
+                  isRestoring={restoringItemIds.has(item.id)}
                   onRestore={onRestore}
                   onDelete={onDelete}
                   onDeleteWorktree={onDeleteWorktree}

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -1007,9 +1007,12 @@ export const useTabStore = create<TabStore>()((set, get) => ({
         get().setActiveTab(existingPreview.id);
       }
       // 활성 패널의 세션을 교체
-      const tabData = panelStore.tabPanels[panelStore.activeTabId];
+      // setActiveTab() replaces the Zustand state object, so the snapshot read
+      // before the switch still points at the previously active tab.
+      const activePanelStore = usePanelStore.getState();
+      const tabData = activePanelStore.tabPanels[activePanelStore.activeTabId];
       if (tabData) {
-        panelStore.assignSession(
+        activePanelStore.assignSession(
           tabData.activePanelId,
           sessionId,
           inferSessionWorktreeId(sessionId, existingPreview.projectDir),

--- a/tests/archive-retention-restoration-contract.test.mjs
+++ b/tests/archive-retention-restoration-contract.test.mjs
@@ -83,3 +83,22 @@ test('retention days are committed only after editing finishes', () => {
     assert.match(source, /onBlur=\{\(\) => void commitRetentionDays\(\)\}/);
   }
 });
+
+test('Archive restore updates one row without replacing the dashboard with a full reload', () => {
+  const archive = read('src/components/archive/archive-dashboard.tsx');
+  const restoreStart = archive.indexOf('const restoreItem = useCallback');
+  const deleteStart = archive.indexOf('const deleteItem = useCallback', restoreStart);
+
+  assert.ok(restoreStart >= 0 && deleteStart > restoreStart);
+  const restoreHandler = archive.slice(restoreStart, deleteStart);
+
+  assert.doesNotMatch(
+    restoreHandler,
+    /loadArchive\(\)/,
+    'restoring one row must not put the whole Archive dashboard back into its loading screen',
+  );
+  assert.match(restoreHandler, /setRestoringItemIds/);
+  assert.match(restoreHandler, /removeRestoredArchiveItem/);
+  assert.match(archive, /ariaBusy=\{isRestoring\}/);
+  assert.match(archive, /isRestoring && 'animate-spin'/);
+});

--- a/tests/tab-session-open.test.ts
+++ b/tests/tab-session-open.test.ts
@@ -68,3 +68,47 @@ test('opening a session preserves an occupied selected tab', () => {
     'session-2',
   );
 });
+
+test('opening a session from another tab replaces the inactive session preview', () => {
+  const previewTabId = 'session-preview-tab';
+  const previewPanelId = 'session-preview-panel';
+  const archiveTabId = 'archive-tab';
+  const archivePanelId = 'archive-panel';
+
+  useTabStore.setState({
+    tabs: [
+      { id: previewTabId, projectDir: null, title: null, isPreview: true },
+      { id: archiveTabId, projectDir: null, title: 'Archive', isPreview: false },
+    ],
+    activeTabId: archiveTabId,
+    lruTabIds: [archiveTabId, previewTabId],
+  });
+  usePanelStore.setState({
+    tabPanels: {
+      [previewTabId]: {
+        layout: { type: 'leaf', panelId: previewPanelId },
+        panels: {
+          [previewPanelId]: { id: previewPanelId, sessionId: 'session-a' },
+        },
+        activePanelId: previewPanelId,
+      },
+      [archiveTabId]: {
+        layout: { type: 'leaf', panelId: archivePanelId },
+        panels: {
+          [archivePanelId]: { id: archivePanelId, sessionId: 'archive-dashboard' },
+        },
+        activePanelId: archivePanelId,
+      },
+    },
+    activeTabId: archiveTabId,
+  });
+
+  useTabStore.getState().openPreview('session-b');
+
+  assert.equal(useTabStore.getState().activeTabId, previewTabId);
+  assert.equal(usePanelStore.getState().activeTabId, previewTabId);
+  assert.equal(
+    usePanelStore.getState().tabPanels[previewTabId]?.panels[previewPanelId]?.sessionId,
+    'session-b',
+  );
+});


### PR DESCRIPTION
## Summary
- keep archive restore feedback scoped to the clicked row
- remove restored items locally instead of reloading the dashboard
- fix inactive preview replacement when opening archived sessions

## Verification
- node --test tests/archive-retention-restoration-contract.test.mjs
- tsx --test archive/session/tab regression tests
- tsc --noEmit
- eslint archive dashboard and contract test