### PR TITLE
fix: unify PTY Peek header while keeping an accessible close target

### DIFF
--- a/src/components/board/session-peek.tsx
+++ b/src/components/board/session-peek.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { MessageSquare, SquareTerminal, Terminal, X } from 'lucide-react';
 import { PeekContextMenu } from './peek-context-menu';
+import { Header } from '@/components/chat/header';
 import { ChatArea } from '@/components/chat/chat-area';
 import { ShortcutTooltip } from '@/components/keyboard/shortcut-tooltip';
 import { MemoryFileTab } from '@/components/memory/memory-file-tab';
@@ -316,8 +317,8 @@ export function SessionPeek({
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-labelledby={showSessionContent ? titleId : undefined}
-        aria-label={isFileOnly ? peekFileLabel : undefined}
+        aria-labelledby={showSessionContent && !isTerminal ? titleId : undefined}
+        aria-label={isFileOnly ? peekFileLabel : isTerminal ? session.title : undefined}
         tabIndex={-1}
         onContextMenuCapture={(event) => {
           const target = event.target as HTMLElement;
@@ -339,7 +340,19 @@ export function SessionPeek({
         data-session-kind={isTerminal ? 'terminal' : 'chat'}
       >
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          {showSessionContent ? (
+          {showSessionContent && isTerminal ? (
+            <div className="shrink-0">
+              <TabIdContext.Provider value={PEEK_TAB_ID}>
+                <Header
+                  sessionId={sessionId}
+                  panelId={PEEK_PANEL_ID}
+                  projectViewDir={projectViewDir}
+                  isSinglePanel
+                  peek={{ onClose, closeButtonRef }}
+                />
+              </TabIdContext.Provider>
+            </div>
+          ) : showSessionContent ? (
             <header className="flex h-11 shrink-0 items-center gap-2 border-b border-(--chat-header-border) bg-(--chat-header-bg) px-3">
               <SessionIcon className="h-4 w-4 shrink-0 text-(--accent)" aria-hidden="true" />
               <h2

--- a/src/components/chat/header.module.css
+++ b/src/components/chat/header.module.css
@@ -59,3 +59,9 @@
   }
 
 }
+
+/* Peek needs a reachable dismiss target even with a mouse. */
+.compact[data-peek='true'] {
+  height: auto;
+  min-height: 44px;
+}

--- a/src/components/chat/header.tsx
+++ b/src/components/chat/header.tsx
@@ -48,6 +48,10 @@ interface HeaderProps {
   panelId: string;
   projectViewDir?: string | null;
   isSinglePanel?: boolean;
+  peek?: {
+    onClose: () => void;
+    closeButtonRef: React.RefObject<HTMLButtonElement | null>;
+  };
   search?: {
     isOpen: boolean;
     query: string;
@@ -62,7 +66,7 @@ interface HeaderProps {
   };
 }
 
-export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = false, search }: HeaderProps) {
+export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = false, search, peek }: HeaderProps) {
   const { t } = useI18n();
   const tabId = useContext(TabIdContext);
   const session = useProjectViewSession(sessionId, projectViewDir);
@@ -259,6 +263,7 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
         // being restated, so it stays right if the floor ever moves (#259).
         'max-sm:h-auto',
       )}
+      data-peek={peek ? "true" : undefined}
       data-search-open={Boolean(search?.isOpen)}
       onContextMenu={handleContextMenu}
     >
@@ -548,25 +553,29 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
 
           {/* 세션 닫기 / 패널 닫기 버튼 */}
           {/* 세션 열림 → 세션 해제(빈 패널), 멀티패널 빈 상태 → 패널 닫기, 싱글패널 빈 상태 → 숨김 */}
-          {(panelCount >= 2 || panel?.sessionId) && (
+          {(peek || panelCount >= 2 || panel?.sessionId) && (
             <button
+              ref={peek?.closeButtonRef}
               onClick={() => {
-                if (panel?.sessionId) {
+                if (peek) {
+                  peek.onClose();
+                } else if (panel?.sessionId) {
                   assignSession(panelId, null);
                 } else {
                   closePanel(panelId);
                 }
               }}
               {...telemetryClickAttributes('chat_header.close_panel', 'chat_header')}
-              title={panel?.sessionId ? t('chat.closeSession') : t('panel.closePanel')}
-              aria-label={panel?.sessionId ? t('chat.closeSession') : t('panel.closePanel')}
-              data-testid="panel-close-button"
+              title={peek ? t('common.close') : panel?.sessionId ? t('chat.closeSession') : t('panel.closePanel')}
+              aria-label={peek ? t('common.close') : panel?.sessionId ? t('chat.closeSession') : t('panel.closePanel')}
+              data-testid={peek ? "kanban-session-peek-close" : "panel-close-button"}
               className={cn(
                 'rounded p-0.5 transition-colors hover:bg-(--sidebar-hover)',
                 PHONE_TOUCH_TARGET,
+                peek && 'flex h-11 w-11 shrink-0 items-center justify-center',
               )}
             >
-              <XIcon className="h-3.5 w-3.5 text-(--text-muted)" />
+              <XIcon className={cn('text-(--text-muted)', peek ? 'h-4 w-4' : 'h-3.5 w-3.5')} />
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary

PTY sessions opened in Kanban Peek now reuse the list-view session header, including provider/title presentation, view switching, and session actions. Peek retains a minimum 44px header height and a 44×44px close target; closing dismisses Peek without closing a workspace panel.

## Testing

- [x] ESLint on both changed TSX files
- [x] `tsc --noEmit`
- [x] Peek contract tests: 12 passed
- [x] `git diff --check`
- [ ] Production build and manual browser/Electron QA were not run.
- Existing mobile header density contract test fails on a pre-existing literal className assertion (the baseline already uses `cn`).

## Screenshots or Recordings

No updated application screenshots captured.
