### PR TITLE
fix(sidebar): clarify project branch filters

### DIFF
--- a/src/components/chat/all-projects-list.tsx
+++ b/src/components/chat/all-projects-list.tsx
@@ -322,10 +322,13 @@ function AllProjectSection({
                 diffStats={project.projectWorktree.diffStats}
                 displayPath={project.projectWorktree.displayPath}
                 onSelect={handleProjectWorktreeSelect}
-              />
-              <ProjectBranchFilter
-                projectId={project.encodedDir}
-                branches={project.creationBranches ?? []}
+                trailingControl={(
+                  <ProjectBranchFilter
+                    compact
+                    projectId={project.encodedDir}
+                    branches={project.creationBranches ?? []}
+                  />
+                )}
               />
             </>
           ) : null}

--- a/src/components/chat/sidebar.tsx
+++ b/src/components/chat/sidebar.tsx
@@ -830,10 +830,13 @@ export function Sidebar() {
                   name={selectedProject.displayName}
                   displayPath={selectedProject.projectWorktree.displayPath}
                   onSelect={handleProjectWorktreeSelect}
-                />
-                <ProjectBranchFilter
-                  projectId={selectedProject.encodedDir}
-                  branches={selectedProject.creationBranches ?? []}
+                  trailingControl={(
+                    <ProjectBranchFilter
+                      compact
+                      projectId={selectedProject.encodedDir}
+                      branches={selectedProject.creationBranches ?? []}
+                    />
+                  )}
                 />
                 {selectedProject.branchRenameWarning ? (
                   <BranchRenameWarning

--- a/src/components/worktree/project-branch-filter.tsx
+++ b/src/components/worktree/project-branch-filter.tsx
@@ -10,13 +10,14 @@ import { useSessionStore } from '@/stores/session-store';
 interface ProjectBranchFilterProps {
   projectId: string;
   branches: string[];
+  compact?: boolean;
 }
 
 const SEARCH_THRESHOLD = 7;
 const MENU_WIDTH = 264;
 
 /** Filters the folder-owned Project View; it never changes the checkout branch. */
-export function ProjectBranchFilter({ projectId, branches }: ProjectBranchFilterProps) {
+export function ProjectBranchFilter({ projectId, branches, compact = false }: ProjectBranchFilterProps) {
   const { t } = useI18n();
   const selectedBranch = useSessionStore((state) => state.projectCreationBranchFilters[projectId]);
   const setBranchFilter = useSessionStore((state) => state.setProjectCreationBranchFilter);
@@ -88,8 +89,7 @@ export function ProjectBranchFilter({ projectId, branches }: ProjectBranchFilter
     triggerRef.current?.focus();
   };
 
-  return (
-    <div className="mx-2 mb-1" data-testid="project-branch-view-filter">
+  const trigger = (
       <button
         ref={triggerRef}
         type="button"
@@ -99,7 +99,11 @@ export function ProjectBranchFilter({ projectId, branches }: ProjectBranchFilter
         title={t('chat.projectViewBranchFilterHint')}
         onClick={() => setIsOpen((open) => !open)}
         className={cn(
-          'flex h-7 w-full items-center gap-1.5 rounded-md px-2 text-left text-[0.75rem] transition-colors',
+          // It is scoped metadata for the project, not a toolbar competing
+          // with the worktree or the session groups below it.
+          compact
+            ? 'flex h-7 max-w-[11rem] items-center gap-1.5 rounded-md px-1.5 transition-colors'
+            : 'flex h-7 max-w-full items-center gap-1.5 rounded-md px-2 text-left transition-colors',
           'text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--sidebar-text-active)',
           'focus-visible:bg-(--sidebar-hover) focus-visible:outline-none',
           isOpen && 'bg-(--sidebar-hover) text-(--sidebar-text-active)',
@@ -107,46 +111,59 @@ export function ProjectBranchFilter({ projectId, branches }: ProjectBranchFilter
         data-testid="project-branch-view-filter-trigger"
       >
         <Filter className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-        <span className="shrink-0">{t('chat.projectViewBranchFilterLabel')}</span>
-        <span className="min-w-0 flex-1 truncate border-l border-(--divider) pl-1.5 text-(--sidebar-text-active)">{selectedLabel}</span>
-        <ChevronDown className={cn('h-3.5 w-3.5 shrink-0 transition-transform', isOpen && 'rotate-180')} aria-hidden="true" />
+        {compact && selectedBranch && (
+          <span className="min-w-0 truncate text-[0.625rem] font-medium text-(--sidebar-text-active)">
+            {t('chat.projectViewBranchFilterMenuLabel')}: {selectedBranch}
+          </span>
+        )}
+        {!compact && <span className="min-w-0 flex-1 truncate text-[0.75rem] font-medium text-(--sidebar-text-active)">{selectedLabel}</span>}
+        {!compact && <ChevronDown className={cn('h-3.5 w-3.5 shrink-0 transition-transform', isOpen && 'rotate-180')} aria-hidden="true" />}
       </button>
+  );
 
-      {isOpen && position && typeof document !== 'undefined' && createPortal(
-        <div
-          ref={menuRef}
-          role="listbox"
-          aria-label={t('chat.projectViewBranchFilterAriaLabel')}
-          className="fixed z-[9999] overflow-hidden rounded-lg border border-(--divider) bg-(--sidebar-bg) p-1.5 shadow-[0_8px_32px_rgba(0,0,0,0.24),0_2px_8px_rgba(0,0,0,0.16)]"
-          style={{ top: position.top, left: position.left, width: MENU_WIDTH }}
-          data-testid="project-branch-view-filter-menu"
-        >
-          {showSearch && (
-            <div className="mb-1 flex items-center gap-2 border-b border-(--divider) px-2 pb-1.5">
-              <Search className="h-3.5 w-3.5 text-(--text-muted)" aria-hidden="true" />
-              <input
-                ref={searchRef}
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder={t('chat.projectViewBranchSearchPlaceholder')}
-                className="h-7 min-w-0 flex-1 bg-transparent text-xs text-(--sidebar-text-active) outline-none placeholder:text-(--text-muted)"
-                data-testid="project-branch-view-filter-search"
-              />
-            </div>
-          )}
-          <p className="px-2 pb-1 pt-0.5 text-[0.625rem] font-medium uppercase tracking-[0.08em] text-(--text-muted)">
-            {t('chat.projectViewBranchFilterMenuLabel')}
-          </p>
-          <div className="max-h-72 overflow-y-auto py-0.5">
-            <BranchOption label={t('chat.projectViewAllBranches')} selected={!selectedBranch} onChoose={() => choose()} testId="all" />
-            {filteredBranches.map((branch) => (
-              <BranchOption key={branch} label={branch} selected={selectedBranch === branch} onChoose={() => choose(branch)} testId={branch} />
-            ))}
-            {filteredBranches.length === 0 && <p className="px-2 py-2 text-xs text-(--text-muted)">{t('chat.projectViewBranchNoMatches')}</p>}
-          </div>
-        </div>,
-        document.body,
+  const menu = isOpen && position && typeof document !== 'undefined' && createPortal(
+    <div
+      ref={menuRef}
+      role="listbox"
+      aria-label={t('chat.projectViewBranchFilterAriaLabel')}
+      className="fixed z-[9999] overflow-hidden rounded-lg border border-(--divider) bg-(--sidebar-bg) p-1.5 shadow-[0_8px_32px_rgba(0,0,0,0.24),0_2px_8px_rgba(0,0,0,0.16)]"
+      style={{ top: position.top, left: position.left, width: MENU_WIDTH }}
+      data-testid="project-branch-view-filter-menu"
+    >
+      {showSearch && (
+        <div className="mb-1 flex items-center gap-2 border-b border-(--divider) px-2 pb-1.5">
+          <Search className="h-3.5 w-3.5 text-(--text-muted)" aria-hidden="true" />
+          <input
+            ref={searchRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={t('chat.projectViewBranchSearchPlaceholder')}
+            className="h-7 min-w-0 flex-1 bg-transparent text-xs text-(--sidebar-text-active) outline-none placeholder:text-(--text-muted)"
+            data-testid="project-branch-view-filter-search"
+          />
+        </div>
       )}
+      <p className="px-2 pb-1 pt-0.5 text-[0.625rem] font-medium uppercase tracking-[0.08em] text-(--text-muted)">
+        {t('chat.projectViewBranchFilterMenuLabel')}
+      </p>
+      <div className="max-h-72 overflow-y-auto py-0.5">
+        <BranchOption label={t('chat.projectViewAllBranches')} selected={!selectedBranch} onChoose={() => choose()} testId="all" />
+        {filteredBranches.map((branch) => (
+          <BranchOption key={branch} label={branch} selected={selectedBranch === branch} onChoose={() => choose(branch)} testId={branch} />
+        ))}
+        {filteredBranches.length === 0 && <p className="px-2 py-2 text-xs text-(--text-muted)">{t('chat.projectViewBranchNoMatches')}</p>}
+      </div>
+    </div>,
+    document.body,
+  );
+
+  if (compact) {
+    return <div className="shrink-0" data-testid="project-branch-view-filter">{trigger}{menu}</div>;
+  }
+
+  return (
+    <div className="mb-1 flex justify-end px-2.5" data-testid="project-branch-view-filter">
+      {trigger}{menu}
     </div>
   );
 }

--- a/src/components/worktree/project-worktree-row.tsx
+++ b/src/components/worktree/project-worktree-row.tsx
@@ -1,93 +1,103 @@
 import { FolderGit2, GitBranch } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { DiffStatsBadge } from '@/components/chat/diff-stats-badge';
 import { cn } from '@/lib/utils';
 import type { WorktreeDiffStats } from '@/types/worktree-diff-stats';
 import { telemetryClickAttributes } from '@/lib/telemetry/ui-click';
 
-export function ProjectWorktreeRow({ active, branch, name, displayPath, diffStats, onSelect }: {
+export function ProjectWorktreeRow({ active, branch, name, displayPath, diffStats, onSelect, trailingControl }: {
   active: boolean;
   branch: string | null;
   name: string;
   displayPath: string;
   diffStats?: WorktreeDiffStats | null;
   onSelect: () => void;
+  /** Independent actions must be siblings of the worktree-open button. */
+  trailingControl?: ReactNode;
 }) {
   const branchLabel = branch ?? 'unknown';
 
   return (
-    <button
-      {...telemetryClickAttributes('worktree.select', 'worktree')}
-      type="button"
-      onClick={onSelect}
-      aria-current={active ? 'true' : undefined}
-      aria-label={`${name}, ${displayPath}, branch ${branchLabel}`}
-      title={displayPath}
+    <div
       className={cn(
-        'mb-0.5 flex w-full items-start gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors',
+        'mb-2 flex w-full min-w-0 items-center rounded-xl border border-(--divider) bg-(--input-bg) transition-colors',
         active
-          ? 'bg-(--sidebar-hover) text-(--text-primary)'
-          : 'text-(--text-secondary) hover:bg-(--sidebar-hover)',
+          ? 'border-(--accent)/35 bg-(--sidebar-hover) text-(--text-primary)'
+          : 'text-(--text-secondary) hover:border-(--accent)/25 hover:bg-(--sidebar-hover)',
       )}
       data-testid="project-worktree-row"
       data-variant="detailed"
     >
-      <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-(--accent)/10 text-(--accent)">
-        <FolderGit2 className="h-4 w-4" />
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="flex min-w-0 items-center gap-2">
-          <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-(--text-primary)">
-            {name}
+      <button
+        {...telemetryClickAttributes('worktree.select', 'worktree')}
+        type="button"
+        onClick={onSelect}
+        aria-current={active ? 'true' : undefined}
+        aria-label={`${name}, ${displayPath}, branch ${branchLabel}`}
+        title={displayPath}
+        className="flex min-w-0 flex-1 items-start gap-2.5 px-2.5 py-2 text-left outline-none"
+      >
+        <FolderGit2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-(--accent)" />
+        <span className="min-w-0 flex-1">
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="min-w-0 truncate text-[13px] font-semibold text-(--text-primary)">{name}</span>
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-(--accent)/35 bg-(--accent)/12 px-2 py-0.5 text-[10px] font-medium text-(--sidebar-text-active)">
+              <GitBranch className="h-3 w-3 shrink-0 text-(--accent)" />
+              <span>{branchLabel}</span>
+            </span>
           </span>
-          <DiffStatsBadge stats={diffStats} />
-          <span className="inline-flex max-w-[48%] shrink-0 items-center gap-1 rounded-full border border-(--divider) bg-(--input-bg) px-1.5 py-0.5 font-mono text-[10px] text-(--text-secondary)">
-            <GitBranch className="h-2.5 w-2.5 shrink-0" />
-            <span className="truncate">{branchLabel}</span>
-          </span>
+          <span className="mt-0.5 block truncate font-mono text-[10px] leading-4 text-(--text-muted)">{displayPath}</span>
         </span>
-        <span className="mt-0.5 block truncate font-mono text-[10px] leading-4 text-(--text-muted)">
-          {displayPath}
-        </span>
-      </span>
-    </button>
+      </button>
+      <div className="flex shrink-0 items-center justify-end gap-1 pr-2.5">
+        <DiffStatsBadge stats={diffStats} />
+        {trailingControl}
+      </div>
+    </div>
   );
 }
 
-export function CompactProjectWorktreeRow({ active, branch, displayPath, diffStats, onSelect }: {
+export function CompactProjectWorktreeRow({ active, branch, displayPath, diffStats, onSelect, trailingControl }: {
   active: boolean;
   branch: string | null;
   displayPath: string;
   diffStats?: WorktreeDiffStats | null;
   onSelect: () => void;
+  trailingControl?: ReactNode;
 }) {
   const branchLabel = branch ?? 'unknown';
 
   return (
-    <button
-      {...telemetryClickAttributes('worktree.select', 'worktree')}
-      type="button"
-      onClick={onSelect}
-      aria-current={active ? 'true' : undefined}
-      aria-label={`${displayPath}, branch ${branchLabel}`}
-      title={displayPath}
+    <div
       className={cn(
-        'mb-0.5 flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1 text-left transition-colors',
+        'mb-1 flex w-full min-w-0 items-center rounded-lg border border-(--divider) bg-(--input-bg) transition-colors',
         active
-          ? 'bg-(--sidebar-hover) text-(--text-primary)'
-          : 'text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--text-secondary)',
+          ? 'border-(--accent)/35 bg-(--sidebar-hover) text-(--text-primary)'
+          : 'text-(--text-muted) hover:border-(--accent)/25 hover:bg-(--sidebar-hover) hover:text-(--text-secondary)',
       )}
       data-testid="project-worktree-row"
       data-variant="compact"
     >
-      <FolderGit2 className="h-3.5 w-3.5 shrink-0 text-(--accent)" />
-      <span className="min-w-0 flex-1 truncate font-mono text-[10px]">
-        {displayPath}
-      </span>
-      <DiffStatsBadge stats={diffStats} />
-      <span className="inline-flex max-w-[42%] shrink-0 items-center gap-1 rounded-full border border-(--divider) bg-(--input-bg) px-1.5 py-0.5 font-mono text-[9px] text-(--text-secondary)">
-        <GitBranch className="h-2.5 w-2.5 shrink-0" />
-        <span className="truncate">{branchLabel}</span>
-      </span>
-    </button>
+      <button
+        {...telemetryClickAttributes('worktree.select', 'worktree')}
+        type="button"
+        onClick={onSelect}
+        aria-current={active ? 'true' : undefined}
+        aria-label={`${displayPath}, branch ${branchLabel}`}
+        title={displayPath}
+        className="flex min-w-0 items-center gap-2 px-2 py-1 text-left outline-none"
+      >
+        <FolderGit2 className="h-3.5 w-3.5 shrink-0 text-(--accent)" />
+        <span className="max-w-[12rem] truncate font-mono text-[10px]">{displayPath}</span>
+        <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-(--accent)/35 bg-(--accent)/12 px-2 py-0.5 font-mono text-[10px] font-medium text-(--sidebar-text-active)">
+          <GitBranch className="h-3 w-3 shrink-0 text-(--accent)" />
+          <span>{branchLabel}</span>
+        </span>
+      </button>
+      <div className="ml-auto flex shrink-0 items-center justify-end gap-1 pr-2">
+        <DiffStatsBadge stats={diffStats} />
+        {trailingControl}
+      </div>
+    </div>
   );
 }

--- a/tests/project-worktree-target.test.tsx
+++ b/tests/project-worktree-target.test.tsx
@@ -59,7 +59,8 @@ test('Project Worktree rows render detailed and compact variants', () => {
   assert.match(row, /−3/);
   assert.match(row, /aria-current="true"/);
   assert.match(row, /data-variant="detailed"/);
-  assert.match(row, /mb-0\.5[^\"]*py-2(?:\s|\")/);
+  assert.match(row, /mb-2[^\"]*rounded-xl/);
+  assert.match(row, /px-2\.5 py-2/);
 
   const compactRow = renderToStaticMarkup(createElement(CompactProjectWorktreeRow, {
     active: false,
@@ -82,7 +83,8 @@ test('Project Worktree rows render detailed and compact variants', () => {
   assert.match(compactRow, /\+12/);
   assert.match(compactRow, /−3/);
   assert.match(compactRow, /data-variant="compact"/);
-  assert.match(compactRow, /mb-0\.5[^\"]*py-1(?:\s|\")/);
+  assert.match(compactRow, /mb-1[^\"]*rounded-lg/);
+  assert.match(compactRow, /px-2 py-1/);
 });
 
 test('Worktree overview renders branch and path without duplicate creation actions', () => {


### PR DESCRIPTION
## Summary
- keep the current checkout branch beside the project/worktree identity
- place creation-branch filtering as an independent right-side control in both project views
- give the project worktree row a distinct header surface and align its metadata

## Verification
- npx eslint src/components/worktree/project-branch-filter.tsx src/components/worktree/project-worktree-row.tsx src/components/chat/sidebar.tsx src/components/chat/all-projects-list.tsx tests/project-worktree-target.test.tsx
- npx tsx --test tests/project-worktree-target.test.tsx tests/project-branch-filter-store.test.ts
- npx tsc --noEmit --pretty false