### PR TITLE
fix: release temporary session runtimes when Kanban Peek closes

### DIFF
--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -157,10 +157,13 @@ export function TerminalPanel({
   const assignTerminal = usePanelStore((state) => state.assignTerminal);
   const connectionStatus = useChatStore((state) => state.connectionStatus);
   const sessionOwned = runtimeOwnership !== 'standalone';
-  const previewOwnsRuntimeRef = useRef(runtimeOwnership === 'session-preview');
+  const isPreviewRuntime = runtimeOwnership === 'session-preview' || runtimeOwnership === 'session-peek';
+  const previewOwnsRuntimeRef = useRef(isPreviewRuntime);
   const handleTerminalInput = useCallback(() => {
-    if (runtimeOwnership === 'standalone' || runtimeOwnership === 'session-peek') return;
+    if (runtimeOwnership === 'standalone') return;
+    // Peek input retains the runtime without pinning the unrelated active tab.
     previewOwnsRuntimeRef.current = false;
+    if (runtimeOwnership === 'session-peek') return;
     useTabStore.getState().pinTab(tabId);
   }, [runtimeOwnership, tabId]);
   const isTabActive = useTabStore((state) => surfaceActive || state.activeTabId === tabId);
@@ -177,12 +180,12 @@ export function TerminalPanel({
     cwd: getInitialTerminalCwd(terminalSessionId, terminalCwd),
     sessionId: getSessionSelectionId(terminalSessionId),
     launch,
-    previewOwned: runtimeOwnership === 'session-preview',
+    previewOwned: isPreviewRuntime,
   }), [
     isDark,
     launch,
     panelId,
-    runtimeOwnership,
+    isPreviewRuntime,
     selectedThemePreset,
     tabId,
     terminalFontSize,
@@ -346,8 +349,8 @@ export function TerminalPanel({
   }, [handleTerminalInput, surface]);
 
   useEffect(() => {
-    if (runtimeOwnership !== 'session-preview') previewOwnsRuntimeRef.current = false;
-  }, [runtimeOwnership]);
+    if (!isPreviewRuntime) previewOwnsRuntimeRef.current = false;
+  }, [isPreviewRuntime]);
 
   useEffect(() => {
     if (runtimeOwnership === 'session-preview' && terminalSessionId) {

--- a/src/lib/terminal/terminal-manager.ts
+++ b/src/lib/terminal/terminal-manager.ts
@@ -1495,6 +1495,8 @@ export class TerminalManager {
     runtime.semanticPromptPending = true;
     try {
       runtime.process.write(bracketSemanticPrompt(body));
+      // A submitted prompt retains work even if its Peek closes during delayed Enter.
+      runtime.previewOwnerToken = undefined;
       const delayMs = this.managerOptions.semanticPromptSubmitDelayMs ?? 500;
       await new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, delayMs)));
       if (

--- a/tests/kanban-session-peek-contract.test.mjs
+++ b/tests/kanban-session-peek-contract.test.mjs
@@ -126,10 +126,14 @@ test('Session Peek uses a compact, accessible loading indicator instead of the f
   assert.match(terminalPanelSource, /status === 'starting' && startupOverlay/);
 });
 
-test('PTY sessions use retained Peek ownership without pinning or killing a tab runtime', () => {
+test('PTY Peek owns a temporary runtime and retains it only after user input', () => {
   assert.match(chatAreaSource, /isPeek\s*\? 'session-peek'/);
   assert.match(chatAreaSource, /surfaceActive=\{isPeek\}/);
-  assert.match(terminalPanelSource, /runtimeOwnership === 'standalone' \|\| runtimeOwnership === 'session-peek'/);
+  assert.match(terminalPanelSource, /const isPreviewRuntime = runtimeOwnership === 'session-preview' \|\| runtimeOwnership === 'session-peek'/);
+  assert.match(terminalPanelSource, /previewOwned: isPreviewRuntime/);
+  assert.match(terminalPanelSource, /useRef\(isPreviewRuntime\)/);
+  assert.match(terminalPanelSource, /if \(!isPreviewRuntime\) previewOwnsRuntimeRef\.current = false/);
+  assert.match(terminalPanelSource, /previewOwnsRuntimeRef\.current = false;\s*if \(runtimeOwnership === 'session-peek'\) return;/);
   assert.match(terminalPanelSource, /clearTimeout\(pendingSurfaceCleanupRef\.current\)/);
 });
 

--- a/tests/terminal-manager-lifecycle.test.ts
+++ b/tests/terminal-manager-lifecycle.test.ts
@@ -2078,3 +2078,22 @@ test('a cursor report reflects where the program actually left the cursor', asyn
   // Row 5, column 9 plus the six characters written there.
   assert.deepEqual(spawned[0].writes, ['\x1b[5;15R']);
 });
+
+
+test('closing Peek during a chat submission retains its preview-created runtime', async () => {
+  const spawned: FakePty[] = [];
+  const manager = new TerminalManager(() => {}, async () => createFactory(spawned), undefined, {
+    semanticPromptSubmitDelayMs: 20,
+  });
+  await manager.startDetached({ ...createOptions(), previewOwnerToken: 'peek-owner' });
+  manager.recordSessionState({
+    type: 'session_state', sessionId: 'session-a', terminalId: 'terminal-a',
+    status: 'completed', hookEvent: 'Stop', stateAt: 100,
+  }, 'user-a');
+  const submission = manager.submitSessionChatPrompt('session-a', 'user-a', 'continue work', 'peek-submit');
+  const outcome = submission.then(() => true, () => false);
+  await manager.releasePreview('terminal-a', 'user-a', 'session-a', 'peek-owner');
+  assert.equal(await outcome, true);
+  assert.equal(spawned[0].killCount, 0);
+  await manager.close('terminal-a', 'user-a');
+});


### PR DESCRIPTION
Closing Kanban Session Peek after inspecting a stopped session left its newly started CLI running. Give Peek temporary runtime ownership so closing it releases the runtime it created, while retaining existing runtimes and sessions that receive user input.

Retain the runtime when a chat prompt is submitted, including when Peek closes during the delayed Enter write.

Validation: 81 related contract and unit tests passed, along with TypeScript and targeted ESLint checks. The user confirmed the reported behavior is resolved. Packaged Windows app launch and board navigation were checked; automated end-to-end close verification was not completed.
