### PR TITLE
fix: exclude generated environments from workspace watchers

### DIFF
--- a/src/lib/workspace-files/workspace-file-scan.ts
+++ b/src/lib/workspace-files/workspace-file-scan.ts
@@ -18,6 +18,9 @@ export const IGNORED_WORKSPACE_DIR_NAMES = new Set([
   ".idea",
   ".vscode",
   "out",
+  "target",
+  ".venv",
+  "__pycache__",
 ]);
 
 export type WorkspaceFileWalkResult = {

--- a/tests/workspace-file-exclusions.test.ts
+++ b/tests/workspace-file-exclusions.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  isIgnoredWorkspacePath,
+  walkWorkspaceFiles,
+} from "../src/lib/workspace-files/workspace-file-scan";
+
+test("workspace scans and watch filters prune nested environments, Python caches, and Rust output", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "tessera-workspace-exclusions-"));
+  try {
+    for (const directory of [".venv", "__pycache__", "target"]) {
+      const relativePath = `tools/seed-vc/${directory}`;
+      const output = path.join(root, relativePath, "nested");
+      await mkdir(output, { recursive: true });
+      await writeFile(path.join(output, "artifact"), "");
+
+      for (const candidate of [relativePath, relativePath.replaceAll("/", "\\")]) {
+        assert.equal(isIgnoredWorkspacePath(candidate, { isDirectory: () => true }, { includeHidden: true }), true);
+        assert.equal(isIgnoredWorkspacePath(`${candidate}/nested/artifact`, undefined, { includeHidden: true }), true);
+      }
+    }
+    await writeFile(path.join(root, "tools/seed-vc/app.py"), "");
+
+    const result = await walkWorkspaceFiles(root);
+
+    assert.equal(result.truncated, false);
+    assert.deepEqual(result.directories, ["tools", "tools/seed-vc"]);
+    assert.deepEqual(result.files, ["tools/seed-vc/app.py"]);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});

--- a/tests/wsl-inotify-bridge.test.ts
+++ b/tests/wsl-inotify-bridge.test.ts
@@ -158,6 +158,9 @@ test('buildInotifyExcludeRegex skips high-churn descendants without excluding a 
   assert.ok(regex.test('/home/work/proj/.git/HEAD'));
   assert.ok(regex.test('/home/work/proj/.next/'));
   assert.ok(regex.test('/home/work/proj/dist'));
+  assert.ok(regex.test('/home/work/proj/tools/seed-vc/.venv/lib/pkg/index.py'));
+  assert.ok(regex.test('/home/work/proj/tools/seed-vc/__pycache__/app.pyc'));
+  assert.ok(regex.test('/home/work/proj/crates/worker/target/debug/worker'));
   assert.equal(regex.test('/home/work/proj/src/.hidden/file.ts'), false);
   assert.equal(regex.test('/home/work/proj/.env.example'), false);
   assert.equal(regex.test('/home/work/proj/src/app/route.ts'), false);


### PR DESCRIPTION
## Summary

- Add `.venv`, `__pycache__`, and `target` to the shared workspace directory exclusions, covering all exclusions currently used by Orca while preserving existing Tessera entries.
- Apply the same exclusions to recursive scans, file listings, Chokidar watchers, and WSL inotify filtering through the existing shared list.
- Add regression coverage for nested generated directories, Windows path separators, hidden-file inclusion, and WSL exclusions.

Large generated environments were still being recursively watched even when Git ignored them. On the affected macOS installation, tens of thousands of watched files caused app-wide stalls and process-spawn failures. The user confirmed normal operation after installing this build.

## Testing

- [x] Targeted ESLint on all three changed files.
- [x] `npx tsc --noEmit` (after moving stale, untracked Next.js development route types out of the checkout).
- [x] 30 workspace scan, watcher, exclusion, and WSL bridge tests.
- [x] Production Next.js build and Electron TypeScript compilation.
- [x] macOS arm64 app and DMG packaging, signature/checksum verification, and confirmation that the exclusion fix is present in the packaged app.
- [x] Packaged native SQLite and piped process-spawn probes.
- [x] Manual test: user confirmed the updated macOS desktop app is operating normally.
- [ ] Full-repository lint and full test suite were not run.
- [ ] Native Windows, WSL, and Linux desktop smoke tests were not run; their shared exclusion logic is covered by automated tests.

## Notes

This is a minimal exclusion-list fix. It does not change watcher lifetime, recursive-watch architecture, session restoration, or provider-specific code.