### PR TITLE
fix(panel): restore PTY file drops and tab splitting

### DIFF
--- a/src/components/panel/panel-wrapper.tsx
+++ b/src/components/panel/panel-wrapper.tsx
@@ -118,6 +118,7 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
   >(null);
   const sessionInsertZoneRef = useRef(false);
   const dropEdgeRef = useRef<DropEdge | null>(null);
+  const capturedDropRef = useRef<{ edge: DropEdge | null; sessionInsert: boolean } | null>(null);
   const dragCounterRef = useRef(0);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -280,6 +281,16 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
     setSessionInsertZone(null);
   }, []);
 
+  const handleDropCapture = useCallback(() => {
+    // Capture runs before handleDrop. Preserve its routing decision before
+    // clearing the highlight, including when a child stops propagation.
+    capturedDropRef.current = {
+      edge: dropEdgeRef.current,
+      sessionInsert: sessionInsertZoneRef.current,
+    };
+    clearDropIndicators();
+  }, [clearDropIndicators]);
+
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     if (!isPanelCompatibleDrag(e)) return;
     e.preventDefault();
@@ -296,8 +307,9 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
 
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
-    const currentEdge = dropEdgeRef.current;
-    const droppedInSessionInsertZone = sessionInsertZoneRef.current;
+    const currentEdge = capturedDropRef.current?.edge ?? dropEdgeRef.current;
+    const droppedInSessionInsertZone = capturedDropRef.current?.sessionInsert ?? sessionInsertZoneRef.current;
+    capturedDropRef.current = null;
     clearDropIndicators();
 
     // OS (Finder/Explorer) file drop → insert each absolute path into the PTY.
@@ -613,7 +625,7 @@ export const PanelWrapper = memo(function PanelWrapper({ panelId, children }: Pa
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
-      onDropCapture={clearDropIndicators}
+      onDropCapture={handleDropCapture}
       onDrop={handleDrop}
     >
       {children}

--- a/tests/panel-drop-event-order.test.mjs
+++ b/tests/panel-drop-event-order.test.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const ts = createRequire(import.meta.url)('typescript');
+const source = fs.readFileSync(new URL('../src/components/panel/panel-wrapper.tsx', import.meta.url), 'utf8');
+const ast = ts.createSourceFile('panel.tsx', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+const callbacks = [];
+let capture;
+function visit(node) {
+  if (ts.isVariableDeclaration(node)
+    && ['clearDropIndicators', 'handleDropCapture', 'handleDrop'].includes(node.name.getText(ast))) {
+    callbacks.push(`const ${node.name.getText(ast)} = ${node.initializer.arguments[0].getText(ast)};`);
+  }
+  if (ts.isJsxAttribute(node) && node.name.getText(ast) === 'onDropCapture') {
+    capture = node.initializer.expression.getText(ast);
+  }
+  ts.forEachChild(node, visit);
+}
+visit(ast);
+assert.ok(capture, 'exercise the capture handler wired to the real wrapper');
+const code = ts.transpileModule(`${callbacks.join('\n')}\nconst capture = ${capture};`, {
+  compilerOptions: { target: ts.ScriptTarget.ES2022 },
+}).outputText;
+
+// Execute the production callbacks in browser event order. Only external
+// stores/PTY I/O are stubbed; this is not a packaged Electron integration test.
+function fixture(kind) {
+  const calls = [];
+  const context = {
+    dropEdgeRef: { current: kind.endsWith('image') ? 'center' : 'right' },
+    capturedDropRef: { current: null },
+    sessionInsertZoneRef: { current: false },
+    dragCounterRef: { current: 1 },
+    setDropEdge() {}, setInsertPathHint() {}, setSessionInsertZone() {},
+    isNativeFilePathInsertTarget: () => kind === 'native-image',
+    isTerminalPathInsertTarget: () => kind === 'workspace-image',
+    isTerminalSessionRefTarget: () => false,
+    resolveInsertTargetTerminalId: () => 'pty-1',
+    getNativeFileDropAbsolutePaths: () => ['C:\\images\\test.png'],
+    getInternalPathDropPaths: () => ['/home/work/images/test.png'],
+    insertFilePathIntoTerminal: (...args) => { calls.push(['insert', ...args]); return true; },
+    panelId: 'target', focusPanelControl() {},
+    SESSION_DRAG_MIME: 'session', TAB_PANEL_TREE_DND_MIME: 'tree', TAB_DRAG_MIME: 'tab',
+    parsePanelNodeDragData: () => null, parsePanelTitleDragData: () => null,
+    wrapperRef: { current: { getBoundingClientRect: () => ({ width: 1200, height: 800 }) } },
+    MIN_PANEL_WIDTH: 100, MIN_PANEL_HEIGHT: 100,
+    usePanelStore: { getState: () => ({
+      activeTabId: 'active',
+      tabPanels: { active: { panels: { target: { sessionId: 'old' } } }, source: { panels: {} } },
+      setActivePanelId() {},
+      graftTabIntoActiveTab: (...args) => { calls.push(['graft', ...args]); return 'new'; },
+    }) },
+    useTabStore: { getState: () => ({ closeTab() {}, pinTab() {} }) },
+    captureTelemetryEvent() {}, projectViewWorkspaceState: { resolveSession: () => null },
+    event: { preventDefault() {}, dataTransfer: {
+      types: kind === 'native-image' ? ['Files'] : ['tab', 'tree'],
+      getData: (key) => key === 'tree' && kind !== 'native-image' ? 'source' : '',
+    } },
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  return {
+    calls, context,
+    dispatch(childConsumes = false) {
+      vm.runInContext(`capture(event);${childConsumes ? '' : 'handleDrop(event);'}`, context);
+    },
+  };
+}
+
+test('Explorer image drop reaches the PTY after wrapper capture', () => {
+  const run = fixture('native-image');
+  run.dispatch();
+  assert.deepEqual(run.calls, [['insert', 'pty-1', 'C:\\images\\test.png']]);
+  assert.equal(run.context.dropEdgeRef.current, null);
+});
+
+test('tab edge drop grafts the source tab after wrapper capture', () => {
+  const run = fixture('tab-split');
+  run.dispatch();
+  assert.deepEqual(run.calls, [['graft', 'source', 'target', 'right']]);
+  assert.equal(run.context.dropEdgeRef.current, null);
+});
+
+test('workspace explorer image drop inserts its path after wrapper capture', () => {
+  const run = fixture('workspace-image');
+  run.dispatch();
+  assert.deepEqual(run.calls, [['insert', 'pty-1', '/home/work/images/test.png']]);
+});
+
+test('a child consuming the drop still clears the parent indicators and refs', () => {
+  const run = fixture('native-image');
+  const visuals = [];
+  run.context.setDropEdge = (value) => visuals.push(value);
+  run.context.sessionInsertZoneRef.current = true;
+  run.dispatch(true);
+  assert.deepEqual(run.calls, []);
+  assert.deepEqual(visuals, [null]);
+  assert.equal(run.context.dropEdgeRef.current, null);
+  assert.equal(run.context.sessionInsertZoneRef.current, false);
+  assert.equal(run.context.dragCounterRef.current, 0);
+});
+
+test('the next drop replaces a snapshot left by a child consuming the prior drop', () => {
+  const run = fixture('tab-split');
+  run.dispatch(true);
+  run.context.dropEdgeRef.current = 'left';
+  run.dispatch();
+  assert.deepEqual(run.calls, [['graft', 'source', 'target', 'left']]);
+  assert.equal(run.context.capturedDropRef.current, null);
+});

--- a/tests/terminal-chat-composer-path-input-contract.test.mjs
+++ b/tests/terminal-chat-composer-path-input-contract.test.mjs
@@ -37,7 +37,8 @@ test('terminal Chat View clears the parent panel drop highlight before consuming
   );
 
   assert.match(panelWrapperSource, /const clearDropIndicators = useCallback\(/);
-  assert.match(panelWrapperSource, /onDropCapture=\{clearDropIndicators\}/);
+  assert.match(panelWrapperSource, /onDropCapture=\{handleDropCapture\}/);
+  assert.match(panelWrapperSource, /const handleDropCapture = useCallback\([\s\S]*?clearDropIndicators\(\);/);
   assert.match(panelWrapperSource, /const handleDrop = useCallback\([\s\S]*?clearDropIndicators\(\);/);
 });
 


### PR DESCRIPTION
Dragging an Explorer image into a PTY or dropping another tab on a panel edge became a no-op after 3ac96162. The wrapper's capture handler cleared the drop edge before its bubbling handler could read it.

Preserve the edge and session-reference insertion decision during capture, then clear the visual indicators. The bubbling handler consumes that snapshot, restoring path insertion and tab splitting while retaining cleanup when a child consumes the drop.

Validation:
- Regression tests reproduced both no-op failures before the fix. Tests cover native and workspace image paths, tab grafting, child-consumed drops, and the next drop replacing a previous snapshot.
- Focused tests and ESLint passed; the production build and TypeScript checks passed.
- Isolated Windows Electron + Windows packaged backend + WSL PTY: a CDP native file drop reached PTY input/output; dispatched tab drag/drop events produced two panels and removed the source tab. Numbered screenshots were captured locally.
- Physical-pointer tab dragging and Ctrl+V clipboard paste are not covered by the successful automated run.
