### PR TITLE
fix: keep Peek panel toggle accessible and match Windows caption colors

### DIFF
--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -64,7 +64,10 @@ export const AppHeader = memo(function AppHeader() {
         ) : null}
         <div
           className={cn(
-            'relative z-10 flex min-w-0 flex-1 items-center gap-2 px-3',
+            'relative flex min-w-0 flex-1 items-center gap-2 px-3',
+            // Let the Git control participate in the Peek backdrop's stacking
+            // context; a z-10 parent would trap its z-60 below the backdrop.
+            !isKanbanPeekMode && 'z-10',
             isElectronTitlebar && 'pointer-events-none self-stretch',
             isMacElectron && 'pl-10',
             // Peek mode stretches the header across the window, so it has to

--- a/src/components/layout/electron-titlebar.tsx
+++ b/src/components/layout/electron-titlebar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, type MouseEvent } from 'react';
 import { useElectronPlatform } from '@/hooks/use-electron-platform';
 import { useSettingsStore } from '@/stores/settings-store';
+import { useGitStore } from '@/stores/git-store';
 import { ElectronWindowControls } from '@/components/layout/electron-window-controls';
 import { cn } from '@/lib/utils';
 import { openSingletonNewTab } from '@/lib/tab/open-singleton-new-tab';
@@ -44,13 +45,18 @@ function getElectronApi(): ElectronApi | undefined {
   return (window as Window & { electronAPI?: ElectronApi }).electronAPI;
 }
 
-function hasOpenModalDialog(): boolean {
+function hasOpenModalDialog(gitPanelOpen: boolean): boolean {
   if (typeof document === 'undefined') return false;
-  return document.querySelector(MODAL_DIALOG_SELECTOR) !== null;
+  return Array.from(document.querySelectorAll(MODAL_DIALOG_SELECTOR)).some((dialog) => {
+    // Peek covers only the board. With the right panel open, the native
+    // caption buttons sit above its undimmed titlebar instead.
+    return !gitPanelOpen || !dialog.closest('[data-testid="kanban-session-peek-backdrop"]');
+  });
 }
 
 function useElectronTitlebarThemeSync(isWindowsElectron: boolean) {
   const isSettingsOpen = useSettingsStore((state) => state.isOpen);
+  const gitPanelOpen = useGitStore((state) => state.isOpen);
 
   useEffect(() => {
     if (!isWindowsElectron) return;
@@ -62,7 +68,7 @@ function useElectronTitlebarThemeSync(isWindowsElectron: boolean) {
     const applyTheme = () => {
       const isDark = document.documentElement.classList.contains('dark');
       setTitlebarTheme(isDark ? 'dark' : 'light', {
-        dimmed: isSettingsOpen || hasOpenModalDialog(),
+        dimmed: isSettingsOpen || hasOpenModalDialog(gitPanelOpen),
       });
     };
 
@@ -92,7 +98,7 @@ function useElectronTitlebarThemeSync(isWindowsElectron: boolean) {
       themeObserver.disconnect();
       dialogObserver.disconnect();
     };
-  }, [isWindowsElectron, isSettingsOpen]);
+  }, [isWindowsElectron, isSettingsOpen, gitPanelOpen]);
 }
 
 export function ElectronTitlebarThemeSync() {


### PR DESCRIPTION
## Summary

Opening a Kanban Session Peek blurred and blocked the right-panel toggle because its z-60 wrapper was trapped inside a z-10 parent. Remove that parent stacking context in Peek mode so the control stays clickable above the backdrop.

When the right panel is open, exclude the board-scoped Peek from Windows caption dimming. The native minimize/maximize/close background now matches the uncovered panel header; other modal dialogs still dim it.

## Testing

- Changed-file ESLint and `git diff --check` passed.
- Seven existing Electron drag-region, Linux packaging, and singleton-tab contract tests passed.
- `npm run electron:prebuild` passed, including the production Next.js build, TypeScript check, and Electron compilation; Windows unpacked packaging passed.
- Isolated Windows Electron + Windows packaged backend + WSL Codex: ordinary pointer clicks closed and reopened the panel while Peek remained visible.
- Native-window screenshots confirmed both the panel header and caption background are `#17191c`.
- Test instance removed; original server PID/port and source database SHA-256 remained unchanged.
- Full-repository lint and separate standalone `tsc --noEmit` were not run.

## Screenshots or Recordings

Native Windows screenshots were captured and reviewed with the requester. Local evidence is retained in `C:\Users\work\Downloads\Tessera-peek-header-QA`, including `04-peek-panel-closed-native.png` and `05-peek-panel-reopened-native.png`.
