### PR TITLE
feat(tabs): open selected sessions in split view

### DIFF
--- a/src/components/chat/selection-action-bar.tsx
+++ b/src/components/chat/selection-action-bar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { CheckCircle2, Archive, Trash2, X } from 'lucide-react';
+import { CheckCircle2, Archive, LayoutGrid, Trash2, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSelectionStore } from '@/stores/selection-store';
 import { telemetryClickAttributes } from '@/lib/telemetry/ui-click';
@@ -20,7 +20,7 @@ const VIEWPORT_PADDING = 8;
 
 function computePosition(anchorEl: Element): { top: number; left: number } {
   const rect = anchorEl.getBoundingClientRect();
-  const barWidth = 340; // approximate max width
+  const barWidth = Math.min(500, window.innerWidth - VIEWPORT_PADDING * 2);
   const barHeight = 44;
 
   // Try right side first
@@ -46,6 +46,7 @@ interface SelectionActionBarContentProps {
   bulkMarkDone: () => void;
   bulkArchive: () => void;
   bulkDelete: () => void;
+  openInSplitView: () => void;
 }
 
 function SelectionActionBarContent({
@@ -55,6 +56,7 @@ function SelectionActionBarContent({
   bulkMarkDone,
   bulkArchive,
   bulkDelete,
+  openInSplitView,
 }: SelectionActionBarContentProps) {
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -72,7 +74,7 @@ function SelectionActionBarContent({
       style={{ top: position.top, left: position.left }}
       className={cn(
         'fixed z-[9998]',
-        'flex items-center gap-2 px-4 py-2.5 rounded-xl',
+        'flex w-max max-w-[calc(100vw-16px)] items-center gap-2 overflow-x-auto px-4 py-2.5 rounded-xl',
         'bg-(--sidebar-bg) border border-(--divider)',
         'shadow-[0_8px_32px_rgba(0,0,0,0.3),0_2px_8px_rgba(0,0,0,0.2)]',
         'animate-in fade-in duration-150',
@@ -99,6 +101,20 @@ function SelectionActionBarContent({
       >
         <CheckCircle2 className="w-3.5 h-3.5" />
         Done
+      </button>
+
+      <button
+        {...telemetryClickAttributes('list.selection.open_split_view', 'workspace_list')}
+        onClick={openInSplitView}
+        className={cn(
+          'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[12px] font-medium',
+          'text-(--text-secondary) hover:bg-(--sidebar-hover)',
+          'transition-colors whitespace-nowrap',
+        )}
+        data-testid="bulk-open-split-view"
+      >
+        <LayoutGrid className="w-3.5 h-3.5" />
+        Open in Split View
       </button>
 
       <button
@@ -159,6 +175,7 @@ export function SelectionActionBar() {
   const bulkMarkDone = useSelectionStore((state) => state.bulkMarkDone);
   const bulkArchive = useSelectionStore((state) => state.bulkArchive);
   const bulkDelete = useSelectionStore((state) => state.bulkDelete);
+  const openInSplitView = useSelectionStore((state) => state.openInSplitView);
   const position = useMemo(() => {
     if (!barAnchorId || selectedCount === 0 || typeof document === 'undefined') {
       return null;
@@ -191,6 +208,7 @@ export function SelectionActionBar() {
       bulkMarkDone={bulkMarkDone}
       bulkArchive={bulkArchive}
       bulkDelete={bulkDelete}
+      openInSplitView={openInSplitView}
     />
   );
 }

--- a/src/lib/telemetry/ui-click.ts
+++ b/src/lib/telemetry/ui-click.ts
@@ -347,6 +347,7 @@ export const TELEMETRY_UI_CONTROLS = [
   'message.load_more',
   'message.scroll_bottom',
   'list.selection.done',
+  'list.selection.open_split_view',
   'list.selection.archive',
   'list.selection.delete',
   'list.selection.clear',

--- a/src/stores/selection-store.ts
+++ b/src/stores/selection-store.ts
@@ -5,6 +5,7 @@ import { toast } from './notification-store';
 import { fetchWithClientId } from '@/lib/api/fetch-with-client-id';
 import { projectViewWorkspaceState } from '@/lib/projects/project-view-workspace-state-client';
 import { resolveSessionWorktreeLifecycleTarget } from '@/lib/session/session-worktree-lifecycle';
+import { useTabStore } from './tab-store';
 
 interface SelectionState {
   /** Set of selected session IDs */
@@ -35,6 +36,8 @@ interface SelectionState {
   bulkArchive: () => Promise<void>;
   /** Delete all selected sessions */
   bulkDelete: () => Promise<void>;
+  /** Open selected sessions together in a new split-view tab. */
+  openInSplitView: () => void;
 }
 
 export const useSelectionStore = create<SelectionState>((set, get) => ({
@@ -136,6 +139,11 @@ export const useSelectionStore = create<SelectionState>((set, get) => ({
     }
     set({ selectedIds: new Set(), lastClickedId: null, barAnchorId: null });
     toast.success(`${successCount}개 항목을 아카이브했습니다`);
+  },
+
+  openInSplitView: () => {
+    const tabId = useTabStore.getState().createTabWithSessions([...get().selectedIds]);
+    if (tabId) set({ selectedIds: new Set(), lastClickedId: null, barAnchorId: null });
   },
 
   bulkDelete: async () => {

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -36,6 +36,52 @@ function findFirstLeafId(node: PanelNode): string {
   return findFirstLeafId(node.children[0]);
 }
 
+/**
+ * Build a near-square, row-major panel grid.  The short first column keeps
+ * incomplete grids balanced while preserving the supplied panel order.
+ */
+export function buildBalancedPanelLayout(panelIds: readonly string[]): PanelNode | null {
+  if (panelIds.length === 0) return null;
+
+  function buildVerticalStack(ids: readonly string[]): PanelNode {
+    if (ids.length === 1) return { type: 'leaf', panelId: ids[0]! };
+    const splitIndex = Math.ceil(ids.length / 2);
+    return {
+      type: 'vsplit',
+      children: [
+        buildVerticalStack(ids.slice(0, splitIndex)),
+        buildVerticalStack(ids.slice(splitIndex)),
+      ],
+      ratio: splitIndex / ids.length,
+    };
+  }
+
+  const columnCount = Math.ceil(Math.sqrt(panelIds.length));
+  const columnSizes = Array.from({ length: columnCount }, (_, index) =>
+    Math.floor((panelIds.length + index) / columnCount),
+  ).filter((size) => size > 0);
+  let offset = 0;
+  const columns = columnSizes.map((size) => {
+    const columnPanelIds = panelIds.slice(offset, offset + size);
+    offset += size;
+    return buildVerticalStack(columnPanelIds);
+  });
+
+  function joinColumns(nodes: readonly PanelNode[]): PanelNode {
+    if (nodes.length === 1) return nodes[0]!;
+    const splitIndex = Math.ceil(nodes.length / 2);
+    const left = joinColumns(nodes.slice(0, splitIndex));
+    const right = joinColumns(nodes.slice(splitIndex));
+    return {
+      type: 'hsplit',
+      children: [left, right],
+      ratio: splitIndex / nodes.length,
+    };
+  }
+
+  return columns.length > 1 ? joinColumns(columns) : columns[0]!;
+}
+
 /** LRU 목록에 새 ID를 프론트에 추가하고 LRU_LIMIT를 초과하면 잘라냄 (BR-002, BR-003) */
 function computeNewLru(currentLru: string[], promotedId: string): string[] {
   return [promotedId, ...currentLru.filter(id => id !== promotedId)].slice(0, LRU_LIMIT);
@@ -982,6 +1028,56 @@ export const useTabStore = create<TabStore>()((set, get) => ({
     get().createTab(sessionId);
   },
 
+  createTabWithSessions: (sessionIds: string[]): string | null => {
+    const orderedSessionIds = [...new Set(sessionIds)];
+    if (orderedSessionIds.length === 0) return null;
+    const sessionProjectDirs = orderedSessionIds.map((sessionId) =>
+      inferTabProjectDir(sessionId, null)
+    );
+    const destinationProjectDir = sessionProjectDirs.every(
+      (projectDir) => projectDir === sessionProjectDirs[0],
+    )
+      ? sessionProjectDirs[0]!
+      : null;
+
+    // Create an empty destination first. This prevents retireSessionSurface
+    // from introducing a temporary last-tab placeholder while source tabs close.
+    const destinationTabId = get().createTab();
+    // A cross-project selection belongs to the global tab scope. A selection
+    // from one Project retains that Project's normal tab ownership.
+    get().setTabProject(destinationTabId, destinationProjectDir);
+
+    for (const sessionId of orderedSessionIds) {
+      get().retireSessionSurface(sessionId);
+    }
+
+    const panelIds = orderedSessionIds.map(() => uuidv4());
+    const layout = buildBalancedPanelLayout(panelIds);
+    if (!layout) return null;
+    const panels = Object.fromEntries(panelIds.map((panelId, index) => {
+      const sessionId = orderedSessionIds[index]!;
+      return [panelId, {
+        id: panelId,
+        sessionId,
+        worktreeId: inferSessionWorktreeId(
+          sessionId,
+          sessionProjectDirs[index] ?? destinationProjectDir,
+        ),
+      }];
+    }));
+
+    const panelStore = usePanelStore.getState();
+    panelStore.initTab(destinationTabId, {
+      layout,
+      panels,
+      activePanelId: panelIds[0]!,
+    });
+    get().setActiveTab(destinationTabId);
+    panelStore.setActiveTabId(destinationTabId);
+
+    return destinationTabId;
+  },
+
   openPreview: (sessionId: string): void => {
     const state = get();
     const panelStore = usePanelStore.getState();
@@ -1152,7 +1248,7 @@ export const useTabStore = create<TabStore>()((set, get) => ({
     });
   },
 
-  setTabProject: (tabId: string, projectDir: string): void => {
+  setTabProject: (tabId: string, projectDir: string | null): void => {
     const state = get();
     if (!state.tabs.some((item) => item.id === tabId)) return;
 

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -167,6 +167,12 @@ export interface TabStoreActions {
   createTabWithSession(sessionId: string): void;
 
   /**
+   * 선택한 세션들을 하나의 고정 분할 탭으로 옮겨 열기.
+   * @returns 새 탭 ID. 세션이 없으면 null.
+   */
+  createTabWithSessions(sessionIds: string[]): string | null;
+
+  /**
    * 프리뷰 탭에서 세션 열기. 기존 프리뷰 탭이 있으면 세션만 교체, 없으면 새 프리뷰 탭 생성.
    * 채팅/세션 프리뷰 슬롯만 재사용한다.
    */
@@ -196,8 +202,9 @@ export interface TabStoreActions {
 
   /**
    * 세션이 없는 프로젝트 셸처럼 프로젝트 소유권을 직접 지정해야 하는 탭에 사용.
+   * null은 모든 프로젝트에서 보이는 전역 탭이다.
    */
-  setTabProject(tabId: string, projectDir: string): void;
+  setTabProject(tabId: string, projectDir: string | null): void;
 
   /**
    * 주어진 세션이 열려 있는 탭과 패널을 찾음 (BR-007).

--- a/tests/tab-split-view.test.ts
+++ b/tests/tab-split-view.test.ts
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { usePanelStore } from '@/stores/panel-store';
+import { useSelectionStore } from '@/stores/selection-store';
+import { useSessionStore } from '@/stores/session-store';
+import { buildBalancedPanelLayout, useTabStore } from '@/stores/tab-store';
+import type { PanelNode, TabPanelData } from '@/types/panel';
+import type { Tab } from '@/types/tab';
+import type { ProjectGroup, UnifiedSession } from '@/types/chat';
+import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
+
+function leafIds(node: PanelNode): string[] {
+  return node.type === 'leaf'
+    ? [node.panelId]
+    : [...leafIds(node.children[0]), ...leafIds(node.children[1])];
+}
+
+function leafTabData(panelId: string, sessionId: string | null): TabPanelData {
+  return {
+    layout: { type: 'leaf', panelId },
+    panels: { [panelId]: { id: panelId, sessionId } },
+    activePanelId: panelId,
+  };
+}
+
+function setVisibleTabs(tabs: Tab[], tabPanels: Record<string, TabPanelData>, activeTabId: string): void {
+  useTabStore.setState({
+    tabs,
+    activeTabId,
+    lruTabIds: [activeTabId, ...tabs.map((tab) => tab.id).filter((id) => id !== activeTabId)],
+    projectTabStates: {},
+    globalTabState: null,
+    tabOrderIdsByScope: {},
+    currentProjectDir: null,
+  });
+  usePanelStore.setState({ tabPanels, activeTabId });
+  useSelectionStore.getState().clearSelection();
+}
+
+test('balanced split layouts preserve panel order for 2, 3, 4, 5, and larger counts', () => {
+  for (const count of [2, 3, 4, 5, 11]) {
+    const ids = Array.from({ length: count }, (_, index) => `panel-${index + 1}`);
+    const layout = buildBalancedPanelLayout(ids);
+
+    assert.ok(layout);
+    assert.deepEqual(leafIds(layout), ids);
+  }
+
+  const three = buildBalancedPanelLayout(['a', 'b', 'c'])!;
+  assert.equal(three.type, 'hsplit');
+  assert.equal(three.children[0].type, 'leaf');
+  assert.equal(three.children[1].type, 'vsplit');
+
+  const four = buildBalancedPanelLayout(['a', 'b', 'c', 'd'])!;
+  assert.equal(four.type, 'hsplit');
+  assert.equal(four.children[0].type, 'vsplit');
+  assert.equal(four.children[1].type, 'vsplit');
+
+  const five = buildBalancedPanelLayout(['a', 'b', 'c', 'd', 'e'])!;
+  assert.equal(five.type, 'hsplit');
+  assert.equal(five.children[0].type, 'hsplit');
+  assert.equal(five.children[1].type, 'vsplit');
+});
+
+test('split view moves selected sessions, closes emptied tabs, retains unrelated surfaces, and activates its tab', () => {
+  const sourceTab: Tab = { id: 'source', projectDir: null, title: null, isPreview: false };
+  const emptiedTab: Tab = { id: 'emptied', projectDir: null, title: null, isPreview: false };
+  const unrelatedTab: Tab = { id: 'unrelated', projectDir: null, title: null, isPreview: false };
+  setVisibleTabs(
+    [sourceTab, emptiedTab, unrelatedTab],
+    {
+      source: {
+        layout: {
+          type: 'hsplit',
+          children: [
+            { type: 'leaf', panelId: 'source-a' },
+            { type: 'leaf', panelId: 'source-b' },
+          ],
+          ratio: 0.5,
+        },
+        panels: {
+          'source-a': { id: 'source-a', sessionId: 'selected-a' },
+          'source-b': { id: 'source-b', sessionId: 'kept-b' },
+        },
+        activePanelId: 'source-a',
+      },
+      emptied: leafTabData('emptied-panel', 'selected-c'),
+      unrelated: leafTabData('unrelated-panel', 'unrelated-d'),
+    },
+    sourceTab.id,
+  );
+
+  const destinationTabId = useTabStore.getState().createTabWithSessions(['selected-a', 'selected-c']);
+
+  assert.ok(destinationTabId);
+  assert.equal(useTabStore.getState().activeTabId, destinationTabId);
+  assert.equal(usePanelStore.getState().activeTabId, destinationTabId);
+  assert.equal(useTabStore.getState().tabs.some((tab) => tab.id === 'emptied'), false);
+  assert.deepEqual(
+    Object.values(usePanelStore.getState().tabPanels.source!.panels).map((panel) => panel.sessionId),
+    ['kept-b'],
+  );
+  assert.equal(usePanelStore.getState().tabPanels.unrelated?.panels['unrelated-panel']?.sessionId, 'unrelated-d');
+
+  const destination = usePanelStore.getState().tabPanels[destinationTabId!];
+  assert.deepEqual(leafIds(destination!.layout).map((panelId) => destination!.panels[panelId]!.sessionId), [
+    'selected-a',
+    'selected-c',
+  ]);
+  assert.equal(destination!.panels[destination!.activePanelId]?.sessionId, 'selected-a');
+});
+
+test('split view retires a selected session from a hidden global snapshot', () => {
+  const visibleTab: Tab = { id: 'visible', projectDir: null, title: null, isPreview: false };
+  const hiddenTab: Tab = { id: 'hidden-global', projectDir: null, title: null, isPreview: false };
+  setVisibleTabs([visibleTab], { visible: leafTabData('visible-panel', 'visible-session') }, visibleTab.id);
+  useTabStore.setState({
+    globalTabState: {
+      tabs: [hiddenTab],
+      activeTabId: hiddenTab.id,
+      lruTabIds: [hiddenTab.id],
+      tabPanelSnapshots: { [hiddenTab.id]: leafTabData('hidden-panel', 'selected-hidden') },
+    },
+  });
+
+  const destinationTabId = useTabStore.getState().createTabWithSessions(['selected-hidden']);
+
+  assert.ok(destinationTabId);
+  assert.equal(useTabStore.getState().globalTabState, null);
+  assert.equal(
+    usePanelStore.getState().tabPanels[destinationTabId!]?.panels[
+      usePanelStore.getState().tabPanels[destinationTabId!]!.activePanelId
+    ]?.sessionId,
+    'selected-hidden',
+  );
+});
+
+test('mixed-project selections create a global tab and retain each session worktree', (t) => {
+  const originalSessionState = useSessionStore.getState();
+  t.after(() => useSessionStore.setState(originalSessionState, true));
+
+  const session = (id: string, projectDir: string, worktreeId: string): UnifiedSession => ({
+    id,
+    title: id,
+    projectDir,
+    originProjectId: projectDir,
+    worktreeId,
+    isRunning: false,
+    status: 'completed',
+    lastModified: '',
+    createdAt: '',
+    archived: false,
+  });
+  const project = (projectDir: string, worktreeId: string): ProjectGroup => ({
+    encodedDir: projectDir,
+    displayName: projectDir,
+    decodedPath: `/${projectDir}`,
+    isCurrent: false,
+    sessions: [session(`session-${projectDir}`, projectDir, worktreeId)],
+    totalSessions: 1,
+    loadedCount: 1,
+    allLoaded: true,
+    nextCursor: null,
+    loadBatchIndex: 0,
+  });
+  useSessionStore.setState({
+    ...useSessionStore.getInitialState(),
+    projects: [project('project-a', 'worktree-a'), project('project-b', 'worktree-b')],
+  }, true);
+
+  const sourceA: Tab = { id: 'source-a', projectDir: 'project-a', title: null, isPreview: false };
+  const sourceB: Tab = { id: 'source-b', projectDir: 'project-b', title: null, isPreview: false };
+  setVisibleTabs(
+    [sourceA, sourceB],
+    {
+      [sourceA.id]: leafTabData('panel-a', 'session-project-a'),
+      [sourceB.id]: leafTabData('panel-b', 'session-project-b'),
+    },
+    sourceA.id,
+  );
+  useTabStore.setState({ currentProjectDir: ALL_PROJECTS_SENTINEL });
+
+  const destinationTabId = useTabStore.getState().createTabWithSessions([
+    'session-project-a',
+    'session-project-b',
+  ]);
+
+  assert.ok(destinationTabId);
+  assert.equal(
+    useTabStore.getState().tabs.find((tab) => tab.id === destinationTabId)?.projectDir,
+    null,
+  );
+  const destination = usePanelStore.getState().tabPanels[destinationTabId!];
+  const panelsBySession = Object.fromEntries(
+    Object.values(destination!.panels).map((panel) => [panel.sessionId, panel]),
+  );
+  assert.equal(panelsBySession['session-project-a']?.worktreeId, 'worktree-a');
+  assert.equal(panelsBySession['session-project-b']?.worktreeId, 'worktree-b');
+});
+
+test('opening the current selection in split view clears it after the tab is created', () => {
+  const sourceTab: Tab = { id: 'source', projectDir: null, title: null, isPreview: false };
+  setVisibleTabs([sourceTab], { source: leafTabData('source-panel', 'selected-a') }, sourceTab.id);
+  useSelectionStore.setState({
+    selectedIds: new Set(['selected-a']),
+    lastClickedId: 'selected-a',
+    barAnchorId: 'selected-a',
+  });
+
+  useSelectionStore.getState().openInSplitView();
+
+  const selection = useSelectionStore.getState();
+  assert.equal(selection.selectedIds.size, 0);
+  assert.equal(selection.lastClickedId, null);
+  assert.equal(selection.barAnchorId, null);
+  assert.equal(useTabStore.getState().tabs.length, 1);
+  assert.equal(
+    usePanelStore.getState().tabPanels[useTabStore.getState().activeTabId]?.panels[
+      usePanelStore.getState().tabPanels[useTabStore.getState().activeTabId]!.activePanelId
+    ]?.sessionId,
+    'selected-a',
+  );
+});


### PR DESCRIPTION
## Summary
- add an **Open in Split View** bulk action for selected sessions
- consolidate selected sessions into one balanced split-layout tab without a panel-count cap
- retire duplicate session surfaces and close tabs emptied by the move

## Verification
- `tsx --test tests/tab-split-view.test.ts tests/tab-session-open.test.ts tests/tab-new-tab.test.ts` (14 passed)
- focused ESLint
- `tsc --noEmit`
- browser E2E: selected five running sessions, opened one tab with five panels, and confirmed prior tabs were closed