### PR TITLE
fix(git): compact changed-file rows

### DIFF
--- a/src/components/git/git-panel-sections.tsx
+++ b/src/components/git/git-panel-sections.tsx
@@ -164,12 +164,34 @@ function FileBadge({ file }: { file: GitChangedFile }) {
   return (
     <span
       className={cn(
-        "inline-flex h-5 w-5 shrink-0 items-center justify-center font-mono text-[11px] font-semibold leading-none",
+        "inline-flex h-4 shrink-0 items-center font-mono text-[10px] font-semibold leading-none",
         meta.statusClassName,
       )}
       aria-label={meta.label}
     >
       {display}
+    </span>
+  );
+}
+
+/**
+ * Keep the leaf name visible when the Git panel is narrow. A conventional
+ * end-truncated path hides the part people use to tell adjacent files apart.
+ */
+function FilePath({ path }: { path: string }) {
+  const slashIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  if (slashIndex === -1) {
+    return <span className="truncate">{path}</span>;
+  }
+
+  const directory = path.slice(0, slashIndex);
+  const filename = path.slice(slashIndex + 1);
+
+  return (
+    <span className="flex min-w-0 items-baseline" title={path}>
+      <span className="min-w-0 truncate text-(--text-muted)">{directory}</span>
+      <span className="shrink-0 text-(--text-muted)">/</span>
+      <span className="shrink-0">{filename}</span>
     </span>
   );
 }
@@ -852,7 +874,7 @@ export function GitPanelContentSection({
               />
             ) : (
               <>
-                <div className="flex items-center justify-between gap-2 px-1">
+                <div className="flex items-center justify-between gap-2 pl-1.5 pr-1">
                   <label className="flex min-w-0 items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-(--text-muted)">
                     <input
                       ref={selectAllCheckboxRef}
@@ -952,7 +974,7 @@ export function GitPanelContentSection({
                                 path: file.path,
                               })}
                               data-testid={`git-commit-file-checkbox-${file.path}`}
-                              className="ml-2 h-3.5 w-3.5 shrink-0 cursor-pointer accent-(--accent) disabled:cursor-not-allowed disabled:opacity-50"
+                              className="ml-1 h-3.5 w-3.5 shrink-0 cursor-pointer accent-(--accent) disabled:cursor-not-allowed disabled:opacity-50"
                             />
                             <button
                               type="button"
@@ -965,11 +987,11 @@ export function GitPanelContentSection({
                                 setSelectedPath(file.path);
                                 onPinDiffFile(file);
                               }}
-                              className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left"
+                              className="flex min-w-0 flex-1 items-center gap-1 px-1 py-1.5 text-left"
                             >
                               <FileBadge file={file} />
-                              <span className="min-w-0 flex-1 truncate font-mono text-[11px]">
-                                {file.path}
+                              <span className="min-w-0 flex-1 font-mono text-[11px]">
+                                <FilePath path={file.path} />
                               </span>
                               {/* The inversion of the rule below: the diff stats give way
                                   to the action overlay. Below the Phone viewport step that


### PR DESCRIPTION
## Summary
- reclaim horizontal space in right-side Git changed-file rows
- keep the leaf filename visible when paths are long
- align bulk and per-file selection controls

## Verification
- npm run lint -- --quiet
- node --import tsx --test tests/git-desktop-commit-control.test.tsx
- isolated Git panel E2E visual check