### PR TITLE
fix: hide subscription usage for API provider authentication

### DIFF
--- a/src/components/chat/provider-usage-rail.tsx
+++ b/src/components/chat/provider-usage-rail.tsx
@@ -106,7 +106,7 @@ export function ProviderUsageRail() {
     () => [
       buildProviderUsageRailModel('claude-code', claudeSnapshot),
       buildProviderUsageRailModel('codex', codexSnapshot),
-    ],
+    ].filter((model) => model.shortTerm !== null || model.weekly !== null),
     [claudeSnapshot, codexSnapshot],
   );
   const railRef = useRef<HTMLDivElement>(null);
@@ -114,7 +114,7 @@ export function ProviderUsageRail() {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [openProviderId, setOpenProviderId] = useState<string | null>(null);
   const [now, setNow] = useState(Date.now);
-  const isOpen = openProviderId !== null;
+  const isOpen = models.some((model) => model.providerId === openProviderId);
   const close = useCallback(() => setOpenProviderId(null), []);
   const calculatePosition = useCallback((trigger: HTMLElement) => {
     const rect = trigger.getBoundingClientRect();
@@ -151,6 +151,10 @@ export function ProviderUsageRail() {
     updatePosition();
     setOpenProviderId(providerId);
   };
+
+  // Forget an open provider when its quota disappears, including a later switch back.
+  if (openProviderId !== null && !isOpen) setOpenProviderId(null);
+  if (models.length === 0) return null;
 
   return (
     <>

--- a/src/lib/cli/providers/claude-code/adapter.ts
+++ b/src/lib/cli/providers/claude-code/adapter.ts
@@ -46,6 +46,7 @@ import {
 import { getRuntimePlatform } from '@/lib/system/runtime-platform';
 import logger from '@/lib/logger';
 import { getRateLimitData } from '@/lib/rate-limit/fetcher';
+import { hasClaudeSubscription } from '../../subscription-auth';
 import { buildClaudeRateLimitSnapshot } from '@/lib/status-display/rate-limit-snapshots';
 import {
   createClaudeTerminalSessionObserver,
@@ -216,6 +217,11 @@ export class ClaudeCodeAdapter implements CliProvider {
   }
 
   async fetchRateLimits({ environment }: { environment: 'native' | 'wsl' }) {
+    const command = await resolveProviderCliCommand(PROVIDER_ID, DEFAULT_COMMAND, environment);
+    const auth = await execCli(command, ['auth', 'status'], environment, STATUS_CHECK_TIMEOUT_MS);
+    if (hasClaudeSubscription(auth) === false) {
+      return { providerId: PROVIDER_ID, windows: [], updatedAt: new Date().toISOString() };
+    }
     const data = await getRateLimitData({ environment });
     return data ? buildClaudeRateLimitSnapshot(data) : null;
   }

--- a/src/lib/cli/providers/codex/adapter.ts
+++ b/src/lib/cli/providers/codex/adapter.ts
@@ -77,6 +77,8 @@ import logger from '@/lib/logger';
 import { getTesseraDataPath } from '@/lib/tessera-data-dir';
 import { materializeTerminalTranscriptImage } from '@/lib/session/terminal-transcript-image-cache';
 import { fetchCodexRateLimitSnapshot } from './rate-limit-client';
+import { executeCodexAppServerRequest } from './app-server-request-client';
+import type { CodexAccountStatus } from '../../subscription-auth';
 import { codexScreenShowsConversationReset } from '@/lib/terminal/terminal-conversation-reset-screen';
 
 const CLI_TIMEOUT_MS = 120_000;
@@ -419,7 +421,22 @@ export class CodexAdapter implements CliProvider {
     }
 
     const version = parseVersion(versionResult.stdout);
-    const finalStatus = synthesizeRunnableStatus(versionResult, classifyAuthStatus(loginResult));
+    let authStatus = classifyAuthStatus(loginResult);
+    if (authStatus.status === 'needs_login') {
+      try {
+        const account = await executeCodexAppServerRequest<CodexAccountStatus>(
+          { environment: options.environment, userId: options.userId },
+          'account/read',
+          { refreshToken: false },
+        );
+        if (account.requiresOpenaiAuth === false || account.account?.type) {
+          authStatus = { status: 'connected', detectionReason: 'connected' };
+        }
+      } catch {
+        // Older CLIs may not expose account/read. Keep the CLI login verdict.
+      }
+    }
+    const finalStatus = synthesizeRunnableStatus(versionResult, authStatus);
 
     return {
       status: finalStatus.status,

--- a/src/lib/cli/providers/codex/rate-limit-client.ts
+++ b/src/lib/cli/providers/codex/rate-limit-client.ts
@@ -2,6 +2,7 @@ import { buildCodexRateLimitSnapshot } from '@/lib/status-display/rate-limit-sna
 import type { ProviderRateLimitsSnapshot } from '@/lib/status-display/types';
 import type { CliEnvironment } from '@/lib/cli/cli-exec';
 import { executeCodexAppServerRequest } from './app-server-request-client';
+import { hasCodexSubscription, type CodexAccountStatus } from '../../subscription-auth';
 
 type CodexRateLimits = Parameters<typeof buildCodexRateLimitSnapshot>[0];
 
@@ -17,6 +18,12 @@ interface CodexRateLimitReadResult {
 export async function fetchCodexRateLimitSnapshot(
   environment: CliEnvironment,
 ): Promise<ProviderRateLimitsSnapshot | null> {
+  const account = await executeCodexAppServerRequest<CodexAccountStatus>(
+    { environment }, 'account/read', { refreshToken: false },
+  );
+  if (hasCodexSubscription(account) === false) {
+    return { providerId: 'codex', windows: [], updatedAt: new Date().toISOString() };
+  }
   const result = await executeCodexAppServerRequest<CodexRateLimitReadResult>(
     { environment },
     'account/rateLimits/read',

--- a/src/lib/cli/subscription-auth.ts
+++ b/src/lib/cli/subscription-auth.ts
@@ -1,0 +1,26 @@
+import type { ExecResult } from './cli-exec';
+
+/** Unknown/failed probes must not be mistaken for a change of billing mode. */
+export function hasClaudeSubscription(result: ExecResult): boolean | null {
+  if (!result.ok) return null;
+  try {
+    const value = JSON.parse(result.stdout);
+    if (!value || typeof value !== 'object') return null;
+    if (value.apiProvider && value.apiProvider !== 'firstParty') return false;
+    if (value.authMethod === 'claude.ai') return value.subscriptionType !== null;
+    if (['api_key', 'api_key_helper', 'oauth_token', 'third_party'].includes(value.authMethod)) return false;
+  } catch { /* Older CLIs may not return JSON. */ }
+  return null;
+}
+
+export interface CodexAccountStatus {
+  account?: { type?: string } | null;
+  requiresOpenaiAuth?: boolean;
+}
+
+export function hasCodexSubscription(account: CodexAccountStatus): boolean | null {
+  if (account.requiresOpenaiAuth === false) return false;
+  if (account.account?.type === 'chatgpt') return true;
+  if (account.account?.type === 'apiKey' || account.account?.type === 'amazonBedrock') return false;
+  return null;
+}

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -498,8 +498,9 @@ export class WebSocketServer {
 
     // Send cached rate limit data to new connection
     const cachedRateLimit = getCachedRateLimitData();
+    const polledSnapshots = rateLimitPoller.getCachedSnapshots();
     const sentProviders = new Set<string>();
-    if (cachedRateLimit) {
+    if (cachedRateLimit && !polledSnapshots.some((snapshot) => snapshot.providerId === 'claude-code')) {
       this.sendToUser(userId, {
         type: 'rate_limit_update',
         ...buildClaudeRateLimitSnapshot(cachedRateLimit),
@@ -507,7 +508,7 @@ export class WebSocketServer {
       sentProviders.add('claude-code');
     }
 
-    for (const snapshot of rateLimitPoller.getCachedSnapshots()) {
+    for (const snapshot of polledSnapshots) {
       if (sentProviders.has(snapshot.providerId)) continue;
       this.sendToUser(userId, {
         type: 'rate_limit_update',

--- a/tests/codex-global-rate-limit-client.test.ts
+++ b/tests/codex-global-rate-limit-client.test.ts
@@ -12,6 +12,7 @@ test('reads Codex limits through an isolated app-server request without a sessio
   let observedMethod = '';
   let observedParams: Record<string, unknown> | null = null;
   setCodexAppServerRequestExecutorForTests(async (context, method, params) => {
+    if (method === 'account/read') return { account: { type: 'chatgpt' }, requiresOpenaiAuth: true };
     observedEnvironment = context.environment ?? '';
     observedMethod = method;
     observedParams = params;
@@ -40,3 +41,21 @@ test('reads Codex limits through an isolated app-server request without a sessio
   assert.equal(snapshot?.windows[0]?.usedPercent, 48);
   assert.equal(snapshot?.windows[0]?.windowDurationMins, 10080);
 });
+
+for (const account of [
+  { account: { type: 'apiKey' }, requiresOpenaiAuth: true },
+  { account: null, requiresOpenaiAuth: false },
+  { account: { type: 'chatgpt' }, requiresOpenaiAuth: false },
+]) {
+  test(`clears subscription windows without fetching quotas: ${JSON.stringify(account)}`, async () => {
+    const methods: string[] = [];
+    setCodexAppServerRequestExecutorForTests(async (context, method) => {
+      assert.equal(context.environment, 'wsl');
+      methods.push(method);
+      return account;
+    });
+    const snapshot = await fetchCodexRateLimitSnapshot('wsl');
+    assert.deepEqual(snapshot?.windows, []);
+    assert.deepEqual(methods, ['account/read']);
+  });
+}

--- a/tests/provider-usage-rail-contract.test.mjs
+++ b/tests/provider-usage-rail-contract.test.mjs
@@ -15,8 +15,10 @@ const chatLayoutSource = fs.readFileSync(
   'utf8',
 );
 
-test('the project strip always renders Claude and Codex usage summaries', () => {
+test('the project strip mounts usage summaries and hides providers without windows', () => {
   assert.match(projectStripSource, /<ProviderUsageRail\s*\/>/);
+  assert.match(railSource, /filter\(\(model\) => model.shortTerm !== null \|\| model.weekly !== null\)/);
+  assert.match(railSource, /if \(models.length === 0\) return null/);
   assert.match(railSource, /limitsByProvider\['claude-code'\]/);
   assert.match(railSource, /limitsByProvider\.codex/);
   assert.match(railSource, /data-testid=\{`provider-usage-\$\{model\.providerId\}`\}/);

--- a/tests/subscription-auth.test.ts
+++ b/tests/subscription-auth.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { hasClaudeSubscription, hasCodexSubscription } from '../src/lib/cli/subscription-auth';
+import type { ExecResult } from '../src/lib/cli/cli-exec';
+
+function probe(value: unknown, ok = true): ExecResult {
+  return { ok, stdout: JSON.stringify(value), stderr: '', exitCode: ok ? 0 : 1, timedOut: false, durationMs: 1 };
+}
+
+test('Claude subscription is distinct from API, helper, bearer token and cloud provider authentication', () => {
+  assert.equal(hasClaudeSubscription(probe({ authMethod: 'claude.ai', subscriptionType: 'max' })), true);
+  assert.equal(hasClaudeSubscription(probe({ authMethod: 'claude.ai', subscriptionType: null })), false);
+  for (const authMethod of ['api_key', 'api_key_helper', 'oauth_token', 'third_party']) {
+    assert.equal(hasClaudeSubscription(probe({ loggedIn: true, authMethod, apiProvider: 'firstParty' })), false);
+  }
+  assert.equal(hasClaudeSubscription(probe({ authMethod: 'claude.ai', apiProvider: 'bedrock' })), false);
+});
+
+test('inconclusive auth probes do not declare an API billing switch', () => {
+  assert.equal(hasClaudeSubscription(probe({ authMethod: 'none' }, false)), null);
+  assert.equal(hasClaudeSubscription(probe({ authMethod: 'future-mode' })), null);
+  assert.equal(hasCodexSubscription({}), null);
+  assert.equal(hasCodexSubscription({ account: null, requiresOpenaiAuth: true }), null);
+});
+
+test('the active Codex provider takes precedence over a retained ChatGPT login', () => {
+  assert.equal(hasCodexSubscription({ account: { type: 'chatgpt' }, requiresOpenaiAuth: false }), false);
+  assert.equal(hasCodexSubscription({ account: { type: 'chatgpt' }, requiresOpenaiAuth: true }), true);
+  assert.equal(hasCodexSubscription({ account: { type: 'apiKey' }, requiresOpenaiAuth: true }), false);
+});


### PR DESCRIPTION
## Summary

- Hide Claude Code and Codex usage rail entries and details when no subscription quota windows are available. API-key and external-provider authentication now clears previous subscription windows and skips subscription quota requests.
- When Codex reports `Not logged in`, consult `account/read` before displaying a login requirement: an external provider with `requiresOpenaiAuth: false` remains connected.
- Prefer the latest polled Claude snapshot on reconnect so cached subscription usage does not reappear after switching to API authentication. Close a removed provider's popover and keep it closed when subscription usage returns.

## Testing

- 22 focused regression tests passed, covering authentication classification, Codex quota requests, rail models/contracts, and polling.
- [x] `npm run lint` — no errors; four existing warnings. Changed-file ESLint also passed.
- [x] `npx tsc --noEmit`
- [x] Production build and Windows Electron packaging via the isolated Electron test workflow.
- [x] Windows Node executing Tessera backend code against real WSL CLIs with isolated configurations: Claude external-token authentication succeeded; Codex reproduced login exit code 1 while `account/read` returned `requiresOpenaiAuth: false`, and the adapter returned `connected`.
- [x] Packaged Windows Electron with its own Windows backend: both usage entries, details, one/both entries hidden, popup closure, and subscription restoration passed.
- Not tested: live external-provider inference or billing. Renderer quota transitions used synthetic WebSocket snapshots, not live subscription usage responses.

## Screenshots or Recordings

Eight ordered screenshots and a QA report are saved locally in Windows Downloads under `Tessera-subscription-qa-0907`. Screenshots include copied workspace content and are not uploaded to this public PR.

## Notes

Test instances and copied builds were removed through their ownership manifests. The original application remained running and the source database hash was unchanged.
