### PR TITLE
Fix image panel memory retention with a persistent incremental index

### DIFF
--- a/docs/image-index-qa-2026-09-05.md
+++ b/docs/image-index-qa-2026-09-05.md
@@ -1,0 +1,28 @@
+# Image index verification — 2026-09-05
+
+## Contract
+
+- Codex terminal Images tabs load persisted cards first. Only the selected session's visible Images tab synchronizes, on a serial two-second timer.
+- SQLite stores cards, ordered image occurrences, pending image calls, decoder state, and the complete-line byte checkpoint together. Images live in session-owned disk files; persisted state contains no image base64.
+- Initial indexing reads the transcript in bounded batches. Later indexing reads appended records; replacement/truncation invalidates the checkpoint. Incomplete final lines are retried.
+- References are resolved against history at invocation time. Ambiguous references/results are explicitly unresolved, not guessed.
+- Session deletion removes its cache. Closing a tab or restarting the application preserves it.
+- Transient decoding and browser image display still use memory; this is not a claim of zero memory usage or proof against all application OOM causes.
+
+## Evidence
+
+Actual packaged Windows Electron/backend with WSL transcript files, separate owned test database and profile. UI tests append recorded protocol fixtures; they do not invoke a paid model or image generator.
+
+- Final build: call card 1,877 ms; completed image 2,046 ms; tab revisit 35 ms.
+- Verified appended-byte count, inactive-session polling stop, closed-Images-tab polling stop, cached display with source unavailable, and page reload.
+- Full server restart on the preceding build: two cached cards in 154 ms; pending call restored and completed on the same card with unchanged reference inputs; cached image HTTP 200.
+- Final build, read-only real transcript (472,434,659 bytes): initial indexing 5,025 ms across 18 batches; 48 cards; subsequent cached metadata query 18 ms, 301,887 bytes.
+- Windows-over-WSL testing caught unstable birth time in file identity. Identity now uses device/inode; append no longer triggers a complete rescan.
+- 49 focused tests pass; TypeScript and targeted ESLint pass.
+- Full unit suite: 1,925 pass, two skip, two fail. Both failures reproduced on clean HEAD: `git-action-failure-report.test.ts` action count and `worktree-identity-persistence.test.ts` ordering.
+
+Screenshots: `C:\Users\work\Downloads\image-index-qa-final-0905`.
+
+## Boundaries
+
+Incremental indexing currently targets Codex terminal sessions. A first-ever index can take seconds; warm cards do not wait for it. Individual image files are capped at 25 MiB and JSONL records at 96 MiB. Unsupported dynamic reference expressions remain unresolved. Existing heap diagnostics are retained for sustained real-use observation.

--- a/electron/server-child.ts
+++ b/electron/server-child.ts
@@ -7,6 +7,7 @@ import '../runtime/register-runtime-aliases';
 import next from 'next';
 import { createServer, type Server } from 'http';
 import { networkInterfaces } from 'node:os';
+import { getHeapSpaceStatistics, getHeapStatistics } from 'node:v8';
 import { initDatabase } from '../src/lib/db/database';
 import { bootstrapCanonicalWorktreeRegistry } from '../src/lib/db/worktree-bootstrap';
 import '../src/lib/cli/providers/bootstrap';
@@ -97,8 +98,55 @@ function logStartup(level: StartupLogLevel, msg: string) {
 
 let shutdownHandler: ((reason: string) => Promise<void>) | null = null;
 let parentWatchdog: NodeJS.Timeout | null = null;
+let oomDiagnosticsTimer: NodeJS.Timeout | null = null;
 let parentShutdownRequested = false;
 let controlRuntime: ControlRuntimeHost | null = null;
+
+const OOM_DIAGNOSTICS_TAG = '[DEBUG-oom-memory-v1]';
+const OOM_DIAGNOSTICS_INTERVAL_MS = 1_000;
+
+function bytesToMiB(value: number): number {
+  return Math.round((value / (1024 * 1024)) * 10) / 10;
+}
+
+function logOomDiagnostics(): void {
+  const memory = process.memoryUsage();
+  const heap = getHeapStatistics();
+  const oldSpaceUsed = getHeapSpaceStatistics()
+    .filter((space) => space.space_name === 'old_space' || space.space_name === 'old_large_object_space')
+    .reduce((total, space) => total + space.space_used_size, 0);
+  const terminal = terminalManager.collectOomDiagnostics();
+  const websocket = wsServer.collectOomDiagnostics();
+  const heapPressure = heap.heap_size_limit > 0 ? memory.heapUsed / heap.heap_size_limit : 0;
+  const elevated = heapPressure >= 0.7
+    || terminal.headlessPendingChars >= 64 * 1024 * 1024
+    || terminal.pendingFrameChars >= 64 * 1024 * 1024
+    || websocket.totalBufferedBytes >= 64 * 1024 * 1024;
+  const fields = {
+    diagnosticTag: OOM_DIAGNOSTICS_TAG,
+    memoryMiB: {
+      rss: bytesToMiB(memory.rss),
+      heapUsed: bytesToMiB(memory.heapUsed),
+      heapTotal: bytesToMiB(memory.heapTotal),
+      heapLimit: bytesToMiB(heap.heap_size_limit),
+      oldSpaceUsed: bytesToMiB(oldSpaceUsed),
+      external: bytesToMiB(memory.external),
+      arrayBuffers: bytesToMiB(memory.arrayBuffers),
+    },
+    heapPressure: Math.round(heapPressure * 10_000) / 10_000,
+    terminal,
+    websocket,
+  };
+  if (elevated) logger.warn(fields, `${OOM_DIAGNOSTICS_TAG} Server memory pressure sample`);
+  else logger.debug(fields, `${OOM_DIAGNOSTICS_TAG} Server memory sample`);
+}
+
+function startOomDiagnostics(): void {
+  if (STARTUP_LOG_LEVEL !== 'debug' || oomDiagnosticsTimer) return;
+  logOomDiagnostics();
+  oomDiagnosticsTimer = setInterval(logOomDiagnostics, OOM_DIAGNOSTICS_INTERVAL_MS);
+  oomDiagnosticsTimer.unref?.();
+}
 
 function isProcessAlive(pid: number): boolean {
   try {
@@ -220,6 +268,7 @@ initDatabase().then(async () => {
       });
 
       wsServer.start(server);
+      startOomDiagnostics();
       // Only now can a direct listener serve /ws, so bind it after the
       // WebSocket server exists rather than alongside the loopback listen.
       await directListeners.sync();
@@ -286,6 +335,10 @@ initDatabase().then(async () => {
     if (parentWatchdog) {
       clearInterval(parentWatchdog);
       parentWatchdog = null;
+    }
+    if (oomDiagnosticsTimer) {
+      clearInterval(oomDiagnosticsTimer);
+      oomDiagnosticsTimer = null;
     }
 
     const forceShutdownTimer = setTimeout(() => {

--- a/src/app/api/sessions/[id]/image-generations/route.ts
+++ b/src/app/api/sessions/[id]/image-generations/route.ts
@@ -5,6 +5,8 @@ import { jsonError } from '@/lib/http/json-error';
 import { ensureTraceInputAgentPaths, readSessionImageGenerationTraces } from '@/lib/image-generation/session-traces';
 import { toPublicImageGenerationTraces } from '@/lib/image-generation/traces';
 import logger from '@/lib/logger';
+import { syncTerminalImageIndex } from '@/lib/image-generation/terminal-image-index';
+import { supportsTerminalTranscriptHistory } from '@/lib/session/terminal-session-history';
 
 export async function GET(
   request: NextRequest,
@@ -18,9 +20,12 @@ export async function GET(
     if ('response' in auth) return auth.response;
     const session = dbSessions.getSession(id);
     if (!session) return jsonError('not_found', 'Session not found', 404);
+    const indexed = session.provider === 'codex' && supportsTerminalTranscriptHistory(session);
+    const sync = indexed && request.nextUrl.searchParams.get('sync') === '1'
+      ? await syncTerminalImageIndex(session, auth.userId, request.signal) : { more: false };
     const traces = await readSessionImageGenerationTraces(session, auth.userId);
     await ensureTraceInputAgentPaths(traces, auth.userId);
-    return NextResponse.json({ traces: toPublicImageGenerationTraces(id, traces) });
+    return NextResponse.json({ traces: toPublicImageGenerationTraces(id, traces), more: sync.more });
   } catch (error) {
     logger.error({ error, sessionId: id }, 'Failed to read image generation traces');
     return jsonError('internal_error', 'Failed to read image generation traces', 500);

--- a/src/app/api/sessions/[id]/tool-image/route.ts
+++ b/src/app/api/sessions/[id]/tool-image/route.ts
@@ -10,7 +10,8 @@ import {
   readTerminalToolCallParams,
   supportsTerminalTranscriptHistory,
 } from '@/lib/session/terminal-session-history';
-import { inferImageMime, isImagePath } from '@/lib/tool-results/tool-image';
+import { extractImageToolPath, inferImageMime, isImagePath } from '@/lib/tool-results/tool-image';
+import { extractCachedTerminalTranscriptImagePath } from '@/lib/session/terminal-transcript-image-cache';
 
 // Codex screenshots / large reads can be a few MB; cap to avoid serving huge files.
 const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
@@ -52,12 +53,11 @@ export async function GET(
       return jsonError('not_found', 'Tool call not found', 404);
     }
 
-    // `path` for Codex view_image, `file_path` for Claude Code Read.
-    const rawPath = typeof toolParams.path === 'string'
-      ? toolParams.path
-      : typeof toolParams.file_path === 'string'
-        ? toolParams.file_path
-        : '';
+    // `path` for Codex view_image, `file_path` for Claude Code Read, and
+    // `savedPath` for Codex imageGeneration.
+    const rawPath = extractCachedTerminalTranscriptImagePath(toolParams)
+      ?? extractImageToolPath(toolParams)
+      ?? '';
 
     if (!rawPath.trim() || rawPath.includes('\0')) {
       return jsonError('invalid_file_path', 'Tool call has no image path', 422);

--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -705,6 +705,7 @@ export function ChatLayout() {
               )}
               <GitPanel
                 sessionId={activeGitTargetSessionId}
+                isActive={Boolean(activeGitTargetSessionId)}
                 worktreeId={activeGitWorktreeId}
                 width={isCompactViewport ? "100vw" : gitPanelWidth}
                 className={cn(

--- a/src/components/chat/tool-call-grid.tsx
+++ b/src/components/chat/tool-call-grid.tsx
@@ -13,7 +13,12 @@ import { ToolCallDetailPanel } from './tool-call-detail-panel';
 import { MESSAGE_BODY_OFFSET_CLASS } from './message-layout';
 import { MessageRowShell } from './message-row-shell';
 import { ImageLightbox } from './image-lightbox';
-import { buildToolImageUrl, isImagePath, resolveImageToolResultSrc } from '@/lib/tool-results/tool-image';
+import {
+  buildToolImageUrl,
+  extractImageToolPath,
+  isImagePath,
+  resolveImageToolResultSrc,
+} from '@/lib/tool-results/tool-image';
 
 // --- Layout threshold ---
 const SUMMARY_BAR_MIN = 4;
@@ -99,8 +104,8 @@ async function prefetchToolOutput(tc: ToolCallMessage): Promise<boolean> {
 function isImageToolCall(tc: ToolCallMessage): boolean {
   if (tc.status === 'error') return false;
   if (resolveImageToolResultSrc(tc.toolUseResult)) return true;
-  if (tc.toolKind !== 'file_read' && tc.toolName !== 'ViewImage') return false;
-  return isImagePath(tc.toolParams?.file_path ?? tc.toolParams?.path);
+  if (tc.toolKind !== 'file_read' && tc.toolName !== 'ViewImage' && tc.toolName !== 'ImageGeneration') return false;
+  return isImagePath(extractImageToolPath(tc.toolParams));
 }
 
 /** Renders the image inline in the chat flow (no click needed), with click-to-zoom. */
@@ -114,7 +119,7 @@ function InlineToolImage({ toolCall, alignWithMessageBody }: {
   const embeddedSrc = resolveImageToolResultSrc(toolCall.toolUseResult);
   const url = embeddedSrc ?? (toolUseId && sessionId ? buildToolImageUrl(sessionId, toolUseId) : undefined);
   if (!url) return null;
-  const filePath = toolCall.toolParams?.file_path ?? toolCall.toolParams?.path;
+  const filePath = extractImageToolPath(toolCall.toolParams);
   const caption = typeof filePath === 'string' ? filePath : shortenToolName(toolCall.toolName);
 
   const content = (

--- a/src/components/git/git-panel.tsx
+++ b/src/components/git/git-panel.tsx
@@ -82,6 +82,7 @@ function GitPanelTabButton({
 
 export function GitPanel({
   sessionId,
+  isActive = true,
   worktreeId = null,
   width,
   className,
@@ -89,6 +90,7 @@ export function GitPanel({
   onClose,
 }: {
   sessionId: string | null;
+  isActive?: boolean;
   worktreeId?: string | null;
   width: number | string;
   className?: string;
@@ -371,7 +373,7 @@ export function GitPanel({
         </div>
       ) : effectivePanelTab === "images" ? (
         <div className="min-h-0 flex-1">
-          <ImageGenerationsPanel key={sessionId ?? "no-session"} sessionId={sessionId} />
+          <ImageGenerationsPanel key={sessionId ?? "no-session"} sessionId={sessionId} isActive={isActive} />
         </div>
       ) : (
         <>

--- a/src/components/image-generation/image-generations-panel.tsx
+++ b/src/components/image-generation/image-generations-panel.tsx
@@ -2,7 +2,7 @@
 
 /* eslint-disable @next/next/no-img-element -- Authenticated, session-scoped image routes cannot use Next's unauthenticated optimizer. */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { AlertTriangle, ChevronDown, ChevronUp, Copy, Download, ImageIcon, LoaderCircle, RefreshCw } from "lucide-react";
 import { ImageLightbox } from "@/components/chat/image-lightbox";
 import { clearPathInsertDragData, setPathInsertDragData } from "@/lib/dnd/panel-session-drag";
@@ -13,81 +13,92 @@ import { cn } from "@/lib/utils";
 import { toast } from "@/stores/notification-store";
 
 const REFRESH_INTERVAL_MS = 2_000;
+// Small URL/metadata-only cache; persistence and authoritative state live on the server.
+const panelCache = new Map<string, PublicImageGenerationTrace[]>();
 
 interface LightboxImage {
   src: string;
   alt: string;
 }
 
-export function ImageGenerationsPanel({ sessionId }: { sessionId: string | null }) {
+export function ImageGenerationsPanel({ sessionId, isActive = true }: { sessionId: string | null; isActive?: boolean }) {
   const { t } = useI18n();
-  const [traces, setTraces] = useState<PublicImageGenerationTrace[]>([]);
-  const [loading, setLoading] = useState(Boolean(sessionId));
+  const [traces, setTraces] = useState<PublicImageGenerationTrace[]>(() => sessionId ? panelCache.get(sessionId) ?? [] : []);
+  const [loading, setLoading] = useState(Boolean(sessionId && !panelCache.has(sessionId)));
   const [error, setError] = useState(false);
   const [lightboxImage, setLightboxImage] = useState<LightboxImage | null>(null);
-  const requestInFlightRef = useRef(false);
+  const [retry, setRetry] = useState(0);
 
-  const load = useCallback(async (signal?: AbortSignal) => {
+  const load = useCallback(async (signal: AbortSignal, sync: boolean) => {
     if (!sessionId) {
       setTraces([]);
       setLoading(false);
       return;
     }
-    if (requestInFlightRef.current) return;
-    requestInFlightRef.current = true;
     try {
-      const response = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/image-generations`, {
+      const response = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/image-generations${sync ? '?sync=1' : ''}`, {
         signal,
         cache: "no-store",
       });
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const body = await response.json() as { traces?: PublicImageGenerationTrace[] };
+      const body = await response.json() as { traces?: PublicImageGenerationTrace[]; more?: boolean };
+      if (signal.aborted) return;
       const nextTraces = Array.isArray(body.traces) ? body.traces : [];
+      panelCache.delete(sessionId);
+      panelCache.set(sessionId, nextTraces);
+      while (panelCache.size > 8) panelCache.delete(panelCache.keys().next().value!);
       setTraces((current) => (
         JSON.stringify(current) === JSON.stringify(nextTraces) ? current : nextTraces
       ));
       setError(false);
+      if (nextTraces.length || (sync && !body.more)) setLoading(false);
+      return Boolean(body.more);
     } catch (loadError) {
-      if ((loadError as Error).name !== "AbortError") setError(true);
-    } finally {
-      requestInFlightRef.current = false;
-      if (!signal?.aborted) setLoading(false);
+      if (!signal.aborted && (loadError as Error).name !== "AbortError") {
+        setError(true);
+        setLoading(false);
+      }
     }
   }, [sessionId]);
 
-  useEffect(function loadImageGenerationTraces() {
+  useEffect(function synchronizeActiveImageTab() {
     const controller = new AbortController();
-    setLoading(Boolean(sessionId));
-    void load(controller.signal);
-    return () => controller.abort();
-  }, [load, sessionId]);
-
-  useEffect(function refreshImageGenerationTracesWhileOpen() {
-    if (!sessionId) return;
-    const refresh = () => {
-      if (document.visibilityState === "visible") void load();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let busy = false;
+    const refresh = async () => {
+      if (busy || controller.signal.aborted || !isActive || document.visibilityState !== 'visible') return;
+      clearTimeout(timer);
+      busy = true;
+      const more = await load(controller.signal, true);
+      busy = false;
+      if (!controller.signal.aborted) timer = setTimeout(() => void refresh(), more ? 0 : REFRESH_INTERVAL_MS);
     };
-    const refreshWhenVisible = () => {
-      if (document.visibilityState === "visible") refresh();
+    const resume = () => { void refresh(); };
+    const start = async () => {
+      busy = true;
+      await load(controller.signal, false); // Never wait for transcript I/O to show saved cards.
+      busy = false;
+      await refresh();
     };
-    const timer = window.setInterval(refresh, REFRESH_INTERVAL_MS);
-    window.addEventListener("focus", refresh);
-    document.addEventListener("visibilitychange", refreshWhenVisible);
+    void start();
+    window.addEventListener('focus', resume);
+    document.addEventListener('visibilitychange', resume);
     return () => {
-      window.clearInterval(timer);
-      window.removeEventListener("focus", refresh);
-      document.removeEventListener("visibilitychange", refreshWhenVisible);
+      controller.abort();
+      clearTimeout(timer);
+      window.removeEventListener('focus', resume);
+      document.removeEventListener('visibilitychange', resume);
     };
-  }, [load, sessionId]);
+  }, [isActive, load, retry]);
 
   if (!sessionId) return <EmptyState text={t("imagePanel.selectSession")} />;
   if (loading) return <EmptyState loading text={t("imagePanel.loading")} />;
-  if (error) {
+  if (error && traces.length === 0) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 px-5 text-center text-xs text-(--text-muted)">
         <AlertTriangle className="h-5 w-5" />
         <p>{t("imagePanel.loadFailed")}</p>
-        <button {...telemetryClickAttributes("image_generation.retry", "right_panel")} type="button" onClick={() => void load()} className="flex items-center gap-1 rounded border px-2 py-1 text-(--text-primary)">
+        <button {...telemetryClickAttributes("image_generation.retry", "right_panel")} type="button" onClick={() => setRetry((value) => value + 1)} className="flex items-center gap-1 rounded border px-2 py-1 text-(--text-primary)">
           <RefreshCw className="h-3 w-3" /> {t("imagePanel.retry")}
         </button>
       </div>
@@ -253,7 +264,7 @@ function ResultHeroMedia({
             src={result.url}
             draggable={false}
             alt=""
-            loading="eager"
+            loading="lazy"
             onLoad={(event) => {
               const image = event.currentTarget;
               setDimensions({ width: image.naturalWidth, height: image.naturalHeight });

--- a/src/lib/cli/providers/codex/adapter.ts
+++ b/src/lib/cli/providers/codex/adapter.ts
@@ -75,6 +75,7 @@ import { updateProviderStateWithRetry } from '../../process-manager-side-effects
 import { getRuntimePlatform } from '@/lib/system/runtime-platform';
 import logger from '@/lib/logger';
 import { getTesseraDataPath } from '@/lib/tessera-data-dir';
+import { materializeTerminalTranscriptImage } from '@/lib/session/terminal-transcript-image-cache';
 import { fetchCodexRateLimitSnapshot } from './rate-limit-client';
 import { codexScreenShowsConversationReset } from '@/lib/terminal/terminal-conversation-reset-screen';
 
@@ -327,7 +328,9 @@ export class CodexAdapter implements CliProvider {
     try {
       const lines = createInterface({ input: stream, crlfDelay: Infinity });
       for await (const line of lines) {
-        events.push(...decodeCodexTranscriptLine(line, decoderState));
+        for (const event of decodeCodexTranscriptLine(line, decoderState)) {
+          events.push(await materializeTerminalTranscriptImage(options.sessionId, event));
+        }
       }
     } catch (error) {
       // A rollout that vanished mid-read (overlay cleaned up) is the same

--- a/src/lib/cli/providers/codex/protocol-parser.ts
+++ b/src/lib/cli/providers/codex/protocol-parser.ts
@@ -2061,16 +2061,21 @@ export class CodexProtocolParser {
     const output = status === 'running' || isImageGeneration
       ? undefined
       : this.buildGenericCodexItemOutput(item);
+    const savedImagePath = typeof toolParams.savedPath === 'string'
+      ? toolParams.savedPath
+      : undefined;
     const generatedImageResult: FileReadImageToolResult | undefined = isImageGeneration
       && status === 'completed'
-      && typeof item.result === 'string'
-      && item.result.length > 0
-      ? {
-          kind: 'file_read',
-          contentType: 'image',
-          base64: item.result,
-          mimeType: 'image/png',
-        }
+      ? itemId && isImagePath(savedImagePath)
+        ? buildImageToolResult(sessionId, itemId)
+        : typeof item.result === 'string' && item.result.length > 0
+          ? {
+              kind: 'file_read',
+              contentType: 'image',
+              base64: item.result,
+              mimeType: 'image/png',
+            }
+          : undefined
       : undefined;
 
     // `view_image` (imageView) injects a local file into context with no image

--- a/src/lib/cli/providers/codex/transcript-decoder.ts
+++ b/src/lib/cli/providers/codex/transcript-decoder.ts
@@ -258,21 +258,32 @@ function decodeEventMessage(
 function decodeImageGenerationCompleted(
   payload: Record<string, any>,
   timestamp: string,
+  preferInlineImages = false,
 ): SessionHistoryEvent | null {
   if (payload.type !== 'item_completed' || !isRecord(payload.item)) return null;
   const item = payload.item;
   if (item.kind !== 'image_gen.generation' && item.type !== 'imageGeneration') return null;
   const id = typeof item.id === 'string' && item.id ? item.id : `image-generation-${timestamp}`;
   const status = item.status === 'failed' || item.failure ? 'error' : 'completed';
+  const savedPath = typeof item.savedPath === 'string' && item.savedPath
+    ? item.savedPath
+    : undefined;
   const imageResult: FileReadImageToolResult | undefined = status === 'completed'
-    && typeof item.result === 'string'
-    && item.result.length > 0
-    ? {
+    ? savedPath && !(preferInlineImages && typeof item.result === 'string' && item.result.length > 0)
+      ? {
+          kind: 'file_read',
+          contentType: 'image',
+          path: savedPath,
+          mimeType: 'image/png',
+        }
+      : typeof item.result === 'string' && item.result.length > 0
+        ? {
         kind: 'file_read',
         contentType: 'image',
         base64: item.result,
         mimeType: 'image/png',
       }
+        : undefined
     : undefined;
   return {
     v: HISTORY_VERSION,
@@ -282,7 +293,7 @@ function decodeImageGenerationCompleted(
     toolParams: {
       itemType: 'imageGeneration',
       ...(typeof item.revisedPrompt === 'string' ? { revisedPrompt: item.revisedPrompt } : {}),
-      ...(typeof item.savedPath === 'string' ? { savedPath: item.savedPath } : {}),
+      ...(savedPath ? { savedPath } : {}),
       ...(typeof item.transparentBackground === 'boolean'
         ? { transparentBackground: item.transparentBackground }
         : {}),
@@ -367,6 +378,7 @@ function decodeResponseMessage(
 export function decodeCodexTranscriptLine(
   line: string,
   state: CodexTranscriptDecoderState,
+  options: { preferInlineImages?: boolean } = {},
 ): SessionHistoryEvent[] {
   const trimmed = line.trim();
   if (!trimmed) return [];
@@ -388,7 +400,7 @@ export function decodeCodexTranscriptLine(
   }
 
   if (record.type === 'event_msg') {
-    const imageGeneration = decodeImageGenerationCompleted(payload, timestamp);
+    const imageGeneration = decodeImageGenerationCompleted(payload, timestamp, options.preferInlineImages);
     if (imageGeneration) return [imageGeneration];
     if (state.readResponseItemConversation) return [];
     const event = decodeEventMessage(payload, timestamp);

--- a/src/lib/db/image-generation-cache.ts
+++ b/src/lib/db/image-generation-cache.ts
@@ -1,0 +1,26 @@
+import { getDb } from './database';
+import type { ImageGenerationTrace } from '@/lib/image-generation/traces';
+
+export const IMAGE_CACHE_VERSION = 1;
+
+export function readImageCache(sessionId: string): {
+  source_json: string; state_json: string; cards_json: string;
+} | undefined {
+  return getDb().prepare('SELECT source_json, state_json, cards_json FROM image_generation_cache WHERE session_id = ? AND version = ?')
+    .get(sessionId, IMAGE_CACHE_VERSION);
+}
+
+export function readImageCards(sessionId: string): ImageGenerationTrace[] {
+  const row = getDb().prepare('SELECT cards_json FROM image_generation_cache WHERE session_id = ? AND version = ?')
+    .get(sessionId, IMAGE_CACHE_VERSION);
+  return row ? JSON.parse(row.cards_json) : [];
+}
+
+/** One SQLite statement commits cards, reference history and checkpoint together. */
+export function saveImageCache(sessionId: string, source: unknown, state: unknown, cards: ImageGenerationTrace[]): void {
+  getDb().prepare(`INSERT INTO image_generation_cache(session_id, version, source_json, state_json, cards_json)
+    SELECT ?, ?, ?, ?, ? WHERE EXISTS (SELECT 1 FROM sessions WHERE id = ? AND deleted = 0)
+    ON CONFLICT(session_id) DO UPDATE SET version=excluded.version, source_json=excluded.source_json,
+    state_json=excluded.state_json, cards_json=excluded.cards_json`)
+    .run(sessionId, IMAGE_CACHE_VERSION, JSON.stringify(source), JSON.stringify(state), JSON.stringify(cards), sessionId);
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -81,6 +81,14 @@ CREATE TABLE IF NOT EXISTS session_messages (
   created_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS image_generation_cache (
+  session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+  version INTEGER NOT NULL,
+  source_json TEXT NOT NULL,
+  state_json TEXT NOT NULL,
+  cards_json TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS terminal_provider_sessions (
   provider_id        TEXT NOT NULL,
   provider_session_id TEXT NOT NULL,

--- a/src/lib/db/sessions.ts
+++ b/src/lib/db/sessions.ts
@@ -3,6 +3,7 @@
  */
 
 import fs from 'fs';
+import { imageSessionCacheDirectory } from '@/lib/image-generation/cache-files';
 import { getDb } from './database';
 import { deleteTerminalProviderSessionsForTesseraSession } from './terminal-provider-sessions';
 import { getTesseraDataPath } from '@/lib/tessera-data-dir';
@@ -317,6 +318,8 @@ export function createSession(
 export function deleteSession(id: string): void {
   deleteTerminalProviderSessionsForTesseraSession(id);
   getDb().prepare('DELETE FROM sessions WHERE id = ?').run(id);
+  // Only this server-owned, hashed per-session directory is removed.
+  void fs.promises.rm(imageSessionCacheDirectory(id), { recursive: true, force: true }).catch(() => {});
 }
 
 /**
@@ -460,6 +463,8 @@ export function clearWorktreeMetadataByWorkDir(workDir: string): void {
 export function softDeleteSession(id: string): void {
   getDb().prepare('UPDATE sessions SET deleted = 1, updated_at = ? WHERE id = ?')
     .run(new Date().toISOString(), id);
+  getDb().prepare('DELETE FROM image_generation_cache WHERE session_id = ?').run(id);
+  void fs.promises.rm(imageSessionCacheDirectory(id), { recursive: true, force: true }).catch(() => {});
 }
 
 /**

--- a/src/lib/image-generation/cache-files.ts
+++ b/src/lib/image-generation/cache-files.ts
@@ -1,0 +1,49 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { getTesseraDataPath } from '@/lib/tessera-data-dir';
+import { resolveAgentReportedPath } from '@/lib/filesystem/path-environment';
+import { resolveCodexAccountOverlayPath } from '@/lib/codex-home';
+import { isBridgedAgentEnvironment, resolveAgentHomeFilesystemPath } from '@/lib/filesystem/path-environment';
+import type { AgentEnvironment } from '@/lib/settings/types';
+import type { ImageLocator } from './traces';
+
+export function imageSessionCacheDirectory(sessionId: string): string {
+  return getTesseraDataPath('cache', 'image-generations', createHash('sha256').update(sessionId).digest('hex'));
+}
+
+/** Own the file: a CLI overlay or original generated file can disappear later. */
+export async function cacheImageFile(sessionId: string, locator: ImageLocator, environment: AgentEnvironment): Promise<ImageLocator | undefined> {
+  const maxBytes = 25 * 1024 * 1024;
+  let bytes: Buffer;
+  let extension: string;
+  if (locator.kind === 'inline') {
+    if (locator.data.length > Math.ceil(maxBytes * 4 / 3)) return undefined;
+    bytes = Buffer.from(locator.data, 'base64');
+    extension = ({ 'image/png': '.png', 'image/jpeg': '.jpg', 'image/webp': '.webp', 'image/gif': '.gif',
+      'image/avif': '.avif', 'image/bmp': '.bmp', 'image/svg+xml': '.svg' } as Record<string, string>)[locator.mimeType] ?? '.png';
+  } else {
+    let source = locator.path;
+    if (locator.kind === 'path') {
+      source = await resolveAgentReportedPath(source, environment);
+      source = resolveCodexAccountOverlayPath(source, isBridgedAgentEnvironment(environment)
+        ? { env: { NODE_ENV: process.env.NODE_ENV }, homeDir: await resolveAgentHomeFilesystemPath(environment) } : undefined);
+    }
+    const stat = await fs.stat(source);
+    if (!stat.isFile() || stat.size > maxBytes) return undefined;
+    bytes = await fs.readFile(source);
+    extension = path.extname(source).toLowerCase();
+    if (!/^\.(png|jpe?g|webp|gif|avif|bmp|svg)$/.test(extension)) return undefined;
+  }
+  if (!bytes.length || bytes.length > maxBytes) return undefined;
+  const directory = imageSessionCacheDirectory(sessionId);
+  const target = path.join(directory, `${createHash('sha256').update(bytes).digest('hex')}${extension}`);
+  await fs.mkdir(directory, { recursive: true });
+  if ((await fs.stat(target).catch(() => undefined))?.size === bytes.length) return { kind: 'cache', path: target };
+  const temporary = path.join(directory, `${randomUUID()}.tmp`);
+  try {
+    await fs.writeFile(temporary, bytes, { flag: 'wx' });
+    await fs.rename(temporary, target);
+  } finally { await fs.rm(temporary, { force: true }); }
+  return { kind: 'cache', path: target };
+}

--- a/src/lib/image-generation/incremental-reader.ts
+++ b/src/lib/image-generation/incremental-reader.ts
@@ -1,0 +1,78 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+
+export interface ImageCheckpoint {
+  path: string;
+  identity: string;
+  offset: number;
+  size: number;
+  mtimeMs: number;
+  boundary: string;
+}
+
+async function boundaryHash(file: fs.FileHandle, offset: number): Promise<string> {
+  const buffer = Buffer.alloc(Math.min(256, offset));
+  const { bytesRead } = await file.read(buffer, 0, buffer.length, offset - buffer.length);
+  return createHash('sha256').update(buffer.subarray(0, bytesRead)).digest('hex');
+}
+
+/** Byte offsets, complete JSONL records, bounded batches; never retain a whole transcript. */
+export async function readImageTranscriptBatch(
+  path: string,
+  previous: ImageCheckpoint | undefined,
+  reset: () => void,
+  consume: (line: string, offset: number) => Promise<void>,
+  signal?: AbortSignal,
+): Promise<{ checkpoint: ImageCheckpoint; more: boolean; bytesRead: number }> {
+  const file = await fs.open(path, 'r');
+  try {
+    const stat = await file.stat();
+    // WSL's Windows file server can report mtime as birthtime. Including it
+    // would misclassify every append as a replacement and rescan from zero.
+    const identity = `${stat.dev}:${stat.ino}`;
+    let offset = previous?.offset ?? 0;
+    const valid = previous && previous.path === path && previous.identity === identity && stat.size >= offset
+      && previous.boundary === await boundaryHash(file, offset)
+      && !(stat.size === previous.size && stat.mtimeMs !== previous.mtimeMs);
+    if (!valid) { offset = 0; reset(); }
+    const start = offset;
+    let more = false;
+    if (stat.size > offset) {
+      let readPosition = offset;
+      let fragments: Buffer[] = [];
+      let length = 0;
+      const started = Date.now();
+        outer: while (readPosition < stat.size) {
+          const chunk = Buffer.allocUnsafe(Math.min(256 * 1024, stat.size - readPosition));
+          const read = await file.read(chunk, 0, chunk.length, readPosition);
+          if (!read.bytesRead) break;
+          readPosition += read.bytesRead;
+          const buffer = chunk.subarray(0, read.bytesRead);
+          let cursor = 0;
+          while (cursor < buffer.length) {
+            if (signal?.aborted) break outer;
+            const newline = buffer.indexOf(10, cursor);
+            const end = newline === -1 ? buffer.length : newline + 1;
+            const part = buffer.subarray(cursor, end);
+            fragments.push(part);
+            length += part.length;
+            // Fail explicitly instead of retaining unbounded malformed/huge JSON records.
+            if (length > 96 * 1024 * 1024) throw new Error('Image transcript record exceeds 96 MiB');
+            cursor = end;
+            if (newline === -1) continue;
+            const line = Buffer.concat(fragments, length).toString('utf8');
+            await consume(line, offset);
+            offset += length;
+            fragments = [];
+            length = 0;
+            if (offset - start >= 32 * 1024 * 1024 || Date.now() - started >= 250) {
+              more = offset < stat.size;
+              break outer;
+            }
+          }
+        }
+    }
+    return { checkpoint: { path, identity, offset, size: stat.size, mtimeMs: stat.mtimeMs, boundary: await boundaryHash(file, offset) },
+      more, bytesRead: offset - start };
+  } finally { await file.close(); }
+}

--- a/src/lib/image-generation/incremental-state.ts
+++ b/src/lib/image-generation/incremental-state.ts
@@ -1,0 +1,88 @@
+import type { EnhancedMessage } from '@/types/chat';
+import { imageFromTool, isImageGenerationResult, parseImageGenerationInvocations, resultImage,
+  type ImageGenerationTrace, type ResolvedTraceImage } from './traces';
+
+export interface ImageIndexState {
+  ledger: ResolvedTraceImage[];
+  traces: ImageGenerationTrace[];
+  pending: string[];
+  seenResults: string[];
+}
+
+export function createImageIndex(): ImageIndexState {
+  return { ledger: [], traces: [], pending: [], seenResults: [] };
+}
+
+/** File-backed images only. Preserve occurrences, not just unique file hashes. */
+export function appendImage(state: ImageIndexState, image: ResolvedTraceImage): void {
+  if (state.ledger.some((entry) => entry.sourceMessageId === image.sourceMessageId)) return;
+  state.ledger.push(image);
+}
+
+/** Incremental counterpart of projectImageGenerationTraces; no full chat replay. */
+export function applyImageTool(state: ImageIndexState, message: Extract<EnhancedMessage, { type: 'tool_call' }>): void {
+  if (isImageGenerationResult(message)) {
+    if (state.seenResults.includes(message.id)) return;
+    state.seenResults.push(message.id);
+    // The transcript does not always supply a parent call ID. Do not assign an
+    // out-of-order result to an arbitrary pending prompt when association is ambiguous.
+    if (state.pending.length > 1) {
+      for (const pending of state.traces.filter((entry) => state.pending.includes(entry.id))) {
+        pending.status = 'error';
+        pending.error = 'Image result could not be matched to this call.';
+      }
+      state.pending = [];
+    }
+    const traceId = state.pending.shift();
+    const trace = state.traces.find((entry) => entry.id === traceId);
+    const image = resultImage(message);
+    if (trace) {
+      trace.status = message.status;
+      trace.revisedPrompt = typeof message.toolParams.revisedPrompt === 'string' ? message.toolParams.revisedPrompt : undefined;
+      trace.error = message.error;
+      trace.result = image;
+    } else {
+      state.traces.push({ id: `result-${message.id}`, invocationMessageId: message.id,
+        prompt: typeof message.toolParams.revisedPrompt === 'string' ? message.toolParams.revisedPrompt : 'Image generation',
+        inputs: [], unresolvedInputCount: 1, status: message.status, result: image,
+        timestamp: message.timestamp, error: message.error });
+    }
+    // Both result representations belong to the same invocation occurrence.
+    // Identical pixels from two different calls still count as two images.
+    if (image) appendImage(state, { ...image, sourceMessageId: trace?.id ?? message.id });
+    return;
+  }
+  const source = ['input', 'source', 'code', 'command', 'arguments']
+    .map((key) => message.toolParams[key])
+    .find((value): value is string => typeof value === 'string' && value.includes('image_gen__imagegen'));
+  const invocations = source ? parseImageGenerationInvocations(source) : [];
+  for (const [index, invocation] of invocations.entries()) {
+    const id = `${message.toolUseId ?? message.id}-${index}`;
+    // A tool result repeats its call parameters. It must never create another card.
+    if (state.traces.some((trace) => trace.id === id)) continue;
+    const requested = invocation.numLastImagesToInclude ?? 0;
+    let inputs: ResolvedTraceImage[] = invocation.referencedImagePaths
+      ? invocation.referencedImagePaths.map((path) => ({ source: 'explicit-path', label: path, locator: { kind: 'path', path } }))
+      : requested > 0 && requested <= state.ledger.length ? state.ledger.slice(-requested) : [];
+    const missing = invocation.referencesUnresolved || (index > 0 && requested > 0) || (!invocation.referencedImagePaths && (requested > state.ledger.length
+      || inputs.some((image) => image.locator.kind === 'cache' && !image.locator.path)));
+    if (missing) inputs = [];
+    state.traces.push({ id, invocationMessageId: message.id, ...invocation, inputs: inputs.map((image) => ({ ...image })),
+      unresolvedInputCount: missing ? Math.max(1, requested) : 0,
+      status: 'running', timestamp: message.timestamp });
+    state.pending.push(id);
+  }
+  if (message.status === 'error') {
+    for (const trace of state.traces.filter((entry) => entry.invocationMessageId === message.id && entry.status === 'running')) {
+      trace.status = 'error';
+      trace.error = message.error;
+      state.pending = state.pending.filter((id) => id !== trace.id);
+    }
+  }
+  if (message.status !== 'running') {
+    const image = imageFromTool(message, Boolean(source));
+    if (image && invocations.length <= 1) appendImage(state, {
+      ...image, sourceMessageId: invocations.length === 1 ? `${message.toolUseId ?? message.id}-0` : image.sourceMessageId,
+    });
+  }
+}

--- a/src/lib/image-generation/session-traces.ts
+++ b/src/lib/image-generation/session-traces.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/session/terminal-session-history';
 import { inferImageMime, isImagePath } from '@/lib/tool-results/tool-image';
 import logger from '@/lib/logger';
+import { readImageCards } from '@/lib/db/image-generation-cache';
 import {
   projectImageGenerationTraces,
   type ImageGenerationTrace,
@@ -40,6 +41,7 @@ export async function readSessionImageGenerationTraces(
   session: dbSessions.SessionRow,
   userId: string,
 ): Promise<ImageGenerationTrace[]> {
+  if (session.provider === 'codex' && supportsTerminalTranscriptHistory(session)) return readImageCards(session.id);
   const replay = supportsTerminalTranscriptHistory(session)
     ? await readTerminalSessionReplayState(session, userId)
     : reduceSessionReplayEvents(session.id, await sessionHistory.readEvents(session.id), {
@@ -61,8 +63,12 @@ export async function ensureTraceInputAgentPaths(
   const userKey = createHash('sha256').update(userId).digest('hex').slice(0, 16);
   const inputDir = join(tmpdir(), 'tessera-image-generation-inputs', userKey);
 
-  await Promise.all(traces.flatMap((trace) => trace.inputs.map(async (input) => {
+  await Promise.all(traces.flatMap((trace) => [...trace.inputs, ...(trace.result ? [trace.result] : [])].map(async (input) => {
     if (input.agentPath) return;
+    if (input.locator.kind === 'cache') {
+      input.agentPath = normalizeCwdForCliEnvironment(input.locator.path, environment);
+      return;
+    }
     if (input.locator.kind === 'path') {
       input.agentPath = input.locator.path;
       return;
@@ -102,6 +108,13 @@ export async function readTraceImageBytes(
     return { bytes, mimeType: locator.mimeType };
   }
   if (locator.path.includes('\0') || !isImagePath(locator.path)) return null;
+  if (locator.kind === 'cache') {
+    try {
+      const stat = await fs.stat(locator.path);
+      if (!stat.isFile() || stat.size > MAX_IMAGE_BYTES) return null;
+      return { bytes: await fs.readFile(locator.path), mimeType: inferImageMime(locator.path) ?? 'application/octet-stream' };
+    } catch { return null; }
+  }
   const environment = await getAgentEnvironment(userId);
   const reportedHostPath = await resolveAgentReportedPath(locator.path, environment);
   const hostPath = resolveCodexAccountOverlayPath(reportedHostPath, isBridgedAgentEnvironment(environment)

--- a/src/lib/image-generation/terminal-image-index.ts
+++ b/src/lib/image-generation/terminal-image-index.ts
@@ -1,0 +1,115 @@
+import type { SessionRow } from '@/lib/db/sessions';
+import { getSession } from '@/lib/db/sessions';
+import fs from 'node:fs/promises';
+import { readImageCache, readImageCards, saveImageCache } from '@/lib/db/image-generation-cache';
+import { getTerminalProviderSessionForTesseraSession } from '@/lib/db/terminal-provider-sessions';
+import { readPersistedTerminalProviderSessionId } from '@/lib/terminal/provider-session-identity';
+import { resolveCodexTranscriptPath } from '@/lib/cli/providers/codex/transcript-path';
+import { createCodexTranscriptDecoderState, decodeCodexTranscriptLine, type CodexTranscriptDecoderState } from '@/lib/cli/providers/codex/transcript-decoder';
+import { getAgentEnvironment } from '@/lib/cli/spawn-cli';
+import type { EnhancedMessage } from '@/types/chat';
+import logger from '@/lib/logger';
+import { appendImage, applyImageTool, createImageIndex, type ImageIndexState } from './incremental-state';
+import { cacheImageFile, imageSessionCacheDirectory } from './cache-files';
+import { imageFromTool, isImageGenerationResult, resultImage } from './traces';
+import { readImageTranscriptBatch, type ImageCheckpoint } from './incremental-reader';
+
+interface SavedState {
+  index: ImageIndexState;
+  rebuilding?: boolean;
+  decoder: { readResponseItemConversation: boolean; pendingToolCalls: Array<[string, CodexTranscriptDecoderState['pendingToolCalls'] extends Map<string, infer V> ? V : never]> };
+}
+
+const key = Symbol.for('tessera.imageIndexReads');
+const globalReads = globalThis as unknown as Record<symbol, Map<string, Promise<{ more: boolean }>>>;
+const reads = globalReads[key] ?? (globalReads[key] = new Map());
+
+export { readImageCards };
+
+export function syncTerminalImageIndex(session: SessionRow, userId: string, signal?: AbortSignal): Promise<{ more: boolean }> {
+  const existing = reads.get(session.id);
+  if (existing) return existing;
+  const promise = sync(session, userId, signal).finally(async () => {
+    try {
+      const current = getSession(session.id);
+      if (!current || current.deleted) await fs.rm(imageSessionCacheDirectory(session.id), { recursive: true, force: true });
+    } finally { reads.delete(session.id); }
+  });
+  reads.set(session.id, promise);
+  return promise;
+}
+
+async function sync(session: SessionRow, userId: string, signal?: AbortSignal): Promise<{ more: boolean }> {
+  const providerSessionId = readPersistedTerminalProviderSessionId(session);
+  if (!providerSessionId) return { more: false };
+  const environment = await getAgentEnvironment(userId);
+  const filePath = await resolveCodexTranscriptPath({ providerSessionId,
+    transcriptPath: getTerminalProviderSessionForTesseraSession(session.id)?.transcript_path, environment });
+  if (!filePath) return { more: false };
+  const cached = readImageCache(session.id);
+  const saved: SavedState | undefined = cached ? JSON.parse(cached.state_json) : undefined;
+  let index = saved?.index ?? createImageIndex();
+  if (cached && !saved?.rebuilding) index.traces = JSON.parse(cached.cards_json);
+  let rebuilding = saved?.rebuilding ?? false;
+  let reset = false;
+  let decoder = saved ? { ...saved.decoder, pendingToolCalls: new Map(saved.decoder.pendingToolCalls) } : createCodexTranscriptDecoderState();
+  const checkpoint: ImageCheckpoint | undefined = cached ? JSON.parse(cached.source_json) : undefined;
+  const scanned = await readImageTranscriptBatch(filePath, checkpoint, () => {
+    index = createImageIndex(); decoder = createCodexTranscriptDecoderState(); rebuilding = Boolean(cached); reset = true;
+  }, async (line, offset) => {
+    for (const event of decodeCodexTranscriptLine(line, decoder, { preferInlineImages: true })) {
+      if (event.type === 'user_message' && Array.isArray(event.content)) {
+        for (const [ordinal, block] of event.content.entries()) {
+          if (block.type !== 'image') continue;
+          const locator = await cacheImageFile(session.id, { kind: 'inline', data: block.source.data, mimeType: block.source.media_type }, environment).catch(() => undefined);
+          appendImage(index, { source: 'conversation', label: `Conversation image ${ordinal + 1}`,
+            locator: locator ?? { kind: 'cache', path: '' }, sourceMessageId: `image-${offset}-${ordinal}` });
+        }
+      }
+      if (event.type !== 'tool_call') continue;
+      const message = { ...event, id: `hist-tool-${event.toolUseId ?? offset}`, sessionId: session.id } as Extract<EnhancedMessage, { type: 'tool_call' }>;
+      const isGeneration = isImageGenerationResult(message);
+      const toolImage = message.status !== 'running' ? imageFromTool(message, isGeneration) : undefined;
+      const image = isGeneration ? toolImage ?? resultImage(message) : toolImage;
+      if (image) {
+        let locator;
+        try { locator = await cacheImageFile(session.id, image.locator, environment); }
+        catch { /* Preserve an unresolved occurrence, never substitute an older image. */ }
+        message.toolParams = { ...message.toolParams, _tesseraTranscriptImagePath: locator && locator.kind === 'cache' ? locator.path : '' };
+        message.toolUseResult = undefined;
+      }
+      const previousCardCount = index.traces.length;
+      applyImageTool(index, message);
+      for (const trace of index.traces.slice(previousCardCount)) {
+        for (const input of trace.inputs) {
+          if (input.locator.kind !== 'path') continue;
+          const locator = await cacheImageFile(session.id, input.locator, environment).catch(() => undefined);
+          input.locator = locator ?? { kind: 'cache', path: '' };
+          if (!locator) trace.unresolvedInputCount += 1;
+        }
+        trace.inputs = trace.inputs.filter((input) => input.locator.kind !== 'cache' || Boolean(input.locator.path));
+      }
+      // Keep only call metadata needed to interpret image-related outputs across batches.
+      // Arbitrary shell output, code and base64 are never persisted in this decoder state.
+      if (event.toolUseId && event.status === 'running') {
+        const params = event.toolParams;
+        const relevant = Object.values(params).some((value) => typeof value === 'string' && value.includes('image_gen__imagegen'));
+        if (!relevant) decoder.pendingToolCalls.delete(event.toolUseId);
+      }
+    }
+  }, signal);
+  const currentSession = getSession(session.id);
+  if (!currentSession || currentSession.deleted) {
+    await fs.rm(imageSessionCacheDirectory(session.id), { recursive: true, force: true });
+    return { more: false };
+  }
+  if (!signal?.aborted && (scanned.bytesRead > 0 || !cached || reset)) {
+    const keepPrevious = rebuilding && scanned.more;
+    saveImageCache(session.id, scanned.checkpoint, { index: { ...index, traces: keepPrevious ? index.traces : [] }, rebuilding: keepPrevious,
+      decoder: { readResponseItemConversation: decoder.readResponseItemConversation, pendingToolCalls: [...decoder.pendingToolCalls] } },
+    keepPrevious && cached ? JSON.parse(cached.cards_json) : index.traces);
+  }
+  logger.debug({ sessionId: session.id, bytesRead: scanned.bytesRead, offset: scanned.checkpoint.offset,
+    cardCount: index.traces.length, more: scanned.more }, 'Image index incremental read');
+  return { more: scanned.more };
+}

--- a/src/lib/image-generation/traces.ts
+++ b/src/lib/image-generation/traces.ts
@@ -3,6 +3,7 @@ import type { EnhancedMessage } from '@/types/chat';
 
 export type ImageLocator =
   | { kind: 'inline'; data: string; mimeType: string }
+  | { kind: 'cache'; path: string }
   | { kind: 'path'; path: string };
 
 export type ImageTraceSource = 'conversation' | 'generated' | 'file' | 'explicit-path';
@@ -45,6 +46,7 @@ interface ImageGenerationInvocation {
   prompt: string;
   referencedImagePaths?: string[];
   numLastImagesToInclude?: number;
+  referencesUnresolved?: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -137,7 +139,7 @@ function readStringProperty(source: string, name: string): string | undefined {
 function readIntegerProperty(source: string, name: string): number | undefined {
   const property = findProperty(source, name);
   if (property === undefined) return undefined;
-  const match = source.slice(skipSpace(source, property)).match(/^\d+/)?.[0];
+  const match = source.slice(skipSpace(source, property)).match(/^(\d+)\s*(?=[,}])/)?.[1];
   if (!match) return undefined;
   const value = Number(match);
   return Number.isSafeInteger(value) ? value : undefined;
@@ -152,12 +154,12 @@ function readStringArrayProperty(source: string, name: string): string[] | undef
   const values: string[] = [];
   while (cursor < source.length) {
     cursor = skipSpace(source, cursor);
-    if (source[cursor] === ']') return values;
+    if (source[cursor] === ']') return /^[,}]/.test(source.slice(skipSpace(source, cursor + 1))) ? values : undefined;
     const item = readQuoted(source, cursor);
     if (!item) return undefined;
     values.push(item.value);
     cursor = skipSpace(source, item.end);
-    if (source[cursor] === ']') return values;
+    if (source[cursor] === ']') return /^[,}]/.test(source.slice(skipSpace(source, cursor + 1))) ? values : undefined;
     if (source[cursor] !== ',') return undefined;
     cursor += 1;
   }
@@ -220,13 +222,21 @@ export function parseImageGenerationInvocations(source: string): ImageGeneration
     if (source[cursor] !== '(') continue;
     cursor = skipSpace(source, cursor + 1);
     const object = extractBalancedObject(source, cursor);
-    if (!object) continue;
+    if (!object) {
+      calls.push({ prompt: 'Image generation', referencesUnresolved: true });
+      continue;
+    }
     const prompt = readStringProperty(object.source, 'prompt');
-    if (prompt !== undefined) {
+    {
       const referencedImagePaths = readStringArrayProperty(object.source, 'referenced_image_paths');
       const numLastImagesToInclude = readIntegerProperty(object.source, 'num_last_images_to_include');
       calls.push({
-        prompt,
+        prompt: prompt ?? 'Image generation',
+        ...((findProperty(object.source, 'referenced_image_paths') !== undefined && referencedImagePaths === undefined
+          && !/^\s*null\b/.test(object.source.slice(findProperty(object.source, 'referenced_image_paths'))))
+          || (findProperty(object.source, 'num_last_images_to_include') !== undefined && numLastImagesToInclude === undefined
+          && !/^\s*null\b/.test(object.source.slice(findProperty(object.source, 'num_last_images_to_include'))))
+          ? { referencesUnresolved: true } : {}),
         ...(referencedImagePaths ? { referencedImagePaths } : {}),
         ...(numLastImagesToInclude !== undefined ? { numLastImagesToInclude } : {}),
       });
@@ -255,11 +265,16 @@ function invocationSource(message: Extract<EnhancedMessage, { type: 'tool_call' 
   return undefined;
 }
 
-function imageFromTool(
+export function imageFromTool(
   message: Extract<EnhancedMessage, { type: 'tool_call' }>,
   generatedByInvocation: boolean,
 ): ResolvedTraceImage | undefined {
   const result = message.toolUseResult;
+  const cachedPath = message.toolParams._tesseraTranscriptImagePath;
+  if (typeof cachedPath === 'string') {
+    return { source: generatedByInvocation ? 'generated' : 'file', label: 'Tool image',
+      locator: { kind: 'cache', path: cachedPath }, sourceMessageId: message.id };
+  }
   if (isRecord(result) && result.kind === 'file_read' && result.contentType === 'image') {
     const source = generatedByInvocation ? 'generated' as const : 'file' as const;
     const label = generatedByInvocation
@@ -295,32 +310,35 @@ function sameImage(left: ResolvedTraceImage, right: ResolvedTraceImage): boolean
   return false;
 }
 
-function isImageGenerationResult(message: Extract<EnhancedMessage, { type: 'tool_call' }>): boolean {
+export function isImageGenerationResult(message: Extract<EnhancedMessage, { type: 'tool_call' }>): boolean {
   return message.toolName === 'ImageGeneration'
     || message.toolName === 'imageGeneration'
     || message.toolParams.itemType === 'imageGeneration';
 }
 
-function resultImage(message: Extract<EnhancedMessage, { type: 'tool_call' }>): ResolvedTraceImage | undefined {
+export function resultImage(message: Extract<EnhancedMessage, { type: 'tool_call' }>): ResolvedTraceImage | undefined {
+  if (typeof message.toolParams._tesseraTranscriptImagePath === 'string') return imageFromTool(message, true);
   const result = message.toolUseResult;
   const savedPath = typeof message.toolParams.savedPath === 'string' && message.toolParams.savedPath
     ? message.toolParams.savedPath
     : undefined;
-  if (isRecord(result) && result.kind === 'file_read' && result.contentType === 'image' && typeof result.base64 === 'string') {
-    return {
-      source: 'generated',
-      label: 'Generated image',
-      locator: { kind: 'inline', data: result.base64, mimeType: typeof result.mimeType === 'string' ? result.mimeType : 'image/png' },
-      ...(savedPath ? { agentPath: savedPath } : {}),
-      sourceMessageId: message.id,
-    };
-  }
+  // Codex has already persisted generated output at savedPath. Prefer that
+  // file over its duplicate base64 result so replay/cache objects do not pin
+  // the complete image bytes in the server heap.
   if (savedPath) {
     return {
       source: 'generated',
       label: savedPath,
       locator: { kind: 'path', path: savedPath },
       agentPath: savedPath,
+      sourceMessageId: message.id,
+    };
+  }
+  if (isRecord(result) && result.kind === 'file_read' && result.contentType === 'image' && typeof result.base64 === 'string') {
+    return {
+      source: 'generated',
+      label: 'Generated image',
+      locator: { kind: 'inline', data: result.base64, mimeType: typeof result.mimeType === 'string' ? result.mimeType : 'image/png' },
       sourceMessageId: message.id,
     };
   }

--- a/src/lib/session/terminal-session-history.ts
+++ b/src/lib/session/terminal-session-history.ts
@@ -29,9 +29,19 @@ interface CacheEntry {
   state: SessionReplayState;
 }
 
+interface InFlightEntry {
+  /** Identity of the decode input being read by this promise. */
+  fingerprint: string;
+  promise: Promise<SessionReplayState | null>;
+}
+
 const CACHE_KEY = Symbol.for('tessera.terminalSessionHistoryCache');
 const cacheGlobal = globalThis as unknown as Record<symbol, Map<string, CacheEntry>>;
 const cache = cacheGlobal[CACHE_KEY] ?? (cacheGlobal[CACHE_KEY] = new Map());
+const IN_FLIGHT_KEY = Symbol.for('tessera.terminalSessionHistoryInFlight');
+const inFlightGlobal = globalThis as unknown as Record<symbol, Map<string, InFlightEntry>>;
+const inFlight = inFlightGlobal[IN_FLIGHT_KEY]
+  ?? (inFlightGlobal[IN_FLIGHT_KEY] = new Map());
 
 /**
  * Decoded transcripts are large (a busy session reduces to hundreds of
@@ -162,19 +172,37 @@ export async function readTerminalSessionReplayState(
     return cached.state;
   }
 
-  const state = await decodeReplayState(session, userId);
-  if (!state) {
-    cache.delete(session.id);
-    return null;
-  }
+  // The metadata route and every image URL can arrive together. Without a
+  // single-flight guard they all decode the same multi-megabyte transcript
+  // before the first request has populated the cache.
+  const running = inFlight.get(session.id);
+  if (running?.fingerprint === fingerprint) return running.promise;
 
-  rememberDecoded(session.id, { fingerprint, state });
-  logger.debug({
-    sessionId: session.id,
-    provider: session.provider,
-    messageCount: state.messages.length,
-  }, 'Decoded terminal session transcript');
-  return state;
+  const entry = {} as InFlightEntry;
+  entry.fingerprint = fingerprint;
+  entry.promise = (async () => {
+    const state = await decodeReplayState(session, userId);
+    // A newer fingerprint may have started decoding while this read was in
+    // progress. Return this request's result, but never overwrite newer cache.
+    if (inFlight.get(session.id) !== entry) return state;
+    if (!state) {
+      cache.delete(session.id);
+      return null;
+    }
+
+    if (fingerprint === 'unresolved') cache.delete(session.id);
+    else rememberDecoded(session.id, { fingerprint, state });
+    logger.debug({
+      sessionId: session.id,
+      provider: session.provider,
+      messageCount: state.messages.length,
+    }, 'Decoded terminal session transcript');
+    return state;
+  })().finally(() => {
+    if (inFlight.get(session.id) === entry) inFlight.delete(session.id);
+  });
+  inFlight.set(session.id, entry);
+  return entry.promise;
 }
 
 /**

--- a/src/lib/session/terminal-transcript-image-cache.ts
+++ b/src/lib/session/terminal-transcript-image-cache.ts
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { getTesseraDataPath } from '@/lib/tessera-data-dir';
+import { buildImageToolResult } from '@/lib/tool-results/tool-image';
+import type { SessionHistoryEvent } from '@/lib/session-replay-types';
+
+const CACHED_IMAGE_PATH_KEY = '_tesseraTranscriptImagePath';
+const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
+
+const EXTENSION_BY_MIME: Record<string, string> = {
+  'image/avif': '.avif',
+  'image/bmp': '.bmp',
+  'image/gif': '.gif',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/svg+xml': '.svg',
+  'image/webp': '.webp',
+};
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Server-owned cache path recorded while replaying an inline transcript image. */
+export function extractCachedTerminalTranscriptImagePath(
+  toolParams: unknown,
+): string | undefined {
+  if (!isRecord(toolParams)) return undefined;
+  const value = toolParams[CACHED_IMAGE_PATH_KEY];
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+/**
+ * Move a decoded inline tool image out of the replay graph and into a
+ * content-addressed server cache. The renderer receives only its authenticated
+ * session URL; repeated transcript reads reuse the same file.
+ */
+export async function materializeTerminalTranscriptImage(
+  sessionId: string,
+  event: SessionHistoryEvent,
+): Promise<SessionHistoryEvent> {
+  if (event.type !== 'tool_call' || !event.toolUseId || !isRecord(event.toolUseResult)) {
+    return event;
+  }
+  const result = event.toolUseResult as Record<string, any>;
+  if (
+    result.kind !== 'file_read'
+    || result.contentType !== 'image'
+    || typeof result.base64 !== 'string'
+    || !result.base64
+  ) {
+    return event;
+  }
+
+  const mimeType = typeof result.mimeType === 'string' ? result.mimeType : 'image/png';
+  const extension = EXTENSION_BY_MIME[mimeType];
+  // Reject before Buffer allocation. Base64 carries at most three bytes per
+  // four characters (padding only makes this estimate slightly high).
+  const estimatedBytes = Math.ceil(result.base64.length * 3 / 4);
+  if (!extension || estimatedBytes > MAX_IMAGE_BYTES) {
+    return { ...event, toolUseResult: undefined };
+  }
+
+  const digest = createHash('sha256')
+    .update(mimeType)
+    .update('\0')
+    .update(result.base64)
+    .digest('hex');
+  const cacheDir = getTesseraDataPath('cache', 'terminal-transcript-images');
+  const cachePath = path.join(cacheDir, `${digest}${extension}`);
+
+  try {
+    await fs.mkdir(cacheDir, { recursive: true, mode: 0o700 });
+    try {
+      const bytes = Buffer.from(result.base64, 'base64');
+      if (bytes.byteLength === 0 || bytes.byteLength > MAX_IMAGE_BYTES) {
+        return { ...event, toolUseResult: undefined };
+      }
+      await fs.writeFile(cachePath, bytes, { flag: 'wx', mode: 0o600 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    }
+  } catch {
+    // A cache failure must not keep the very bytes this path exists to evict.
+    return { ...event, toolUseResult: undefined };
+  }
+
+  return {
+    ...event,
+    toolParams: {
+      ...event.toolParams,
+      [CACHED_IMAGE_PATH_KEY]: cachePath,
+    },
+    toolUseResult: buildImageToolResult(sessionId, event.toolUseId),
+  };
+}

--- a/src/lib/terminal/terminal-headless-model.ts
+++ b/src/lib/terminal/terminal-headless-model.ts
@@ -37,6 +37,13 @@ export interface TerminalHeadlessSnapshot {
   pendingEscapeTailAnsi?: string;
 }
 
+export interface TerminalHeadlessDiagnostics {
+  pendingWrites: number;
+  pendingChars: number;
+  totalWrites: number;
+  totalChars: number;
+}
+
 /**
  * Server-side xterm model used only for cold surface reattachment.
  *
@@ -49,6 +56,10 @@ export class TerminalHeadlessModel {
   private readonly serializer: SerializeAddon;
   private writeTail: Promise<void> = Promise.resolve();
   private readonly pendingWriteCompletions = new Set<() => void>();
+  private pendingWriteCount = 0;
+  private pendingWriteChars = 0;
+  private totalWriteCount = 0;
+  private totalWriteChars = 0;
   private readonly activeSnapshotOnlyDecModes = new Set<number>();
   private pendingEscapeTail = '';
   private disposed = false;
@@ -163,9 +174,22 @@ export class TerminalHeadlessModel {
   write(data: string): void {
     if (this.disposed || data.length === 0) return;
 
+    this.pendingWriteCount += 1;
+    this.pendingWriteChars += data.length;
+    this.totalWriteCount += 1;
+    this.totalWriteChars += data.length;
+    let pending = true;
+    const settlePendingWrite = () => {
+      if (!pending) return;
+      pending = false;
+      this.pendingWriteCount = Math.max(0, this.pendingWriteCount - 1);
+      this.pendingWriteChars = Math.max(0, this.pendingWriteChars - data.length);
+    };
+
     this.writeTail = this.writeTail
       .then(() => new Promise<void>((resolve) => {
         if (this.disposed) {
+          settlePendingWrite();
           resolve();
           return;
         }
@@ -173,9 +197,13 @@ export class TerminalHeadlessModel {
         const complete = () => {
           if (completed) return;
           completed = true;
-          this.pendingEscapeTail = advancePartialEscapeTail(this.pendingEscapeTail, data);
-          this.pendingWriteCompletions.delete(complete);
-          resolve();
+          try {
+            this.pendingEscapeTail = advancePartialEscapeTail(this.pendingEscapeTail, data);
+          } finally {
+            this.pendingWriteCompletions.delete(complete);
+            settlePendingWrite();
+            resolve();
+          }
         };
         this.pendingWriteCompletions.add(complete);
         try {
@@ -185,9 +213,19 @@ export class TerminalHeadlessModel {
         }
       }))
       .catch(() => {
+        settlePendingWrite();
         // Keep later writes/snapshots usable after one parser failure. The
         // caller retains a bounded raw replay buffer as a fallback.
       });
+  }
+
+  diagnostics(): TerminalHeadlessDiagnostics {
+    return {
+      pendingWrites: this.pendingWriteCount,
+      pendingChars: this.pendingWriteChars,
+      totalWrites: this.totalWriteCount,
+      totalChars: this.totalWriteChars,
+    };
   }
 
   /**

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -200,6 +200,8 @@ interface TerminalRuntime {
   viewportOwner: string | null;
   outputBuffer: string[];
   outputBufferSize: number;
+  diagnosticOutputChunks: number;
+  diagnosticOutputChars: number;
   // 출력 coalescing(M0): 한 event-loop tick에 도착한 청크를 모아 setImmediate에서
   // 1회 WS 전송한다. replay 버퍼/prefill 감지와는 독립.
   pendingSend: string[];
@@ -280,8 +282,43 @@ export type TerminalHeadlessModelLike = Pick<
   'write' | 'resize' | 'snapshot' | 'readVisibleText' | 'dispose'
 > & Partial<Pick<
   TerminalHeadlessModel,
-  'whenSettled' | 'cursorPosition' | 'isAlternateScreen'
+  'whenSettled' | 'cursorPosition' | 'isAlternateScreen' | 'diagnostics'
 >>;
+
+export interface TerminalManagerOomDiagnostics {
+  runtimeCount: number;
+  outputChunks: number;
+  outputChars: number;
+  headlessPendingWrites: number;
+  headlessPendingChars: number;
+  replayBufferChars: number;
+  pendingSendChunks: number;
+  pendingSendChars: number;
+  pendingFrameCount: number;
+  pendingFrameChars: number;
+  pendingSessionSnapshots: number;
+  subscribers: number;
+  unreadySubscribers: number;
+  topRuntimes: Array<{
+    terminalId: string;
+    sessionId: string | null;
+    generation: number;
+    outputChunks: number;
+    outputChars: number;
+    headlessPendingWrites: number;
+    headlessPendingChars: number;
+    headlessTotalWrites: number;
+    headlessTotalChars: number;
+    replayBufferChars: number;
+    pendingSendChunks: number;
+    pendingSendChars: number;
+    pendingFrameCount: number;
+    pendingFrameChars: number;
+    pendingSessionSnapshots: number;
+    subscribers: number;
+    unreadySubscribers: number;
+  }>;
+}
 
 export interface TerminalManagerOptions {
   closeExitGraceMs?: number;
@@ -854,6 +891,8 @@ export class TerminalManager {
         viewportOwner: null,
         outputBuffer: [],
         outputBufferSize: 0,
+        diagnosticOutputChunks: 0,
+        diagnosticOutputChars: 0,
         pendingSend: [],
         pendingSendTimer: null,
         handoffSessionId,
@@ -960,6 +999,8 @@ export class TerminalManager {
 
       const emitOutput = (data: string) => {
         if (data.length === 0) return;
+        runtime.diagnosticOutputChunks += 1;
+        runtime.diagnosticOutputChars += data.length;
         // replay 버퍼: 원본 청크 순서/내용 그대로 즉시 누적 — coalescing과 독립.
         this.appendBufferedOutput(runtime, data);
         runtime.model.write(data);
@@ -2043,6 +2084,94 @@ export class TerminalManager {
       sessionCount: runtimes.filter((runtime) => runtime.sessionId !== null).length
         + openingEntries.filter((key) => this.openingSessionByTerminalKey.get(key) != null).length,
     };
+  }
+
+  /**
+   * Lightweight counters for the packaged debug build's periodic OOM probe.
+   * No PTY output is copied into the result; interval counters are reset only
+   * after the sample has captured them.
+   */
+  collectOomDiagnostics(): TerminalManagerOomDiagnostics {
+    const totals: Omit<TerminalManagerOomDiagnostics, 'topRuntimes'> = {
+      runtimeCount: this.terminals.size,
+      outputChunks: 0,
+      outputChars: 0,
+      headlessPendingWrites: 0,
+      headlessPendingChars: 0,
+      replayBufferChars: 0,
+      pendingSendChunks: 0,
+      pendingSendChars: 0,
+      pendingFrameCount: 0,
+      pendingFrameChars: 0,
+      pendingSessionSnapshots: 0,
+      subscribers: 0,
+      unreadySubscribers: 0,
+    };
+    const runtimes: TerminalManagerOomDiagnostics['topRuntimes'] = [];
+
+    for (const runtime of this.terminals.values()) {
+      const headless = runtime.model.diagnostics?.() ?? {
+        pendingWrites: 0,
+        pendingChars: 0,
+        totalWrites: 0,
+        totalChars: 0,
+      };
+      let pendingFrameCount = 0;
+      let pendingFrameChars = 0;
+      let unreadySubscribers = 0;
+      for (const subscriber of runtime.subscribers.values()) {
+        if (!subscriber.ready) unreadySubscribers += 1;
+        pendingFrameCount += subscriber.pendingFrames.length;
+        for (const frame of subscriber.pendingFrames) pendingFrameChars += frame.data.length;
+      }
+      let pendingSendChars = 0;
+      for (const chunk of runtime.pendingSend) pendingSendChars += chunk.length;
+
+      const sample = {
+        terminalId: runtime.terminalId,
+        sessionId: runtime.sessionId,
+        generation: runtime.generation,
+        outputChunks: runtime.diagnosticOutputChunks,
+        outputChars: runtime.diagnosticOutputChars,
+        headlessPendingWrites: headless.pendingWrites,
+        headlessPendingChars: headless.pendingChars,
+        headlessTotalWrites: headless.totalWrites,
+        headlessTotalChars: headless.totalChars,
+        replayBufferChars: runtime.outputBufferSize,
+        pendingSendChunks: runtime.pendingSend.length,
+        pendingSendChars,
+        pendingFrameCount,
+        pendingFrameChars,
+        pendingSessionSnapshots: runtime.pendingSessionSnapshots.size,
+        subscribers: runtime.subscribers.size,
+        unreadySubscribers,
+      };
+      runtimes.push(sample);
+
+      totals.outputChunks += sample.outputChunks;
+      totals.outputChars += sample.outputChars;
+      totals.headlessPendingWrites += sample.headlessPendingWrites;
+      totals.headlessPendingChars += sample.headlessPendingChars;
+      totals.replayBufferChars += sample.replayBufferChars;
+      totals.pendingSendChunks += sample.pendingSendChunks;
+      totals.pendingSendChars += sample.pendingSendChars;
+      totals.pendingFrameCount += sample.pendingFrameCount;
+      totals.pendingFrameChars += sample.pendingFrameChars;
+      totals.pendingSessionSnapshots += sample.pendingSessionSnapshots;
+      totals.subscribers += sample.subscribers;
+      totals.unreadySubscribers += sample.unreadySubscribers;
+
+      runtime.diagnosticOutputChunks = 0;
+      runtime.diagnosticOutputChars = 0;
+    }
+
+    runtimes.sort((left, right) => (
+      (right.headlessPendingChars + right.pendingFrameChars + right.pendingSendChars)
+      - (left.headlessPendingChars + left.pendingFrameChars + left.pendingSendChars)
+      || right.outputChars - left.outputChars
+    ));
+
+    return { ...totals, topRuntimes: runtimes.slice(0, 8) };
   }
 
   getActiveSessionIds(userId?: string): Set<string> {

--- a/src/lib/tool-results/tool-image.ts
+++ b/src/lib/tool-results/tool-image.ts
@@ -111,6 +111,16 @@ export function isImagePath(filePath: unknown): boolean {
   return IMAGE_EXTENSIONS.has(extensionOf(filePath));
 }
 
+/** Read the provider-recorded image path without exposing a client-supplied path. */
+export function extractImageToolPath(toolParams: unknown): string | undefined {
+  if (!isRecord(toolParams)) return undefined;
+  for (const key of ['path', 'file_path', 'savedPath']) {
+    const value = toolParams[key];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return undefined;
+}
+
 /** Best-effort image MIME type from a file path; undefined when not an image. */
 export function inferImageMime(filePath: string): string | undefined {
   return IMAGE_MIME_BY_EXT[extensionOf(filePath)];

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -57,6 +57,21 @@ export interface WebSocketConnectionInfo extends WebSocketIdentity {
   connectionId: string;
 }
 
+export interface WebSocketOomDiagnostics {
+  connectionCount: number;
+  openConnectionCount: number;
+  sentMessages: number;
+  sentBytes: number;
+  totalBufferedBytes: number;
+  maxBufferedBytes: number;
+  topConnections: Array<{
+    connectionId: string | null;
+    kind: CredentialKind | null;
+    readyState: number;
+    bufferedBytes: number;
+  }>;
+}
+
 interface AuthenticatedWebSocket extends WebSocket {
   connectionId?: string;
   identity?: WebSocketIdentity;
@@ -111,6 +126,8 @@ export class WebSocketServer {
   private readonly rejectionGraceMs: number;
   private readonly heartbeatIntervalMs: number;
   private readonly heartbeat: WebSocketServerHeartbeat;
+  private diagnosticSentMessages = 0;
+  private diagnosticSentBytes = 0;
 
   constructor(options: WebSocketServerOptions = {}) {
     this.maxConnections = options.maxConnections ?? MAX_WS_CONNECTIONS;
@@ -272,6 +289,7 @@ export class WebSocketServer {
       try {
         const startTime = Date.now();
         ws.send(payload);
+        this.recordDiagnosticSend(payload);
         const duration = Date.now() - startTime;
 
         if (duration > 50) {
@@ -293,7 +311,9 @@ export class WebSocketServer {
       for (const ws of wsSet) {
         if (ws.connectionId !== connectionId || ws.readyState !== WebSocket.OPEN) continue;
         try {
-          ws.send(JSON.stringify(message));
+          const payload = JSON.stringify(message);
+          ws.send(payload);
+          this.recordDiagnosticSend(payload);
         } catch (error) {
           logger.error({ connectionId, error, messageType: message.type }, 'Failed to send connection message');
         }
@@ -310,7 +330,9 @@ export class WebSocketServer {
     if (ws.readyState !== WebSocket.OPEN) return;
 
     try {
-      ws.send(JSON.stringify(message));
+      const payload = JSON.stringify(message);
+      ws.send(payload);
+      this.recordDiagnosticSend(payload);
     } catch (err) {
       logger.error({
         userId,
@@ -318,6 +340,51 @@ export class WebSocketServer {
         messageType: message.type,
       }, 'Failed to send message to WebSocket connection');
     }
+  }
+
+  private recordDiagnosticSend(payload: string): void {
+    this.diagnosticSentMessages += 1;
+    this.diagnosticSentBytes += Buffer.byteLength(payload);
+  }
+
+  collectOomDiagnostics(): WebSocketOomDiagnostics {
+    const connections: WebSocketOomDiagnostics['topConnections'] = [];
+    let connectionCount = 0;
+    let openConnectionCount = 0;
+    let totalBufferedBytes = 0;
+    let maxBufferedBytes = 0;
+
+    for (const sockets of this.connections.values()) {
+      for (const socket of sockets) {
+        connectionCount += 1;
+        if (socket.readyState === WebSocket.OPEN) openConnectionCount += 1;
+        const bufferedBytes = socket.bufferedAmount;
+        totalBufferedBytes += bufferedBytes;
+        maxBufferedBytes = Math.max(maxBufferedBytes, bufferedBytes);
+        connections.push({
+          connectionId: socket.connectionId ?? null,
+          kind: socket.identity?.kind ?? null,
+          readyState: socket.readyState,
+          bufferedBytes,
+        });
+      }
+    }
+
+    const sentMessages = this.diagnosticSentMessages;
+    const sentBytes = this.diagnosticSentBytes;
+    this.diagnosticSentMessages = 0;
+    this.diagnosticSentBytes = 0;
+    connections.sort((left, right) => right.bufferedBytes - left.bufferedBytes);
+
+    return {
+      connectionCount,
+      openConnectionCount,
+      sentMessages,
+      sentBytes,
+      totalBufferedBytes,
+      maxBufferedBytes,
+      topConnections: connections.slice(0, 8),
+    };
   }
 
   /**

--- a/tests/codex-transcript-decoder.test.ts
+++ b/tests/codex-transcript-decoder.test.ts
@@ -109,7 +109,7 @@ test('Codex response user messages retain inline input images', () => {
   ]);
 });
 
-test('image_gen completion keeps image bytes out of textual output', () => {
+test('image_gen completion uses the saved file instead of retaining image bytes', () => {
   const events = decodeCodexTranscript([
     line('session_meta', { cli_version: '0.147.0' }),
     line('event_msg', {
@@ -140,10 +140,33 @@ test('image_gen completion keeps image bytes out of textual output', () => {
     toolUseResult: {
       kind: 'file_read',
       contentType: 'image',
-      base64: 'a-very-large-base64-value',
+      path: '/tmp/output.png',
       mimeType: 'image/png',
     },
     toolUseId: 'image-1',
+  });
+});
+
+test('image_gen completion keeps inline bytes only when no saved file exists', () => {
+  const events = decodeCodexTranscript([
+    line('session_meta', { cli_version: '0.147.0' }),
+    line('event_msg', {
+      type: 'item_completed',
+      item: {
+        type: 'Extension',
+        kind: 'image_gen.generation',
+        id: 'image-inline',
+        status: 'completed',
+        result: 'fallback-base64-value',
+      },
+    }),
+  ]);
+
+  assert.deepEqual((events[0] as any).toolUseResult, {
+    kind: 'file_read',
+    contentType: 'image',
+    base64: 'fallback-base64-value',
+    mimeType: 'image/png',
   });
 });
 

--- a/tests/image-generation-traces.test.ts
+++ b/tests/image-generation-traces.test.ts
@@ -163,7 +163,7 @@ test('public path inputs expose the agent path for PTY dragging', () => {
   );
 });
 
-test('inline generated results retain savedPath as the agent drag path', () => {
+test('generated results use savedPath instead of retaining duplicate inline bytes', () => {
   const generated = inlineGeneratedResult('generated', 'IMAGE_BYTES');
   generated.toolParams.savedPath = '/home/work/generated.png';
   const [trace] = projectImageGenerationTraces([
@@ -171,7 +171,10 @@ test('inline generated results retain savedPath as the agent drag path', () => {
     generated,
   ]);
 
-  assert.equal(trace.result?.locator.kind, 'inline');
+  assert.deepEqual(trace.result?.locator, {
+    kind: 'path',
+    path: '/home/work/generated.png',
+  });
   assert.equal(
     toPublicImageGenerationTraces('session', [trace])[0].result?.path,
     '/home/work/generated.png',

--- a/tests/image-index-benchmark.cjs
+++ b/tests/image-index-benchmark.cjs
@@ -1,0 +1,44 @@
+const { DatabaseSync } = require('node:sqlite');
+const fs = require('node:fs');
+const path = require('node:path');
+const { chromium } = require('@playwright/test');
+const assert = require('node:assert/strict');
+
+(async () => {
+  const [manifestPath, source, providerId, mode = 'scan'] = process.argv.slice(2);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath,'utf8').replace(/^\uFEFF/,''));
+  assert.ok(manifest.sessionId.startsWith('codex-0904ry-image-index'));
+  const instance = manifest.instances[0];
+  assert.notEqual(instance.serverPort,32123);
+  const db = new DatabaseSync(path.join(instance.dataDir,'tessera.db'));
+  const id = 'image-index-qa-session';
+  if (mode === 'scan') {
+    db.prepare('UPDATE sessions SET provider_state=? WHERE id=?').run(JSON.stringify({kind:'terminal',codexSessionId:providerId}),id);
+    db.prepare('UPDATE terminal_provider_sessions SET provider_session_id=?,transcript_path=? WHERE tessera_session_id=?').run(providerId,source,id);
+    db.prepare('DELETE FROM image_generation_cache WHERE session_id=?').run(id);
+  }
+  const browser = await chromium.connectOverCDP(instance.cdpUrl);
+  try {
+    const page=browser.contexts()[0].pages()[0];
+    const files=page.getByRole('tab',{name:/^Files$|^파일$/});
+    if(await files.count())await files.click();
+    const started=Date.now();
+    let batches=0, response;
+    do {
+      response=await page.evaluate(async id=>{
+        const r=await fetch(`/api/sessions/${id}/image-generations?sync=1`);
+        return {status:r.status,...await r.json()};
+      },id);
+      assert.equal(response.status,200,JSON.stringify(response));
+      batches++;
+      if(batches>200)throw Error('Index did not catch up');
+    }while(response.more);
+    const scanMs=Date.now()-started;
+    const loadStart=Date.now();
+    const cached=await page.evaluate(async id=>(await fetch(`/api/sessions/${id}/image-generations`)).json(),id);
+    const cacheMs=Date.now()-loadStart;
+    const row=db.prepare('SELECT source_json,state_json,cards_json FROM image_generation_cache WHERE session_id=?').get(id);
+    console.log(JSON.stringify({mode,scanMs,cacheMs,batches,cards:cached.traces.length,source:JSON.parse(row.source_json),
+      metadataBytes:Buffer.byteLength(row.state_json)+Buffer.byteLength(row.cards_json)},null,2));
+  }finally{db.close();await browser.close();}
+})().catch(error=>{console.error(error);process.exitCode=1;});

--- a/tests/image-index-electron.e2e.cjs
+++ b/tests/image-index-electron.e2e.cjs
@@ -1,0 +1,110 @@
+// Windows Node + an ownership-manifest-isolated Electron backend + WSL JSONL fixtures.
+// No provider calls: append recorded protocol shapes to exercise the real HTTP/UI path.
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+const { DatabaseSync } = require('node:sqlite');
+const { chromium } = require('@playwright/test');
+
+async function main() {
+  const [manifestPath, fixtureDirectory, artifactDirectory] = process.argv.slice(2);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8').replace(/^\uFEFF/, ''));
+  assert.ok(manifest.sessionId.startsWith('codex-0904ry-image-index'));
+  const instance = manifest.instances[0];
+  assert.notEqual(instance.serverPort, 32123);
+  assert.ok(instance.dataDir.includes('TesseraTestInstances'));
+  assert.ok(fixtureDirectory.includes('image-index-qa'));
+  fs.mkdirSync(fixtureDirectory, { recursive: true });
+  fs.mkdirSync(artifactDirectory, { recursive: true });
+  const file = path.join(fixtureDirectory, 'rollout.jsonl');
+  const png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII=';
+  const record = (type, payload) => JSON.stringify({ type, timestamp: new Date().toISOString(), payload }) + '\n';
+  fs.writeFileSync(file, record('session_meta', { cli_version: '0.147.0' })
+    + record('response_item', { type: 'message', role: 'user', content: [{ type: 'input_image', image_url: `data:image/png;base64,${png}` }] }));
+  const db = new DatabaseSync(path.join(instance.dataDir, 'tessera.db'));
+  db.exec('PRAGMA busy_timeout=5000');
+  const project = db.prepare('SELECT * FROM projects WHERE decoded_path = ?').get('/home/work/Source/tessera-dev');
+  assert.ok(project);
+  const id = 'image-index-qa-session';
+  const title = 'IMAGE INDEX QA';
+  const now = new Date().toISOString();
+  db.prepare(`INSERT OR REPLACE INTO sessions(id,project_id,title,provider,provider_state,work_dir,created_at,updated_at)
+    VALUES(?,?,?,?,?,?,?,?)`).run(id, project.id, title, 'codex', JSON.stringify({kind:'terminal',codexSessionId:'image-index-qa-provider'}), project.decoded_path, now, now);
+  db.prepare(`INSERT OR REPLACE INTO terminal_provider_sessions(provider_id,provider_session_id,tessera_session_id,transcript_path,created_at,updated_at)
+    VALUES(?,?,?,?,?,?)`).run('codex','image-index-qa-provider',id,file,now,now);
+  db.prepare('DELETE FROM image_generation_cache WHERE session_id=?').run(id);
+  db.prepare(`INSERT OR REPLACE INTO sessions(id,project_id,title,provider,provider_state,work_dir,created_at,updated_at)
+    VALUES(?,?,?,?,?,?,?,?)`).run('image-index-qa-other',project.id,'IMAGE INDEX OTHER','codex',JSON.stringify({kind:'terminal',codexSessionId:'image-index-other-provider'}),project.decoded_path,now,now);
+  db.close();
+  const browser = await chromium.connectOverCDP(instance.cdpUrl);
+  const page = browser.contexts()[0].pages()[0];
+  const requests = [];
+  page.on('request', (request) => { if(request.url().includes(`/sessions/${id}/image-generations`)) requests.push({time:Date.now(),url:request.url()}); });
+  await page.addInitScript(() => {
+    const send = WebSocket.prototype.send;
+    WebSocket.prototype.send = function(data) {
+      try { if (JSON.parse(data).type === 'terminal_create') return; } catch {}
+      return send.call(this,data);
+    };
+    localStorage.setItem('tessera:git-panel',JSON.stringify({state:{isOpen:true,panelWidth:450,drawerHeight:300,panelTab:'images'},version:0}));
+  });
+  const capture = (name) => page.screenshot({path:path.join(artifactDirectory,name)});
+  try {
+    await page.reload({waitUntil:'domcontentloaded'});
+    await capture('02-fixture-ready.png');
+    await page.getByText(title,{exact:true}).first().click({timeout:20000});
+    await page.getByRole('tab',{name:/Images|이미지/}).click({timeout:15000});
+    await capture('03-image-tab-before-call.png');
+    const started = Date.now();
+    fs.appendFileSync(file,record('response_item',{type:'custom_tool_call',call_id:'qa-call',name:'functions.exec',input:'tools.image_gen__imagegen({prompt: "QA generated image", num_last_images_to_include: 1})'}));
+    await page.getByTestId('image-generations-panel').getByText('QA generated image',{exact:true}).waitFor({timeout:15000});
+    const cardLatencyMs = Date.now()-started;
+    await capture('04-running-card.png');
+    const completed = Date.now();
+    fs.appendFileSync(file,record('event_msg',{type:'item_completed',item:{id:'qa-result',type:'imageGeneration',result:png}}));
+    await page.waitForFunction(() => {
+      const img=document.querySelector('[data-testid="image-generation-hero"] img');
+      return img && img.complete && img.naturalWidth>0 && Number(getComputedStyle(img).opacity)>0.99;
+    },undefined,{timeout:15000});
+    const imageLatencyMs = Date.now()-completed;
+    await capture('05-completed-image.png');
+    const logLines=fs.readFileSync(path.join(instance.dataDir,'tessera-main.log'),'utf8').split('\n');
+    const samples=logLines.flatMap(line=>{
+      const start=line.indexOf('{"level"');
+      if(start<0)return [];
+      try{const entry=JSON.parse(line.slice(start));return entry.sessionId===id&&entry.msg==='Image index incremental read'?[entry]:[];}catch{return [];}
+    }).filter(entry=>entry.bytesRead>0);
+    assert.ok(samples.length>=2);
+    const last=samples.at(-1),previous=samples.at(-2);
+    assert.equal(last.bytesRead,last.offset-previous.offset,'append must not rescan the previous transcript (including on WSL)');
+    await page.getByText('IMAGE INDEX OTHER',{exact:true}).first().click();
+    await capture('06a-other-session.png');
+    const beforeSwitch=requests.filter(entry=>entry.url.includes('sync=1')).length;
+    fs.appendFileSync(file,record('response_item',{type:'custom_tool_call',call_id:'qa-next',name:'functions.exec',input:'tools.image_gen__imagegen({prompt: "QA next image", num_last_images_to_include: 1})'}));
+    await page.waitForTimeout(2300);
+    assert.equal(requests.filter(entry=>entry.url.includes('sync=1')).length,beforeSwitch,'unselected session must not poll');
+    await page.getByText(title,{exact:true}).first().click();
+    await page.getByTestId('image-generations-panel').getByText('QA next image',{exact:true}).waitFor({timeout:10000});
+    await capture('06b-session-return-catches-up.png');
+    // Revisit must restore cards without waiting for transcript access.
+    await page.getByRole('tab',{name:/^Files$|^파일$/}).click();
+    await capture('06-other-tab.png');
+    const closedRequests=requests.filter(entry=>entry.url.includes('sync=1')).length;
+    await page.waitForTimeout(2300);
+    assert.equal(requests.filter(entry=>entry.url.includes('sync=1')).length,closedRequests,'hidden image tab must stop polling');
+    const savedFile = file+'.saved';
+    fs.renameSync(file,savedFile);
+    const revisit = Date.now();
+    await page.getByRole('tab',{name:/Images|이미지/}).click();
+    await page.getByTestId('image-generations-panel').waitFor();
+    const revisitMs = Date.now()-revisit;
+    await capture('07-cached-without-transcript.png');
+    fs.renameSync(savedFile,file);
+    await page.reload({waitUntil:'domcontentloaded'});
+    await page.getByTestId('image-generations-panel').waitFor({timeout:15000});
+    await capture('08-renderer-restart-cache.png');
+    console.log(JSON.stringify({cardLatencyMs,imageLatencyMs,revisitMs,requests},null,2));
+  } catch(error) { await capture('99-error.png'); throw error; }
+  finally { await browser.close(); }
+}
+main().catch(error=>{console.error(error);process.exitCode=1;});

--- a/tests/image-index-incremental.test.ts
+++ b/tests/image-index-incremental.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { readImageTranscriptBatch } from '@/lib/image-generation/incremental-reader';
+import { appendImage, applyImageTool, createImageIndex, type ImageIndexState } from '@/lib/image-generation/incremental-state';
+import type { EnhancedMessage } from '@/types/chat';
+
+const call = (id: string, status: 'running' | 'completed' = 'running'): Extract<EnhancedMessage, { type: 'tool_call' }> => ({
+  id, toolUseId: id, sessionId: 's', type: 'tool_call', toolName: 'Bash', timestamp: '2026-09-05T00:00:00Z', status,
+  toolParams: { input: 'tools.image_gen__imagegen({ prompt: "edit", num_last_images_to_include: 1 })' },
+});
+
+test('restart keeps image order, frozen references and a pending call across increments', () => {
+  let state = createImageIndex();
+  appendImage(state, { source: 'conversation', label: 'one', sourceMessageId: 'one', locator: { kind: 'cache', path: '/cache/one.png' } });
+  applyImageTool(state, call('call'));
+  state = JSON.parse(JSON.stringify(state)) as ImageIndexState;
+  appendImage(state, { source: 'conversation', label: 'later', sourceMessageId: 'later', locator: { kind: 'cache', path: '/cache/later.png' } });
+  applyImageTool(state, call('call', 'completed'));
+  assert.equal(state.traces.length, 1);
+  assert.equal(state.traces[0].inputs[0].sourceMessageId, 'one');
+  applyImageTool(state, { ...call('result', 'completed'), toolName: 'ImageGeneration',
+    toolParams: { _tesseraTranscriptImagePath: '/cache/result.png' } });
+  assert.equal(state.traces[0].status, 'completed');
+  assert.equal(state.traces[0].result?.locator.kind, 'cache');
+  applyImageTool(state, call('second'));
+  assert.equal(state.traces[1].inputs[0].sourceMessageId, 'call-0');
+});
+
+test('a missing cached occurrence cannot shift selection onto an older image', () => {
+  const state = createImageIndex();
+  appendImage(state, { source: 'file', label: 'old', sourceMessageId: 'old', locator: { kind: 'cache', path: '/cache/old.png' } });
+  appendImage(state, { source: 'file', label: 'missing', sourceMessageId: 'missing', locator: { kind: 'cache', path: '' } });
+  applyImageTool(state, call('call'));
+  assert.equal(state.traces[0].inputs.length, 0);
+  assert.equal(state.traces[0].unresolvedInputCount, 1);
+});
+
+test('dynamic reference expressions are unresolved instead of guessed from a literal prefix', () => {
+  const state = createImageIndex();
+  appendImage(state, { source: 'file', label: 'old', sourceMessageId: 'old', locator: { kind: 'cache', path: '/cache/old.png' } });
+  const message = call('dynamic');
+  message.toolParams.input = 'tools.image_gen__imagegen({prompt: "edit", num_last_images_to_include: 1 + count})';
+  applyImageTool(state, message);
+  assert.equal(state.traces[0].inputs.length, 0);
+  assert.equal(state.traces[0].unresolvedInputCount, 1);
+});
+
+test('two distinct generations with identical pixels preserve both occurrences', () => {
+  const state = createImageIndex();
+  for (const id of ['a', 'b']) {
+    const message = call(id);
+    message.toolParams.input = 'tools.image_gen__imagegen({prompt: "create"})';
+    applyImageTool(state, message);
+    applyImageTool(state, { ...call(`${id}-result`, 'completed'), toolName: 'ImageGeneration', toolParams: { _tesseraTranscriptImagePath: '/cache/same.png' } });
+    applyImageTool(state, { ...message, status: 'completed', toolParams: { ...message.toolParams, _tesseraTranscriptImagePath: '/cache/same.png' } });
+  }
+  assert.equal(state.ledger.length, 2);
+  assert.deepEqual(state.ledger.map((image) => image.sourceMessageId), ['a-0', 'b-0']);
+});
+
+test('ambiguous result association never attaches an image to a guessed prompt', () => {
+  const state = createImageIndex();
+  applyImageTool(state, call('a'));
+  applyImageTool(state, call('b'));
+  applyImageTool(state, { ...call('result', 'completed'), toolName: 'ImageGeneration', toolParams: { _tesseraTranscriptImagePath: '/cache/result.png' } });
+  assert.equal(state.traces[0].result, undefined);
+  assert.equal(state.traces[1].result, undefined);
+  assert.equal(state.traces[2].unresolvedInputCount, 1);
+  assert.equal(state.traces[2].result?.locator.kind, 'cache');
+});
+
+test('reader resumes on byte boundaries, waits for complete UTF-8 lines and detects replacement', async () => {
+  const directory = await fs.mkdtemp(path.join(process.cwd(), '.image-index-test-'));
+  const file = path.join(directory, 'transcript.jsonl');
+  try {
+    await fs.writeFile(file, '{"text":"고양이"}\n{"partial":');
+    const records: string[] = [];
+    let resets = 0;
+    const reset = () => { resets++; };
+    const consume = async (line: string) => { records.push(line); };
+    const first = await readImageTranscriptBatch(file, undefined, reset, consume);
+    assert.equal(records.length, 1);
+    assert.equal(first.checkpoint.offset, Buffer.byteLength('{"text":"고양이"}\n'));
+    const unchanged = await readImageTranscriptBatch(file, first.checkpoint, reset, consume);
+    assert.equal(unchanged.bytesRead, 0);
+    assert.equal(resets, 1);
+    await fs.appendFile(file, 'true}\n');
+    const resumed = await readImageTranscriptBatch(file, unchanged.checkpoint, reset, consume);
+    assert.equal(records.length, 2);
+    assert.deepEqual(JSON.parse(records[1]), { partial: true });
+    assert.equal(resumed.bytesRead, Buffer.byteLength('{"partial":true}\n'));
+    await fs.writeFile(file, '{}\n');
+    await readImageTranscriptBatch(file, resumed.checkpoint, reset, consume);
+    assert.equal(resets, 2);
+  } finally { await fs.rm(directory, { recursive: true, force: true }); }
+});

--- a/tests/image-index-persistence.test.ts
+++ b/tests/image-index-persistence.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+const directory = mkdtempSync(path.join(process.cwd(), '.image-index-db-test-'));
+process.env.TESSERA_DATA_DIR = directory;
+process.env.NODE_ENV = 'test';
+
+test('disk-backed index restores a pending call, reads only appends and serves cards with the transcript gone', async () => {
+  const { initDatabase, getDb } = await import('@/lib/db/database');
+  const { registerProject } = await import('@/lib/db/projects');
+  const { createSession, getSession, deleteSession } = await import('@/lib/db/sessions');
+  const { bindTerminalProviderSession } = await import('@/lib/db/terminal-provider-sessions');
+  const { readImageCache, readImageCards } = await import('@/lib/db/image-generation-cache');
+  const { syncTerminalImageIndex } = await import('@/lib/image-generation/terminal-image-index');
+  const { readTraceImageBytes } = await import('@/lib/image-generation/session-traces');
+  const { imageSessionCacheDirectory } = await import('@/lib/image-generation/cache-files');
+  await initDatabase();
+  const file = path.join(directory, 'rollout.jsonl');
+  const record = (type: string, payload: unknown) => JSON.stringify({ type, timestamp: '2026-09-05T00:00:00Z', payload }) + '\n';
+  const inline = Buffer.from('test-image-bytes').toString('base64');
+  try {
+    registerProject('image-project', directory, 'Image test', 'codex');
+    createSession('image-session', 'image-project', 'Image test', 'codex', {
+      providerState: JSON.stringify({ kind: 'terminal', codexSessionId: 'provider-image-session' }),
+    });
+    bindTerminalProviderSession({ providerId: 'codex', providerSessionId: 'provider-image-session',
+      tesseraSessionId: 'image-session', transcriptPath: file });
+    const session = getSession('image-session')!;
+    await fs.writeFile(file, record('session_meta', { cli_version: '0.147.0' })
+      + record('response_item', { type: 'message', role: 'user', content: [{ type: 'input_image', image_url: `data:image/png;base64,${inline}` }] })
+      + record('response_item', { type: 'custom_tool_call', call_id: 'call', name: 'functions.exec',
+        input: 'tools.image_gen__imagegen({prompt: "edit", num_last_images_to_include: 1})' }));
+    while ((await syncTerminalImageIndex(session, '')).more) { /* bounded catch-up */ }
+    const first = readImageCards(session.id);
+    assert.equal(first.length, 1);
+    assert.equal(first[0].status, 'running');
+    assert.equal(first[0].inputs.length, 1);
+    assert.equal(first[0].inputs[0].locator.kind, 'cache');
+    const saved = readImageCache(session.id)!;
+    assert.equal(saved.state_json.includes(inline), false);
+    const initialOffset = JSON.parse(saved.source_json).offset;
+    await syncTerminalImageIndex(session, '');
+    assert.equal(readImageCache(session.id)!.source_json, saved.source_json);
+    await fs.appendFile(file, record('event_msg', { type: 'item_completed', item: { id: 'result', type: 'imageGeneration',
+      savedPath: path.join(directory, 'deleted-original.png'), result: inline } }));
+    while ((await syncTerminalImageIndex(session, '')).more) { /* restores SQLite state */ }
+    assert.ok(JSON.parse(readImageCache(session.id)!.source_json).offset > initialOffset);
+    const completed = readImageCards(session.id);
+    assert.equal(completed.length, 1);
+    assert.equal(completed[0].status, 'completed');
+    assert.deepEqual(completed[0].inputs, first[0].inputs);
+    await fs.unlink(file);
+    const stillCached = readImageCards(session.id);
+    const bytes = await readTraceImageBytes(stillCached[0].result!.locator, '');
+    assert.equal(bytes?.bytes.toString(), 'test-image-bytes');
+    deleteSession(session.id);
+    assert.equal(readImageCache(session.id), undefined);
+    // Directory removal is asynchronous and deliberately scoped to this session.
+    for (let attempt = 0; attempt < 20; attempt++) {
+      if (!(await fs.stat(imageSessionCacheDirectory(session.id)).catch(() => null))) break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(await fs.stat(imageSessionCacheDirectory(session.id)).catch(() => null), null);
+  } finally {
+    getDb().close();
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});

--- a/tests/image-index-restart.e2e.cjs
+++ b/tests/image-index-restart.e2e.cjs
@@ -1,0 +1,38 @@
+const fs=require('node:fs');
+const path=require('node:path');
+const assert=require('node:assert/strict');
+const {chromium}=require('@playwright/test');
+(async()=>{
+  const [manifestPath,fixtureDirectory,artifactDirectory,mode]=process.argv.slice(2);
+  const manifest=JSON.parse(fs.readFileSync(manifestPath,'utf8').replace(/^\uFEFF/,''));
+  assert.ok(manifest.sessionId.startsWith('codex-0904ry-image-index'));
+  const instance=manifest.instances[0];
+  assert.notEqual(instance.serverPort,32123);
+  const browser=await chromium.connectOverCDP(instance.cdpUrl);
+  try{
+    const page=browser.contexts()[0].pages()[0];
+    if(mode==='prepare') {
+      await page.getByText('IMAGE INDEX OTHER',{exact:true}).first().click();
+      await page.screenshot({path:path.join(artifactDirectory,'08b-before-server-restart.png')});
+      return;
+    }
+    const id='image-index-qa-session';
+    const start=Date.now();
+    const cached=await page.evaluate(async id=>(await fetch(`/api/sessions/${id}/image-generations`)).json(),id);
+    const cacheMs=Date.now()-start;
+    assert.equal(cached.traces.length,2);
+    assert.equal(cached.traces[1].status,'running');
+    const inputBefore=cached.traces[1].inputs;
+    const png='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII=';
+    fs.appendFileSync(path.join(fixtureDirectory,'rollout.jsonl'),JSON.stringify({type:'event_msg',timestamp:new Date().toISOString(),payload:{type:'item_completed',item:{id:'qa-next-result',type:'imageGeneration',result:png}}})+'\n');
+    const updated=await page.evaluate(async id=>(await fetch(`/api/sessions/${id}/image-generations?sync=1`)).json(),id);
+    assert.equal(updated.traces.length,2);
+    assert.equal(updated.traces[1].status,'completed');
+    assert.deepEqual(updated.traces[1].inputs,inputBefore);
+    const bytes=await page.evaluate(async url=>{const r=await fetch(url);return {status:r.status,length:(await r.arrayBuffer()).byteLength};},updated.traces[1].result.url);
+    assert.equal(bytes.status,200);
+    assert.ok(bytes.length>0);
+    await page.screenshot({path:path.join(artifactDirectory,'09-server-restarted.png')});
+    console.log(JSON.stringify({cacheMs,cards:updated.traces.length,pendingRestoredAndCompleted:true,bytes},null,2));
+  }finally{await browser.close();}
+})().catch(error=>{console.error(error);process.exitCode=1;});

--- a/tests/terminal-headless-model.test.ts
+++ b/tests/terminal-headless-model.test.ts
@@ -10,6 +10,29 @@ function writeTerminal(terminal: Terminal, data: string): Promise<void> {
   return new Promise((resolve) => terminal.write(data, resolve));
 }
 
+test('headless diagnostics count queued bytes and settle back to zero', async () => {
+  const model = new TerminalHeadlessModel(80, 24);
+  const first = 'first output\n'.repeat(10_000);
+  const second = 'second output\n'.repeat(10_000);
+  model.write(first);
+  model.write(second);
+
+  const queued = model.diagnostics();
+  assert.equal(queued.totalWrites, 2);
+  assert.equal(queued.totalChars, first.length + second.length);
+  assert.equal(queued.pendingWrites, 2);
+  assert.equal(queued.pendingChars, first.length + second.length);
+
+  await model.whenSettled();
+  assert.deepEqual(model.diagnostics(), {
+    pendingWrites: 0,
+    pendingChars: 0,
+    totalWrites: 2,
+    totalChars: first.length + second.length,
+  });
+  model.dispose();
+});
+
 test('disposing during a pending xterm write releases the snapshot boundary', async () => {
   const model = new TerminalHeadlessModel(80, 24);
   model.write('output before dispose\n'.repeat(50_000));

--- a/tests/terminal-session-history-single-flight.test.ts
+++ b/tests/terminal-session-history-single-flight.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import type { CliProvider } from '@/lib/cli/providers/types';
+import type { SessionRow } from '@/lib/db/sessions';
+import type { SessionHistoryEvent } from '@/lib/session-replay-types';
+
+process.env.TESSERA_DATA_DIR = mkdtempSync(path.join(tmpdir(), 'tessera-history-single-flight-'));
+process.env.NODE_ENV = 'test';
+
+function terminalSession(id: string): SessionRow {
+  const timestamp = new Date().toISOString();
+  return {
+    id,
+    project_id: 'project',
+    title: 'Session',
+    has_custom_title: 0,
+    provider: 'codex',
+    provider_state: JSON.stringify({ kind: 'terminal', codexSessionId: `provider-${id}` }),
+    model: null,
+    reasoning_effort: null,
+    service_tier: null,
+    work_dir: null,
+    worktree_branch: null,
+    worktree_id: null,
+    scope_branch: null,
+    archived: 0,
+    archived_at: null,
+    worktree_deleted_at: null,
+    deleted: 0,
+    task_id: null,
+    chat_workflow_status: null,
+    collection_id: null,
+    sort_order: 0,
+    created_at: timestamp,
+    updated_at: timestamp,
+  };
+}
+
+test('concurrent requests share one terminal transcript decode', async () => {
+  const { initDatabase } = await import('@/lib/db/database');
+  const { cliProviderRegistry } = await import('@/lib/cli/providers/registry');
+  const { readTerminalSessionReplayState } = await import('@/lib/session/terminal-session-history');
+  await initDatabase();
+
+  let decodeCount = 0;
+  let releaseDecode!: () => void;
+  const decodeGate = new Promise<void>((resolve) => {
+    releaseDecode = resolve;
+  });
+  const events: SessionHistoryEvent[] = [{
+    v: 1,
+    type: 'assistant_message',
+    timestamp: '2026-09-04T00:00:00.000Z',
+    content: 'done',
+  }];
+  const provider = {
+    readTerminalTranscriptFingerprint: async () => 'same-transcript',
+    readTerminalTranscriptEvents: async () => {
+      decodeCount += 1;
+      await decodeGate;
+      return events;
+    },
+  } as unknown as CliProvider;
+  cliProviderRegistry.register('codex', provider);
+
+  const session = terminalSession(`single-flight-${Date.now()}`);
+  const first = readTerminalSessionReplayState(session, 'user');
+  const second = readTerminalSessionReplayState(session, 'user');
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(decodeCount, 1);
+  releaseDecode();
+  const [firstState, secondState] = await Promise.all([first, second]);
+  assert.strictEqual(firstState, secondState);
+  assert.equal(firstState?.messages.length, 1);
+});

--- a/tests/terminal-transcript-image-cache.test.ts
+++ b/tests/terminal-transcript-image-cache.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import type { SessionHistoryEvent } from '@/lib/session-replay-types';
+
+process.env.TESSERA_DATA_DIR = mkdtempSync(path.join(tmpdir(), 'tessera-transcript-image-cache-'));
+
+test('inline transcript tool images are replaced by a cached file URL', async () => {
+  const {
+    extractCachedTerminalTranscriptImagePath,
+    materializeTerminalTranscriptImage,
+  } = await import('@/lib/session/terminal-transcript-image-cache');
+  const event: SessionHistoryEvent = {
+    v: 1,
+    type: 'tool_call',
+    timestamp: '2026-09-04T00:00:00.000Z',
+    toolName: 'exec',
+    toolParams: {},
+    status: 'completed',
+    toolUseId: 'call/image',
+    toolUseResult: {
+      kind: 'file_read',
+      contentType: 'image',
+      base64: Buffer.from('image bytes').toString('base64'),
+      mimeType: 'image/png',
+    },
+  };
+
+  const materialized = await materializeTerminalTranscriptImage('session id', event);
+  assert.deepEqual((materialized as any).toolUseResult, {
+    kind: 'file_read',
+    contentType: 'image',
+    url: '/api/sessions/session%20id/tool-image?toolUseId=call%2Fimage',
+  });
+  const cachePath = extractCachedTerminalTranscriptImagePath((materialized as any).toolParams);
+  assert.ok(cachePath);
+  assert.equal((await fs.readFile(cachePath)).toString(), 'image bytes');
+  assert.equal(JSON.stringify(materialized).includes('aW1hZ2UgYnl0ZXM='), false);
+});
+
+test('content-addressed transcript image writes are reused', async () => {
+  const { materializeTerminalTranscriptImage } = await import('@/lib/session/terminal-transcript-image-cache');
+  const event: SessionHistoryEvent = {
+    v: 1,
+    type: 'tool_call',
+    timestamp: '2026-09-04T00:00:00.000Z',
+    toolName: 'exec',
+    toolParams: {},
+    status: 'completed',
+    toolUseId: 'repeat',
+    toolUseResult: {
+      kind: 'file_read',
+      contentType: 'image',
+      base64: Buffer.from('same image').toString('base64'),
+      mimeType: 'image/png',
+    },
+  };
+
+  const first = await materializeTerminalTranscriptImage('one', event);
+  const second = await materializeTerminalTranscriptImage('two', event);
+  assert.equal(
+    (first as any).toolParams._tesseraTranscriptImagePath,
+    (second as any).toolParams._tesseraTranscriptImagePath,
+  );
+});

--- a/tests/tool-image-rendering.test.ts
+++ b/tests/tool-image-rendering.test.ts
@@ -5,6 +5,7 @@ import test from 'node:test';
 import {
   buildImageToolResult,
   buildToolImageUrl,
+  extractImageToolPath,
   inferImageMime,
   isImagePath,
   resolveImageToolResultSrc,
@@ -41,6 +42,11 @@ test('buildToolImageUrl / buildImageToolResult encode session + toolUseId', () =
   });
 });
 
+test('extractImageToolPath accepts generated-image savedPath', () => {
+  assert.equal(extractImageToolPath({ savedPath: '/tmp/generated.png' }), '/tmp/generated.png');
+  assert.equal(extractImageToolPath({ path: '/tmp/view.png', savedPath: '/tmp/generated.png' }), '/tmp/view.png');
+});
+
 // --- the route reads through the host filesystem, not the CLI's path ---
 
 test('tool-image route resolves the recorded path for the host filesystem', () => {
@@ -68,6 +74,8 @@ test('tool-image route reads a PTY session\'s tool call from the provider transc
   // inline image 404s. The transcript the chat view decodes is the only source.
   assert.match(routeSource, /supportsTerminalTranscriptHistory\(session\)/);
   assert.match(routeSource, /readTerminalToolCallParams\(session, toolUseId/);
+  assert.match(routeSource, /extractCachedTerminalTranscriptImagePath\(toolParams\)/);
+  assert.match(routeSource, /extractImageToolPath\(toolParams\)/);
 });
 
 // --- codex view_image (imageView) end-to-end through the parser ---
@@ -155,7 +163,7 @@ test('Codex dynamic tool image output is preserved for inline rendering', () => 
   assert.equal(resolveImageToolResultSrc(toolCall.toolUseResult), 'data:image/png;base64,QUJDRA==');
 });
 
-test('Codex imageGeneration keeps durable image bytes out of textual output', () => {
+test('Codex imageGeneration serves the saved file without retaining duplicate image bytes', () => {
   const parsed = codexProtocolParser.parseStdout(
     'codex-generated-image',
     JSON.stringify({
@@ -181,8 +189,7 @@ test('Codex imageGeneration keeps durable image bytes out of textual output', ()
   assert.deepEqual(toolCall.toolUseResult, {
     kind: 'file_read',
     contentType: 'image',
-    base64: 'QUJDRA==',
-    mimeType: 'image/png',
+    url: '/api/sessions/codex-generated-image/tool-image?toolUseId=generated_image_1',
   });
   assert.equal(toolCall.toolParams.savedPath, '/tmp/generated.png');
 });


### PR DESCRIPTION
## Summary
- Persist image cards, ordered reference history, pending calls, and transcript byte checkpoints in SQLite.
- Store images in session-owned files instead of retaining base64 in long-lived state.
- Show cached cards immediately and synchronize only the selected visible Images tab every two seconds, reading appended records.
- Preserve debug heap, terminal queue, and WebSocket diagnostics.

## Verification
- 49 focused image tests passed; TypeScript and targeted ESLint passed.
- 17 image-index and headless-terminal tests rerun before publication: passed.
- Real Windows packaged backend + WSL transcript fixtures: card 1.9s, completion 2.0s, revisit 35ms; restart restored cached cards and pending calls.
- Real 472MB transcript: initial index 5.0s; cached metadata query 18ms.
- User debug build after ~36 minutes: server heap ~194MiB versus ~192MiB earlier; no sustained growth observed. This is not a guarantee against all OOM causes.
- Full unit suite previously reported two failures reproduced on clean HEAD: git-action-failure-report action count and worktree-identity-persistence ordering (1,925 passed, two skipped).

## Boundaries
- Incremental indexing targets Codex terminal sessions.
- First-ever indexing can take seconds; ambiguous references remain unresolved instead of guessed.
- Per-image limit 25MiB; per-JSONL-record limit 96MiB.
