### PR TITLE
fix(chat): prevent image dismissal from reopening mobile keyboard

### DIFF
--- a/src/components/chat/image-lightbox.tsx
+++ b/src/components/chat/image-lightbox.tsx
@@ -32,9 +32,8 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
   const avoidsWindowControls = electronPlatform === 'win32';
   const resolvedAlt = alt || t('chat.imageOriginalView');
 
-  // The opener is a button, so it remains focused behind this portal. Android
-  // Chrome can restore that focus when the portal is removed, which summons the
-  // software keyboard even though the user only dismissed an image.
+  // Clear any focus left behind the portal when dismissing the image. The click
+  // boundary below must also prevent the message list from focusing it again.
   const closeLightbox = useCallback(() => {
     if (document.activeElement instanceof HTMLElement) {
       document.activeElement.blur();
@@ -55,7 +54,11 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
     };
   }, []);
 
-  const handleOverlayClick = useCallback(() => {
+  const handleOverlayClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    // Portals still bubble through the React tree. The message list treats an
+    // image/backdrop click as a blank-area click and focuses the composer after
+    // closeLightbox has blurred it, reopening the mobile keyboard.
+    event.stopPropagation();
     if (suppressClickRef.current) {
       suppressClickRef.current = false;
       return;
@@ -124,7 +127,10 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
       <button
         {...telemetryClickAttributes('message.image.close', 'message')}
         type="button"
-        onClick={closeLightbox}
+        onClick={(event) => {
+          event.stopPropagation();
+          closeLightbox();
+        }}
         className={cn(
           'absolute z-10 right-4 w-10 h-10 flex items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors text-xl',
           avoidsWindowControls ? 'top-12' : 'top-4',

--- a/tests/image-lightbox-focus.test.mjs
+++ b/tests/image-lightbox-focus.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import ts from 'typescript';
+import { build } from 'esbuild';
+import { launchPhoneBrowser } from './helpers/phone-browser.mjs';
+import { createPhoneContext } from './helpers/phone-viewport.mjs';
+
+// Keep the real message-list focus handler and React portal propagation in the
+// same browser. A lightbox-only test misses the focus that happens after blur().
+const root = path.resolve(import.meta.dirname, '..');
+const source = ts.createSourceFile('message-list.tsx', fs.readFileSync(
+  path.join(root, 'src/components/chat/message-list.tsx'), 'utf8'),
+  ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+let clickHandler;
+function visit(node) {
+  if (ts.isVariableDeclaration(node) && node.name.getText(source) === 'handleContentAreaClick') {
+    clickHandler = node.initializer.arguments[0].getText(source);
+  }
+  ts.forEachChild(node, visit);
+}
+visit(source);
+assert.ok(clickHandler, 'must use the shipped message-list click handler');
+const bundle = await build({
+  stdin: { resolveDir: root, loader: 'tsx', contents: `
+    import React, { useState } from 'react';
+    import { createRoot } from 'react-dom/client';
+    import { ImageLightbox } from './src/components/chat/image-lightbox';
+    function Probe() {
+      const [open, setOpen] = useState(false);
+      const sessionId = 'focus-probe';
+      const selectedToolCallId = null;
+      const setSelectedToolCallId = () => {};
+      const handleClick = ${clickHandler};
+      return <div data-panel-wrapper={location.hash === '#peek' ? undefined : ''}>
+        <div data-testid="messages" onClick={handleClick}>
+          <button onClick={() => setOpen(true)}>Open image</button>
+          <div data-testid="blank">Message blank area</div>
+          {open && <ImageLightbox src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Crect width='100' height='100' fill='teal'/%3E%3C/svg%3E" onClose={() => { window.closes++; setOpen(false); }} />}
+        </div>
+        <textarea data-session-input={sessionId} onFocus={() => window.inputFocuses++} />
+      </div>;
+    }
+    window.closes = 0;
+    window.inputFocuses = 0;
+    createRoot(document.getElementById('root')).render(<Probe />);
+  ` },
+  bundle: true, write: false, jsx: 'automatic',
+  plugins: [{ name: 'presentation-stubs', setup(builder) {
+    builder.onResolve({ filter: /^@\/lib\/(i18n|utils|telemetry\/ui-click)$/ }, args => ({ path: args.path, namespace: 'stub' }));
+    builder.onLoad({ filter: /.*/, namespace: 'stub' }, () => ({ contents: `
+      export const useI18n = () => ({ t: key => key });
+      export const cn = (...args) => args.filter(Boolean).join(' ');
+      export const telemetryClickAttributes = () => ({});
+      export const telemetryIgnoreAttributes = () => ({});
+    ` }));
+  } }],
+});
+
+for (const surface of ['panel', 'peek']) {
+  test(`${surface}: closing a portaled image must not refocus the composer`, async () => {
+    const browser = await launchPhoneBrowser();
+    try {
+      const context = await createPhoneContext(browser);
+      const page = await context.newPage();
+      await page.setContent(`<div id="root"></div><style>
+        [role=dialog] { position:fixed; inset:0; background:#ddd; display:flex; align-items:center; justify-content:center }
+        [role=dialog]>button { position:absolute; top:10px; right:10px }
+        [role=dialog]>div { position:absolute; bottom:20px }
+      </style>`);
+      await page.evaluate(value => { location.hash = value; }, surface);
+      await page.addScriptTag({ content: bundle.outputFiles[0].text });
+      // Positive control: the real parent's blank-area click focuses the input.
+      await page.getByTestId('blank').tap();
+      assert.equal(await page.evaluate(() => window.inputFocuses), 1);
+      for (const close of ['backdrop', 'image', 'button', 'escape']) {
+        await page.getByRole('button', { name: 'Open image', exact: true }).tap();
+        await page.evaluate(() => { window.inputFocuses = 0; window.closes = 0; });
+        const dialog = page.getByRole('dialog');
+        await dialog.waitFor();
+        if (close === 'backdrop') await dialog.tap({ position: { x: 10, y: 150 } });
+        if (close === 'image') await dialog.locator('img').tap();
+        if (close === 'button') await page.getByRole('button', { name: 'common.close', exact: true }).tap();
+        if (close === 'escape') await page.keyboard.press('Escape');
+        await dialog.waitFor({ state: 'detached' });
+        assert.equal(await page.evaluate(() => window.inputFocuses), 0, `${close} must not focus the input after closing`);
+        assert.equal(await page.evaluate(() => window.closes), 1, `${close} closes exactly once`);
+      }
+    } finally { await browser.close(); }
+  });
+}

--- a/tests/image-lightbox-pan.test.mjs
+++ b/tests/image-lightbox-pan.test.mjs
@@ -59,12 +59,12 @@ test('zoomed image moves with left drag, stays open on release, and reset recent
   tree = app.render();
   img = descendants(tree).find(node => node.type === 'img');
   assert.match(img.props.style.transform, /translate\(80px, 40px\)/);
-  tree.props.onClick();
+  tree.props.onClick({ stopPropagation() {} });
   assert.equal(app.closes, 0);
   button(tree, 'chat.imageZoomReset').props.onClick();
   img = descendants(app.render()).find(node => node.type === 'img');
   assert.match(img.props.style.transform, /translate\(0px, 0px\) scale\(1\)/);
-  app.render().props.onClick();
+  app.render().props.onClick({ stopPropagation() {} });
   assert.equal(app.closes, 1);
 });
 
@@ -82,6 +82,6 @@ test('right button does not pan and cancelled drags stop tracking', () => {
   assert.match(img.props.style.transform, /translate\(80px, 40px\)/);
   const tree = app.render();
   tree.props.onPointerDownCapture();
-  tree.props.onClick();
+  tree.props.onClick({ stopPropagation() {} });
   assert.equal(app.closes, 1);
 });


### PR DESCRIPTION
Closing an image in PTY chat could reopen the mobile keyboard: React portal clicks bubbled to the message list, which focused the composer after the lightbox had blurred it. Stop dismissal clicks at the lightbox boundary, including the close button, so dismissal cannot refocus the composer or call close twice.

Validation: all 6 focused tests pass, including a browser regression using the actual message-list click handler and shared lightbox with and without a panel wrapper (Peek boundary). The regression failed before the fix. Covers backdrop, image, close button and Escape dismissal, plus existing zoom/pan behavior. Targeted ESLint and git diff checks pass.

This is browser component coverage, not full panel/Peek E2E or verification of the software keyboard on a physical phone.
