### PR TITLE
fix(board): reduce Kanban spacing and visual clutter

### DIFF
--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -493,6 +493,17 @@ export const KanbanBoard = memo(function KanbanBoard() {
     return scopeData.projects.find((project) => project.encodedDir === focusedProjectId) ?? null;
   }, [focusedProjectId, scopeData.projects]);
 
+  const portfolioFilterProjects = useMemo(() => {
+    const items = selectKanbanProjectionItems(scopeData, null);
+    const projectIds = new Set([
+      ...items.chats.map((session) => session.projectDir),
+      ...items.tasks.map((task) => task.projectId),
+    ]);
+    return scopeData.projects.filter((project) =>
+      projectIds.has(project.encodedDir) || project.encodedDir === portfolioProjectFilter
+    );
+  }, [scopeData, portfolioProjectFilter]);
+
   const visibleProjects = useMemo(() => {
     if (!isAllProjects || !portfolioProjectFilter) return scopeData.projects;
     return scopeData.projects.filter((project) => project.encodedDir === portfolioProjectFilter);
@@ -1112,7 +1123,7 @@ export const KanbanBoard = memo(function KanbanBoard() {
     >
       {isAllProjects ? (
         <PortfolioFilterBar
-          projects={scopeData.projects}
+          projects={portfolioFilterProjects}
           activeProjectId={portfolioProjectFilter}
           onProjectFilter={handlePortfolioProjectFilter}
           trailingControls={headerControls}

--- a/src/components/board/kanban-column.tsx
+++ b/src/components/board/kanban-column.tsx
@@ -137,11 +137,11 @@ function PortfolioProjectHeader({
 }) {
   return (
     <div
-      className="sticky top-0 z-10 -mx-0.5 flex items-center gap-1.5 bg-(--board-bg) px-1 py-1.5"
+      className="sticky top-0 z-10 -mx-0.5 flex items-center gap-1.5 bg-(--board-bg) px-1 py-0"
       data-testid={`kanban-project-group-${project.encodedDir}`}
     >
       <span
-        className="h-2.5 w-2.5 shrink-0 rounded-full"
+        className={cn('h-2.5 w-2.5 shrink-0 rounded-full', count === 0 && 'invisible')}
         style={{ backgroundColor: getProjectColor(project.displayName) }}
         aria-hidden="true"
       />
@@ -262,11 +262,6 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
         'flex items-center gap-2 mx-1 px-2.5 pt-1 pb-2.5 shrink-0 border-b',
         'border-[color-mix(in_srgb,var(--text-muted)_15%,transparent)]',
       )}>
-        {/* Accent color dot */}
-        <div
-          className="w-2 h-2 rounded-full shrink-0 opacity-60"
-          style={{ background: 'var(--text-muted)' }}
-        />
         {/* Status label */}
         <span className="flex-1 text-[0.75rem] font-bold uppercase tracking-wider truncate text-(--text-muted)">
           {t('task.status.chat')}
@@ -302,7 +297,7 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
         onDragLeave={isEditable ? (e) => onColumnDragLeave('chat', e) : undefined}
         onDrop={isEditable ? (e) => onColumnDrop('chat', e) : undefined}
       >
-        <div className="flex flex-col gap-2.5">
+        <div className="flex flex-col gap-0.5">
           {chatGroups.map((group, groupIndex) => (
             <Fragment key={group.project?.encodedDir ?? `single-${groupIndex}`}>
               {group.project && (
@@ -318,7 +313,7 @@ export const KanbanChatColumn = memo(function KanbanChatColumn({
                   onCloseQuickCreate={onCloseQuickCreate}
                 />
               )}
-              <div className="flex flex-col gap-1.5">
+              <div className="flex flex-col gap-1.5 empty:hidden">
                 {group.chats.map((session) => (
                   <KanbanChatCard
                     key={session.id}
@@ -809,24 +804,6 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
           ? 'border-[color-mix(in_srgb,var(--status-color)_20%,transparent)]'
           : 'border-[color-mix(in_srgb,var(--text-muted)_15%,transparent)]',
       )}>
-        {/* Status dot */}
-        {status === 'todo' ? (
-          <div
-            className="w-2 h-2 rounded-full shrink-0 border-2 box-border"
-            style={{ borderColor: config.color }}
-          />
-        ) : status === 'done' ? (
-          <span className="text-[0.6875rem] text-(--text-muted) opacity-50 shrink-0">&#10003;</span>
-        ) : (
-          <div
-            className="w-2 h-2 rounded-full shrink-0"
-            style={{
-              background: config.color,
-              ...(status === 'in_progress' ? { boxShadow: `0 0 6px color-mix(in srgb, ${config.color} 42%, transparent)` } : {}),
-            }}
-          />
-        )}
-
         {/* Status label */}
         <span
           className={cn(
@@ -874,7 +851,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
         )}
         data-testid="kanban-column-cards"
       >
-        <div className="flex flex-col gap-2.5">
+        <div className="flex flex-col gap-0.5">
           {projectGroups.map((group, groupIndex) => (
             <Fragment key={group.project?.encodedDir ?? `single-${groupIndex}`}>
               {group.project && (
@@ -890,7 +867,7 @@ export const KanbanWorkflowColumn = memo(function KanbanWorkflowColumn({
                   onCloseQuickCreate={onCloseQuickCreate}
                 />
               )}
-              <div className="flex flex-col gap-1.5">
+              <div className="flex flex-col gap-1.5 empty:hidden">
                 {group.tasks.map((task) => (
                   <KanbanTaskCard
                     key={task.id}


### PR DESCRIPTION
Reduce vertical whitespace between Kanban project headers and cards, and hide empty card containers so they do not add extra gaps. Hide project color dots for zero-item groups and remove decorative status icons from column headers.

The portfolio filter now shows projects with board sessions or tasks, retaining the selected project so its filter stays accessible. Empty project rows inside columns and their existing order are preserved.

Validation: targeted ESLint, git diff --check, and all 5 tests in tests/kanban-board-scope.test.ts passed. The user inspected the development UI during iteration; no automated browser QA was performed.
