### PR TITLE
fix(images): allow dragging images in shared lightbox

### DIFF
--- a/src/components/chat/image-lightbox.tsx
+++ b/src/components/chat/image-lightbox.tsx
@@ -2,7 +2,7 @@
 
 import { telemetryClickAttributes, telemetryIgnoreAttributes } from '@/lib/telemetry/ui-click';
 
-import { useEffect, useCallback, useState } from 'react';
+import { useEffect, useCallback, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Minus, Plus, RotateCcw } from 'lucide-react';
 import { useCloseOnEscape } from '@/hooks/use-close-on-escape';
@@ -19,6 +19,10 @@ export interface ImageLightboxProps {
 export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
   const { t } = useI18n();
   const [zoom, setZoom] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [isPanning, setIsPanning] = useState(false);
+  const panRef = useRef<{ pointerId: number; x: number; y: number; offsetX: number; offsetY: number } | null>(null);
+  const suppressClickRef = useRef(false);
   const electronPlatform = useElectronPlatform();
   // On Windows the window controls are a native titleBarOverlay the page can
   // never paint above, so a close button in the top-right corner sits *under*
@@ -52,6 +56,10 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
   }, []);
 
   const handleOverlayClick = useCallback(() => {
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false;
+      return;
+    }
     closeLightbox();
   }, [closeLightbox]);
 
@@ -64,6 +72,37 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
     zoomBy(event.deltaY < 0 ? 0.25 : -0.25);
   }, [zoomBy]);
 
+  const handlePanStart = (event: React.PointerEvent<HTMLImageElement>) => {
+    suppressClickRef.current = false;
+    if (event.button !== 0 || panRef.current) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    panRef.current = {
+      pointerId: event.pointerId, x: event.clientX, y: event.clientY,
+      offsetX: offset.x, offsetY: offset.y,
+    };
+    setIsPanning(true);
+  };
+
+  const handlePanMove = (event: React.PointerEvent<HTMLImageElement>) => {
+    const pan = panRef.current;
+    if (!pan || pan.pointerId !== event.pointerId) return;
+    const dx = event.clientX - pan.x;
+    const dy = event.clientY - pan.y;
+    if (!suppressClickRef.current && Math.hypot(dx, dy) < 4) return;
+    suppressClickRef.current = true;
+    setOffset({ x: pan.offsetX + dx, y: pan.offsetY + dy });
+  };
+
+  const handlePanEnd = (event: React.PointerEvent<HTMLImageElement>) => {
+    if (panRef.current?.pointerId !== event.pointerId) return;
+    panRef.current = null;
+    setIsPanning(false);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
   if (typeof document === 'undefined') {
     return null;
   }
@@ -71,8 +110,11 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
   return createPortal(
     <div
       {...telemetryClickAttributes('message.image.close', 'message')}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-black/80"
       onClick={handleOverlayClick}
+      onPointerDownCapture={() => {
+        if (!panRef.current) suppressClickRef.current = false;
+      }}
       style={{ touchAction: 'none' }}
       onWheel={handleWheel}
       role="dialog"
@@ -84,25 +126,25 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
         type="button"
         onClick={closeLightbox}
         className={cn(
-          'absolute right-4 w-10 h-10 flex items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors text-xl',
+          'absolute z-10 right-4 w-10 h-10 flex items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors text-xl',
           avoidsWindowControls ? 'top-12' : 'top-4',
         )}
         aria-label={t('common.close')}
       >
         ×
       </button>
-      {/*
-        Nothing swallows the click: clicking anywhere — the backdrop or the
-        picture itself — dismisses. The old wrapper was sized to the viewport
-        and stopped propagation, so the click that opened the image could not
-        close it again anywhere the user would naturally aim.
-      */}
       {/* eslint-disable-next-line @next/next/no-img-element -- dynamic local image, dimensions unknown */}
       <img
         src={src}
         alt=""
-        className="max-h-[82vh] max-w-[90vw] rounded-lg object-contain shadow-2xl transition-transform duration-150"
-        style={{ transform: `scale(${zoom})` }}
+        draggable={false}
+        onPointerDown={handlePanStart}
+        onPointerMove={handlePanMove}
+        onPointerUp={handlePanEnd}
+        onPointerCancel={handlePanEnd}
+        onLostPointerCapture={handlePanEnd}
+        className={cn('max-h-[82vh] max-w-[90vw] select-none rounded-lg object-contain shadow-2xl', isPanning ? 'cursor-grabbing' : 'cursor-grab')}
+        style={{ transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})` }}
       />
       <div
         {...telemetryIgnoreAttributes('event_boundary')}
@@ -135,7 +177,7 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
         <button
           {...telemetryClickAttributes('message.image.zoom_reset', 'message')}
           type="button"
-          onClick={() => setZoom(1)}
+          onClick={() => { setZoom(1); setOffset({ x: 0, y: 0 }); }}
           className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-white/15"
           aria-label={t('chat.imageZoomReset')}
           title={t('chat.imageZoomReset')}

--- a/tests/image-lightbox-pan.test.mjs
+++ b/tests/image-lightbox-pan.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import test from 'node:test';
+import { transformSync } from 'esbuild';
+
+// Exercise the component's pointer handlers with persistent React hook state.
+function mountLightbox() {
+  const slots = [];
+  let cursor = 0;
+  let closes = 0;
+  const react = {
+    createElement: (type, props, ...children) => ({ type, props: props ?? {}, children }),
+    useState(initial) {
+      const index = cursor++;
+      if (!(index in slots)) slots[index] = initial;
+      return [slots[index], value => { slots[index] = typeof value === 'function' ? value(slots[index]) : value; }];
+    },
+    useRef(initial) {
+      const index = cursor++;
+      return slots[index] ??= { current: initial };
+    },
+    useCallback: fn => fn,
+    useEffect: () => {},
+  };
+  const source = fs.readFileSync(new URL('../src/components/chat/image-lightbox.tsx', import.meta.url), 'utf8');
+  const context = { module: { exports: {} }, document: { body: {} }, HTMLElement: class {}, React: react,
+    require(name) {
+      if (name === 'react') return react;
+      if (name === 'react-dom') return { createPortal: node => node };
+      if (name === 'lucide-react') return {};
+      if (name.endsWith('ui-click')) return { telemetryClickAttributes: () => ({}), telemetryIgnoreAttributes: () => ({}) };
+      if (name.endsWith('use-close-on-escape')) return { useCloseOnEscape() {} };
+      if (name.endsWith('use-electron-platform')) return { useElectronPlatform: () => null };
+      if (name.endsWith('i18n')) return { useI18n: () => ({ t: key => key }) };
+      if (name.endsWith('utils')) return { cn: (...items) => items.join(' ') };
+      throw new Error(name);
+    },
+  };
+  vm.runInNewContext(transformSync(source, { loader: 'tsx', format: 'cjs', jsx: 'transform' }).code, context);
+  return { render() { cursor = 0; return context.module.exports.ImageLightbox({ src: 'test.png', onClose: () => closes++ }); }, get closes() { return closes; } };
+}
+function descendants(node) {
+  return [node, ...(node.children ?? []).flat().filter(value => value && typeof value === 'object').flatMap(descendants)];
+}
+function button(tree, label) { return descendants(tree).find(node => node.props['aria-label'] === label); }
+const surface = { setPointerCapture() {}, hasPointerCapture: () => true, releasePointerCapture() {} };
+const pointer = (x, y, button = 0) => ({ pointerId: 1, pointerType: 'mouse', button, clientX: x, clientY: y, currentTarget: surface, preventDefault() {} });
+
+test('zoomed image moves with left drag, stays open on release, and reset recenters', () => {
+  const app = mountLightbox();
+  button(app.render(), 'chat.imageZoomIn').props.onClick();
+  let tree = app.render();
+  let img = descendants(tree).find(node => node.type === 'img');
+  assert.equal(typeof img.props.onPointerDown, 'function');
+  img.props.onPointerDown(pointer(100, 100));
+  img.props.onPointerMove(pointer(180, 140));
+  img.props.onPointerUp(pointer(180, 140));
+  tree = app.render();
+  img = descendants(tree).find(node => node.type === 'img');
+  assert.match(img.props.style.transform, /translate\(80px, 40px\)/);
+  tree.props.onClick();
+  assert.equal(app.closes, 0);
+  button(tree, 'chat.imageZoomReset').props.onClick();
+  img = descendants(app.render()).find(node => node.type === 'img');
+  assert.match(img.props.style.transform, /translate\(0px, 0px\) scale\(1\)/);
+  app.render().props.onClick();
+  assert.equal(app.closes, 1);
+});
+
+test('right button does not pan and cancelled drags stop tracking', () => {
+  const app = mountLightbox();
+  let img = descendants(app.render()).find(node => node.type === 'img');
+  img.props.onPointerDown(pointer(100, 100, 2));
+  img.props.onPointerMove(pointer(180, 140));
+  assert.match(descendants(app.render()).find(node => node.type === 'img').props.style.transform, /translate\(0px, 0px\)/);
+  img.props.onPointerDown(pointer(100, 100));
+  img.props.onPointerMove(pointer(180, 140));
+  img.props.onPointerCancel(pointer(180, 140));
+  img.props.onPointerMove(pointer(250, 200));
+  img = descendants(app.render()).find(node => node.type === 'img');
+  assert.match(img.props.style.transform, /translate\(80px, 40px\)/);
+  const tree = app.render();
+  tree.props.onPointerDownCapture();
+  tree.props.onClick();
+  assert.equal(app.closes, 1);
+});


### PR DESCRIPTION
The shared image lightbox could zoom but had no drag handling, leaving enlarged regions inaccessible. Add left-button dragging with pointer capture for chat attachments, tool results, and generated images. Suppress dismissal after a drag, disable native image dragging, and restore both position and zoom on reset.

Validation: four targeted regression/contract tests passed, ESLint passed for changed files, and TypeScript `tsc --noEmit` passed. Tests cover movement, release without dismissal, reset, right-button rejection, cancellation, and existing Escape/mobile contracts. Actual app mouse interaction has not been verified.
