### PR TITLE
fix(board): use default cursor for project headers

### DIFF
--- a/src/components/board/kanban-column.tsx
+++ b/src/components/board/kanban-column.tsx
@@ -137,7 +137,7 @@ function PortfolioProjectHeader({
 }) {
   return (
     <div
-      className="sticky top-0 z-10 -mx-0.5 flex items-center gap-1.5 bg-(--board-bg) px-1 py-0"
+      className="sticky top-0 z-10 -mx-0.5 flex cursor-default items-center gap-1.5 bg-(--board-bg) px-1 py-0"
       data-testid={`kanban-project-group-${project.encodedDir}`}
     >
       <span


### PR DESCRIPTION
Kanban project headers showed a text-selection cursor when hovering over project names. Apply `cursor-default` to the shared project header so this area shows the standard arrow cursor.

Validation: `git diff --check` passed. ESLint could not run because `eslint-config-next` is missing in this worktree. No browser QA was performed for this CSS-only change.
