### PR TITLE
Refine project sidebar headers and worktree peek interactions

### DIFF
--- a/src/components/chat/all-projects-list.tsx
+++ b/src/components/chat/all-projects-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronRight, Pin, Plus } from 'lucide-react';
+import { ChevronRight, GitBranch, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 import { useSessionStore } from '@/stores/session-store';
@@ -245,7 +245,7 @@ function AllProjectSection({
   const handleProjectWorktreeSelect = useCallback(() => {
     const projectWorktree = project.projectWorktree;
     if (!projectWorktree) return;
-    useWorkspacePeekStore.getState().openWorktree(
+    useWorkspacePeekStore.getState().toggleWorktree(
       projectWorktree.id,
       project.encodedDir,
     );
@@ -273,15 +273,30 @@ function AllProjectSection({
         >
           {project.displayName.charAt(0).toUpperCase()}
         </div>
-        <Tooltip content={project.displayName} delay={400} wrapperClassName="min-w-0 flex-1">
+        <Tooltip content={project.displayName} delay={400} wrapperClassName="min-w-0">
           <span className="block truncate text-[0.625rem] font-semibold uppercase tracking-widest text-(--text-muted)">
             {project.displayName}
           </span>
         </Tooltip>
-        <span className="shrink-0 tabular-nums text-[0.625rem] text-(--text-muted)">
+        {project.projectWorktree && (
+          <button
+            {...telemetryClickAttributes('worktree.select', 'worktree')}
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              handleProjectWorktreeSelect();
+            }}
+            className="ml-1 inline-flex min-w-0 max-w-[40%] shrink-0 items-center gap-1 rounded font-mono text-[11px] font-medium text-(--sidebar-text-active) transition-colors hover:bg-(--sidebar-bg) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--accent)"
+            title={project.projectWorktree.currentBranch ?? 'unknown'}
+            aria-label={`${project.displayName}, ${project.projectWorktree.displayPath}, branch ${project.projectWorktree.currentBranch ?? 'unknown'}`}
+          >
+            <GitBranch className="h-3.5 w-3.5 shrink-0 text-(--accent)" />
+            <span className="truncate">{project.projectWorktree.currentBranch ?? 'unknown'}</span>
+          </button>
+        )}
+        <span className="ml-auto shrink-0 tabular-nums text-[0.625rem] text-(--text-muted)">
           {sectionSessionCount}
         </span>
-        {project.isCurrent ? <Pin className="h-3 w-3 shrink-0 text-(--accent)" /> : null}
         <button
           ref={projectQuickCreateTriggerRef}
           {...telemetryClickAttributes('sidebar.project.add', 'sidebar')}
@@ -298,7 +313,6 @@ function AllProjectSection({
           <Plus className="h-3 w-3" />
         </button>
       </div>
-
       {isProjectQuickCreateOpen && (
         <CollectionQuickCreateSheet
           collection={null}

--- a/src/components/chat/sidebar.tsx
+++ b/src/components/chat/sidebar.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, useMemo, type MouseEvent } from 'react';
-import { Check, CircleDot, CircleStop, ListCollapse, ListTree } from 'lucide-react';
+import { Check, CircleDot, CircleStop, ListCollapse, ListTree, Plus } from 'lucide-react';
+import { CollectionQuickCreateSheet } from './collection-quick-create-sheet';
 import { useSessionStore } from '@/stores/session-store';
 import { requestSessionArchive } from '@/lib/session/session-archive-client';
 import { useSessionCrud } from '@/hooks/use-session-crud';
@@ -298,6 +299,8 @@ function SidebarRunningFilterEmpty({ label }: { label: string }) {
 }
 
 export function Sidebar() {
+  const [quickCreateProjectId, setQuickCreateProjectId] = useState<string | null>(null);
+  const projectQuickCreateTriggerRef = useRef<HTMLButtonElement>(null);
   const { t } = useI18n();
   const projects = useLoadedProjectViews();
   const dismissBranchRenameWarning = useSessionStore(
@@ -570,7 +573,7 @@ export function Sidebar() {
     const projectWorktree = selectedProject?.projectWorktree;
     if (!projectWorktree || !selectedProject) return;
     stepAsidePhoneSidebar();
-    useWorkspacePeekStore.getState().openWorktree(
+    useWorkspacePeekStore.getState().toggleWorktree(
       projectWorktree.id,
       selectedProject.encodedDir,
     );
@@ -830,6 +833,19 @@ export function Sidebar() {
                   name={selectedProject.displayName}
                   displayPath={selectedProject.projectWorktree.displayPath}
                   onSelect={handleProjectWorktreeSelect}
+                  headerControl={(
+                    <button
+                      ref={projectQuickCreateTriggerRef}
+                      {...telemetryClickAttributes('sidebar.project.add', 'sidebar')}
+                      type="button"
+                      aria-label={t('sidebar.createNewSession')}
+                      title={t('sidebar.createNewSession')}
+                      className="shrink-0 rounded p-0.5 text-(--text-muted) transition-colors hover:bg-(--sidebar-hover) hover:text-(--accent) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--accent)"
+                      onClick={() => setQuickCreateProjectId((current) => current === selectedProject.encodedDir ? null : selectedProject.encodedDir)}
+                    >
+                      <Plus className="h-3 w-3" />
+                    </button>
+                  )}
                   trailingControl={(
                     <ProjectBranchFilter
                       compact
@@ -838,6 +854,19 @@ export function Sidebar() {
                     />
                   )}
                 />
+                {quickCreateProjectId === selectedProject.encodedDir && (
+                  <CollectionQuickCreateSheet
+                    key={selectedProject.encodedDir}
+                    collection={null}
+                    collections={collections}
+                    projectDir={selectedProject.decodedPath}
+                    projectId={selectedProject.encodedDir}
+                    allowCollectionSelection
+                    anchorRef={projectQuickCreateTriggerRef}
+                    scopeId={`project-${selectedProject.encodedDir}`}
+                    onClose={() => setQuickCreateProjectId(null)}
+                  />
+                )}
                 {selectedProject.branchRenameWarning ? (
                   <BranchRenameWarning
                     warning={selectedProject.branchRenameWarning}

--- a/src/components/worktree/project-branch-filter.tsx
+++ b/src/components/worktree/project-branch-filter.tsx
@@ -107,6 +107,7 @@ export function ProjectBranchFilter({ projectId, branches, compact = false }: Pr
           'text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--sidebar-text-active)',
           'focus-visible:bg-(--sidebar-hover) focus-visible:outline-none',
           isOpen && 'bg-(--sidebar-hover) text-(--sidebar-text-active)',
+          selectedBranch && 'text-(--accent)',
         )}
         data-testid="project-branch-view-filter-trigger"
       >

--- a/src/components/worktree/project-worktree-row.tsx
+++ b/src/components/worktree/project-worktree-row.tsx
@@ -1,11 +1,12 @@
-import { FolderGit2, GitBranch } from 'lucide-react';
+import { GitBranch } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { DiffStatsBadge } from '@/components/chat/diff-stats-badge';
 import { cn } from '@/lib/utils';
 import type { WorktreeDiffStats } from '@/types/worktree-diff-stats';
 import { telemetryClickAttributes } from '@/lib/telemetry/ui-click';
+import { getProjectColor } from '@/lib/constants/project-strip';
 
-export function ProjectWorktreeRow({ active, branch, name, displayPath, diffStats, onSelect, trailingControl }: {
+export function ProjectWorktreeRow({ active, branch, name, displayPath, diffStats, onSelect, trailingControl, headerControl }: {
   active: boolean;
   branch: string | null;
   name: string;
@@ -14,20 +15,22 @@ export function ProjectWorktreeRow({ active, branch, name, displayPath, diffStat
   onSelect: () => void;
   /** Independent actions must be siblings of the worktree-open button. */
   trailingControl?: ReactNode;
+  headerControl?: ReactNode;
 }) {
   const branchLabel = branch ?? 'unknown';
 
   return (
     <div
       className={cn(
-        'mb-2 flex w-full min-w-0 items-center rounded-xl border border-(--divider) bg-(--input-bg) transition-colors',
+        'mt-1 w-full min-w-0 rounded-md transition-colors',
         active
-          ? 'border-(--accent)/35 bg-(--sidebar-hover) text-(--text-primary)'
-          : 'text-(--text-secondary) hover:border-(--accent)/25 hover:bg-(--sidebar-hover)',
+          ? 'text-(--text-primary)'
+          : 'text-(--text-secondary)',
       )}
       data-testid="project-worktree-row"
       data-variant="detailed"
     >
+      <div className="flex min-w-0 items-center pr-2">
       <button
         {...telemetryClickAttributes('worktree.select', 'worktree')}
         type="button"
@@ -35,47 +38,56 @@ export function ProjectWorktreeRow({ active, branch, name, displayPath, diffStat
         aria-current={active ? 'true' : undefined}
         aria-label={`${name}, ${displayPath}, branch ${branchLabel}`}
         title={displayPath}
-        className="flex min-w-0 flex-1 items-start gap-2.5 px-2.5 py-2 text-left outline-none"
+        className="flex min-w-0 flex-1 items-center gap-1 rounded-md px-2 py-1.5 text-left outline-none transition-colors hover:bg-(--sidebar-hover)/50 focus-visible:ring-1 focus-visible:ring-(--accent)"
       >
-        <FolderGit2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-(--accent)" />
-        <span className="min-w-0 flex-1">
-          <span className="flex min-w-0 items-center gap-1.5">
-            <span className="min-w-0 truncate text-[13px] font-semibold text-(--text-primary)">{name}</span>
-            <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-(--accent)/35 bg-(--accent)/12 px-2 py-0.5 text-[10px] font-medium text-(--sidebar-text-active)">
-              <GitBranch className="h-3 w-3 shrink-0 text-(--accent)" />
-              <span>{branchLabel}</span>
-            </span>
-          </span>
-          <span className="mt-0.5 block truncate font-mono text-[10px] leading-4 text-(--text-muted)">{displayPath}</span>
+        <span
+          className="mr-0.5 flex h-4 w-4 shrink-0 select-none items-center justify-center rounded text-[0.5rem] font-bold text-white"
+          style={{ backgroundColor: getProjectColor(name) }}
+          aria-hidden="true"
+        >
+          {name.charAt(0).toUpperCase()}
+        </span>
+        <span className="min-w-0 truncate text-[0.625rem] font-semibold uppercase tracking-widest text-(--text-muted)">{name}</span>
+        <span className="ml-1 inline-flex min-w-0 max-w-[40%] shrink-0 items-center gap-1 font-mono text-[11px] font-medium text-(--sidebar-text-active)">
+          <GitBranch className="h-3.5 w-3.5 shrink-0 text-(--accent)" />
+          <span className="truncate">{branchLabel}</span>
         </span>
       </button>
-      <div className="flex shrink-0 items-center justify-end gap-1 pr-2.5">
-        <DiffStatsBadge stats={diffStats} />
-        {trailingControl}
+      {headerControl}
       </div>
+      <CompactProjectWorktreeRow
+        testId="project-worktree-path-row"
+        active={active}
+        branch={branch}
+        displayPath={displayPath}
+        diffStats={diffStats}
+        onSelect={onSelect}
+        trailingControl={trailingControl}
+      />
     </div>
   );
 }
 
-export function CompactProjectWorktreeRow({ active, branch, displayPath, diffStats, onSelect, trailingControl }: {
+export function CompactProjectWorktreeRow({ active, branch, displayPath, diffStats, onSelect, trailingControl, testId = 'project-worktree-row' }: {
   active: boolean;
   branch: string | null;
   displayPath: string;
   diffStats?: WorktreeDiffStats | null;
   onSelect: () => void;
   trailingControl?: ReactNode;
+  testId?: string;
 }) {
   const branchLabel = branch ?? 'unknown';
 
   return (
     <div
       className={cn(
-        'mb-1 flex w-full min-w-0 items-center rounded-lg border border-(--divider) bg-(--input-bg) transition-colors',
+        '-mt-1 -mb-1 flex w-full min-w-0 items-center rounded-md transition-colors',
         active
-          ? 'border-(--accent)/35 bg-(--sidebar-hover) text-(--text-primary)'
-          : 'text-(--text-muted) hover:border-(--accent)/25 hover:bg-(--sidebar-hover) hover:text-(--text-secondary)',
+          ? 'text-(--text-secondary)'
+          : 'text-(--text-muted)',
       )}
-      data-testid="project-worktree-row"
+      data-testid={testId}
       data-variant="compact"
     >
       <button
@@ -85,16 +97,11 @@ export function CompactProjectWorktreeRow({ active, branch, displayPath, diffSta
         aria-current={active ? 'true' : undefined}
         aria-label={`${displayPath}, branch ${branchLabel}`}
         title={displayPath}
-        className="flex min-w-0 items-center gap-2 px-2 py-1 text-left outline-none"
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left outline-none transition-colors hover:bg-(--sidebar-hover)/50 hover:text-(--text-secondary) focus-visible:ring-1 focus-visible:ring-(--accent)"
       >
-        <FolderGit2 className="h-3.5 w-3.5 shrink-0 text-(--accent)" />
-        <span className="max-w-[12rem] truncate font-mono text-[10px]">{displayPath}</span>
-        <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-(--accent)/35 bg-(--accent)/12 px-2 py-0.5 font-mono text-[10px] font-medium text-(--sidebar-text-active)">
-          <GitBranch className="h-3 w-3 shrink-0 text-(--accent)" />
-          <span>{branchLabel}</span>
-        </span>
+        <span className="min-w-0 max-w-[12rem] truncate font-mono text-[10px]">{displayPath}</span>
       </button>
-      <div className="ml-auto flex shrink-0 items-center justify-end gap-1 pr-2">
+      <div className="ml-auto flex shrink-0 items-center justify-end gap-1 pr-2 has-[button]:pr-0.5">
         <DiffStatsBadge stats={diffStats} />
         {trailingControl}
       </div>

--- a/src/stores/workspace-peek-store.ts
+++ b/src/stores/workspace-peek-store.ts
@@ -9,6 +9,7 @@ export interface WorktreePeekTarget {
 interface WorkspacePeekState {
   target: WorktreePeekTarget | null;
   openWorktree: (worktreeId: string, projectDir: string) => void;
+  toggleWorktree: (worktreeId: string, projectDir: string) => void;
   close: () => void;
 }
 
@@ -18,4 +19,9 @@ export const useWorkspacePeekStore = create<WorkspacePeekState>()((set) => ({
     target: { kind: 'worktree', worktreeId, projectDir },
   }),
   close: () => set({ target: null }),
+  toggleWorktree: (worktreeId, projectDir) => set((state) => ({
+    target: state.target?.worktreeId === worktreeId && state.target.projectDir === projectDir
+      ? null
+      : { kind: 'worktree', worktreeId, projectDir },
+  })),
 }));

--- a/tests/project-worktree-target.test.tsx
+++ b/tests/project-worktree-target.test.tsx
@@ -34,6 +34,21 @@ const chatLayoutSource = fs.readFileSync(
   'utf8',
 );
 
+test('selecting the same Worktree toggles Peek while another Worktree replaces it', () => {
+  const store = useWorkspacePeekStore.getState();
+  store.close();
+  store.toggleWorktree('wt_a', 'project-a');
+  assert.equal(useWorkspacePeekStore.getState().target?.worktreeId, 'wt_a');
+  store.toggleWorktree('wt_a', 'project-a');
+  assert.equal(useWorkspacePeekStore.getState().target, null);
+  store.toggleWorktree('wt_a', 'project-a');
+  store.toggleWorktree('wt_b', 'project-b');
+  assert.deepEqual(useWorkspacePeekStore.getState().target, {
+    kind: 'worktree', worktreeId: 'wt_b', projectDir: 'project-b',
+  });
+  store.close();
+});
+
 test('Project Worktree rows render detailed and compact variants', () => {
   const row = renderToStaticMarkup(createElement(ProjectWorktreeRow, {
     active: true,
@@ -50,7 +65,7 @@ test('Project Worktree rows render detailed and compact variants', () => {
     },
     onSelect: () => {},
   }));
-  assert.match(row, /lucide-folder-git-2/);
+  assert.doesNotMatch(row, /lucide-folder-git-2/);
   assert.match(row, /lucide-git-branch/);
   assert.match(row, /tessera-dev/);
   assert.match(row, /\/repo\/tessera-dev/);
@@ -59,8 +74,8 @@ test('Project Worktree rows render detailed and compact variants', () => {
   assert.match(row, /−3/);
   assert.match(row, /aria-current="true"/);
   assert.match(row, /data-variant="detailed"/);
-  assert.match(row, /mb-2[^\"]*rounded-xl/);
-  assert.match(row, /px-2\.5 py-2/);
+  assert.doesNotMatch(row, /bg-\(--input-bg\)|rounded-full|border-\(--divider\)/);
+  assert.match(row, /focus-visible:ring-1/);
 
   const compactRow = renderToStaticMarkup(createElement(CompactProjectWorktreeRow, {
     active: false,
@@ -76,15 +91,15 @@ test('Project Worktree rows render detailed and compact variants', () => {
     },
     onSelect: () => {},
   }));
-  assert.match(compactRow, /lucide-folder-git-2/);
-  assert.match(compactRow, /lucide-git-branch/);
+  assert.doesNotMatch(compactRow, /lucide-folder-git-2/);
+  assert.doesNotMatch(compactRow, /lucide-git-branch/);
   assert.match(compactRow, /\/repo\/tessera-dev/);
   assert.match(compactRow, /feature\/root-target/);
   assert.match(compactRow, /\+12/);
   assert.match(compactRow, /−3/);
   assert.match(compactRow, /data-variant="compact"/);
-  assert.match(compactRow, /mb-1[^\"]*rounded-lg/);
-  assert.match(compactRow, /px-2 py-1/);
+  assert.doesNotMatch(compactRow, /bg-\(--input-bg\)|rounded-full|border-\(--divider\)/);
+  assert.match(compactRow, /focus-visible:ring-1/);
 });
 
 test('Worktree overview renders branch and path without duplicate creation actions', () => {


### PR DESCRIPTION
Project worktree headers previously resembled selected sessions and differed between All Projects and individual project views. Align their project identity and branch presentation, remove persistent card styling and the server-folder pin, and tighten path, filter, and diff alignment.

Branch clicks now open the project's Worktree Peek without collapsing the project; selecting the same target again closes it. Individual project headers also expose the existing project-scoped session creation sheet through a + button.

Validation: ESLint passed for all changed production files; all 15 project-worktree-target tests passed, including same-target toggle and different-target replacement. Iterative visual review was performed on the development web UI. No packaged Windows backend validation was performed; this change is confined to frontend presentation and client state.
