### PR TITLE
fix: remember right panel tabs per session

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -1070,6 +1070,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
               />
               <span className="ml-auto inline-flex items-center gap-1.5">
                 <TaskPreparationBadge
+                  sessionId={primarySessionId ?? null}
                   status={task.preparationStatus}
                 />
                 <TaskPrBadge

--- a/src/components/chat/collection-group-sections.tsx
+++ b/src/components/chat/collection-group-sections.tsx
@@ -1127,6 +1127,7 @@ export function TaskItemRow({
         <span className={SIDEBAR_TREE_LEADING_SLOT}>
           {hasPreparationBadge ? (
             <TaskPreparationBadge
+              sessionId={density === 'composite' ? primarySessionId ?? null : null}
               status={task.preparationStatus}
               presentation="icon"
             />

--- a/src/components/git/git-desktop-commit-control.tsx
+++ b/src/components/git/git-desktop-commit-control.tsx
@@ -187,8 +187,8 @@ function GitDesktopCommitControlView({
 
   const openChangedFiles = useCallback(() => {
     closeComposer();
-    useGitStore.getState().openTab("git");
-  }, [closeComposer]);
+    useGitStore.getState().openTab("git", controller.sessionId);
+  }, [closeComposer, controller.sessionId]);
 
   const openComposer = useCallback(() => {
     if (!canOpenComposer) {

--- a/src/components/git/git-panel.tsx
+++ b/src/components/git/git-panel.tsx
@@ -105,7 +105,9 @@ export function GitPanel({
   const controller = useSharedGitPanelController();
   // The selection lives in the store so a preparation badge can send the user
   // straight to the Scripts tab.
-  const activePanelTab = useGitStore((state) => state.panelTab);
+  const activePanelTab = useGitStore((state) => sessionId
+    ? state.panelTabsBySessionId[sessionId] ?? 'git'
+    : state.panelTab);
   const setActivePanelTab = useGitStore((state) => state.setPanelTab);
   const openedTelemetryRef = useRef(false);
   const resolvedCloseLabel = closeLabel ?? t("chat.closeGitPanel");
@@ -131,7 +133,7 @@ export function GitPanel({
 
   // Derive the visible tab instead of forcing state: if the stored selection
   // is one this session can't show, fall back to Git for rendering while
-  // preserving the selection for sessions that can.
+  // preserving this session's selection while its capabilities are loading.
   const tabUnavailable =
     (!showMemoryTab && activePanelTab === "memory")
     || (!showImagesTab && activePanelTab === "images")
@@ -177,7 +179,7 @@ export function GitPanel({
 
   const handlePanelTabChange = useCallback((tab: GitPanelTab) => {
     if (activePanelTab === tab) return;
-    setActivePanelTab(tab);
+    setActivePanelTab(tab, sessionId);
     void captureTelemetryEvent("git_panel_tab_changed", {
       source: "git_panel",
       provider_id: sessionProvider,
@@ -191,6 +193,7 @@ export function GitPanel({
     });
   }, [
     activePanelTab,
+    sessionId,
     sessionProvider,
     sessionKind,
     showImagesTab,

--- a/src/components/git/use-git-panel-controller.ts
+++ b/src/components/git/use-git-panel-controller.ts
@@ -1143,7 +1143,7 @@ export function useGitPanelController(
   const runPrimaryAction = useCallback(() => {
     if (!primaryAction.enabled) return;
     if (primaryAction.action === "resolve_conflicts") {
-      useGitStore.getState().openConflictRecovery();
+      useGitStore.getState().openConflictRecovery(sessionId);
       return;
     }
     if (primaryAction.action === "commit") return commitSelectedFiles();
@@ -1173,6 +1173,7 @@ export function useGitPanelController(
     commitSelectedFiles,
     handleArchiveClick,
     primaryAction,
+    sessionId,
     runBranchAction,
     stateSnapshot,
     viewPullRequest,
@@ -1206,7 +1207,7 @@ export function useGitPanelController(
 
     if (id === "commit") return commitSelectedFiles();
     if (id === "open_source_control") {
-      return useGitStore.getState().openTab("git");
+      return useGitStore.getState().openTab("git", sessionId);
     }
     if (chosen.kind === "view_pr") return viewPullRequest();
 
@@ -1234,6 +1235,7 @@ export function useGitPanelController(
     commitDraftBlocked,
     commitSelectedFiles,
     menuActions,
+    sessionId,
     runBranchAction,
     runCommitAndPush,
     stateSnapshot,
@@ -1363,6 +1365,7 @@ export function useGitPanelController(
 
 
   return {
+    sessionId,
     hasActiveSession: Boolean(target),
     changedFileCount,
     commitSelectionKey: worktreeKey,

--- a/src/components/tab/tab-bar.tsx
+++ b/src/components/tab/tab-bar.tsx
@@ -118,15 +118,15 @@ export const TabBar = memo(function TabBar() {
   const toggleSidebar = useSettingsStore((state) => state.toggleSidebar);
   const gitPanelOpen = useGitStore((state) => state.isOpen);
   const toggleGitPanel = useGitStore((state) => state.toggle);
-  const openGitPanelTab = useGitStore((state) => state.openTab);
+  const openGitPanel = useGitStore((state) => state.open);
   const isPhoneViewport = usePhoneViewport();
   const handlePhoneGitToggle = useCallback(() => {
     if (gitPanelOpen) {
       toggleGitPanel();
       return;
     }
-    openGitPanelTab('git');
-  }, [gitPanelOpen, openGitPanelTab, toggleGitPanel]);
+    openGitPanel();
+  }, [gitPanelOpen, openGitPanel, toggleGitPanel]);
 
   // Scrollable container ref
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/task/task-preparation-view.tsx
+++ b/src/components/task/task-preparation-view.tsx
@@ -25,9 +25,11 @@ import {
  */
 export function TaskPreparationBadge({
   status,
+  sessionId,
   presentation = 'label',
 }: {
   status: PreparationStatus | undefined;
+  sessionId: string | null;
   presentation?: 'label' | 'icon';
 }) {
   const { t } = useI18n();
@@ -54,7 +56,7 @@ export function TaskPreparationBadge({
         // The click is left to bubble on purpose: the row it sits in opens the
         // session, and the panel then shows that worktree's scripts rather
         // than whichever worktree happened to be open before.
-        openTab('scripts');
+        openTab('scripts', sessionId);
       }}
       title={tooltip}
       aria-label={label}

--- a/src/hooks/use-worktree-session.ts
+++ b/src/hooks/use-worktree-session.ts
@@ -283,7 +283,7 @@ export function useWorktreeSession() {
           if (project?.hasPreparationScript) {
             const { useGitStore } = await import('@/stores/git-store');
             const git = useGitStore.getState();
-            if (git.isOpen) git.setPanelTab('scripts');
+            if (git.isOpen) git.setPanelTab('scripts', sessionId);
           }
         }
         return {

--- a/src/stores/git-store.ts
+++ b/src/stores/git-store.ts
@@ -15,7 +15,10 @@ interface GitPanelUIState {
    * send the user to a particular tab — a preparation badge, a worktree that
    * has just been created — can open the panel on it.
    */
+  /** Selection for a panel without a session; also reads legacy persisted state. */
   panelTab: GitPanelTab
+  panelTabsBySessionId: Record<string, GitPanelTab>
+  getPanelTab: (sessionId: string | null) => GitPanelTab
   /** Monotonic request used to focus recovery even when the panel is open. */
   conflictRecoveryFocusRequest: number
 
@@ -26,16 +29,16 @@ interface GitPanelUIState {
   setDrawerOpen: (open: boolean) => void
   toggleDrawer: () => void
   setDrawerHeight: (height: number) => void
-  setPanelTab: (tab: GitPanelTab) => void
+  setPanelTab: (tab: GitPanelTab, sessionId?: string | null) => void
   /** Open the panel and show one tab, whatever was showing before. */
-  openTab: (tab: GitPanelTab) => void
+  openTab: (tab: GitPanelTab, sessionId?: string | null) => void
   /** Open the Git tab and focus its conflict-recovery surface. */
-  openConflictRecovery: () => void
+  openConflictRecovery: (sessionId?: string | null) => void
 }
 
 type PersistedGitPanelUIState = Pick<
   GitPanelUIState,
-  'isOpen' | 'panelWidth' | 'drawerHeight' | 'panelTab'
+  'isOpen' | 'panelWidth' | 'drawerHeight' | 'panelTab' | 'panelTabsBySessionId'
 >
 
 export const useGitStore = create<GitPanelUIState>()(
@@ -46,6 +49,10 @@ export const useGitStore = create<GitPanelUIState>()(
       drawerOpen: false,
       drawerHeight: 320,
       panelTab: 'git',
+      panelTabsBySessionId: {},
+      getPanelTab: (sessionId) => sessionId
+        ? get().panelTabsBySessionId[sessionId] ?? 'git'
+        : get().panelTab,
       conflictRecoveryFocusRequest: 0,
 
       toggle: () => set({ isOpen: !get().isOpen }),
@@ -55,13 +62,20 @@ export const useGitStore = create<GitPanelUIState>()(
       setDrawerOpen: (open) => set({ drawerOpen: open }),
       toggleDrawer: () => set({ drawerOpen: !get().drawerOpen }),
       setDrawerHeight: (height) => set({ drawerHeight: height }),
-      setPanelTab: (tab) => set({ panelTab: tab }),
-      openTab: (tab) => set({ isOpen: true, panelTab: tab }),
-      openConflictRecovery: () => set((state) => ({
-        isOpen: true,
-        panelTab: 'git',
-        conflictRecoveryFocusRequest: state.conflictRecoveryFocusRequest + 1,
-      })),
+      setPanelTab: (tab, sessionId) => set((state) => sessionId
+        ? { panelTabsBySessionId: { ...state.panelTabsBySessionId, [sessionId]: tab } }
+        : { panelTab: tab }),
+      openTab: (tab, sessionId) => {
+        get().setPanelTab(tab, sessionId);
+        set({ isOpen: true });
+      },
+      openConflictRecovery: (sessionId) => {
+        get().setPanelTab('git', sessionId);
+        set((state) => ({
+          isOpen: true,
+          conflictRecoveryFocusRequest: state.conflictRecoveryFocusRequest + 1,
+        }));
+      },
     }),
     {
       name: 'tessera:git-panel',
@@ -71,6 +85,7 @@ export const useGitStore = create<GitPanelUIState>()(
         panelWidth: state.panelWidth,
         drawerHeight: state.drawerHeight,
         panelTab: state.panelTab,
+        panelTabsBySessionId: state.panelTabsBySessionId,
       }),
     }
   )

--- a/tests/git-panel-session-tabs.test.ts
+++ b/tests/git-panel-session-tabs.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { useGitStore } from '@/stores/git-store';
+
+test('right panel remembers each session independently and persists selections', () => {
+  const store = useGitStore.getState();
+  store.setPanelTab('files', 'session-a');
+  store.setPanelTab('memory', 'session-b');
+  assert.equal(useGitStore.getState().getPanelTab('session-a'), 'files');
+  assert.equal(useGitStore.getState().getPanelTab('session-b'), 'memory');
+  assert.equal(useGitStore.getState().getPanelTab('session-new'), 'git');
+  store.openTab('scripts', 'session-b');
+  assert.equal(useGitStore.getState().getPanelTab('session-a'), 'files');
+  store.openConflictRecovery('session-b');
+  assert.equal(useGitStore.getState().getPanelTab('session-b'), 'git');
+  assert.equal(useGitStore.getState().getPanelTab('session-a'), 'files');
+  const persisted = useGitStore.persist.getOptions().partialize!(useGitStore.getState());
+  assert.equal(persisted.panelTabsBySessionId['session-a'], 'files');
+});
+
+test('rehydration restores session tabs and legacy global tabs do not leak into sessions', async () => {
+  useGitStore.getState().setPanelTab('files', 'session-a');
+  useGitStore.getState().setPanelTab('git', 'session-b');
+  const options = useGitStore.persist.getOptions();
+  const saved = options.partialize!(useGitStore.getState());
+  try {
+    useGitStore.persist.setOptions({
+      storage: {
+        getItem: () => ({ state: saved, version: 0 }),
+        setItem: () => {},
+        removeItem: () => {},
+      },
+    });
+    useGitStore.setState({ panelTabsBySessionId: {} });
+    await useGitStore.persist.rehydrate();
+    assert.equal(useGitStore.getState().getPanelTab('session-a'), 'files');
+    assert.equal(useGitStore.getState().getPanelTab('session-b'), 'git');
+
+    useGitStore.persist.setOptions({
+      storage: {
+        getItem: () => ({ state: { panelTab: 'images' }, version: 0 }),
+        setItem: () => {},
+        removeItem: () => {},
+      },
+    });
+    useGitStore.setState({ panelTabsBySessionId: {} });
+    await useGitStore.persist.rehydrate();
+    assert.equal(useGitStore.getState().getPanelTab(null), 'images');
+    assert.equal(useGitStore.getState().getPanelTab('session-new'), 'git');
+  } finally {
+    useGitStore.persist.setOptions({ storage: options.storage });
+  }
+});


### PR DESCRIPTION
Switching sessions previously reused one global right-panel tab selection. Store and persist selections per session so returning to a session restores its last tab, including after restart. Sessions without a saved selection start on Git.

Scope preparation badges, newly created sessions, and Git recovery shortcuts to their target session. Reopening the phone panel preserves the selected tab.

Validation: 5 focused tests passed, including independent session selection, recovery navigation, persisted-state restoration, and legacy-state compatibility. TypeScript checking and ESLint passed. Interactive app QA was not run.
