### PR TITLE
feat(terminal): add native panel context actions

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,7 +8,6 @@ import {
   Menu,
   nativeTheme,
   screen,
-  type ContextMenuParams,
   type MenuItemConstructorOptions,
 } from 'electron';
 import { fork, ChildProcess, spawnSync } from 'child_process';
@@ -50,6 +49,11 @@ import {
   type RestorableWindowState,
   type WindowBounds,
 } from './window-layout-state';
+import {
+  buildWebContentsContextMenuTemplate,
+  resolveTerminalPanelAtPoint,
+} from './web-contents-context-menu';
+import type { PanelSplitPlacement } from '../src/lib/panel/panel-split';
 
 // Must run before getTesseraDataPath() or app.requestSingleInstanceLock().
 // Normal builds do not set the test instance env and keep the production path.
@@ -313,38 +317,59 @@ function buildTitlebarMenuTemplate(
   }
 }
 
-function menuItemEnabled(value: boolean | undefined): boolean {
-  return value ?? true;
+function sendTerminalPanelSplitCommand(
+  win: BrowserWindow,
+  panelId: string,
+  placement: PanelSplitPlacement,
+): void {
+  if (win.isDestroyed() || win.webContents.isDestroyed()) return;
+  win.webContents.send('terminal-panel-split-requested', { panelId, placement });
 }
 
-function buildWebContentsContextMenuTemplate(
-  params: ContextMenuParams
-): MenuItemConstructorOptions[] {
-  const { editFlags } = params;
+function sendTerminalPanelViewModeCommand(
+  win: BrowserWindow,
+  panelId: string,
+  mode: 'terminal' | 'chat',
+): void {
+  if (win.isDestroyed() || win.webContents.isDestroyed()) return;
+  win.webContents.send('terminal-panel-view-mode-requested', { panelId, mode });
+}
 
-  if (params.isEditable) {
-    return [
-      { role: 'undo', enabled: menuItemEnabled(editFlags.canUndo) },
-      { role: 'redo', enabled: menuItemEnabled(editFlags.canRedo) },
-      { type: 'separator' },
-      { role: 'cut', enabled: menuItemEnabled(editFlags.canCut) },
-      { role: 'copy', enabled: menuItemEnabled(editFlags.canCopy) },
-      { role: 'paste', enabled: menuItemEnabled(editFlags.canPaste) },
-      { role: 'delete', enabled: menuItemEnabled(editFlags.canDelete) },
-      { type: 'separator' },
-      { role: 'selectAll', enabled: menuItemEnabled(editFlags.canSelectAll) },
-    ];
-  }
+function attachWebContentsContextMenu(win: BrowserWindow): void {
+  win.webContents.on('context-menu', (_event, params) => {
+    void (async () => {
+      const terminalPanel = await resolveTerminalPanelAtPoint(params.frame, params.x, params.y);
+      if (win.isDestroyed() || win.webContents.isDestroyed()) return;
 
-  if (params.selectionText.length > 0) {
-    return [
-      { role: 'copy', enabled: menuItemEnabled(editFlags.canCopy) },
-      { type: 'separator' },
-      { role: 'selectAll', enabled: menuItemEnabled(editFlags.canSelectAll) },
-    ];
-  }
+      const template = buildWebContentsContextMenuTemplate(
+        params,
+        terminalPanel
+          ? {
+              panelId: terminalPanel.panelId,
+              onSplit: (targetPanelId, placement) => {
+                sendTerminalPanelSplitCommand(win, targetPanelId, placement);
+              },
+              viewMode: terminalPanel.viewMode ?? undefined,
+              onSwitchView: terminalPanel.viewMode
+                ? (targetPanelId, mode) => sendTerminalPanelViewModeCommand(
+                    win,
+                    targetPanelId,
+                    mode,
+                  )
+                : undefined,
+            }
+          : undefined,
+      );
+      if (template.length === 0) return;
 
-  return [];
+      const menu = Menu.buildFromTemplate(template);
+      menu.popup({
+        window: win,
+        x: params.x,
+        y: params.y,
+      });
+    })();
+  });
 }
 
 // ── Diagnostic log to file (visible on Windows) ─────────────────────────
@@ -1551,17 +1576,7 @@ function createWindow(port: number, restoredState?: RestorableWindowState): Brow
     return { action: 'deny' };
   });
 
-  win.webContents.on('context-menu', (_event, params) => {
-    const template = buildWebContentsContextMenuTemplate(params);
-    if (template.length === 0) return;
-
-    const menu = Menu.buildFromTemplate(template);
-    menu.popup({
-      window: win,
-      x: params.x,
-      y: params.y,
-    });
-  });
+  attachWebContentsContextMenu(win);
 
   // Windows asks in the renderer so the prompt matches the Tessera UI and can
   // remember the chosen behavior. Other platforms preserve tray behavior.
@@ -1657,12 +1672,7 @@ function createPopoutWindow(
     return { action: 'deny' };
   });
 
-  win.webContents.on('context-menu', (_event, params) => {
-    const template = buildWebContentsContextMenuTemplate(params);
-    if (template.length === 0) return;
-    const menu = Menu.buildFromTemplate(template);
-    menu.popup({ window: win, x: params.x, y: params.y });
-  });
+  attachWebContentsContextMenu(win);
 
   popoutWindows.add(win);
   popoutRoutes.set(win, route);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,6 +2,14 @@ import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import type { PairingDecision } from '../src/lib/auth/pairing-contract';
 import type { TerminalClipboardPayload } from '../src/lib/terminal/terminal-clipboard-paste';
 
+type PanelSplitPlacement = 'left' | 'right' | 'up' | 'down';
+
+// Sandboxed Electron preload scripts cannot load arbitrary compiled sibling
+// modules at runtime. Keep this tiny boundary validator local to the preload.
+function isPanelSplitPlacement(value: unknown): value is PanelSplitPlacement {
+  return value === 'left' || value === 'right' || value === 'up' || value === 'down';
+}
+
 contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
   isElectron: true,
@@ -27,6 +35,40 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('read-terminal-clipboard') as Promise<TerminalClipboardPayload>,
   writeTerminalClipboardText: (text: string) =>
     ipcRenderer.invoke('write-terminal-clipboard-text', text) as Promise<void>,
+  onTerminalPanelSplitRequested: (
+    callback: (payload: { panelId: string; placement: PanelSplitPlacement }) => void,
+  ) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: { panelId?: unknown; placement?: unknown },
+    ) => {
+      if (typeof payload?.panelId !== 'string' || !isPanelSplitPlacement(payload.placement)) return;
+      callback({ panelId: payload.panelId, placement: payload.placement });
+    };
+    ipcRenderer.on('terminal-panel-split-requested', listener);
+    return () => {
+      ipcRenderer.removeListener('terminal-panel-split-requested', listener);
+    };
+  },
+  onTerminalPanelViewModeRequested: (
+    callback: (payload: { panelId: string; mode: 'terminal' | 'chat' }) => void,
+  ) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: { panelId?: unknown; mode?: unknown },
+    ) => {
+      if (
+        typeof payload?.panelId === 'string'
+        && (payload.mode === 'terminal' || payload.mode === 'chat')
+      ) {
+        callback({ panelId: payload.panelId, mode: payload.mode });
+      }
+    };
+    ipcRenderer.on('terminal-panel-view-mode-requested', listener);
+    return () => {
+      ipcRenderer.removeListener('terminal-panel-view-mode-requested', listener);
+    };
+  },
   uiStorageGetItem: (key: string) => ipcRenderer.sendSync('ui-storage-get-item', key) as string | null,
   uiStorageSetItem: (key: string, value: string) =>
     ipcRenderer.sendSync('ui-storage-set-item', { key, value }),

--- a/electron/web-contents-context-menu.ts
+++ b/electron/web-contents-context-menu.ts
@@ -1,0 +1,150 @@
+import type { ContextMenuParams, MenuItemConstructorOptions } from 'electron';
+import type { PanelSplitPlacement } from '../src/lib/panel/panel-split';
+
+interface TerminalPanelContextMenuOptions {
+  panelId: string;
+  onSplit: (panelId: string, placement: PanelSplitPlacement) => void;
+  viewMode?: 'terminal' | 'chat';
+  onSwitchView?: (panelId: string, mode: 'terminal' | 'chat') => void;
+}
+
+interface FrameScriptRunner {
+  isDestroyed(): boolean;
+  executeJavaScript(code: string): Promise<unknown>;
+}
+
+const TERMINAL_PANEL_MENU_COPY = {
+  switchToChatView: 'Switch to Chat View',
+  switchToTerminalView: 'Switch to PTY View',
+  splitPanel: 'Split Panel',
+  placements: {
+    left: 'New Panel on Left',
+    right: 'New Panel on Right',
+    up: 'New Panel Above',
+    down: 'New Panel Below',
+  },
+};
+
+const SPLIT_PLACEMENTS: PanelSplitPlacement[] = ['left', 'right', 'up', 'down'];
+
+function menuItemEnabled(value: boolean | undefined): boolean {
+  return value ?? true;
+}
+
+export function buildWebContentsContextMenuTemplate(
+  params: ContextMenuParams,
+  terminalPanel?: TerminalPanelContextMenuOptions,
+): MenuItemConstructorOptions[] {
+  if (terminalPanel) {
+    return [
+      ...(terminalPanel.onSwitchView && terminalPanel.viewMode
+        ? [{
+            label: terminalPanel.viewMode === 'chat'
+              ? TERMINAL_PANEL_MENU_COPY.switchToTerminalView
+              : TERMINAL_PANEL_MENU_COPY.switchToChatView,
+            click: () => terminalPanel.onSwitchView?.(
+              terminalPanel.panelId,
+              terminalPanel.viewMode === 'chat' ? 'terminal' : 'chat',
+            ),
+          }, { type: 'separator' as const }]
+        : []),
+      {
+        label: TERMINAL_PANEL_MENU_COPY.splitPanel,
+        submenu: SPLIT_PLACEMENTS.map((placement) => ({
+          label: TERMINAL_PANEL_MENU_COPY.placements[placement],
+          click: () => terminalPanel.onSplit(terminalPanel.panelId, placement),
+        })),
+      },
+    ];
+  }
+
+  const { editFlags } = params;
+  let template: MenuItemConstructorOptions[];
+
+  if (params.isEditable) {
+    template = [
+      { role: 'undo', enabled: menuItemEnabled(editFlags.canUndo) },
+      { role: 'redo', enabled: menuItemEnabled(editFlags.canRedo) },
+      { type: 'separator' },
+      { role: 'cut', enabled: menuItemEnabled(editFlags.canCut) },
+      { role: 'copy', enabled: menuItemEnabled(editFlags.canCopy) },
+      { role: 'paste', enabled: menuItemEnabled(editFlags.canPaste) },
+      { role: 'delete', enabled: menuItemEnabled(editFlags.canDelete) },
+      { type: 'separator' },
+      { role: 'selectAll', enabled: menuItemEnabled(editFlags.canSelectAll) },
+    ];
+  } else if (params.selectionText.length > 0) {
+    template = [
+      { role: 'copy', enabled: menuItemEnabled(editFlags.canCopy) },
+      { type: 'separator' },
+      { role: 'selectAll', enabled: menuItemEnabled(editFlags.canSelectAll) },
+    ];
+  } else {
+    template = [];
+  }
+
+  return template;
+}
+
+/**
+ * Resolve the terminal panel at the native-menu coordinates without replacing
+ * Electron's edit-aware context menu with a renderer imitation. The matching
+ * wrapper check excludes embedded log/preview terminals that cannot be split.
+ */
+export async function resolveTerminalPanelAtPoint(
+  frame: FrameScriptRunner | null,
+  x: number,
+  y: number,
+): Promise<{ panelId: string; viewMode: 'terminal' | 'chat' | null } | null> {
+  if (!frame || frame.isDestroyed()) return null;
+
+  const script = `(() => {
+    const target = document.elementFromPoint(${JSON.stringify(x)}, ${JSON.stringify(y)});
+    const terminal = target instanceof Element
+      ? target.closest('[data-terminal-panel-id]')
+      : null;
+    const sessionSurface = target instanceof Element
+      ? target.closest('[data-terminal-session-panel-id]')
+      : null;
+    const context = terminal ?? sessionSurface;
+    const wrapper = context?.closest('[data-panel-wrapper="true"][data-panel-id]');
+    const terminalPanelId = terminal instanceof HTMLElement
+      ? terminal.dataset.terminalPanelId
+      : sessionSurface instanceof HTMLElement
+        ? sessionSurface.dataset.terminalSessionPanelId
+      : undefined;
+    const wrapperPanelId = wrapper instanceof HTMLElement
+      ? wrapper.dataset.panelId
+      : undefined;
+    return terminalPanelId && terminalPanelId === wrapperPanelId
+      ? {
+          panelId: terminalPanelId,
+          viewMode: sessionSurface instanceof HTMLElement
+            && sessionSurface.dataset.terminalChatViewAvailable === 'true'
+            && (sessionSurface.dataset.terminalViewMode === 'terminal'
+              || sessionSurface.dataset.terminalViewMode === 'chat')
+              ? sessionSurface.dataset.terminalViewMode
+              : terminal instanceof HTMLElement
+                && terminal.dataset.terminalChatViewAvailable === 'true'
+                ? 'terminal'
+                : null,
+        }
+      : null;
+  })()`;
+
+  try {
+    const result = await frame.executeJavaScript(script);
+    if (!result || typeof result !== 'object') return null;
+    const candidate = result as { panelId?: unknown; viewMode?: unknown };
+    return typeof candidate.panelId === 'string'
+      && candidate.panelId.length > 0
+      && candidate.panelId.length <= 128
+      && (candidate.viewMode === null
+        || candidate.viewMode === 'terminal'
+        || candidate.viewMode === 'chat')
+      ? { panelId: candidate.panelId, viewMode: candidate.viewMode }
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -292,7 +292,14 @@ export const ChatArea = memo(function ChatArea({
     connectionStatus !== "connected" || sessionStatus === "error";
 
   return (
-    <div className="flex-1 flex flex-col h-full bg-(--chat-bg)">
+    <div
+      className="flex-1 flex flex-col h-full bg-(--chat-bg)"
+      data-terminal-session-panel-id={isTerminalSession ? panelId : undefined}
+      data-terminal-chat-view-available={canToggleTerminalChatView ? 'true' : undefined}
+      data-terminal-view-mode={canToggleTerminalChatView
+        ? (isTerminalChatView ? 'chat' : 'terminal')
+        : undefined}
+    >
       {!isPeek && shouldShowSessionHeader({
         isTerminalSession,
         isSinglePanel,
@@ -342,6 +349,7 @@ export const ChatArea = memo(function ChatArea({
               directInputDrop={isPeek}
               startupOverlay={shouldShowPeekLoading ? <SessionPeekLoading /> : undefined}
               launch={{ providerId: sessionProvider, sessionId }}
+              chatViewAvailable={canToggleTerminalChatView}
             />
           ) : null
         ) : (

--- a/src/components/chat/panel-split-picker.tsx
+++ b/src/components/chat/panel-split-picker.tsx
@@ -11,9 +11,7 @@ import { useAnchoredPopover } from '@/hooks/use-anchored-popover';
 import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
 import type { ShortcutId } from '@/lib/keyboard/registry';
 import { telemetryClickAttributes } from '@/lib/telemetry/ui-click';
-
-const MIN_PANEL_WIDTH = 250;
-const MIN_PANEL_HEIGHT = 150;
+import { isPanelLargeEnoughToSplit } from '@/lib/panel/panel-split';
 
 interface FixedPopoverPosition {
   right: number;
@@ -135,16 +133,9 @@ export function PanelSplitPicker({ sessionId, compact = false }: PanelSplitPicke
     }
 
     const rect = getPanelRect(currentPanelId);
-    if (rect) {
-      if (direction === 'horizontal' && rect.width / 2 < MIN_PANEL_WIDTH) {
-        toast.warning(t('panel.tooSmallToSplit'));
-        return;
-      }
-
-      if (direction === 'vertical' && rect.height / 2 < MIN_PANEL_HEIGHT) {
-        toast.warning(t('panel.tooSmallToSplit'));
-        return;
-      }
+    if (rect && !isPanelLargeEnoughToSplit(rect, direction)) {
+      toast.warning(t('panel.tooSmallToSplit'));
+      return;
     }
 
     setActivePanelId(currentPanelId);

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -19,6 +19,7 @@ import { TabIdContext, usePanelStore } from '@/stores/panel-store';
 import { useTabStore } from '@/stores/tab-store';
 import { useChatStore } from '@/stores/chat-store';
 import { useSettingsStore } from '@/stores/settings-store';
+import { useTerminalViewModeStore } from '@/stores/terminal-view-mode-store';
 import { getSessionSelectionId } from '@/lib/constants/special-sessions';
 import { getInitialTerminalCwd } from '@/lib/terminal/client-terminal-cwd';
 import {
@@ -57,6 +58,14 @@ import {
 } from '@/types/panel';
 import { PanelDropZone } from '@/components/panel/panel-drop-zone';
 import { telemetryClickAttributes, telemetryIgnoreAttributes } from '@/lib/telemetry/ui-click';
+import {
+  getPanelSplitSpec,
+  isPanelLargeEnoughToSplit,
+} from '@/lib/panel/panel-split';
+import {
+  subscribeToTerminalPanelViewModeRequests,
+  subscribeToTerminalPanelSplitRequests,
+} from '@/lib/panel/electron-terminal-panel-context-menu';
 
 interface TerminalPanelProps {
   panelId: string;
@@ -86,6 +95,8 @@ interface TerminalPanelProps {
    * on a run somebody else started raises a question it cannot answer.
    */
   showHeader?: boolean;
+  /** Expose the native-menu transition to this session's transcript-backed chat surface. */
+  chatViewAvailable?: boolean;
 }
 
 function isTerminalAssignedToPanel(
@@ -120,6 +131,7 @@ export function TerminalPanel({
   startupOverlay,
   launch,
   showHeader = true,
+  chatViewAvailable = false,
 }: TerminalPanelProps) {
   const tabId = useContext(TabIdContext);
   const { t } = useTranslation();
@@ -340,6 +352,37 @@ export function TerminalPanel({
     }
   }, [runtimeOwnership, surface, terminalSessionId]);
 
+  useEffect(function subscribeToTerminalPanelContextMenu() {
+    return subscribeToTerminalPanelSplitRequests((request) => {
+      if (request.panelId !== panelId) return;
+
+      const wrapper = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-panel-wrapper="true"][data-panel-id]'),
+      ).find((element) => element.dataset.panelId === panelId);
+      const { direction, position } = getPanelSplitSpec(request.placement);
+      if (wrapper && !isPanelLargeEnoughToSplit(wrapper.getBoundingClientRect(), direction)) {
+        toast.warning(t('panel.tooSmallToSplit'));
+        return;
+      }
+
+      const panelStore = usePanelStore.getState();
+      panelStore.setActivePanelId(panelId);
+      const newPanelId = panelStore.splitPanel(panelId, direction, null, position);
+      if (!newPanelId) return;
+
+      const tabStore = useTabStore.getState();
+      tabStore.pinTab(tabStore.activeTabId);
+    });
+  }, [panelId, t]);
+
+  useEffect(function subscribeToTerminalPanelViewModeContextMenu() {
+    if (!chatViewAvailable || !terminalSessionId) return;
+    return subscribeToTerminalPanelViewModeRequests((request) => {
+      if (request.panelId !== panelId) return;
+      useTerminalViewModeStore.getState().setMode(terminalSessionId, request.mode);
+    });
+  }, [chatViewAvailable, panelId, terminalSessionId]);
+
   const handlePanelDragStart = useCallback((event: DragEvent<HTMLElement>) => {
     const didSet = setPanelNodeDragData(event.dataTransfer, { tabId, panelId });
     if (!didSet) event.preventDefault();
@@ -424,6 +467,8 @@ export function TerminalPanel({
     <div
       className="relative flex h-full min-h-0 flex-col"
       data-testid="terminal-panel"
+      data-terminal-panel-id={panelId}
+      data-terminal-chat-view-available={chatViewAvailable ? 'true' : undefined}
       style={{ backgroundColor: terminalTheme.background, color: terminalTheme.foreground }}
       onDragEnter={directInputDrop ? handleInputDragEnter : undefined}
       onDragOver={directInputDrop ? handleInputDragOver : undefined}

--- a/src/lib/panel/electron-terminal-panel-context-menu.ts
+++ b/src/lib/panel/electron-terminal-panel-context-menu.ts
@@ -1,0 +1,74 @@
+import type { PanelSplitPlacement } from './panel-split';
+
+export interface TerminalPanelSplitRequest {
+  panelId: string;
+  placement: PanelSplitPlacement;
+}
+
+type TerminalPanelSplitListener = (request: TerminalPanelSplitRequest) => void;
+
+interface ElectronTerminalPanelContextMenuApi {
+  onTerminalPanelSplitRequested?: (
+    callback: TerminalPanelSplitListener,
+  ) => (() => void) | void;
+  onTerminalPanelViewModeRequested?: (
+    callback: (request: { panelId: string; mode: 'terminal' | 'chat' }) => void,
+  ) => (() => void) | void;
+}
+
+const listeners = new Set<TerminalPanelSplitListener>();
+let releaseElectronListener: (() => void) | null = null;
+const viewModeListeners = new Set<(
+  request: { panelId: string; mode: 'terminal' | 'chat' },
+) => void>();
+let releaseViewModeElectronListener: (() => void) | null = null;
+
+function getElectronApi(): ElectronTerminalPanelContextMenuApi | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return (window as Window & { electronAPI?: ElectronTerminalPanelContextMenuApi }).electronAPI;
+}
+
+function dispatchRequest(request: TerminalPanelSplitRequest): void {
+  for (const listener of listeners) listener(request);
+}
+
+/** Keep one ipcRenderer listener per renderer, regardless of mounted terminal count. */
+export function subscribeToTerminalPanelSplitRequests(
+  listener: TerminalPanelSplitListener,
+): () => void {
+  listeners.add(listener);
+
+  if (listeners.size === 1) {
+    const release = getElectronApi()?.onTerminalPanelSplitRequested?.(dispatchRequest);
+    releaseElectronListener = typeof release === 'function' ? release : null;
+  }
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      releaseElectronListener?.();
+      releaseElectronListener = null;
+    }
+  };
+}
+
+export function subscribeToTerminalPanelViewModeRequests(
+  listener: (request: { panelId: string; mode: 'terminal' | 'chat' }) => void,
+): () => void {
+  viewModeListeners.add(listener);
+
+  if (viewModeListeners.size === 1) {
+    const release = getElectronApi()?.onTerminalPanelViewModeRequested?.((request) => {
+      for (const currentListener of viewModeListeners) currentListener(request);
+    });
+    releaseViewModeElectronListener = typeof release === 'function' ? release : null;
+  }
+
+  return () => {
+    viewModeListeners.delete(listener);
+    if (viewModeListeners.size === 0) {
+      releaseViewModeElectronListener?.();
+      releaseViewModeElectronListener = null;
+    }
+  };
+}

--- a/src/lib/panel/panel-split.ts
+++ b/src/lib/panel/panel-split.ts
@@ -1,0 +1,35 @@
+export const MIN_PANEL_WIDTH = 250;
+export const MIN_PANEL_HEIGHT = 150;
+
+export type PanelSplitDirection = 'horizontal' | 'vertical';
+export type PanelSplitPosition = 'before' | 'after';
+export type PanelSplitPlacement = 'left' | 'right' | 'up' | 'down';
+
+export interface PanelSplitSpec {
+  direction: PanelSplitDirection;
+  position: PanelSplitPosition;
+}
+
+const PANEL_SPLIT_SPECS: Record<PanelSplitPlacement, PanelSplitSpec> = {
+  left: { direction: 'horizontal', position: 'before' },
+  right: { direction: 'horizontal', position: 'after' },
+  up: { direction: 'vertical', position: 'before' },
+  down: { direction: 'vertical', position: 'after' },
+};
+
+export function isPanelSplitPlacement(value: unknown): value is PanelSplitPlacement {
+  return value === 'left' || value === 'right' || value === 'up' || value === 'down';
+}
+
+export function getPanelSplitSpec(placement: PanelSplitPlacement): PanelSplitSpec {
+  return PANEL_SPLIT_SPECS[placement];
+}
+
+export function isPanelLargeEnoughToSplit(
+  rect: Pick<DOMRect, 'width' | 'height'>,
+  direction: PanelSplitDirection,
+): boolean {
+  return direction === 'horizontal'
+    ? rect.width / 2 >= MIN_PANEL_WIDTH
+    : rect.height / 2 >= MIN_PANEL_HEIGHT;
+}

--- a/tests/electron-context-menu-contract.test.mjs
+++ b/tests/electron-context-menu-contract.test.mjs
@@ -2,16 +2,16 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import test from 'node:test';
 
-const electronMainSource = fs.readFileSync(
-  new URL('../electron/main.ts', import.meta.url),
+const contextMenuSource = fs.readFileSync(
+  new URL('../electron/web-contents-context-menu.ts', import.meta.url),
   'utf8',
 );
 
 test('Electron context menu does not show Select All for inert app chrome', () => {
-  assert.match(electronMainSource, /if \(params\.isEditable\) \{/);
-  assert.match(electronMainSource, /if \(params\.selectionText\.length > 0\) \{/);
+  assert.match(contextMenuSource, /if \(params\.isEditable\) \{/);
+  assert.match(contextMenuSource, /params\.selectionText\.length > 0/);
   assert.doesNotMatch(
-    electronMainSource,
+    contextMenuSource,
     /if \(editFlags\.canSelectAll\) \{\s*return \[\{ role: 'selectAll' \}\];\s*\}/,
   );
 });

--- a/tests/electron-terminal-context-menu.test.ts
+++ b/tests/electron-terminal-context-menu.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ContextMenuParams, MenuItemConstructorOptions } from 'electron';
+import {
+  buildWebContentsContextMenuTemplate,
+  resolveTerminalPanelAtPoint,
+} from '../electron/web-contents-context-menu';
+
+function editableParams(): ContextMenuParams {
+  return {
+    isEditable: true,
+    selectionText: '',
+    editFlags: {
+      canUndo: true,
+      canRedo: false,
+      canCut: true,
+      canCopy: true,
+      canPaste: true,
+      canDelete: true,
+      canSelectAll: true,
+    },
+  } as ContextMenuParams;
+}
+
+test('replaces native edit actions with terminal-only view and split actions', () => {
+  const splits: string[] = [];
+  const viewModes: string[] = [];
+  const template = buildWebContentsContextMenuTemplate(editableParams(), {
+    panelId: 'panel-1',
+    onSplit: (panelId, placement) => splits.push(`${panelId}:${placement}`),
+    viewMode: 'terminal',
+    onSwitchView: (panelId, mode) => viewModes.push(`${panelId}:${mode}`),
+  });
+
+  assert.equal(template.length, 3);
+  assert.equal(template[0]?.label, 'Switch to Chat View');
+  assert.equal(template[1]?.type, 'separator');
+  const splitMenu = template.at(-1);
+  assert.equal(splitMenu?.label, 'Split Panel');
+
+  const submenu = splitMenu?.submenu as MenuItemConstructorOptions[];
+  assert.deepEqual(submenu.map((item) => item.label), [
+    'New Panel on Left',
+    'New Panel on Right',
+    'New Panel Above',
+    'New Panel Below',
+  ]);
+  (submenu[0].click as () => void)();
+  (submenu[3].click as () => void)();
+  (template[0].click as () => void)();
+  assert.deepEqual(splits, ['panel-1:left', 'panel-1:down']);
+  assert.deepEqual(viewModes, ['panel-1:chat']);
+  assert.equal(template.some((item) => item.role === 'undo' || item.role === 'copy'), false);
+});
+
+test('offers the reverse transition while the terminal chat view is visible', () => {
+  const viewModes: string[] = [];
+  const template = buildWebContentsContextMenuTemplate(editableParams(), {
+    panelId: 'panel-1',
+    viewMode: 'chat',
+    onSwitchView: (panelId, mode) => viewModes.push(`${panelId}:${mode}`),
+    onSplit: () => undefined,
+  });
+
+  assert.equal(template[0]?.label, 'Switch to PTY View');
+  (template[0].click as () => void)();
+  assert.deepEqual(viewModes, ['panel-1:terminal']);
+});
+
+test('keeps the existing native menu unchanged outside a terminal panel', () => {
+  const template = buildWebContentsContextMenuTemplate(editableParams());
+  assert.equal(template.at(-1)?.role, 'selectAll');
+  assert.equal(template.some((item) => item.label === 'Split panel'), false);
+});
+
+test('resolves only panel ids returned by the matching terminal wrapper query', async () => {
+  let evaluated = '';
+  const frame = {
+    isDestroyed: () => false,
+    executeJavaScript: async (script: string) => {
+      evaluated = script;
+      return { panelId: 'panel-1', viewMode: 'chat' };
+    },
+  };
+
+  assert.deepEqual(await resolveTerminalPanelAtPoint(frame, 42, 84), {
+    panelId: 'panel-1',
+    viewMode: 'chat',
+  });
+  assert.match(evaluated, /elementFromPoint\(42, 84\)/);
+  assert.match(evaluated, /data-terminal-panel-id/);
+  assert.match(evaluated, /data-panel-wrapper/);
+  assert.match(evaluated, /terminalChatViewAvailable/);
+  assert.match(evaluated, /data-terminal-session-panel-id/);
+  assert.equal(await resolveTerminalPanelAtPoint(null, 42, 84), null);
+});

--- a/tests/panel-split.test.ts
+++ b/tests/panel-split.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  getPanelSplitSpec,
+  isPanelLargeEnoughToSplit,
+  isPanelSplitPlacement,
+} from '@/lib/panel/panel-split';
+
+test('maps all four placements onto the panel store split model', () => {
+  assert.deepEqual(getPanelSplitSpec('left'), { direction: 'horizontal', position: 'before' });
+  assert.deepEqual(getPanelSplitSpec('right'), { direction: 'horizontal', position: 'after' });
+  assert.deepEqual(getPanelSplitSpec('up'), { direction: 'vertical', position: 'before' });
+  assert.deepEqual(getPanelSplitSpec('down'), { direction: 'vertical', position: 'after' });
+});
+
+test('validates split placement values crossing the Electron bridge', () => {
+  assert.equal(isPanelSplitPlacement('left'), true);
+  assert.equal(isPanelSplitPlacement('down'), true);
+  assert.equal(isPanelSplitPlacement('center'), false);
+  assert.equal(isPanelSplitPlacement(null), false);
+});
+
+test('requires enough room for both resulting panels', () => {
+  assert.equal(isPanelLargeEnoughToSplit({ width: 500, height: 300 }, 'horizontal'), true);
+  assert.equal(isPanelLargeEnoughToSplit({ width: 499, height: 300 }, 'horizontal'), false);
+  assert.equal(isPanelLargeEnoughToSplit({ width: 500, height: 300 }, 'vertical'), true);
+  assert.equal(isPanelLargeEnoughToSplit({ width: 500, height: 299 }, 'vertical'), false);
+});


### PR DESCRIPTION
## Summary
- replace nonfunctional PTY edit actions with terminal-specific native context actions
- add four-direction panel splitting from PTY and terminal Chat View
- add bidirectional PTY / Chat View switching for supported providers
- preserve the standard native edit menu outside terminal-backed panels

## Verification
- `npx tsx --test tests/electron-terminal-context-menu.test.ts tests/panel-split.test.ts`
- `node --test tests/electron-context-menu-contract.test.mjs`
- `npm run electron:compile`
- `npx tsc --noEmit`
- targeted ESLint
- packaged Windows Electron + WSL CLI smoke test