### PR TITLE
fix(build): preserve LF endings for vendored patches

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch text eol=lf


### PR DESCRIPTION
## Summary
- force vendored `.patch` files to use LF line endings on every platform
- prevent Windows checkout from converting the xterm patch to CRLF and breaking `npm ci`

## Root cause
The Linux Wayland input change added `patches/@xterm+xterm+6.1.0-beta.303.patch` without a `.gitattributes` rule. GitHub Windows runners checked it out with CRLF endings, so `git apply --check` failed against all six patched xterm files.

## Validation
- reproduced the CI failure by applying a CRLF copy of the patch to a clean `@xterm/xterm@6.1.0-beta.303` package
- checked out the patch with `core.autocrlf=true` after this change and confirmed it contains no CRLF
- `git apply --check` succeeds against the clean xterm package
- `git diff --check`