### PR TITLE
fix(terminal): prevent Windows PTY EPIPE from closing Tessera

### DIFF
--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { randomUUID } from 'node:crypto';
+import type { Socket } from 'node:net';
 import { createRequire } from 'module';
 import logger from '@/lib/logger';
 import { buildSpawnEnv, getAgentEnvironment } from '@/lib/cli/spawn-cli';
@@ -822,6 +823,16 @@ export class TerminalManager {
         terminalProcess = spawnPtyProcess({});
       }
       const processHandle = terminalProcess;
+      // node-pty 1.2's Windows input pipe can emit EPIPE before onExit arrives.
+      // It has no error listener (the public PTY events cover the output pipe).
+      // Handle only this pipe's EPIPE; leave output draining and exit unchanged.
+      const inputPipe = (processHandle as TerminalProcessHandle & {
+        _agent?: { inSocket?: Socket };
+      })._agent?.inSocket;
+      inputPipe?.on('error', (error: NodeJS.ErrnoException) => {
+        if (error.code !== 'EPIPE') throw error;
+        logger.debug({ terminalId: options.terminalId }, 'Terminal input pipe closed (EPIPE)');
+      });
       traceTerminalStage('spawn:after', { terminalId: options.terminalId });
       logger.debug({ terminalId: options.terminalId }, 'Terminal PTY spawned');
 

--- a/tests/terminal-manager-lifecycle.test.ts
+++ b/tests/terminal-manager-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -109,6 +110,37 @@ function createOptions(overrides: Partial<TerminalCreateOptions> = {}): Terminal
 function nextImmediate(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
+
+test('Windows input pipe EPIPE preserves output and normal exit without closing other terminals', async () => {
+  const delivered: ServerTransportMessage[] = [];
+  const inputPipe = new EventEmitter();
+  const exiting = Object.assign(new FakePty(), { _agent: { inSocket: inputPipe } });
+  const other = new FakePty();
+  const pending = [exiting, other];
+  const manager = new TerminalManager(
+    (_connectionId, message) => delivered.push(message),
+    async () => ({ spawn: () => pending.shift()! }),
+  );
+  try {
+    await manager.create(createOptions());
+    await manager.create(createOptions({ terminalId: 'terminal-b', sessionId: 'session-two' }));
+    await nextImmediate();
+    assert.doesNotThrow(() => inputPipe.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })));
+    assert.equal(exiting.killCount, 0);
+    exiting.emitData('final output');
+    await nextImmediate();
+    assert.ok(delivered.some(message => message.type === 'terminal_output' && message.data === 'final output'));
+    exiting.emitExit(1);
+    assert.equal(delivered.filter(message => message.type === 'terminal_exit' && message.terminalId === 'terminal-a').length, 1);
+    manager.write('terminal-b', 'user-a', 'connection-a', 'surface-a', 'still running');
+    assert.deepEqual(other.writes, ['still running']);
+    assert.equal(other.killCount, 0);
+    const unexpected = Object.assign(new Error('unexpected pipe error'), { code: 'EIO' });
+    assert.throws(() => inputPipe.emit('error', unexpected), error => error === unexpected);
+  } finally {
+    await manager.closeAllForUser('user-a');
+  }
+});
 
 test('concurrent session opens spawn once and disconnect only detaches its surface', async () => {
   const delivered: Array<{ connectionId: string; message: ServerTransportMessage }> = [];


### PR DESCRIPTION
## Summary

A Windows PTY can close its input pipe before delivering its exit event. Input arriving in that interval raises an unhandled `write EPIPE`, which shuts down the Tessera backend and closes the entire app. A failed Codex session resume triggered this sequence in the captured production log.

Attach an error listener to node-pty's Windows input pipe immediately after spawning. Handle only `EPIPE` locally and keep other errors visible. Input routing, output draining, and session exit behavior are unchanged.

## Testing

- [x] Terminal lifecycle and cancellation tests: 60 passed. The new regression failed before the fix and passed afterward; it checks final output, normal exit, another terminal remaining usable, and propagation of non-EPIPE errors.
- [x] ESLint on both changed files; `git diff --check`.
- [x] `tsc --noEmit -p electron/tsconfig.json`.
- [x] Narrow Windows/WSL reproduction using the packaged Electron Node 20.18.3 runtime and node-pty 1.2.0-beta.13: exiting WSL child plus late input reproduced `write EPIPE`. Loading the actual production guard from this change contained the error and preserved the normal exit event.
- [ ] Full production build and packaged UI E2E were not run.

## Notes

The workaround accesses node-pty's private `_agent.inSocket` because its public PTY error events cover the output pipe. The optional lookup is a no-op for PTYs without this Windows-specific member. Production change: 11 added lines, with no input-path refactor or forced session cleanup.
