### PR TITLE
Fix input autofocus in Kanban session Peek

### DIFF
--- a/src/components/board/session-peek.tsx
+++ b/src/components/board/session-peek.tsx
@@ -69,6 +69,7 @@ export function SessionPeek({
   const terminalViewMode = useTerminalViewMode(sessionId);
   const setTerminalViewMode = useTerminalViewModeStore((state) => state.setMode);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const sessionContentRef = useRef<HTMLDivElement>(null);
   const splitContainerRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const returnFocusRef = useRef<HTMLElement | null>(null);
@@ -144,6 +145,43 @@ export function SessionPeek({
       });
     };
   }, []);
+
+  useEffect(function focusPeekInputWhenReady() {
+    const content = sessionContentRef.current;
+    if (!showSessionContent || !content) return;
+    const selector = isTerminalChatView
+      ? '[data-testid="terminal-chat-composer-input"]:not([disabled])'
+      : isTerminal
+        ? '.xterm-helper-textarea:not([disabled])'
+        : 'textarea:not([disabled])';
+    let frame: number | null = null;
+    let stopped = false;
+    const stop = () => {
+      stopped = true;
+      observer.disconnect();
+      if (frame !== null) cancelAnimationFrame(frame);
+      document.removeEventListener('pointerdown', stop, true);
+      document.removeEventListener('keydown', stop, true);
+    };
+    const scheduleFocus = () => {
+      if (stopped || frame !== null) return;
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        const input = content.querySelector<HTMLTextAreaElement>(selector);
+        if (!input || input.getClientRects().length === 0) return;
+        input.focus({ preventScroll: true });
+        stop();
+      });
+    };
+    // History and xterm load asynchronously. Observe readiness rather than
+    // guessing a delay, and yield if the user chooses a control or file pane.
+    const observer = new MutationObserver(scheduleFocus);
+    observer.observe(content, { childList: true, subtree: true, attributes: true, attributeFilter: ['disabled'] });
+    document.addEventListener('pointerdown', stop, true);
+    document.addEventListener('keydown', stop, true);
+    scheduleFocus();
+    return stop;
+  }, [isTerminal, isTerminalChatView, sessionId, showSessionContent]);
 
   useEffect(() => {
     if (!session) onClose();
@@ -344,7 +382,7 @@ export function SessionPeek({
             data-testid="kanban-peek-split-container"
           >
             {showSessionContent ? (
-              <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+              <div ref={sessionContentRef} className="min-h-0 min-w-0 flex-1 overflow-hidden">
                 <TabIdContext.Provider value={PEEK_TAB_ID}>
                   <ChatArea
                     key={sessionId}

--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -346,6 +346,7 @@ export const ChatArea = memo(function ChatArea({
                   ? 'session-preview'
                   : 'session-retained'}
               surfaceActive={isPeek}
+              autoFocus={!isTerminalChatView}
               directInputDrop={isPeek}
               startupOverlay={shouldShowPeekLoading ? <SessionPeekLoading /> : undefined}
               launch={{ providerId: sessionProvider, sessionId }}

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -76,6 +76,8 @@ interface TerminalPanelProps {
   runtimeOwnership?: 'standalone' | 'session-preview' | 'session-retained' | 'session-peek';
   /** Treat a transient surface as visible/focused without borrowing panel-store state. */
   surfaceActive?: boolean;
+  /** A transcript overlay owns focus while the backing PTY stays connected. */
+  autoFocus?: boolean;
   /** Accept prompt-input drops directly when no PanelWrapper surrounds this surface. */
   directInputDrop?: boolean;
   /**
@@ -126,6 +128,7 @@ export function TerminalPanel({
   terminalCwd = null,
   runtimeOwnership = 'standalone',
   surfaceActive = false,
+  autoFocus = true,
   directInputDrop = false,
   detachOnUnmount = false,
   startupOverlay,
@@ -453,10 +456,12 @@ export function TerminalPanel({
   useEffect(() => {
     const shouldRestoreRetainedSession = runtimeOwnership === 'session-retained';
     if (connectionStatus !== 'connected' || (!isTabActive && !shouldRestoreRetainedSession)) return;
+    let cancelled = false;
     void surface.ensureConnected().then((connected) => {
-      if (connected && isPanelActive) surface.activate();
+      if (!cancelled && connected && isPanelActive && autoFocus) surface.activate();
     });
-  }, [connectionStatus, isPanelActive, isPhoneViewport, isTabActive, runtimeOwnership, surface]);
+    return () => { cancelled = true; };
+  }, [autoFocus, connectionStatus, isPanelActive, isPhoneViewport, isTabActive, runtimeOwnership, surface]);
 
   const canRestart = status === 'exited' || status === 'error';
   const handleThemeRestart = useCallback(() => {

--- a/tests/kanban-peek-autofocus.e2e.mjs
+++ b/tests/kanban-peek-autofocus.e2e.mjs
@@ -1,0 +1,53 @@
+// Windows Node: node tests/kanban-peek-autofocus.e2e.mjs <isolated-CDP-url> <session-id> <screenshots-dir>
+// Use a disposable PTY session in an isolated packaged app, with Board/Peek enabled.
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { chromium, expect } from '@playwright/test';
+
+const [cdpUrl, sessionId, artifactDir] = process.argv.slice(2);
+assert.ok(cdpUrl && sessionId && artifactDir, 'CDP URL, session ID, and screenshot directory are required');
+await fs.mkdir(artifactDir, { recursive: true });
+const browser = await chromium.connectOverCDP(cdpUrl);
+try {
+  const page = browser.contexts()[0].pages().find((candidate) => /localhost:/.test(candidate.url()));
+  assert.ok(page, 'Expected the packaged server renderer');
+  await page.bringToFront();
+  await page.getByTestId('view-mode-board').click();
+  const peek = page.getByTestId('kanban-session-peek');
+  const toggle = peek.getByTestId('kanban-session-peek-terminal-view-toggle');
+  const close = peek.getByTestId('kanban-session-peek-close');
+  const card = page.locator(`[data-testid="kanban-card"][data-session-id="${sessionId}"]`);
+  const shot = (name) => page.screenshot({ path: path.join(artifactDir, `${name}.png`) });
+  // Normalize the fixture without relying on a previous run's persisted view.
+  if (await peek.isVisible()) {
+    if (await toggle.getAttribute('aria-pressed') === 'true') await toggle.click();
+    await close.click();
+  }
+  await shot('30-board-before-peek');
+  await card.click();
+  await expect(peek.locator('.xterm-helper-textarea')).toBeFocused({ timeout: 30_000 });
+  await shot('31-terminal-peek-focused');
+  await toggle.click();
+  const composer = peek.getByTestId('terminal-chat-composer-input');
+  await expect(composer).toBeVisible();
+  await shot('32-chat-view-after-toggle');
+  await expect(composer).toBeFocused();
+  await page.keyboard.insertText('peek focus regression');
+  await expect(composer).toHaveValue('peek focus regression');
+  await shot('33-chat-typed-without-click');
+  await page.keyboard.press('ControlOrMeta+A');
+  await page.keyboard.press('Backspace');
+  await close.click();
+  await shot('34-closed-peek');
+  await card.click();
+  await expect(composer).toBeFocused({ timeout: 30_000 });
+  await shot('35-reopened-chat-focused');
+  await toggle.click();
+  await expect(peek.locator('.xterm-helper-textarea')).toBeFocused();
+  await shot('36-returned-terminal-focused');
+  await close.click();
+  console.log('PASS: terminal open, chat toggle, typing without click, chat reopen, terminal return');
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
Kanban Peek could leave keyboard focus on its view toggle or backing terminal instead of the visible input, requiring another click before typing. Focus the visible session input when it becomes available and when the Peek session or view changes; cancel the pending focus request when the user interacts elsewhere.

Keep the backing PTY connected without requesting autofocus while its chat overlay is visible, and ignore stale connection callbacks after effect cleanup.

Validation:
- Reproduced the inactive Peek chat composer in an isolated packaged Windows Electron app with a Windows backend and WSL Codex PTY.
- The new Electron regression passed terminal opening, chat switching, typing without clicking, chat reopening, and returning to the terminal after the fix.
- A newly created Kanban Worktree's PTY Peek accepted input without another click after the CLI prompt was ready.
- 37 related tests, targeted ESLint, and the packaged build/type checks passed.

The initial PTY creation focus failure was not reproduced; the confirmed pre-fix failure was Peek chat-view focus. The change also explicitly manages initial Peek input focus.
