### PR TITLE
Fix session recovery on the all-project Running board after restart

### DIFF
--- a/electron/server-child.ts
+++ b/electron/server-child.ts
@@ -28,6 +28,9 @@ import { ensureRemoteModelConfigLoaded } from '../src/lib/model-config/remote-co
 import logger from '../src/lib/logger';
 import { getTesseraDataPath } from '../src/lib/tessera-data-dir';
 import { terminalManager } from '../src/lib/terminal/shared-terminal-manager';
+import { providerLaunchModule } from '../src/lib/terminal/shared-provider-launch-module';
+import { restoreSessionRuntimes } from '../src/lib/session/session-runtime-recovery';
+import { markServerShuttingDown } from '../src/lib/server-lifecycle';
 import { handleHookRequest } from '../src/lib/cli/hook-receiver';
 import { CONTROL_ROUTE_PREFIX } from '../src/lib/control/http-handler';
 import { readAppVersion } from '../src/lib/app-version';
@@ -268,6 +271,7 @@ initDatabase().then(async () => {
       });
 
       wsServer.start(server);
+      void restoreSessionRuntimes((request) => providerLaunchModule.launch(request));
       startOomDiagnostics();
       // Only now can a direct listener serve /ws, so bind it after the
       // WebSocket server exists rather than alongside the loopback listen.
@@ -332,6 +336,7 @@ initDatabase().then(async () => {
   const shutdown = async (reason = 'requested') => {
     if (isShuttingDown) return;
     isShuttingDown = true;
+    markServerShuttingDown();
     if (parentWatchdog) {
       clearInterval(parentWatchdog);
       parentWatchdog = null;

--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,6 @@
 import './runtime/register-runtime-aliases';
+import { restoreSessionRuntimes } from './src/lib/session/session-runtime-recovery';
+import { providerLaunchModule } from './src/lib/terminal/shared-provider-launch-module';
 import next from 'next';
 import { loadEnvConfig } from '@next/env';
 import { createServer } from 'http';
@@ -140,6 +142,9 @@ async function startServer() {
 
       // Start WebSocket server on the same HTTP server
       wsServer.start(server);
+      // Resume every previously live provider independently of the selected
+      // project or mounted panels (including the all-project Running board).
+      void restoreSessionRuntimes((request) => providerLaunchModule.launch(request));
       configureArchivedWorktreeRetention(startupRetentionPolicy);
 
       // Pay the first ConPTY spawn cost (~seconds on Windows) before the user

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -73,6 +73,12 @@ CREATE TABLE IF NOT EXISTS sessions (
   updated_at       TEXT NOT NULL
 );
 
+-- Runtime intent survives server shutdown; actual liveness remains in memory.
+CREATE TABLE IF NOT EXISTS session_runtime_recovery (
+  session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS session_messages (
   id         INTEGER PRIMARY KEY AUTOINCREMENT,
   session_id TEXT NOT NULL,

--- a/src/lib/session/session-runtime-recovery.ts
+++ b/src/lib/session/session-runtime-recovery.ts
@@ -1,0 +1,60 @@
+import { getDb } from '@/lib/db/database';
+import { extractSessionKind } from '@/lib/db/sessions';
+import logger from '@/lib/logger';
+import { isServerShuttingDown } from '@/lib/server-lifecycle';
+import type { ProviderLaunchRequest } from '@/lib/terminal/provider-launch-module';
+
+/** Persist intent on real runtime transitions, never on renderer attachment. */
+export function recordSessionRuntime(event: {
+  sessionId: string;
+  userId: string;
+  running: boolean;
+}): void {
+  // Shutdown terminates PTYs but must retain the next launch's recovery set.
+  if (isServerShuttingDown()) return;
+  const db = getDb();
+  if (event.running) {
+    db.prepare(`
+      INSERT INTO session_runtime_recovery (session_id, user_id)
+      SELECT id, ? FROM sessions WHERE id = ? AND deleted = 0
+      ON CONFLICT(session_id) DO UPDATE SET user_id = excluded.user_id
+    `).run(event.userId, event.sessionId);
+  } else {
+    db.prepare('DELETE FROM session_runtime_recovery WHERE session_id = ? AND user_id = ?')
+      .run(event.sessionId, event.userId);
+  }
+}
+
+/** Background recovery has no dependency on tabs, panels, or project selection. */
+export async function restoreSessionRuntimes(
+  launch: (request: ProviderLaunchRequest) => Promise<unknown>,
+): Promise<void> {
+  const db = getDb();
+  const sessions = db.prepare(`
+    SELECT r.session_id, r.user_id, s.provider_state
+    FROM session_runtime_recovery r
+    JOIN sessions s ON s.id = r.session_id
+    LEFT JOIN tasks t ON t.id = s.task_id
+    WHERE s.deleted = 0 AND s.archived = 0
+      AND (s.task_id IS NULL OR COALESCE(t.archived, 0) = 0)
+  `).all() as Array<{ session_id: string; user_id: string; provider_state: string | null }>;
+
+  // Pace OS/WSL process creation while allowing one slow preparation not to
+  // block all the other projects. The launch module arbitrates surface races.
+  let next = 0;
+  await Promise.all(Array.from({ length: Math.min(3, sessions.length) }, async () => {
+    while (next < sessions.length && !isServerShuttingDown()) {
+      const session = sessions[next++];
+      if (extractSessionKind(session.provider_state) !== 'terminal') continue;
+      // An explicit stop may have removed the intent while another launch waited.
+      if (!db.prepare('SELECT 1 FROM session_runtime_recovery WHERE session_id = ?')
+        .get(session.session_id)) continue;
+      try {
+        await launch({ sessionId: session.session_id, userId: session.user_id, mode: 'detached' });
+      } catch (error) {
+        if ((error as { code?: string })?.code === 'SESSION_RUNTIME_ALREADY_RUNNING') continue;
+        logger.warn({ error, sessionId: session.session_id }, 'Session runtime recovery failed');
+      }
+    }
+  }));
+}

--- a/src/lib/terminal/shared-terminal-manager.ts
+++ b/src/lib/terminal/shared-terminal-manager.ts
@@ -1,5 +1,6 @@
 import type { ServerTransportMessage } from '@/lib/ws/message-types';
 import logger from '@/lib/logger';
+import { recordSessionRuntime } from '@/lib/session/session-runtime-recovery';
 import { getManagedSessionWorkDir } from '@/lib/git/session-diff-refresh';
 import { forkTerminalSessionForProviderReset } from './provider-session-reset';
 import { scheduleRecompute } from '@/lib/git/worktree-diff-stats-cache';
@@ -39,6 +40,7 @@ function createSharedState(): SharedTerminalManagerState {
     },
     {
       onSessionRuntimeStateChange: ({ sessionId, terminalId, userId, running }) => {
+        recordSessionRuntime({ sessionId, userId, running });
         state.sendToUser?.(userId, {
           type: 'terminal_session_runtime',
           sessionId,
@@ -67,6 +69,8 @@ function createSharedState(): SharedTerminalManagerState {
         }
       },
       onSessionRuntimeRebound: ({ previousSessionId, sessionId, terminalId, userId }) => {
+        recordSessionRuntime({ sessionId: previousSessionId, userId, running: false });
+        recordSessionRuntime({ sessionId, userId, running: true });
         state.sendToUser?.(userId, {
           type: 'terminal_session_rebound',
           previousSessionId,

--- a/tests/session-runtime-recovery.test.ts
+++ b/tests/session-runtime-recovery.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import test, { after } from 'node:test';
+
+process.env.TESSERA_DATA_DIR = mkdtempSync(path.join(process.cwd(), '.runtime-recovery-test-'));
+process.env.NODE_ENV = 'test';
+after(async () => {
+  const { getDb } = await import('@/lib/db/database');
+  getDb().close();
+  rmSync(process.env.TESSERA_DATA_DIR!, { recursive: true, force: true });
+});
+
+test('restart restores live sessions across projects without mounting a terminal', async () => {
+  const { initDatabase } = await import('@/lib/db/database');
+  await initDatabase();
+  const { registerProject } = await import('@/lib/db/projects');
+  const { createSession } = await import('@/lib/db/sessions');
+  const { recordSessionRuntime, restoreSessionRuntimes } = await import('@/lib/session/session-runtime-recovery');
+  for (const id of ['project-a', 'project-b']) {
+    registerProject(id, process.cwd(), id);
+    createSession(id + '-session', id, id, 'codex', { providerState: JSON.stringify({ kind: 'terminal' }) });
+    recordSessionRuntime({ sessionId: id + '-session', userId: 'wsl-user', running: true });
+  }
+  createSession('stopped-session', 'project-a', 'stopped', 'codex', { providerState: JSON.stringify({ kind: 'terminal' }) });
+  recordSessionRuntime({ sessionId: 'stopped-session', userId: 'wsl-user', running: true });
+  recordSessionRuntime({ sessionId: 'stopped-session', userId: 'wsl-user', running: false });
+  const { getDb } = await import('@/lib/db/database');
+  createSession('archived-session', 'project-a', 'archived', 'codex', { providerState: JSON.stringify({ kind: 'terminal' }) });
+  recordSessionRuntime({ sessionId: 'archived-session', userId: 'wsl-user', running: true });
+  getDb().prepare('UPDATE sessions SET archived = 1 WHERE id = ?').run('archived-session');
+  const { markServerShuttingDown } = await import('@/lib/server-lifecycle');
+  markServerShuttingDown();
+  recordSessionRuntime({ sessionId: 'project-a-session', userId: 'wsl-user', running: false });
+  recordSessionRuntime({ sessionId: 'project-b-session', userId: 'wsl-user', running: false });
+  // Model the next server process while keeping the same persistent database.
+  Reflect.deleteProperty(globalThis, Symbol.for('tessera.serverShuttingDown'));
+  const launched: string[] = [];
+  await restoreSessionRuntimes(async (request) => {
+    assert.equal(request.userId, 'wsl-user');
+    assert.equal(request.mode, 'detached');
+    launched.push(request.sessionId);
+  });
+  assert.deepEqual(launched.sort(), ['project-a-session', 'project-b-session']);
+  const attempted: string[] = [];
+  await restoreSessionRuntimes(async (request) => {
+    attempted.push(request.sessionId);
+    if (request.sessionId === 'project-a-session') throw new Error('WSL temporarily unavailable');
+  });
+  assert.deepEqual(attempted.sort(), ['project-a-session', 'project-b-session']);
+});


### PR DESCRIPTION
## Summary

Restarting Tessera on the all-project Running Kanban could hide previously live sessions until their project panels were opened. Persist terminal runtime recovery intent and resume eligible sessions in the background when either the Electron or standalone server starts, independently of the selected project and mounted panels.

Preserve recovery intent during server shutdown, remove it on normal runtime exit, and transfer it when a session is rebound. Skip archived/deleted sessions and archived tasks, retain the launching user's agent environment, and limit recovery to three concurrent launches with independent error handling.

## Testing

- [x] 57 related tests passed (runtime recovery, terminal lifecycle, and Kanban Running filter).
- [x] ESLint passed for all changed TypeScript files.
- [x] `npx tsc --noEmit` and Electron TypeScript compilation passed.
- [x] Production Next.js build and Windows Electron packaging passed.
- [x] Isolated Windows Electron/server + WSL Ubuntu-24.04 Codex PTY test: quit on All Projects / Board / Running, relaunch with the same isolated data/profile, and verify live session cards return without switching projects or opening terminal panels.
- [x] Original app processes and source database hashes remained unchanged; isolated test app and data were removed afterward.

## Screenshots or Recordings

Eight sequential QA screenshots and a test summary were saved locally in `Downloads/Tessera-restart-QA-0906-y8`. They cover setup, running sessions, the pre-quit board, and restored cards after relaunch.

## Notes

Recovery applies to provider terminal sessions recorded as live by this version. GUI sessions and terminal scrollback restoration are outside this change. This PR does not publish a desktop release.
