### PR TITLE
fix(chat): clear PTY ChatView drop highlight

### DIFF
--- a/src/components/panel/panel-wrapper.tsx
+++ b/src/components/panel/panel-wrapper.tsx
@@ -267,6 +267,19 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     resolveSessionInsertZoneBounds,
   ]);
 
+  // A child drop target (such as the PTY ChatView overlay) can intentionally
+  // stop the bubbling `drop` event after handling its own payload. Clear this
+  // pane's visual state during capture as well, so that ownership transfer
+  // never leaves the panel-level highlight behind.
+  const clearDropIndicators = useCallback(() => {
+    dragCounterRef.current = 0;
+    dropEdgeRef.current = null;
+    sessionInsertZoneRef.current = false;
+    setDropEdge(null);
+    setInsertPathHint(false);
+    setSessionInsertZone(null);
+  }, []);
+
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     if (!isPanelCompatibleDrag(e)) return;
     e.preventDefault();
@@ -285,12 +298,7 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     e.preventDefault();
     const currentEdge = dropEdgeRef.current;
     const droppedInSessionInsertZone = sessionInsertZoneRef.current;
-    dragCounterRef.current = 0;
-    dropEdgeRef.current = null;
-    sessionInsertZoneRef.current = false;
-    setDropEdge(null);
-    setInsertPathHint(false);
-    setSessionInsertZone(null);
+    clearDropIndicators();
 
     // OS (Finder/Explorer) file drop → insert each absolute path into the PTY.
     if (currentEdge === 'center' && isNativeFilePathInsertTarget(e)) {
@@ -580,6 +588,7 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     isNativeFilePathInsertTarget,
     isTerminalSessionRefTarget,
     resolveInsertTargetTerminalId,
+    clearDropIndicators,
   ]);
 
   return (
@@ -604,6 +613,7 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
+      onDropCapture={clearDropIndicators}
       onDrop={handleDrop}
     >
       {children}

--- a/tests/terminal-chat-composer-path-input-contract.test.mjs
+++ b/tests/terminal-chat-composer-path-input-contract.test.mjs
@@ -30,6 +30,17 @@ test('terminal Chat View inserts a whole-overlay path drop into the same compose
   assert.match(chatAreaSource, /event\.stopPropagation\(\)/);
 });
 
+test('terminal Chat View clears the parent panel drop highlight before consuming its drop', () => {
+  const panelWrapperSource = fs.readFileSync(
+    new URL('../src/components/panel/panel-wrapper.tsx', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(panelWrapperSource, /const clearDropIndicators = useCallback\(/);
+  assert.match(panelWrapperSource, /onDropCapture=\{clearDropIndicators\}/);
+  assert.match(panelWrapperSource, /const handleDrop = useCallback\([\s\S]*?clearDropIndicators\(\);/);
+});
+
 test('terminal Chat View uploads image-only paste and inserts the returned path', () => {
   assert.match(
     composerSource,


### PR DESCRIPTION
## Summary
- clear panel-level file drop indicators during capture before PTY ChatView consumes the drop
- preserve ChatView path insertion without duplicate terminal input
- add a regression contract for the stopped-bubbling drop path

## Test
- npx tsx --test tests/terminal-chat-composer-path-input-contract.test.mjs

## Environment note
- Full ESLint and TypeScript checks were unavailable because this worktree has no node_modules.