### PR TITLE
Add Close Peek as the first right-click menu action

### DIFF
--- a/src/components/board/peek-context-menu.tsx
+++ b/src/components/board/peek-context-menu.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
+import { useCloseOnEscape } from '@/hooks/use-close-on-escape';
+import { useMenuNavigation } from '@/hooks/use-menu-navigation';
+import { useI18n } from '@/lib/i18n';
+
+interface PeekContextMenuProps {
+  position: { x: number; y: number };
+  onDismiss: () => void;
+  onClosePeek: () => void;
+  onToggleView?: () => void;
+  toggleViewLabel: string;
+}
+
+export function PeekContextMenu({
+  position, onDismiss, onClosePeek, onToggleView, toggleViewLabel,
+}: PeekContextMenuProps) {
+  const { t } = useI18n();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const handleKeyDown = useMenuNavigation(menuRef);
+  useCloseOnEscape(onDismiss, { capture: true });
+
+  useEffect(() => {
+    const menu = menuRef.current;
+    const previousFocus = document.activeElement;
+    menu?.querySelector<HTMLButtonElement>('button')?.focus();
+    const dismissOutside = (event: PointerEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) onDismiss();
+    };
+    document.addEventListener('pointerdown', dismissOutside, true);
+    window.addEventListener('resize', onDismiss);
+    return () => {
+      document.removeEventListener('pointerdown', dismissOutside, true);
+      window.removeEventListener('resize', onDismiss);
+      if (previousFocus instanceof HTMLElement && previousFocus.isConnected
+        && (document.activeElement === document.body || menu?.contains(document.activeElement))) {
+        previousFocus.focus({ preventScroll: true });
+      }
+    };
+  }, [onDismiss]);
+
+  const itemClass = 'flex h-8 w-full items-center gap-2 rounded-md px-3 text-left text-xs text-(--sidebar-text-active) hover:bg-(--sidebar-hover) focus:bg-(--sidebar-hover) focus:outline-none';
+  const height = onToggleView ? 85 : 44;
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label={t('common.closePeek')}
+      data-testid="kanban-peek-context-menu"
+      className="fixed z-[100] w-[220px] rounded-lg border border-(--divider) bg-(--sidebar-bg) p-1.5 shadow-xl"
+      style={{
+        left: Math.max(8, Math.min(position.x, window.innerWidth - 228)),
+        top: Math.max(8, Math.min(position.y, window.innerHeight - height - 8)),
+      }}
+      onPointerDown={(event) => event.stopPropagation()}
+      onContextMenu={(event) => { event.preventDefault(); event.stopPropagation(); }}
+      onKeyDown={(event) => {
+        event.stopPropagation();
+        if (event.key === 'Tab') {
+          event.preventDefault();
+          onDismiss();
+        } else handleKeyDown(event);
+      }}
+    >
+      <button type="button" role="menuitem" className={itemClass} onClick={() => {
+        onDismiss();
+        onClosePeek();
+      }}>
+        <X className="h-4 w-4" aria-hidden="true" />
+        {t('common.closePeek')}
+      </button>
+      {onToggleView ? (
+        <>
+          <div role="separator" className="my-1 border-t border-(--divider)" />
+          <button type="button" role="menuitem" className={itemClass} onClick={() => {
+            onDismiss();
+            onToggleView();
+          }}>
+            {toggleViewLabel}
+          </button>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/board/session-peek.tsx
+++ b/src/components/board/session-peek.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { MessageSquare, SquareTerminal, Terminal, X } from 'lucide-react';
+import { PeekContextMenu } from './peek-context-menu';
 import { ChatArea } from '@/components/chat/chat-area';
 import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
 import { MemoryFileTab } from '@/components/memory/memory-file-tab';
@@ -68,6 +69,8 @@ export function SessionPeek({
   const setPersistedFileWidth = useBoardStore((state) => state.setPeekFileSidecarWidth);
   const terminalViewMode = useTerminalViewMode(sessionId);
   const setTerminalViewMode = useTerminalViewModeStore((state) => state.setMode);
+  const [contextMenuPosition, setContextMenuPosition] = useState<{ x: number; y: number } | null>(null);
+  const dismissContextMenu = useCallback(() => setContextMenuPosition(null), []);
   const dialogRef = useRef<HTMLDivElement>(null);
   const splitContainerRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -278,6 +281,16 @@ export function SessionPeek({
         aria-labelledby={showSessionContent ? titleId : undefined}
         aria-label={isFileOnly ? peekFileLabel : undefined}
         tabIndex={-1}
+        onContextMenuCapture={(event) => {
+          const target = event.target as HTMLElement;
+          // Keep editors and their own menus intact; capture PTY events before
+          // xterm consumes them, suppressing the native browser/Electron menu.
+          if (target.closest('[role="menu"], aside, input, [contenteditable="true"]')
+            || (target.closest('textarea') && !target.closest('.xterm'))) return;
+          event.preventDefault();
+          event.stopPropagation();
+          setContextMenuPosition({ x: event.clientX, y: event.clientY });
+        }}
         onKeyDown={handleDialogKeyDown}
         className="flex min-h-0 overflow-hidden rounded-xl border border-(--divider) bg-(--chat-bg) shadow-[0_28px_90px_rgba(0,0,0,0.42)]"
         style={{
@@ -417,6 +430,17 @@ export function SessionPeek({
           </div>
         </div>
       </div>
+      {contextMenuPosition ? (
+        <PeekContextMenu
+          position={contextMenuPosition}
+          onDismiss={dismissContextMenu}
+          onClosePeek={onClose}
+          onToggleView={canToggleTerminalView ? () => setTerminalViewMode(
+            sessionId, isTerminalChatView ? 'terminal' : 'chat',
+          ) : undefined}
+          toggleViewLabel={isTerminalChatView ? t('chat.viewAsTerminal') : t('chat.viewAsChat')}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -504,6 +504,7 @@ export const en: I18nMessages = {
     save: 'Save',
     cancel: 'Cancel',
     close: 'Close',
+    closePeek: 'Close Peek',
     reset: 'Reset',
     loading: 'Loading...',
     or: 'or',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -504,6 +504,7 @@ export const ja: I18nMessages = {
     save: '保存',
     cancel: 'キャンセル',
     close: '閉じる',
+    closePeek: 'Peek を閉じる',
     reset: 'リセット',
     loading: '読み込み中...',
     or: 'または',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -506,6 +506,7 @@ export const ko: I18nMessages = {
     save: '저장',
     cancel: '취소',
     close: '닫기',
+    closePeek: 'Peek 닫기',
     reset: '초기화',
     loading: '로딩 중...',
     or: '또는',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -481,6 +481,7 @@ export interface I18nMessages {
     save: string;
     cancel: string;
     close: string;
+    closePeek: string;
     reset: string;
     loading: string;
     or: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -504,6 +504,7 @@ export const zh: I18nMessages = {
     save: '保存',
     cancel: '取消',
     close: '关闭',
+    closePeek: '关闭 Peek',
     reset: '重置',
     loading: '加载中...',
     or: '或',


### PR DESCRIPTION
Right-clicking the Kanban Peek PTY now opens a menu with **Close Peek as its first action**, followed by the existing PTY/chat view toggle. Closing uses the same callback as the header X button. Text editors and the file sidecar retain their own menus.

The renderer menu supports outside-click dismissal, Escape dismissal, keyboard navigation, and viewport bounds. Includes English, Korean, Japanese, and Chinese labels. Integrated the latest dev changes, including Peek terminal view switching, without conflicts.

Validation: 26 existing Peek and Electron context-menu tests passed; targeted ESLint, TypeScript no-emit, and diff whitespace checks passed. Browser and Windows Electron interaction QA has not been run.
