### PR TITLE
Fix archiving running Codex GUI sessions

### DIFF
--- a/src/lib/archive/archive-service.ts
+++ b/src/lib/archive/archive-service.ts
@@ -378,6 +378,13 @@ export async function setTaskArchived(taskId: string, archived: boolean, userId?
       }
     }
 
+    // Release every Codex writer before the first archive RPC, including when
+    // multiple live sessions belong to the same task.
+    if (archived) {
+      await Promise.all(sessionRows
+        .filter((session) => session.provider === 'codex')
+        .map((session) => closeSessionRuntimes(session.id, userId)));
+    }
     await syncCodexThreadsArchived(sessionRows, archived, userId);
     try {
       dbTasks.setTaskArchived(taskId, archived);
@@ -392,7 +399,9 @@ export async function setTaskArchived(taskId: string, archived: boolean, userId?
 
     if (archived) {
       await Promise.all(
-        task.sessions.map((session) => closeSessionRuntimes(session.id, userId)),
+        sessionRows
+          .filter((session) => session.provider !== 'codex')
+          .map((session) => closeSessionRuntimes(session.id, userId)),
       );
     }
   });

--- a/src/lib/session/session-archive.ts
+++ b/src/lib/session/session-archive.ts
@@ -30,6 +30,11 @@ export async function archiveSession(
       throw new Error('Sessions of an archived task must be handled through their task');
     }
 
+    // The archive RPC uses a separate app-server. Release the live writer first
+    // or Codex rejects it with "already has an active writer".
+    if (archived && session.provider === 'codex') {
+      await closeSessionRuntimes(sessionId, userId);
+    }
     await syncCodexThreadsArchived([session], archived, userId);
     try {
       const archivedAt = archived ? new Date().toISOString() : null;
@@ -46,7 +51,7 @@ export async function archiveSession(
       throw error;
     }
 
-    if (archived) {
+    if (archived && session.provider !== 'codex') {
       await closeSessionRuntimes(sessionId, userId);
     }
 

--- a/tests/codex-session-lifecycle-sync.test.ts
+++ b/tests/codex-session-lifecycle-sync.test.ts
@@ -122,6 +122,48 @@ test('archive RPC failure preserves local state and task partial success is comp
   assert.equal(dbTasks.getTask('task-archive')?.archived, false);
 });
 
+for (const scope of ['session', 'task'] as const) {
+  test(`${scope} archive waits for live Codex writers to exit before the archive RPC`, async (t) => {
+    const taskId = `writer-${scope}-task`;
+    if (scope === 'task') {
+      dbTasks.createTask({ id: taskId, projectId: 'project-lifecycle', title: 'Live writers' });
+    }
+    const sessionIds = scope === 'task'
+      ? ['writer-task-1', 'writer-task-2']
+      : ['writer-session'];
+    const liveWriters = new Set(sessionIds);
+    for (const sessionId of sessionIds) {
+      dbSessions.createSession(sessionId, 'project-lifecycle', sessionId, 'codex', {
+        workDir: dataDir,
+        ...(scope === 'task' ? { taskId } : {}),
+        providerState: JSON.stringify({ threadId: `thread-${sessionId}` }),
+      });
+    }
+    const closes: string[] = [];
+    t.mock.method(processManager, 'closeSession', async (sessionId: string) => {
+      assert.equal(dbSessions.getSession(sessionId)?.archived, 0);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      liveWriters.delete(sessionId);
+      closes.push(sessionId);
+    });
+    const archives: unknown[] = [];
+    setCodexThreadControlRequestExecutorForTests(async (_context, method, params) => {
+      assert.equal(method, 'thread/archive');
+      if (liveWriters.size) throw new Error('thread already has an active writer');
+      archives.push(params.threadId);
+      return {};
+    });
+
+    if (scope === 'task') await setTaskArchived(taskId, true, 'user-1');
+    else await archiveSession(sessionIds[0], true, 'user-1');
+
+    assert.deepEqual(closes.sort(), [...sessionIds].sort());
+    assert.equal(archives.length, sessionIds.length);
+    if (scope === 'task') assert.equal(dbTasks.getTask(taskId)?.archived, true);
+    else assert.equal(dbSessions.getSession(sessionIds[0])?.archived, 1);
+  });
+}
+
 test('archive falls back to the project work dir when the session worktree is gone', async () => {
   const missingWorkDir = path.join(dataDir, 'worktrees', 'deleted-branch');
   dbTasks.createTask({ id: 'task-missing-worktree', projectId: 'project-lifecycle', title: 'Missing worktree' });


### PR DESCRIPTION
Fix archiving a running Codex GUI session when its active app-server writer rejects a separate `thread/archive` request.

Archive now closes live Codex runtimes before synchronizing their native archive state. The same ordering applies to task archives with multiple Codex sessions. Claude Code and OpenCode retain their existing post-persistence shutdown behavior.

Validation: `npx tsx --test tests/codex-session-lifecycle-sync.test.ts tests/codex-thread-control-client.test.ts` and targeted ESLint passed. A packaged Windows backend with WSL Codex GUI session also archived successfully after its live writer exited.
