### PR TITLE
Fix stored image references in the incremental image index

### DIFF
--- a/docs/image-reference-qa-2026-09-06.md
+++ b/docs/image-reference-qa-2026-09-06.md
@@ -1,0 +1,46 @@
+# Transcript image reference resolution — 2026-09-06
+
+## Change
+
+The Codex terminal image index now recognizes exec reference-only cells, including
+`const paths = [...] ; store("refs", paths)`, then resolves later
+`load("refs")` and `[p[0], p[1]]` inputs. It interprets data expressions using an
+AST, without executing transcript JavaScript. Locals last for one exec cell;
+stored reference values are persisted with the existing SQLite byte checkpoint.
+Tool outputs do not execute the same bindings a second time. Failed cells discard
+predicted bindings. Cards freeze their resolved inputs at invocation time.
+
+Supported data expressions include strings, numbers, null, arrays, spreads of
+known arrays, array indexes, string concatenation and template interpolation.
+Unknown values, helper shadowing, ambiguous writes and duplicate reference keys
+stay unresolved. This is not an arbitrary JavaScript interpreter. Reference
+storage accepts path-like values only: at most 64 keys, 16 KiB per value, with
+128 KiB source and 32-level expression limits. Other stored output/base64 is not
+retained. Existing checkpoints/cards are preserved; no historical repair runs.
+
+The existing session-owned image files, environment-aware path conversion,
+visible-tab-only polling and incremental transcript reader are unchanged.
+
+## Verification
+
+- Replayed the reported transcript in order: both failing calls resolve all three
+  inputs, including Korean filenames, with no unresolved references.
+- 39 focused decoder, resolver, incremental-state, SQLite persistence and image
+  projection tests passed. TypeScript and targeted ESLint passed.
+- Regression cases cover store/load across serialized state, output replay,
+  frozen inputs, unknown overwrites, storage bounds, Promise wrappers, chained
+  calls, tool-argument mutations, duplicate properties, helper shadowing and
+  unrelated destructuring.
+- Real isolated packaged Windows backend reading WSL JSONL/image fixtures:
+  both reference forms show three inputs; metadata order and cached HTTP image
+  bytes match the supplied files; unknown references show a warning; reload and
+  source-file deletion retain cached inputs. No paid generator/CLI call is made.
+- Full unit suite: 1,941 pass, two skipped, two fail. Contracts: 435 pass, two
+  fail. All four failures reproduced in a detached checkout of the unchanged
+  base `06aa0ef5`: `git-action-failure-report`, `worktree-identity-persistence`,
+  `app-click-telemetry-contract`, `pty-ui-cleanup-contract`.
+
+Repro entry point: `tests/image-reference-electron.e2e.cjs` (Windows Node;
+launcher ownership manifest, Windows-readable WSL fixture directory, corresponding
+Linux fixture directory, screenshot directory). Screenshots are retained in
+`C:\Users\work\Downloads\image-refs-qa-0906ke`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.3-prebuild.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "acorn": "^8.16.0",
         "@tanstack/react-virtual": "^3.13.24",
         "@xterm/addon-fit": "0.12.0-beta.289",
         "@xterm/addon-search": "0.17.0-beta.289",
@@ -4421,7 +4422,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "prepare": "node scripts/patch-xterm-webgl-atlas.mjs && node scripts/patch-xterm-webgl-device-pixel.mjs && node scripts/patch-xterm-touch-scroll.mjs && node scripts/patch-xterm-mouse-report-coords.mjs && node -e \"const fs=require('fs'); if (fs.existsSync('.electron-runtime')) require('child_process').execFileSync('electron-builder', ['install-app-deps'], {stdio:'inherit'});\""
   },
   "dependencies": {
+    "acorn": "^8.16.0",
     "@tanstack/react-virtual": "^3.13.24",
     "@xterm/addon-fit": "0.12.0-beta.289",
     "@xterm/addon-search": "0.17.0-beta.289",

--- a/src/lib/cli/providers/codex/transcript-decoder.ts
+++ b/src/lib/cli/providers/codex/transcript-decoder.ts
@@ -147,6 +147,7 @@ function decodeToolCall(
   payload: Record<string, any>,
   state: CodexTranscriptDecoderState,
   timestamp: string,
+  includeImageReferenceScripts = false,
 ): SessionHistoryEvent | null {
   const rawName = typeof payload.name === 'string' ? payload.name.trim() : '';
   const callId = typeof payload.call_id === 'string' ? payload.call_id.trim() : '';
@@ -154,6 +155,10 @@ function decodeToolCall(
 
   const { toolName, toolKind } = normalizeToolName(rawName);
   const toolParams = buildToolParams(payload, toolKind);
+  if (includeImageReferenceScripts && payload.type === 'custom_tool_call'
+    && (rawName === 'exec' || rawName === 'functions.exec')) {
+    toolParams._tesseraImageReferenceScript = true;
+  }
   const toolDisplay = buildToolDisplay(toolName, toolKind, toolParams);
 
   state.pendingToolCalls.set(callId, {
@@ -378,7 +383,7 @@ function decodeResponseMessage(
 export function decodeCodexTranscriptLine(
   line: string,
   state: CodexTranscriptDecoderState,
-  options: { preferInlineImages?: boolean } = {},
+  options: { preferInlineImages?: boolean; includeImageReferenceScripts?: boolean } = {},
 ): SessionHistoryEvent[] {
   const trimmed = line.trim();
   if (!trimmed) return [];
@@ -414,7 +419,7 @@ export function decodeCodexTranscriptLine(
       return event ? [event] : [];
     }
     if (payload.type === 'function_call' || payload.type === 'custom_tool_call') {
-      const event = decodeToolCall(payload, state, timestamp);
+      const event = decodeToolCall(payload, state, timestamp, options.includeImageReferenceScripts);
       return event ? [event] : [];
     }
     if (payload.type === 'function_call_output' || payload.type === 'custom_tool_call_output') {

--- a/src/lib/image-generation/incremental-state.ts
+++ b/src/lib/image-generation/incremental-state.ts
@@ -1,4 +1,5 @@
 import type { EnhancedMessage } from '@/types/chat';
+import { parseImageReferenceScript, type ImageReferenceBindings } from './reference-script';
 import { imageFromTool, isImageGenerationResult, parseImageGenerationInvocations, resultImage,
   type ImageGenerationTrace, type ResolvedTraceImage } from './traces';
 
@@ -7,6 +8,7 @@ export interface ImageIndexState {
   traces: ImageGenerationTrace[];
   pending: string[];
   seenResults: string[];
+  referenceBindings?: ImageReferenceBindings;
 }
 
 export function createImageIndex(): ImageIndexState {
@@ -55,7 +57,11 @@ export function applyImageTool(state: ImageIndexState, message: Extract<Enhanced
   const source = ['input', 'source', 'code', 'command', 'arguments']
     .map((key) => message.toolParams[key])
     .find((value): value is string => typeof value === 'string' && value.includes('image_gen__imagegen'));
-  const invocations = source ? parseImageGenerationInvocations(source) : [];
+  const script = message.toolParams._tesseraImageReferenceScript === true && typeof message.toolParams.input === 'string'
+    ? message.toolParams.input : undefined;
+  const invocations = script && message.status === 'running'
+    ? parseImageReferenceScript(script, state.referenceBindings ??= { stored: [] })
+    : source ? parseImageGenerationInvocations(source) : [];
   for (const [index, invocation] of invocations.entries()) {
     const id = `${message.toolUseId ?? message.id}-${index}`;
     // A tool result repeats its call parameters. It must never create another card.
@@ -73,6 +79,8 @@ export function applyImageTool(state: ImageIndexState, message: Extract<Enhanced
     state.pending.push(id);
   }
   if (message.status === 'error') {
+    // The executed cell may have failed before a predicted store() write.
+    if (message.toolParams._tesseraImageReferenceScript) state.referenceBindings = { stored: [] };
     for (const trace of state.traces.filter((entry) => entry.invocationMessageId === message.id && entry.status === 'running')) {
       trace.status = 'error';
       trace.error = message.error;

--- a/src/lib/image-generation/reference-script.ts
+++ b/src/lib/image-generation/reference-script.ts
@@ -1,0 +1,223 @@
+import { parse, type Expression, type Node, type Pattern } from 'acorn';
+import { parseImageGenerationInvocations, type ImageGenerationInvocation } from './traces';
+
+type Value = string | number | null | Value[];
+export interface ImageReferenceBindings { stored: Array<[string, Value]> }
+const MAX_SOURCE = 128 * 1024;
+const MAX_VALUE = 16 * 1024;
+const MAX_BINDINGS = 64;
+
+function isReferenceValue(value: Value): boolean {
+  if (Array.isArray(value)) return value.every(isReferenceValue);
+  if (typeof value !== 'string') return true;
+  // Persist path data only. Other exec stores can contain image base64, shell
+  // output or entire documents and must not become long-lived image state.
+  return !/[\r\n\0]/.test(value) && !/^[A-Za-z0-9+/=]{256,}$/.test(value)
+    && (/^(?:\/|[A-Za-z]:[\\/]|\\\\|\.{1,2}[\\/]|file:\/\/)/.test(value)
+      || /\.(?:png|jpe?g|gif|webp|avif|bmp|svg)$/i.test(value));
+}
+
+/** Interpret only data expressions, never execute transcript JavaScript. Locals
+ * belong to one exec cell; only store/load bindings survive the byte checkpoint. */
+export function parseImageReferenceScript(source: string, bindings: ImageReferenceBindings): ImageGenerationInvocation[] {
+  const stored = new Map(bindings.stored);
+  const locals = new Map<string, Value>();
+  const calls: ImageGenerationInvocation[] = [];
+  const forget = () => { locals.clear(); stored.clear(); };
+  const put = (map: Map<string, Value>, key: string, value: Value | undefined) => {
+    map.delete(key);
+    if (value !== undefined && key.length <= 256 && JSON.stringify(value).length <= MAX_VALUE) {
+      if (map.size >= MAX_BINDINGS) map.delete(map.keys().next().value!);
+      map.set(key, structuredClone(value));
+    }
+  };
+  const text = (node: Node) => source.slice(node.start, node.end);
+  const isTool = (node: Node) => /^tools\.[A-Za-z_$][\w$]*$/.test(text(node));
+
+  // Unsupported control flow may overwrite bindings. Invalidate affected data
+  // rather than treating a conditional write as an unconditional assignment.
+  function invalidate(node: Node): void {
+    if (node.type === 'AssignmentExpression' || node.type === 'UpdateExpression') forget();
+    if (node.type === 'VariableDeclaration') locals.clear();
+    if (node.type === 'CallExpression') {
+      const call = node as Extract<Expression, { type: 'CallExpression' }>;
+      if (text(call.callee) === 'store' || (!isTool(call.callee)
+        && !['load', 'image', 'text', 'generatedImage'].includes(text(call.callee)))) forget();
+    }
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value)) {
+        for (const child of value) if (child && typeof child.type === 'string') invalidate(child);
+      } else if (value && typeof value === 'object' && 'type' in value) invalidate(value as Node);
+    }
+  }
+
+  function evaluate(node: Expression | undefined | null, depth = 0): Value | undefined {
+    if (!node || depth > 32) return undefined;
+    const read = (expression: Expression) => evaluate(expression, depth + 1);
+    switch (node.type) {
+      case 'Literal':
+        return typeof node.value === 'string' || typeof node.value === 'number' || node.value === null
+          ? node.value : undefined;
+      case 'Identifier': return locals.get(node.name);
+      case 'ArrayExpression': {
+        if (node.elements.length > 64) return undefined;
+        const values: Value[] = [];
+        let known = true;
+        for (const item of node.elements) {
+          if (!item) { known = false; continue; }
+          const value = read(item.type === 'SpreadElement' ? item.argument : item);
+          if (value === undefined) { known = false; continue; }
+          if (item.type === 'SpreadElement') {
+            if (!Array.isArray(value)) known = false;
+            else values.push(...value);
+          } else values.push(value);
+          if (values.length > 64 || JSON.stringify(values).length > MAX_VALUE) return undefined;
+        }
+        return known ? values : undefined;
+      }
+      case 'ObjectExpression':
+        for (const property of node.properties) {
+          if (property.type === 'SpreadElement') read(property.argument);
+          else {
+            if (property.computed) read(property.key as Expression);
+            if (property.kind === 'init') read(property.value as Expression);
+          }
+        }
+        return undefined;
+      case 'TemplateLiteral': {
+        let value = node.quasis[0].value.cooked ?? '';
+        for (let index = 0; index < node.expressions.length; index++) {
+          const part = read(node.expressions[index]);
+          if (typeof part !== 'string' && typeof part !== 'number') return undefined;
+          value += String(part) + (node.quasis[index + 1].value.cooked ?? '');
+          if (value.length > MAX_VALUE) return undefined;
+        }
+        return value;
+      }
+      case 'BinaryExpression': {
+        const left = read(node.left as Expression), right = read(node.right);
+        if (node.operator !== '+' || typeof left !== 'string' || typeof right !== 'string') return undefined;
+        return left.length + right.length <= MAX_VALUE ? left + right : undefined;
+      }
+      case 'MemberExpression': {
+        const object = read(node.object as Expression);
+        const index = node.computed ? read(node.property as Expression) : undefined;
+        return Array.isArray(object) && typeof index === 'number' && Number.isSafeInteger(index) && index >= 0
+          ? object[index] : undefined;
+      }
+      case 'AwaitExpression': return read(node.argument);
+      case 'SequenceExpression': {
+        let value: Value | undefined;
+        for (const expression of node.expressions) value = read(expression);
+        return value;
+      }
+      case 'AssignmentExpression': {
+        const value = read(node.right);
+        if (node.left.type === 'Identifier') put(locals, node.left.name, node.operator === '=' ? value : undefined);
+        else forget(); // Includes mutations through array aliases and load() values.
+        return node.operator === '=' ? value : undefined;
+      }
+      case 'CallExpression': {
+        const name = text(node.callee);
+        if (node.callee.type === 'MemberExpression') {
+          read(node.callee.object as Expression);
+          if (node.callee.computed) read(node.callee.property as Expression);
+        }
+        if (name === 'tools.image_gen__imagegen') {
+          const [invocation] = parseImageGenerationInvocations(text(node));
+          if (!invocation) return undefined;
+          const object = node.arguments[0];
+          if (object?.type === 'ObjectExpression') {
+            const patches: Array<{ start: number; end: number; value: string }> = [];
+            const keys = new Set<string>();
+            let ambiguous = false;
+            for (const property of object.properties) {
+              if (property.type !== 'Property' || property.computed || property.kind !== 'init') continue;
+              const key = property.key.type === 'Identifier' ? property.key.name
+                : property.key.type === 'Literal' ? property.key.value : undefined;
+              const value = read(property.value as Expression);
+              if (!['referenced_image_paths', 'num_last_images_to_include', 'prompt'].includes(String(key))) continue;
+              if (keys.has(String(key))) ambiguous = true;
+              keys.add(String(key));
+              if (value !== undefined) patches.push({ start: property.start - node.start, end: property.end - node.start,
+                value: `${JSON.stringify(key)}:${JSON.stringify(value)}` });
+            }
+            let rewritten = text(node);
+            for (const patch of patches.reverse()) rewritten = rewritten.slice(0, patch.start) + patch.value + rewritten.slice(patch.end);
+            const resolved = parseImageGenerationInvocations(rewritten)[0];
+            // Spread/computed properties can override an otherwise literal reference.
+            if (ambiguous || object.properties.some((property) => property.type !== 'Property' || property.computed || property.kind !== 'init')) {
+              resolved.referencesUnresolved = true;
+            }
+            calls.push(resolved);
+          } else calls.push(invocation);
+          return undefined;
+        }
+        if (name === 'load' && node.arguments.length === 1 && node.arguments[0].type !== 'SpreadElement') {
+          const key = read(node.arguments[0]);
+          return typeof key === 'string' ? structuredClone(stored.get(key)) : undefined;
+        }
+        if (name === 'store' && node.arguments.length === 2 && node.arguments.every((argument) => argument.type !== 'SpreadElement')) {
+          const key = read(node.arguments[0] as Expression), value = read(node.arguments[1] as Expression);
+          if (typeof key === 'string') put(stored, key, value !== undefined && isReferenceValue(value) ? value : undefined);
+          else stored.clear();
+          return undefined;
+        }
+        // JS evaluates arguments before calling a wrapper, including Promise.all.
+        for (const argument of node.arguments) read(argument.type === 'SpreadElement' ? argument.argument : argument);
+        if (!isTool(node.callee) && !['image', 'text', 'generatedImage', 'Promise.all', 'Promise.allSettled'].includes(name)) forget();
+        return undefined;
+      }
+      default: invalidate(node); return undefined;
+    }
+  }
+
+  try {
+    if (source.length > MAX_SOURCE) throw new Error('Reference script too large');
+    const program = parse(source, { ecmaVersion: 'latest', sourceType: 'module' });
+    // A shadowed helper is user code, not the exec runtime's store/load API.
+    const reserved = new Set(['store', 'load', 'tools', 'Promise', 'image', 'text', 'generatedImage']);
+    function bindsHelper(node: Pattern): boolean {
+      switch (node.type) {
+        case 'Identifier': return reserved.has(node.name);
+        case 'ObjectPattern': return node.properties.some((property) => bindsHelper(
+          property.type === 'RestElement' ? property.argument : property.value as Pattern));
+        case 'ArrayPattern': return node.elements.some((element) => element && bindsHelper(element));
+        case 'RestElement': return bindsHelper(node.argument);
+        case 'AssignmentPattern': return bindsHelper(node.left);
+        case 'MemberExpression': return bindsHelper(node.object as Pattern);
+        default: return false;
+      }
+    }
+    function hasShadow(node: Node): boolean {
+      if (node.type === 'VariableDeclarator' || node.type === 'FunctionDeclaration'
+        || node.type === 'ClassDeclaration' || node.type === 'AssignmentExpression') {
+        const target = (node as Node & { id?: Node; left?: Node }).id ?? (node as Node & { left?: Node }).left;
+        if (target && bindsHelper(target as Pattern)) return true;
+      }
+      return Object.values(node).some((value) => Array.isArray(value)
+        ? value.some((child) => child && typeof child.type === 'string' && hasShadow(child))
+        : value && typeof value === 'object' && 'type' in value && hasShadow(value as Node));
+    }
+    if (hasShadow(program)) throw new Error('Reference helpers or assignment targets are ambiguous');
+    for (const statement of program.body) {
+      if (statement.type === 'VariableDeclaration') {
+        for (const declaration of statement.declarations) {
+          const value = evaluate(declaration.init);
+          if (declaration.id.type === 'Identifier') put(locals, declaration.id.name, value);
+          else locals.clear();
+        }
+      } else if (statement.type === 'ExpressionStatement') evaluate(statement.expression);
+      else {
+        invalidate(statement);
+        calls.push(...parseImageGenerationInvocations(text(statement)).map((call) => ({ ...call, referencesUnresolved: true })));
+      }
+    }
+  } catch {
+    forget();
+    return parseImageGenerationInvocations(source).map((call) => ({ ...call, referencesUnresolved: true }));
+  } finally {
+    bindings.stored = [...stored];
+  }
+  return calls;
+}

--- a/src/lib/image-generation/terminal-image-index.ts
+++ b/src/lib/image-generation/terminal-image-index.ts
@@ -57,7 +57,7 @@ async function sync(session: SessionRow, userId: string, signal?: AbortSignal): 
   const scanned = await readImageTranscriptBatch(filePath, checkpoint, () => {
     index = createImageIndex(); decoder = createCodexTranscriptDecoderState(); rebuilding = Boolean(cached); reset = true;
   }, async (line, offset) => {
-    for (const event of decodeCodexTranscriptLine(line, decoder, { preferInlineImages: true })) {
+    for (const event of decodeCodexTranscriptLine(line, decoder, { preferInlineImages: true, includeImageReferenceScripts: true })) {
       if (event.type === 'user_message' && Array.isArray(event.content)) {
         for (const [ordinal, block] of event.content.entries()) {
           if (block.type !== 'image') continue;
@@ -94,7 +94,15 @@ async function sync(session: SessionRow, userId: string, signal?: AbortSignal): 
       if (event.toolUseId && event.status === 'running') {
         const params = event.toolParams;
         const relevant = Object.values(params).some((value) => typeof value === 'string' && value.includes('image_gen__imagegen'));
-        if (!relevant) decoder.pendingToolCalls.delete(event.toolUseId);
+        if (!relevant) {
+          if (params._tesseraImageReferenceScript) {
+            // Keep the marker to invalidate predicted bindings on failure, but
+            // never persist unrelated exec source/output in the image index.
+            const pending = decoder.pendingToolCalls.get(event.toolUseId);
+            if (pending) decoder.pendingToolCalls.set(event.toolUseId, { ...pending,
+              toolParams: { _tesseraImageReferenceScript: true } });
+          } else decoder.pendingToolCalls.delete(event.toolUseId);
+        }
       }
     }
   }, signal);

--- a/src/lib/image-generation/traces.ts
+++ b/src/lib/image-generation/traces.ts
@@ -42,7 +42,7 @@ export interface PublicImageGenerationTrace extends Omit<ImageGenerationTrace, '
   result?: PublicTraceImage;
 }
 
-interface ImageGenerationInvocation {
+export interface ImageGenerationInvocation {
   prompt: string;
   referencedImagePaths?: string[];
   numLastImagesToInclude?: number;

--- a/tests/image-index-persistence.test.ts
+++ b/tests/image-index-persistence.test.ts
@@ -52,6 +52,24 @@ test('disk-backed index restores a pending call, reads only appends and serves c
     assert.equal(completed.length, 1);
     assert.equal(completed[0].status, 'completed');
     assert.deepEqual(completed[0].inputs, first[0].inputs);
+    const inputPath = path.join(directory, 'reference.png');
+    await fs.writeFile(inputPath, Buffer.from('reference-image-bytes'));
+    await fs.appendFile(file, record('response_item', { type: 'custom_tool_call', call_id: 'store-paths', name: 'exec',
+      input: `const paths=[${JSON.stringify(inputPath)}];store("refs",paths);` }));
+    while ((await syncTerminalImageIndex(session, '')).more) { /* reference-only batch */ }
+    const withBindings = readImageCache(session.id)!;
+    assert.deepEqual(JSON.parse(withBindings.state_json).index.referenceBindings.stored, [['refs', [inputPath]]]);
+    assert.equal(withBindings.state_json.includes('const paths='), false, 'reference-only source must not be retained');
+    await fs.appendFile(file, record('response_item', { type: 'custom_tool_call_output', call_id: 'store-paths', output: 'ok' })
+      + record('response_item', { type: 'custom_tool_call', call_id: 'dynamic', name: 'functions.exec',
+        input: 'const p=load("refs");tools.image_gen__imagegen({prompt:"dynamic",referenced_image_paths:[p[0]]})' }));
+    while ((await syncTerminalImageIndex(session, '')).more) { /* reload persisted bindings */ }
+    const dynamic = readImageCards(session.id)[1];
+    assert.equal(dynamic.unresolvedInputCount, 0);
+    assert.equal(dynamic.inputs.length, 1);
+    assert.equal(dynamic.inputs[0].locator.kind, 'cache');
+    await fs.unlink(inputPath);
+    assert.equal((await readTraceImageBytes(dynamic.inputs[0].locator, ''))?.bytes.toString(), 'reference-image-bytes');
     await fs.unlink(file);
     const stillCached = readImageCards(session.id);
     const bytes = await readTraceImageBytes(stillCached[0].result!.locator, '');

--- a/tests/image-reference-electron.e2e.cjs
+++ b/tests/image-reference-electron.e2e.cjs
@@ -1,0 +1,141 @@
+// Run with Windows Node against a launcher-owned Windows backend and WSL fixtures.
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+const { DatabaseSync } = require('node:sqlite');
+const { chromium } = require('@playwright/test');
+const { crc32, deflateSync } = require('node:zlib');
+
+function solidPng(color) {
+  const chunk = (type, bytes) => {
+    const body = Buffer.concat([Buffer.from(type), bytes]);
+    const length = Buffer.alloc(4), checksum = Buffer.alloc(4);
+    length.writeUInt32BE(bytes.length);
+    checksum.writeUInt32BE(crc32(body));
+    return Buffer.concat([length, body, checksum]);
+  };
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(64, 0); header.writeUInt32BE(64, 4);
+  header[8] = 8; header[9] = 2;
+  const pixels = Buffer.alloc(64 * 193);
+  for (let row = 0; row < 64; row++) {
+    for (let column = 0; column < 64; column++) {
+      Buffer.from(color).copy(pixels, row * 193 + 1 + column * 3);
+    }
+  }
+  return Buffer.concat([Buffer.from([137,80,78,71,13,10,26,10]), chunk('IHDR', header), chunk('IDAT', deflateSync(pixels)), chunk('IEND', Buffer.alloc(0))]);
+}
+
+async function main() {
+  const [manifestPath, fixtureDirectory, linuxDirectory, artifactDirectory] = process.argv.slice(2);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8').replace(/^\uFEFF/, ''));
+  assert.ok(manifest.sessionId.startsWith('codex-0906ke-image-refs'));
+  const instance = manifest.instances[0];
+  assert.notEqual(instance.serverPort, 32123);
+  assert.ok(instance.dataDir.includes('TesseraTestInstances'));
+  assert.ok(fixtureDirectory.includes('image-index-qa-0906ke'));
+  assert.ok(linuxDirectory.startsWith('/home/work/tmp/image-index-qa-0906ke'));
+  fs.mkdirSync(fixtureDirectory, { recursive: true });
+  fs.mkdirSync(artifactDirectory, { recursive: true });
+  const names = ['frame.png', '싹냥이.png', '골냥이.png'];
+  const inputBytes = [[52,100,180], [232,157,62], [60,155,110]].map(solidPng);
+  const png = inputBytes[0].toString('base64');
+  for (const [index, name] of names.entries()) fs.writeFileSync(path.join(fixtureDirectory, name), inputBytes[index]);
+  const refs = names.map(name => `${linuxDirectory}/${name}`);
+  const file = path.join(fixtureDirectory, 'rollout.jsonl');
+  const record = (type, payload) => JSON.stringify({ type, timestamp: new Date().toISOString(), payload }) + '\n';
+  const appendCall = (id, input) => fs.appendFileSync(file, record('response_item', { type: 'custom_tool_call', name: 'functions.exec', call_id: id, input }));
+  fs.writeFileSync(file, record('session_meta', { cli_version: '0.147.0' }));
+  const db = new DatabaseSync(path.join(instance.dataDir, 'tessera.db'));
+  db.exec('PRAGMA busy_timeout=5000');
+  const project = db.prepare('SELECT * FROM projects WHERE decoded_path = ?').get('/home/work/Source/tessera-dev');
+  assert.ok(project);
+  const id = 'image-reference-qa-session', title = 'IMAGE REFERENCE QA';
+  const now = new Date().toISOString();
+  db.prepare(`INSERT OR REPLACE INTO sessions(id,project_id,title,provider,provider_state,work_dir,created_at,updated_at)
+    VALUES(?,?,?,?,?,?,?,?)`).run(id, project.id, title, 'codex', JSON.stringify({ kind: 'terminal', codexSessionId: id }), project.decoded_path, now, now);
+  db.prepare(`INSERT OR REPLACE INTO terminal_provider_sessions(provider_id,provider_session_id,tessera_session_id,transcript_path,created_at,updated_at)
+    VALUES(?,?,?,?,?,?)`).run('codex', id, id, file, now, now);
+  db.prepare('DELETE FROM image_generation_cache WHERE session_id=?').run(id);
+  db.close();
+  const browser = await chromium.connectOverCDP(instance.cdpUrl);
+  const page = browser.contexts()[0].pages()[0];
+  const capture = name => page.screenshot({ path: path.join(artifactDirectory, name) });
+  const read = () => page.evaluate(async id => {
+    const response = await fetch(`/api/sessions/${id}/image-generations?sync=1`);
+    if (!response.ok) throw new Error(`Image metadata HTTP ${response.status}`);
+    return response.json();
+  }, id);
+  try {
+    await capture('01-isolated-start.png');
+    await page.addInitScript(() => {
+      const send = WebSocket.prototype.send;
+      WebSocket.prototype.send = function(data) {
+        try { if (JSON.parse(data).type === 'terminal_create') return; } catch { /* binary */ }
+        return send.call(this, data);
+      };
+      localStorage.setItem('tessera:git-panel', JSON.stringify({ state: { isOpen: true, panelWidth: 450, drawerHeight: 300, panelTab: 'images' }, version: 0 }));
+    });
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.getByText(title, { exact: true }).first().click({ timeout: 20000 });
+    await page.getByRole('tab', { name: /Images|이미지/ }).click({ timeout: 15000 });
+    await capture('02-empty-image-tab.png');
+    appendCall('store', `const paths=${JSON.stringify(refs)};store("realrefs",paths);for(const path of paths){const r=await tools.view_image({path});image(r.image_url);}`);
+    assert.equal((await read()).traces.length, 0);
+    await capture('03-reference-only-cell-indexed.png');
+    fs.appendFileSync(file, record('response_item', { type: 'custom_tool_call_output', call_id: 'store', output: 'ok' }));
+    // Reloading the renderer and a later sync both restore the SQLite checkpoint.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.getByRole('tab', { name: /Images|이미지/ }).waitFor({ timeout: 15000 });
+    await capture('04-reload-before-image-call.png');
+    appendCall('edit', 'const r=await tools.image_gen__imagegen({prompt:"QA load refs",referenced_image_paths:load("realrefs")});generatedImage(r);');
+    const first = (await read()).traces[0];
+    assert.equal(first.inputs.length, 3);
+    assert.equal(first.unresolvedInputCount, 0);
+    assert.deepEqual(first.inputs.map(input => input.label), refs);
+    for (const [index, input] of first.inputs.entries()) {
+      const result = await page.evaluate(async url => {
+        const response = await fetch(url);
+        return { status: response.status, bytes: [...new Uint8Array(await response.arrayBuffer())] };
+      }, input.url);
+      assert.equal(result.status, 200);
+      assert.deepEqual(Buffer.from(result.bytes), inputBytes[index]);
+    }
+    await page.getByTestId('image-generations-panel').getByText('QA load refs', { exact: true }).waitFor({ timeout: 15000 });
+    await page.waitForFunction(() => {
+      const images = [...document.querySelectorAll('img[src*="/inputs/"]')];
+      return images.length === 3 && images.every(img => img.complete && img.naturalWidth > 0);
+    });
+    await capture('05-three-resolved-inputs.png');
+    fs.appendFileSync(file, record('event_msg', { type: 'item_completed', item: { id: 'result', type: 'imageGeneration', result: png } }));
+    await read();
+    await page.waitForFunction(() => {
+      const img = document.querySelector('[data-testid="image-generation-hero"] img');
+      return img && img.complete && img.naturalWidth > 0;
+    });
+    await capture('06-completed-generation.png');
+    appendCall('indexed', `const p=load("realrefs");tools.image_gen__imagegen({prompt:"QA indexed refs",referenced_image_paths:[${JSON.stringify(refs[0])},p[1],p[2]]})`);
+    const second = (await read()).traces[1];
+    assert.equal(second.inputs.length, 3);
+    assert.equal(second.unresolvedInputCount, 0);
+    await page.getByTestId('image-generations-panel').getByText('QA indexed refs', { exact: true }).waitFor({ timeout: 15000 });
+    await capture('07-indexed-array-inputs.png');
+    // Unsupported data is explicit, never an older image silently substituted.
+    appendCall('unknown', 'tools.image_gen__imagegen({prompt:"QA unknown refs",referenced_image_paths:load("missing")})');
+    const third = (await read()).traces[2];
+    assert.equal(third.inputs.length, 0);
+    assert.equal(third.unresolvedInputCount, 1);
+    await page.getByTestId('image-generations-panel').getByText('QA unknown refs', { exact: true }).waitFor({ timeout: 15000 });
+    await capture('08-unknown-reference-warning.png');
+    for (const name of names) fs.unlinkSync(path.join(fixtureDirectory, name));
+    for (const input of second.inputs) assert.equal(await page.evaluate(async url => (await fetch(url)).status, input.url), 200);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.getByTestId('image-generations-panel').waitFor({ timeout: 15000 });
+    await capture('09-cached-inputs-after-source-removed.png');
+    console.log(JSON.stringify({ inputs: [first.inputs.length, second.inputs.length], unresolved: [first.unresolvedInputCount, second.unresolvedInputCount], unknown: third.unresolvedInputCount, cachedAfterSourceRemoval: true }));
+  } catch (error) {
+    await capture('99-error.png');
+    throw error;
+  } finally { await browser.close(); }
+}
+main().catch(error => { console.error(error); process.exitCode = 1; });

--- a/tests/image-reference-script.test.ts
+++ b/tests/image-reference-script.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseImageReferenceScript, type ImageReferenceBindings } from '@/lib/image-generation/reference-script';
+import { applyImageTool, createImageIndex } from '@/lib/image-generation/incremental-state';
+import { createCodexTranscriptDecoderState, decodeCodexTranscriptLine } from '@/lib/cli/providers/codex/transcript-decoder';
+import type { EnhancedMessage } from '@/types/chat';
+
+const paths = ['/mnt/c/Users/work/Downloads/frame.png', '/home/work/assets/싹냥이.png', '/home/work/assets/골냥이.png'];
+const call = (refs: string) => `tools.image_gen__imagegen({prompt:"edit", referenced_image_paths:${refs}})`;
+
+test('resolves the reported store/load and indexed array calls across persisted exec cells', () => {
+  let bindings: ImageReferenceBindings = { stored: [] };
+  parseImageReferenceScript(`const paths=${JSON.stringify(paths)};store("realrefs",paths);
+    for(const path of paths){const r=await tools.view_image({path});image(r.image_url);}`, bindings);
+  bindings = JSON.parse(JSON.stringify(bindings));
+  const [first] = parseImageReferenceScript(`const r=await ${call('load("realrefs")')};generatedImage(r)`, bindings);
+  assert.deepEqual(first.referencedImagePaths, paths);
+  assert.equal(first.referencesUnresolved, undefined);
+  const [second] = parseImageReferenceScript(`const p=load("realrefs");const r=await ${call('["/home/work/generated.png",p[1],p[2]]')}`, bindings);
+  assert.deepEqual(second.referencedImagePaths, ['/home/work/generated.png', ...paths.slice(1)]);
+});
+
+test('locals are cell-scoped; stored data is bounded and unknown overwrites discard stale values', () => {
+  const bindings: ImageReferenceBindings = { stored: [] };
+  parseImageReferenceScript('const p=["a.png"];store("refs",p)', bindings);
+  assert.equal(parseImageReferenceScript(call('p'), bindings)[0].referencesUnresolved, true);
+  parseImageReferenceScript('store("refs",await tools.some_tool({}))', bindings);
+  assert.equal(parseImageReferenceScript(call('load("refs")'), bindings)[0].referencesUnresolved, true);
+  for (let index = 0; index < 100; index++) parseImageReferenceScript(`store("${index}",["a.png"])`, bindings);
+  assert.ok(bindings.stored.length <= 64);
+  parseImageReferenceScript(`store("oversized",["${'x'.repeat(20_000)}"])`, bindings);
+  assert.equal(bindings.stored.some(([key]) => key === 'oversized'), false);
+  parseImageReferenceScript('store("imageBytes","data:image/png;base64,AAAA");store("output","arbitrary shell output")', bindings);
+  assert.equal(bindings.stored.some(([key]) => key === 'imageBytes' || key === 'output'), false);
+});
+
+test('handles data composition without executing functions or inventing conditional values', () => {
+  const bindings: ImageReferenceBindings = { stored: [] };
+  assert.deepEqual(parseImageReferenceScript(`const dir="/home/work"; const p=[dir+"/a.png"]; ${call('[...p, `${dir}/b.png`]')}`, bindings)[0].referencedImagePaths,
+    ['/home/work/a.png', '/home/work/b.png']);
+  for (const change of ['if(flag) store("refs",["b.png"])', 'const p=load("refs");p.push("b.png")', 'mutateReferences()']) {
+    parseImageReferenceScript('store("refs",["a.png"])', bindings);
+    parseImageReferenceScript(change, bindings);
+    assert.equal(parseImageReferenceScript(call('load("refs")'), bindings)[0].referencesUnresolved, true, change);
+  }
+  const [spread] = parseImageReferenceScript('tools.image_gen__imagegen({referenced_image_paths:["a.png"], ...unknown})', bindings);
+  assert.equal(spread.referencesUnresolved, true);
+  assert.deepEqual(parseImageReferenceScript('const example="tools.image_gen__imagegen({prompt: 1})"', bindings), []);
+});
+
+test('the decoder/index seam captures reference-only cells once, survives state reload and freezes inputs', () => {
+  let index = createImageIndex();
+  const decoder = createCodexTranscriptDecoderState();
+  const feed = (payload: unknown) => {
+    for (const event of decodeCodexTranscriptLine(JSON.stringify({type:'response_item',payload}), decoder, {includeImageReferenceScripts:true})) {
+      if (event.type === 'tool_call') applyImageTool(index, {...event,id:event.toolUseId,sessionId:'test'} as Extract<EnhancedMessage,{type:'tool_call'}>);
+    }
+  };
+  feed({type:'custom_tool_call',name:'exec',call_id:'store',input:`store("refs",${JSON.stringify(paths)})`});
+  feed({type:'custom_tool_call',name:'exec',call_id:'edit',input:call('load("refs")')});
+  index = JSON.parse(JSON.stringify(index));
+  feed({type:'custom_tool_call',name:'exec',call_id:'replace',input:'store("refs",["new.png"])'});
+  feed({type:'custom_tool_call_output',call_id:'store',output:'ok'});
+  feed({type:'custom_tool_call_output',call_id:'edit',output:'ok'});
+  assert.equal(index.traces.length, 1);
+  assert.deepEqual(index.traces[0].inputs.map((image) => image.label), paths);
+  assert.equal(index.traces[0].unresolvedInputCount, 0);
+  feed({type:'custom_tool_call',name:'exec',call_id:'next',input:call('load("refs")')});
+  assert.equal(index.traces[1].inputs[0].label, 'new.png');
+});
+
+test('preserves calls inside Promise wrappers and accounts for mutations in tool arguments', () => {
+  const bindings: ImageReferenceBindings = { stored: [] };
+  const calls = parseImageReferenceScript(`await Promise.all([${call('["a.png"]')}, ${call('["b.png"]')}])`, bindings);
+  assert.deepEqual(calls.map((entry) => entry.referencedImagePaths), [['a.png'], ['b.png']]);
+  const [mutated] = parseImageReferenceScript(`const p=["a.png"];await tools.view_image({path:(p[0]="b.png")});${call('p')}`, bindings);
+  assert.equal(mutated.referencesUnresolved, true);
+  const [duplicate] = parseImageReferenceScript(`const refs=["a.png"];tools.image_gen__imagegen({prompt:"edit",referenced_image_paths:refs,referenced_image_paths:["b.png"]})`, bindings);
+  assert.equal(duplicate.referencesUnresolved, true);
+  const [shadowed] = parseImageReferenceScript(`const load=()=>["b.png"];${call('load("refs")')}`, bindings);
+  assert.equal(shadowed.referencesUnresolved, true);
+  assert.deepEqual(parseImageReferenceScript(`await ${call('["a.png"]')}.then(generatedImage)`, bindings)[0].referencedImagePaths, ['a.png']);
+  const [destructured] = parseImageReferenceScript(`const {image_url}=await tools.view_image({path:"a.png"});image(image_url);${call('["a.png"]')}`, bindings);
+  assert.deepEqual(destructured.referencedImagePaths, ['a.png']);
+  assert.equal(destructured.referencesUnresolved, undefined);
+  assert.equal(parseImageReferenceScript(`const {image:preview}=result;${call('["a.png"]')}`, bindings)[0].referencesUnresolved, undefined);
+});


### PR DESCRIPTION
Image generation calls that reuse paths through `store`/`load` or array indexes showed zero input images even when the files existed. Resolve these references from preceding exec records while preserving the persistent incremental image index introduced in #425.

The resolver interprets bounded data expressions without executing transcript JavaScript. Cell-local variables stay local; stored path values survive index checkpoints. Resolved inputs are frozen on their cards and copied through the existing environment-aware image cache. Unknown or ambiguous references remain unresolved; existing history is not rebuilt.

Validation:
- 39 focused decoder, reference-resolution, incremental-state, persistence and image-projection tests passed.
- TypeScript, targeted ESLint and the Windows Electron production build passed.
- Isolated packaged Windows backend with WSL transcript/image fixtures: both reported reference forms display all three inputs in order, returned image bytes match the source files, and reload/source deletion retain cached inputs. No paid generator call was made.
- Full unit suite: 1,941 passed, two skipped, two failed. Contracts: 435 passed, two failed. All four failures reproduced on unchanged base 06aa0ef5 (git-action-failure-report, worktree-identity-persistence, app-click-telemetry-contract and pty-ui-cleanup-contract).

QA details and reproduction entry point: docs/image-reference-qa-2026-09-06.md.
