### PR TITLE
Fix Peek terminal context menus and document surface coverage

### DIFF
--- a/docs/agents/terminal-surfaces.md
+++ b/docs/agents/terminal-surfaces.md
@@ -1,0 +1,23 @@
+# Terminal changes must cover every session surface
+
+When changing PTY interactions (context menus, keyboard input, clipboard, drag and drop,
+focus, or PTY/chat switching), inspect both the workspace panel and Kanban Session Peek.
+Also check popout windows and embedded preview/log terminals when the changed code reaches them.
+Shared terminal rendering does not imply shared wrappers, event routing, or capabilities.
+
+- Trace the caller and DOM wrapper for each affected surface before editing.
+- For Electron context menus, verify surface detection, native menu construction, IPC routing,
+  and the mounted renderer listener in both PTY and terminal chat view.
+- Keep capabilities explicit: Session Peek supports PTY/chat switching for supported providers,
+  but has no workspace panel to split. Embedded log/preview terminals must not acquire
+  workspace actions simply because they render a terminal.
+- Add a regression test at the actual surface detection/menu boundary. Cover Peek without a
+  workspace wrapper, both view directions, and unrelated surfaces retaining their behavior.
+- When performing Electron E2E QA, exercise ordinary panels and Peek in the reported runtime
+  topology, capture ordered screenshots, and copy them to Windows Downloads. State separately
+  which behavior was unit-tested and which was verified in a real Electron window.
+
+The September 2026 Peek context-menu regression happened because native menu detection required
+`data-panel-wrapper`, which Session Peek does not mount. See
+`electron/web-contents-context-menu.ts`, `src/components/chat/chat-area.tsx`, and
+`tests/electron-terminal-context-menu.test.ts`.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -347,6 +347,7 @@ function attachWebContentsContextMenu(win: BrowserWindow): void {
         terminalPanel
           ? {
               panelId: terminalPanel.panelId,
+              canSplit: terminalPanel.canSplit,
               onSplit: (targetPanelId, placement) => {
                 sendTerminalPanelSplitCommand(win, targetPanelId, placement);
               },

--- a/electron/web-contents-context-menu.ts
+++ b/electron/web-contents-context-menu.ts
@@ -3,6 +3,7 @@ import type { PanelSplitPlacement } from '../src/lib/panel/panel-split';
 
 interface TerminalPanelContextMenuOptions {
   panelId: string;
+  canSplit?: boolean;
   onSplit: (panelId: string, placement: PanelSplitPlacement) => void;
   viewMode?: 'terminal' | 'chat';
   onSwitchView?: (panelId: string, mode: 'terminal' | 'chat') => void;
@@ -46,15 +47,15 @@ export function buildWebContentsContextMenuTemplate(
               terminalPanel.panelId,
               terminalPanel.viewMode === 'chat' ? 'terminal' : 'chat',
             ),
-          }, { type: 'separator' as const }]
+          }, ...(terminalPanel.canSplit !== false ? [{ type: 'separator' as const }] : [])]
         : []),
-      {
+      ...(terminalPanel.canSplit !== false ? [{
         label: TERMINAL_PANEL_MENU_COPY.splitPanel,
         submenu: SPLIT_PLACEMENTS.map((placement) => ({
           label: TERMINAL_PANEL_MENU_COPY.placements[placement],
           click: () => terminalPanel.onSplit(terminalPanel.panelId, placement),
         })),
-      },
+      }] : []),
     ];
   }
 
@@ -89,13 +90,14 @@ export function buildWebContentsContextMenuTemplate(
 /**
  * Resolve the terminal panel at the native-menu coordinates without replacing
  * Electron's edit-aware context menu with a renderer imitation. The matching
- * wrapper check excludes embedded log/preview terminals that cannot be split.
+ * wrapper check excludes embedded log/preview terminals. Peek session surfaces
+ * opt in explicitly and expose view switching without workspace splitting.
  */
 export async function resolveTerminalPanelAtPoint(
   frame: FrameScriptRunner | null,
   x: number,
   y: number,
-): Promise<{ panelId: string; viewMode: 'terminal' | 'chat' | null } | null> {
+): Promise<{ panelId: string; viewMode: 'terminal' | 'chat' | null; canSplit?: boolean } | null> {
   if (!frame || frame.isDestroyed()) return null;
 
   const script = `(() => {
@@ -116,9 +118,12 @@ export async function resolveTerminalPanelAtPoint(
     const wrapperPanelId = wrapper instanceof HTMLElement
       ? wrapper.dataset.panelId
       : undefined;
-    return terminalPanelId && terminalPanelId === wrapperPanelId
+    const isPeek = sessionSurface instanceof HTMLElement
+      && sessionSurface.dataset.terminalPeek === 'true';
+    return terminalPanelId && (terminalPanelId === wrapperPanelId || isPeek)
       ? {
           panelId: terminalPanelId,
+          ...(isPeek ? { canSplit: false } : {}),
           viewMode: sessionSurface instanceof HTMLElement
             && sessionSurface.dataset.terminalChatViewAvailable === 'true'
             && (sessionSurface.dataset.terminalViewMode === 'terminal'
@@ -135,14 +140,15 @@ export async function resolveTerminalPanelAtPoint(
   try {
     const result = await frame.executeJavaScript(script);
     if (!result || typeof result !== 'object') return null;
-    const candidate = result as { panelId?: unknown; viewMode?: unknown };
+    const candidate = result as { panelId?: unknown; viewMode?: unknown; canSplit?: unknown };
     return typeof candidate.panelId === 'string'
       && candidate.panelId.length > 0
       && candidate.panelId.length <= 128
       && (candidate.viewMode === null
         || candidate.viewMode === 'terminal'
         || candidate.viewMode === 'chat')
-      ? { panelId: candidate.panelId, viewMode: candidate.viewMode }
+      ? { panelId: candidate.panelId, viewMode: candidate.viewMode,
+          ...(candidate.canSplit === false ? { canSplit: false } : {}) }
       : null;
   } catch {
     return null;

--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -295,6 +295,7 @@ export const ChatArea = memo(function ChatArea({
     <div
       className="flex-1 flex flex-col h-full bg-(--chat-bg)"
       data-terminal-session-panel-id={isTerminalSession ? panelId : undefined}
+      data-terminal-peek={isTerminalSession && isPeek ? 'true' : undefined}
       data-terminal-chat-view-available={canToggleTerminalChatView ? 'true' : undefined}
       data-terminal-view-mode={canToggleTerminalChatView
         ? (isTerminalChatView ? 'chat' : 'terminal')

--- a/tests/electron-terminal-context-menu.test.ts
+++ b/tests/electron-terminal-context-menu.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { runInNewContext } from 'node:vm';
 import type { ContextMenuParams, MenuItemConstructorOptions } from 'electron';
 import {
   buildWebContentsContextMenuTemplate,
@@ -93,4 +94,50 @@ test('resolves only panel ids returned by the matching terminal wrapper query', 
   assert.match(evaluated, /terminalChatViewAvailable/);
   assert.match(evaluated, /data-terminal-session-panel-id/);
   assert.equal(await resolveTerminalPanelAtPoint(null, 42, 84), null);
+});
+
+test('Peek PTY resolves to a view-only menu instead of native edit actions', async () => {
+  class Element {
+    dataset: Record<string, string> = {
+      terminalSessionPanelId: 'kanban-session-peek-panel',
+      terminalChatViewAvailable: 'true',
+      terminalViewMode: 'terminal',
+      terminalPeek: 'true',
+    };
+    closest(selector: string) {
+      return selector === '[data-terminal-session-panel-id]' ? this : null;
+    }
+  }
+  const surface = new Element();
+  const frame = {
+    isDestroyed: () => false,
+    executeJavaScript: async (script: string) => runInNewContext(script, {
+      document: { elementFromPoint: () => surface }, Element, HTMLElement: Element,
+    }),
+  };
+  const resolved = await resolveTerminalPanelAtPoint(frame, 10, 20);
+  assert.ok(resolved, 'Peek must be recognized without a workspace panel wrapper');
+  assert.equal(resolved.viewMode, 'terminal');
+  assert.equal(resolved.canSplit, false);
+  const template = buildWebContentsContextMenuTemplate(editableParams(), {
+    ...resolved,
+    viewMode: resolved.viewMode ?? undefined,
+    onSplit: () => assert.fail('Peek cannot split'),
+    onSwitchView: () => undefined,
+  });
+  assert.deepEqual(template.map((item) => item.label), ['Switch to Chat View']);
+  surface.dataset.terminalViewMode = 'chat';
+  const chat = await resolveTerminalPanelAtPoint(frame, 10, 20);
+  assert.equal(chat?.viewMode, 'chat');
+  const reverse = buildWebContentsContextMenuTemplate(editableParams(), {
+    panelId: resolved.panelId,
+    canSplit: chat?.canSplit,
+    viewMode: chat?.viewMode ?? undefined,
+    onSplit: () => assert.fail('Peek cannot split'),
+    onSwitchView: () => undefined,
+  });
+  assert.deepEqual(reverse.map((item) => item.label), ['Switch to PTY View']);
+  delete surface.dataset.terminalPeek;
+  assert.equal(await resolveTerminalPanelAtPoint(frame, 10, 20), null);
+
 });


### PR DESCRIPTION
Peek PTY right-clicks fell back to the native edit menu because terminal detection required a workspace panel wrapper. Recognize Peek session surfaces explicitly and offer PTY/chat switching without the unsupported workspace split action.

Add regression coverage for Peek detection, both view directions, and non-Peek surfaces, plus agent guidance requiring terminal interaction changes to cover Peek and other affected surfaces. The shared local CLAUDE.md also links this guidance, and its AGENTS.md was regenerated with codex-sync (these local instruction files are gitignored).

Validation: 18 targeted tests pass; Electron TypeScript check passes. Latest dev merged without conflicts. Real Electron window QA was not performed.
