### PR TITLE
feat(tabs): add adjacent navigation shortcuts

### DIFF
--- a/src/components/keyboard/shortcut-tooltip.tsx
+++ b/src/components/keyboard/shortcut-tooltip.tsx
@@ -12,16 +12,26 @@ import type { ShortcutId } from '@/lib/keyboard/registry';
 export interface ShortcutTooltipProps {
   id: ShortcutId;
   label: string;
+  secondaryId?: ShortcutId;
+  secondaryLabel?: string;
   /** Override platform detection. Used in tests. */
   platform?: Platform;
   children: ReactElement;
 }
 
-export function ShortcutTooltip({ id, label, platform, children }: ShortcutTooltipProps) {
+export function ShortcutTooltip({
+  id,
+  label,
+  secondaryId,
+  secondaryLabel,
+  platform,
+  children,
+}: ShortcutTooltipProps) {
   const { t } = useI18n();
   const electronPlatform = useElectronPlatform();
   const isWebMode = !electronPlatform;
   const key = useEffectiveShortcut(id);
+  const secondaryKey = useEffectiveShortcut(secondaryId ?? id);
   const plat = platform ?? detectPlatform();
   const tooltipId = useId();
   const [open, setOpen] = useState(false);
@@ -29,6 +39,13 @@ export function ShortcutTooltip({ id, label, platform, children }: ShortcutToolt
 
   const formatted = key ? formatShortcut(key, plat) : '';
   const conflict = isWebMode && key !== null && isBrowserConflict(key);
+  const secondaryConflict = secondaryId
+    && isWebMode
+    && secondaryKey !== null
+    && isBrowserConflict(secondaryKey);
+  const secondaryFormatted = secondaryId && secondaryKey
+    ? formatShortcut(secondaryKey, plat)
+    : '';
 
   type ChildProps = {
     onMouseEnter?: (e: MouseEvent<HTMLElement>) => void;
@@ -49,7 +66,7 @@ export function ShortcutTooltip({ id, label, platform, children }: ShortcutToolt
     // so only our ShortcutTooltip shows. An empty `title` on the hovered element
     // stops the browser from walking up to a parent's title.
     title: '',
-    'aria-keyshortcuts': key ?? undefined,
+    'aria-keyshortcuts': [key, secondaryId ? secondaryKey : null].filter(Boolean).join(' ') || undefined,
     'aria-describedby': open ? tooltipId : undefined,
     onMouseEnter: (e: MouseEvent<HTMLElement>) => {
       positionFromTrigger(e.currentTarget);
@@ -78,12 +95,25 @@ export function ShortcutTooltip({ id, label, platform, children }: ShortcutToolt
       className="fixed z-[2147483647] rounded-md bg-(--tooltip-bg) px-2.5 py-1 text-xs text-white shadow-md pointer-events-none -translate-x-1/2 whitespace-nowrap"
       style={{ top: position.top, left: position.left }}
     >
-      {label}
-      {formatted && <span className="ml-1.5 opacity-60">{formatted}</span>}
-      {conflict && (
-        <span className="ml-1.5 text-(--warning)" title={t('shortcut.browserConflict')}>
-          ⚠
-        </span>
+      <div>
+        {label}
+        {formatted && <span className="ml-1.5 opacity-60">{formatted}</span>}
+        {conflict && (
+          <span className="ml-1.5 text-(--warning)" title={t('shortcut.browserConflict')}>
+            ⚠
+          </span>
+        )}
+      </div>
+      {secondaryId && secondaryLabel && (
+        <div>
+          {secondaryLabel}
+          {secondaryFormatted && <span className="ml-1.5 opacity-60">{secondaryFormatted}</span>}
+          {secondaryConflict && (
+            <span className="ml-1.5 text-(--warning)" title={t('shortcut.browserConflict')}>
+              ⚠
+            </span>
+          )}
+        </div>
       )}
     </div>
   ) : null;

--- a/src/components/tab/tab-item.tsx
+++ b/src/components/tab/tab-item.tsx
@@ -625,9 +625,16 @@ export const TabItem = memo(function TabItem({
           autoFocus
         />
       ) : (
-        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
-          {label}
-        </span>
+        <ShortcutTooltip
+          id="prev-tab"
+          label={t('shortcut.prevTab')}
+          secondaryId="next-tab"
+          secondaryLabel={t('shortcut.nextTab')}
+        >
+          <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
+            {label}
+          </span>
+        </ShortcutTooltip>
       )}
 
       {/* Close button — always visible (BR-UI-024) */}

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -28,6 +28,7 @@ import { i18n } from '@/lib/i18n';
 import { supportsTerminalChatView } from '@/lib/terminal/terminal-chat-view-support';
 import { v4 as uuidv4 } from 'uuid';
 import { openSingletonNewTab } from '@/lib/tab/open-singleton-new-tab';
+import { getAdjacentTabId, type TabNavigationDirection } from '@/lib/tab/adjacent-tab';
 import { captureTelemetryEvent } from '@/lib/telemetry/client';
 
 export interface UseKeyboardShortcutsOptions {
@@ -147,6 +148,12 @@ export function useKeyboardShortcuts(_options: UseKeyboardShortcutsOptions = {})
     closeTab(id);
   }, []);
 
+  const handleNavigateTab = useCallback((direction: TabNavigationDirection) => {
+    const tabStore = useTabStore.getState();
+    const targetTabId = getAdjacentTabId(tabStore.tabs, tabStore.activeTabId, direction);
+    if (targetTabId) tabStore.setActiveTab(targetTabId);
+  }, []);
+
   const handleToggleSidebar = useCallback(() => {
     settingsStore.toggleSidebar();
   }, [settingsStore]);
@@ -228,6 +235,8 @@ export function useKeyboardShortcuts(_options: UseKeyboardShortcutsOptions = {})
   const handlers: Partial<Record<ShortcutId, () => void | Promise<void>>> = {
     'new-tab':        handleNewTab,
     'close-tab':      handleCloseTab,
+    'prev-tab':       () => handleNavigateTab('previous'),
+    'next-tab':       () => handleNavigateTab('next'),
     'toggle-sidebar': handleToggleSidebar,
     'toggle-view':    handleToggleView,
     'toggle-terminal-view': handleToggleTerminalView,
@@ -263,7 +272,7 @@ export function useKeyboardShortcuts(_options: UseKeyboardShortcutsOptions = {})
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     overrides,
-    handleNewTab, handleCloseTab,
+    handleNewTab, handleCloseTab, handleNavigateTab,
     handleToggleSidebar, handleToggleView, handleToggleTerminalView,
     handleSplitRight, handleSplitDown,
     handleToggleTerminal, handleFocusPanel,

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -824,6 +824,8 @@ export const en: I18nMessages = {
   shortcut: {
     newTab: 'New Tab',
     closeTab: 'Close Tab',
+    prevTab: 'Switch to Previous Tab',
+    nextTab: 'Switch to Next Tab',
     toggleSidebar: 'Toggle Sidebar',
     toggleView: 'Toggle List / Board View',
     toggleTerminalView: 'Toggle PTY Chat / Terminal View',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -824,6 +824,8 @@ export const ja: I18nMessages = {
   shortcut: {
     newTab: '新規タブ',
     closeTab: 'タブを閉じる',
+    prevTab: '前のタブに切り替え',
+    nextTab: '次のタブに切り替え',
     toggleSidebar: 'サイドバー切替',
     toggleView: 'リスト/ボード表示切替',
     toggleTerminalView: 'PTYチャット/ターミナル表示切替',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -826,6 +826,8 @@ export const ko: I18nMessages = {
   shortcut: {
     newTab: '새 탭',
     closeTab: '탭 닫기',
+    prevTab: '이전 탭으로 이동',
+    nextTab: '다음 탭으로 이동',
     toggleSidebar: '사이드바 토글',
     toggleView: '리스트/보드 뷰 전환',
     toggleTerminalView: 'PTY 채팅/터미널 보기 전환',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -801,6 +801,8 @@ export interface I18nMessages {
   shortcut: {
     newTab: string;
     closeTab: string;
+    prevTab: string;
+    nextTab: string;
     toggleSidebar: string;
     toggleView: string;
     toggleTerminalView: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -824,6 +824,8 @@ export const zh: I18nMessages = {
   shortcut: {
     newTab: '新标签',
     closeTab: '关闭标签',
+    prevTab: '切换到上一个标签',
+    nextTab: '切换到下一个标签',
     toggleSidebar: '切换侧边栏',
     toggleView: '切换列表/看板视图',
     toggleTerminalView: '切换 PTY 聊天/终端视图',

--- a/src/lib/keyboard/registry.ts
+++ b/src/lib/keyboard/registry.ts
@@ -11,6 +11,8 @@ export interface ShortcutDefinition {
 export const SHORTCUT_REGISTRY = {
   'new-tab':        { default: '$mod+Alt+t',          category: 'tab',   descKey: 'shortcut.newTab' },
   'close-tab':      { default: '$mod+Alt+w',          category: 'tab',   descKey: 'shortcut.closeTab' },
+  'prev-tab':       { default: 'Control+Alt+Shift+PageUp',   category: 'tab', descKey: 'shortcut.prevTab' },
+  'next-tab':       { default: 'Control+Alt+Shift+PageDown', category: 'tab', descKey: 'shortcut.nextTab' },
   'toggle-sidebar': { default: '$mod+Alt+b',          category: 'view',  descKey: 'shortcut.toggleSidebar' },
   'toggle-view':    { default: '$mod+Alt+k',          category: 'view',  descKey: 'shortcut.toggleView' },
   'toggle-terminal-view': { default: '$mod+Alt+g',    category: 'view',  descKey: 'shortcut.toggleTerminalView' },

--- a/src/lib/tab/adjacent-tab.ts
+++ b/src/lib/tab/adjacent-tab.ts
@@ -1,0 +1,17 @@
+import type { Tab } from '@/types/tab';
+
+export type TabNavigationDirection = 'previous' | 'next';
+
+export function getAdjacentTabId(
+  tabs: readonly Tab[],
+  activeTabId: string,
+  direction: TabNavigationDirection,
+): string | null {
+  if (tabs.length < 2) return null;
+
+  const activeIndex = tabs.findIndex((tab) => tab.id === activeTabId);
+  if (activeIndex === -1) return null;
+
+  const offset = direction === 'previous' ? -1 : 1;
+  return tabs[(activeIndex + offset + tabs.length) % tabs.length].id;
+}

--- a/tests/tab-navigation-commands.test.ts
+++ b/tests/tab-navigation-commands.test.ts
@@ -1,10 +1,58 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import test from 'node:test';
 
 import { SHORTCUT_REGISTRY } from '@/lib/keyboard/registry';
+import { isGlobalShortcutKeydown, setGlobalShortcutKeys } from '@/lib/keyboard/terminal-passthrough';
+import { getAdjacentTabId } from '@/lib/tab/adjacent-tab';
 
-test('adjacent tab navigation commands are not exposed', () => {
-  for (const commandId of ['prev-tab', 'next-tab']) {
-    assert.equal(commandId in SHORTCUT_REGISTRY, false);
-  }
+const tabs = ['first', 'second', 'third'].map((id) => ({
+  id,
+  projectDir: null,
+  title: null,
+  isPreview: false,
+}));
+
+test('adjacent tab navigation commands use the requested shortcuts', () => {
+  assert.equal(SHORTCUT_REGISTRY['prev-tab'].default, 'Control+Alt+Shift+PageUp');
+  assert.equal(SHORTCUT_REGISTRY['next-tab'].default, 'Control+Alt+Shift+PageDown');
+});
+
+test('tab navigation shortcuts pass through a focused terminal to the app', () => {
+  setGlobalShortcutKeys([
+    SHORTCUT_REGISTRY['prev-tab'].default,
+    SHORTCUT_REGISTRY['next-tab'].default,
+  ]);
+
+  const event = {
+    type: 'keydown',
+    key: 'PageUp',
+    code: 'PageUp',
+    getModifierState: (modifier: string) => ['Control', 'Alt', 'Shift'].includes(modifier),
+  } as KeyboardEvent;
+
+  assert.equal(isGlobalShortcutKeydown(event), true);
+  setGlobalShortcutKeys([]);
+});
+
+test('hovering a tab title exposes both navigation shortcuts', () => {
+  const tabItemSource = fs.readFileSync(
+    new URL('../src/components/tab/tab-item.tsx', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(tabItemSource, /id="prev-tab"/);
+  assert.match(tabItemSource, /secondaryId="next-tab"/);
+});
+
+test('adjacent tab navigation follows visual order and wraps', () => {
+  assert.equal(getAdjacentTabId(tabs, 'second', 'previous'), 'first');
+  assert.equal(getAdjacentTabId(tabs, 'second', 'next'), 'third');
+  assert.equal(getAdjacentTabId(tabs, 'first', 'previous'), 'third');
+  assert.equal(getAdjacentTabId(tabs, 'third', 'next'), 'first');
+});
+
+test('adjacent tab navigation is a no-op without another valid tab', () => {
+  assert.equal(getAdjacentTabId(tabs.slice(0, 1), 'first', 'next'), null);
+  assert.equal(getAdjacentTabId(tabs, 'missing', 'next'), null);
 });


### PR DESCRIPTION
## Summary
- add Ctrl+Alt+Shift+PageUp/PageDown shortcuts for previous and next tab navigation
- wrap navigation across the visual tab order and preserve terminal passthrough
- show both shortcuts when hovering a tab title and expose localized settings labels

## Verification
- `npx tsx --test tests/tab-navigation-commands.test.ts`
- `npx tsc --noEmit --pretty false`
- targeted ESLint checks
- `git diff --check origin/dev...HEAD`