### PR TITLE
Fix mobile session headers, menu dismissal, and keyboard focus

### DIFF
--- a/src/components/board/session-peek.tsx
+++ b/src/components/board/session-peek.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { isPhoneViewport } from '@/lib/viewport/phone-viewport';
+
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { MessageSquare, SquareTerminal, Terminal, X } from 'lucide-react';
 import { PeekContextMenu } from './peek-context-menu';
@@ -152,7 +154,7 @@ export function SessionPeek({
 
   useEffect(function focusPeekInputWhenReady() {
     const content = sessionContentRef.current;
-    if (!showSessionContent || !content) return;
+    if (!showSessionContent || !content || isPhoneViewport()) return;
     const selector = isTerminalChatView
       ? '[data-testid="terminal-chat-composer-input"]:not([disabled])'
       : isTerminal

--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { isPhoneViewport } from '@/lib/viewport/phone-viewport';
+
 import { memo, useCallback, useContext, useEffect, useMemo, useRef, useState, type DragEvent } from "react";
 import { selectIsTurnInFlight, useChatStore } from "@/stores/chat-store";
 import { useSessionStore } from "@/stores/session-store";
@@ -188,6 +190,7 @@ export const ChatArea = memo(function ChatArea({
       return;
     }
     requestAnimationFrame(() => {
+      if (isPhoneViewport()) return;
       terminalChatOverlayRef.current
         ?.querySelector<HTMLTextAreaElement>('[data-testid="terminal-chat-composer-input"]')
         ?.focus();

--- a/src/components/chat/header.tsx
+++ b/src/components/chat/header.tsx
@@ -11,6 +11,8 @@ import {
   MoreHorizontal,
   GitBranch,
   Search,
+  Terminal,
+  MessageSquare,
 } from 'lucide-react';
 import { getTitleGeneratingStyle } from '@/lib/title-generating-style';
 import { useSessionStore } from '@/stores/session-store';
@@ -345,7 +347,12 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
                 fullLabel={!session.provider || session.provider === 'claude-code'}
               />
 
-              <span className="flex min-w-0 shrink items-center gap-1 max-sm:flex-1">
+              {/* The mobile workspace tab already names this PTY session.
+                  Peek has no tab, so it retains its only visible title. */}
+              <span className={cn(
+                'flex min-w-0 shrink items-center gap-1 max-sm:flex-1',
+                isCompact && !peek && 'max-sm:hidden',
+              )}>
                 <h2
                   ref={titleRef}
                   className={cn(
@@ -447,6 +454,7 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
                           'chat_header',
                         )}
                         title={mode === 'terminal' ? t('chat.viewAsTerminal') : t('chat.viewAsChat')}
+                        aria-label={mode === 'terminal' ? t('chat.viewAsTerminal') : t('chat.viewAsChat')}
                         aria-pressed={selected}
                         className={cn(
                           'flex h-[18px] items-center justify-center rounded-sm px-1.5 text-[10px] font-medium leading-none whitespace-nowrap',
@@ -457,7 +465,12 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
                             : 'text-(--text-muted) hover:bg-(--chat-header-bg) hover:text-(--text-secondary)',
                         )}
                       >
-                        {mode === 'terminal' ? t('chat.terminalMode') : t('chat.chatMode')}
+                        {mode === 'terminal'
+                          ? <Terminal className="h-3.5 w-3.5 sm:hidden" aria-hidden="true" />
+                          : <MessageSquare className="h-3.5 w-3.5 sm:hidden" aria-hidden="true" />}
+                        <span className="hidden sm:inline">
+                          {mode === 'terminal' ? t('chat.terminalMode') : t('chat.chatMode')}
+                        </span>
                       </button>
                       </ShortcutTooltip>
                     );
@@ -487,6 +500,7 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
             )}
 
             {runtimePresentation.canStop && (
+              <div className="hidden sm:contents">
               <ShortcutTooltip id="stop-session" label={t('status.stopProcess')}>
               <button
                 type="button"
@@ -503,9 +517,11 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
                 <CircleStop className="h-3.5 w-3.5" />
               </button>
               </ShortcutTooltip>
+              </div>
             )}
 
             {(!session.archived || !session.taskId) && (
+              <div className="hidden sm:contents">
               <ShortcutTooltip id="archive-session" label={t(session.archived ? 'task.contextMenu.unarchive' : 'task.contextMenu.archive')}>
               <button
                 type="button"
@@ -527,6 +543,7 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
                   : <Archive className="h-3.5 w-3.5" />}
               </button>
               </ShortcutTooltip>
+              </div>
             )}
 
             {/* More actions button */}
@@ -585,10 +602,14 @@ export function Header({ sessionId, panelId, projectViewDir, isSinglePanel = fal
       {menuAnchorRect && (
         <TaskContextMenu
           anchorRect={menuAnchorRect}
+          triggerRef={moreButtonRef}
           currentStatus={isSingleSessionTask ? currentTaskStatus : undefined}
           isArchived={session.archived ?? false}
           isRunning={runtimePresentation.showRunning}
           onStatusChange={isSingleSessionTask ? handleStatusChange : undefined}
+          onStopProcess={runtimePresentation.canStop ? handleStopProcess : undefined}
+          onArchive={!session.archived ? handleArchive : undefined}
+          onUnarchive={session.archived && !session.taskId ? handleUnarchive : undefined}
           onRename={handleRenameFromMenu}
           onDelete={handleDelete}
           onGenerateTitle={() => generateTitle(sessionId)}

--- a/src/components/chat/task-context-menu.tsx
+++ b/src/components/chat/task-context-menu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback, useMemo } from 'react';
-import type { KeyboardEvent as ReactKeyboardEvent, SyntheticEvent } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, SyntheticEvent, RefObject } from 'react';
 import { createPortal } from 'react-dom';
 import { Archive, ArchiveRestore, CircleStop, Pencil, RefreshCw, RotateCcw, Trash2, ExternalLink, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -15,6 +15,7 @@ import { telemetryClickAttributes } from '@/lib/telemetry/ui-click';
 
 export interface TaskContextMenuProps {
   anchorRect: DOMRect;
+  triggerRef?: RefObject<HTMLElement | null>;
   currentStatus?: string;
   allowChatStatus?: boolean;
   isArchived: boolean;
@@ -42,6 +43,7 @@ const PADDING = 6;
 
 export function TaskContextMenu({
   anchorRect,
+  triggerRef,
   currentStatus,
   allowChatStatus = false,
   isArchived,
@@ -121,15 +123,16 @@ export function TaskContextMenu({
   ]);
 
   useEffect(function handleOutsideClick() {
-    function onMouseDown(e: MouseEvent) {
+    function onPointerDown(e: PointerEvent) {
       const target = e.target as Node;
-      if (!menuRef.current?.contains(target)) {
+      if (!menuRef.current?.contains(target) && !triggerRef?.current?.contains(target)) {
         onClose();
       }
     }
-    document.addEventListener('mousedown', onMouseDown, true);
-    return () => document.removeEventListener('mousedown', onMouseDown, true);
-  }, [onClose]);
+    // Terminal touch handlers can suppress compatibility mouse events.
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [onClose, triggerRef]);
 
   useEffect(function focusFirstItem() {
     const firstItem = menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]');

--- a/src/components/chat/terminal-chat-composer.tsx
+++ b/src/components/chat/terminal-chat-composer.tsx
@@ -14,6 +14,7 @@ import {
 import { ArrowUp, ImagePlus, Loader2, Lock, Square, SquareTerminal } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 import { cn } from '@/lib/utils';
+import { isPhoneViewport } from '@/lib/viewport/phone-viewport';
 import { PHONE_TOUCH_TARGET } from '@/lib/ui/touch-target';
 import { useI18n } from '@/lib/i18n';
 import { toast } from '@/stores/notification-store';
@@ -152,7 +153,7 @@ export const TerminalChatComposer = memo(forwardRef<TerminalChatComposerHandle, 
     requestAnimationFrame(() => {
       const input = textareaRef.current;
       input?.setSelectionRange(edit.nextCursorPos, edit.nextCursorPos);
-      input?.focus();
+      if (!isPhoneViewport()) input?.focus();
     });
   }, []);
 
@@ -212,7 +213,9 @@ export const TerminalChatComposer = memo(forwardRef<TerminalChatComposerHandle, 
       toast.error(t('chat.terminalInputBar.imageAttachFailed'));
     } finally {
       setPendingImageUploads((count) => Math.max(0, count - imageFiles.length));
-      requestAnimationFrame(() => textareaRef.current?.focus());
+      requestAnimationFrame(() => {
+        if (!isPhoneViewport()) textareaRef.current?.focus();
+      });
     }
   }, [insertPaths, t]);
 
@@ -241,6 +244,8 @@ export const TerminalChatComposer = memo(forwardRef<TerminalChatComposerHandle, 
     const text = value;
     if (!text.trim() || isBlocked || isUploadingImage || submittingRef.current) return;
 
+    // Dismiss the mobile keyboard in the user gesture, before awaiting delivery.
+    if (isPhoneViewport()) textareaRef.current?.blur();
     submittingRef.current = true;
     setIsSubmitting(true);
     try {
@@ -269,7 +274,9 @@ export const TerminalChatComposer = memo(forwardRef<TerminalChatComposerHandle, 
     } finally {
       submittingRef.current = false;
       setIsSubmitting(false);
-      requestAnimationFrame(() => textareaRef.current?.focus());
+      requestAnimationFrame(() => {
+        if (!isPhoneViewport()) textareaRef.current?.focus();
+      });
     }
   }, [isBlocked, isUploadingImage, sessionId, t, value]);
 

--- a/src/components/keyboard/shortcut-tooltip.tsx
+++ b/src/components/keyboard/shortcut-tooltip.tsx
@@ -2,6 +2,7 @@
 
 import { ReactElement, cloneElement, useState, useId, type MouseEvent, type FocusEvent } from 'react';
 import { createPortal } from 'react-dom';
+import { useTooltipsEnabled } from '@/hooks/use-tooltips-enabled';
 import { useEffectiveShortcut } from '@/hooks/use-effective-shortcut';
 import { formatShortcut, detectPlatform, type Platform } from '@/lib/keyboard/format';
 import { isBrowserConflict } from '@/lib/keyboard/conflicts';
@@ -28,6 +29,7 @@ export function ShortcutTooltip({
   children,
 }: ShortcutTooltipProps) {
   const { t } = useI18n();
+  const tooltipsEnabled = useTooltipsEnabled();
   const electronPlatform = useElectronPlatform();
   const isWebMode = !electronPlatform;
   const key = useEffectiveShortcut(id);
@@ -48,6 +50,7 @@ export function ShortcutTooltip({
     : '';
 
   type ChildProps = {
+    onClick?: (e: MouseEvent<HTMLElement>) => void;
     onMouseEnter?: (e: MouseEvent<HTMLElement>) => void;
     onMouseLeave?: (e: MouseEvent<HTMLElement>) => void;
     onFocus?: (e: FocusEvent<HTMLElement>) => void;
@@ -67,19 +70,29 @@ export function ShortcutTooltip({
     // stops the browser from walking up to a parent's title.
     title: '',
     'aria-keyshortcuts': [key, secondaryId ? secondaryKey : null].filter(Boolean).join(' ') || undefined,
-    'aria-describedby': open ? tooltipId : undefined,
+    'aria-describedby': tooltipsEnabled && open ? tooltipId : undefined,
     onMouseEnter: (e: MouseEvent<HTMLElement>) => {
-      positionFromTrigger(e.currentTarget);
-      setOpen(true);
+      if (tooltipsEnabled) {
+        positionFromTrigger(e.currentTarget);
+        setOpen(true);
+      }
       childProps.onMouseEnter?.(e);
     },
     onMouseLeave: (e: MouseEvent<HTMLElement>) => {
       setOpen(false);
       childProps.onMouseLeave?.(e);
     },
+    onClick: (e: MouseEvent<HTMLElement>) => {
+      setOpen(false);
+      childProps.onClick?.(e);
+    },
     onFocus: (e: FocusEvent<HTMLElement>) => {
-      positionFromTrigger(e.currentTarget);
-      setOpen(true);
+      // Touch/click focus can persist after activation; only keyboard focus
+      // should open a tooltip without hover.
+      if (tooltipsEnabled && e.currentTarget.matches(':focus-visible')) {
+        positionFromTrigger(e.currentTarget);
+        setOpen(true);
+      }
       childProps.onFocus?.(e);
     },
     onBlur: (e: FocusEvent<HTMLElement>) => {
@@ -88,7 +101,7 @@ export function ShortcutTooltip({
     },
   } as Record<string, unknown>);
 
-  const tooltipNode = open && position ? (
+  const tooltipNode = tooltipsEnabled && open && position ? (
     <div
       id={tooltipId}
       role="tooltip"

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '@/lib/utils';
+import { useTooltipsEnabled } from '@/hooks/use-tooltips-enabled';
 
 interface TooltipProps {
   content: ReactNode;
@@ -23,6 +24,7 @@ export function Tooltip({
   side = 'bottom',
   sideOffset = 16,
 }: TooltipProps) {
+  const tooltipsEnabled = useTooltipsEnabled();
   const [isVisible, setIsVisible] = useState(false);
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -34,13 +36,7 @@ export function Tooltip({
   }, []);
 
   const handleMouseEnter = useCallback(function showTooltip(e: React.MouseEvent) {
-    // A touchscreen has no way to hover away, so the tooltip that a tap
-    // synthesises never receives its own mouseleave and sticks on the page.
-    // `hover: none` covers phones and stylus-only tablets without touching
-    // desktops, where the reveal is still driven by a real pointer.
-    if (typeof window !== 'undefined' && window.matchMedia('(hover: none)').matches) {
-      return;
-    }
+    if (!tooltipsEnabled) return;
     mousePos.current = { x: e.clientX, y: e.clientY };
     const nextPosition = () => ({
       top: side === 'top'
@@ -58,7 +54,7 @@ export function Tooltip({
       setPosition(nextPosition());
       setIsVisible(true);
     }
-  }, [delay, side, sideOffset]);
+  }, [delay, side, sideOffset, tooltipsEnabled]);
 
   const handleMouseLeave = useCallback(function hideTooltip() {
     if (timeoutRef.current) {
@@ -86,8 +82,9 @@ export function Tooltip({
       onMouseLeave={handleMouseLeave}
     >
       {children}
-      {isVisible && position && createPortal(
+      {tooltipsEnabled && isVisible && position && createPortal(
         <div
+          role="tooltip"
           className={cn(
             'fixed z-[9999] max-w-sm rounded-md bg-(--tooltip-bg) px-3 py-1.5 text-xs text-white shadow-lg pointer-events-none break-words',
             className

--- a/src/hooks/use-tooltips-enabled.ts
+++ b/src/hooks/use-tooltips-enabled.ts
@@ -1,0 +1,9 @@
+'use client';
+
+import { useMediaQuery } from '@/hooks/use-media-query';
+import { PHONE_VIEWPORT_MEDIA_QUERY } from '@/lib/viewport/phone-viewport';
+
+/** Tooltips are desktop hints; phones and touch-only devices do not show them. */
+export function useTooltipsEnabled(): boolean {
+  return !useMediaQuery(`${PHONE_VIEWPORT_MEDIA_QUERY}, (hover: none)`);
+}

--- a/tests/mobile-task-menu-dismissal.playwright.js
+++ b/tests/mobile-task-menu-dismissal.playwright.js
@@ -1,0 +1,23 @@
+// Run with playwright-cli -s=<persistent-mobile-session> run-code --filename=tests/mobile-task-menu-dismissal.playwright.js
+// Precondition: an open PTY session in a touch-enabled browser, either a panel or Kanban Peek.
+async page => {
+  const menu = page.getByRole('menu', { name: 'Task options' });
+  const peek = page.getByTestId('kanban-session-peek');
+  const surface = await peek.isVisible() ? peek : page.getByRole('tabpanel');
+  const more = surface.getByTestId('header-more-button');
+  if (await menu.count()) await page.keyboard.press('Escape');
+  const terminalButton = surface.getByTestId('terminal-view-toggle').getByRole('button').first();
+  if (await terminalButton.getAttribute('aria-pressed') !== 'true') await terminalButton.tap();
+
+  await more.tap();
+  if (!await menu.count()) throw new Error('Menu did not open');
+  // Tap to the left of the right-aligned menu, on the real touch-handling PTY.
+  await surface.locator('.xterm-screen').tap({ position: { x: 10, y: 150 } });
+  if (await menu.count()) throw new Error('PTY tap did not dismiss the menu');
+
+  await more.tap();
+  if (!await menu.count()) throw new Error('Menu did not reopen');
+  await more.tap();
+  if (await menu.count()) throw new Error('More-button retap did not dismiss the menu');
+  return 'PASS: PTY outside tap and trigger retap dismiss the menu';
+}

--- a/tests/mobile-terminal-chat-send-focus.playwright.js
+++ b/tests/mobile-terminal-chat-send-focus.playwright.js
@@ -1,0 +1,23 @@
+// Run via playwright-cli -s=<persistent-mobile-session> run-code --filename=<this file>.
+// Requires a disposable, ready PTY chat session in a touch-enabled mobile context.
+async page => {
+  const input = page.getByTestId('terminal-chat-composer-input');
+  await input.tap();
+  await input.fill('UI focus check: reply OK only. Do not use tools or modify files.');
+  await page.getByTestId('terminal-chat-composer-send').tap();
+  await page.waitForFunction(() => {
+    const input = document.querySelector('[data-testid="terminal-chat-composer-input"]');
+    return input && !input.disabled;
+  });
+  await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+  if (await input.evaluate(el => document.activeElement === el)) {
+    throw new Error('Mobile composer regained focus after sending');
+  }
+  if (await input.inputValue()) throw new Error('Send was not accepted; draft remains');
+  await input.tap();
+  if (!await input.evaluate(el => document.activeElement === el)) {
+    throw new Error('Explicit tap must still focus the composer');
+  }
+  await input.blur();
+  return 'PASS: send dismisses focus; explicit tap can restore it';
+}

--- a/tests/shortcut-tooltip-interaction.test.mjs
+++ b/tests/shortcut-tooltip-interaction.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import test from 'node:test';
+import ts from 'typescript';
+
+function harness(tooltipsEnabled = true) {
+  let states = [], cursor = 0;
+  const jsx = (type, props) => ({ type, props });
+  const modules = {
+    react: {
+      useState(initial) { const i = cursor++; if (!(i in states)) states[i] = initial; return [states[i], value => { states[i] = value; }]; },
+      useId: () => 'tooltip',
+      cloneElement: (child, props) => ({ ...child, props: { ...child.props, ...props } }),
+    },
+    'react/jsx-runtime': { jsx, jsxs: jsx, Fragment: 'fragment' },
+    'react-dom': { createPortal: node => node },
+    '@/hooks/use-tooltips-enabled': { useTooltipsEnabled: () => tooltipsEnabled },
+    '@/hooks/use-effective-shortcut': { useEffectiveShortcut: () => null },
+    '@/lib/keyboard/format': { formatShortcut: () => '', detectPlatform: () => 'linux' },
+    '@/lib/keyboard/conflicts': { isBrowserConflict: () => false },
+    '@/hooks/use-electron-platform': { useElectronPlatform: () => null },
+    '@/lib/i18n': { useI18n: () => ({ t: key => key }) },
+  };
+  const source = fs.readFileSync(new URL('../src/components/keyboard/shortcut-tooltip.tsx', import.meta.url), 'utf8');
+  const code = ts.transpileModule(source, { compilerOptions: { jsx: ts.JsxEmit.ReactJSX, module: ts.ModuleKind.CommonJS } }).outputText;
+  const exports = {};
+  vm.runInNewContext(code, { exports, require: id => modules[id], document: { body: {} } });
+  let clicks = 0;
+  function render() {
+    cursor = 0;
+    const result = exports.ShortcutTooltip({ id: 'toggle-terminal-view', label: 'Switch', children: jsx('button', { onClick: () => clicks++ }) });
+    return { button: result.props.children[0], tooltip: result.props.children[1] };
+  }
+  return { render, clicks: () => clicks };
+}
+const event = (focusVisible = false) => ({ currentTarget: { getBoundingClientRect: () => ({ bottom: 20, left: 0, width: 40 }), matches: () => focusVisible } });
+
+test('activating the view toggle dismisses its tooltip and preserves the action', () => {
+  const h = harness();
+  h.render().button.props.onMouseEnter(event());
+  assert.ok(h.render().tooltip);
+  h.render().button.props.onClick(event());
+  assert.equal(h.render().tooltip, null);
+  assert.equal(h.clicks(), 1);
+});
+
+test('touch focus does not leave a tooltip open; keyboard focus still shows it', () => {
+  const h = harness();
+  h.render().button.props.onFocus(event(false));
+  assert.equal(h.render().tooltip, null);
+  h.render().button.props.onFocus(event(true));
+  assert.ok(h.render().tooltip);
+  h.render().button.props.onBlur(event());
+  assert.equal(h.render().tooltip, null);
+});
+
+test('mobile suppresses tooltips on both hover and keyboard focus without blocking clicks', () => {
+  const h = harness(false);
+  h.render().button.props.onMouseEnter(event());
+  h.render().button.props.onFocus(event(true));
+  assert.equal(h.render().tooltip, null);
+  assert.equal(h.render().button.props['aria-describedby'], undefined);
+  h.render().button.props.onClick(event());
+  assert.equal(h.clicks(), 1);
+});

--- a/tests/terminal-chat-submit-focus.test.mjs
+++ b/tests/terminal-chat-submit-focus.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import test from 'node:test';
+import ts from 'typescript';
+
+// Exercise the component's actual async submit callback with a deferred transport.
+const source = fs.readFileSync(new URL('../src/components/chat/terminal-chat-composer.tsx', import.meta.url), 'utf8');
+const ast = ts.createSourceFile('composer.tsx', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+let callback;
+function visit(node) {
+  if (ts.isVariableDeclaration(node) && node.name.getText(ast) === 'submit') callback = node.initializer.arguments[0].getText(ast);
+  ts.forEachChild(node, visit);
+}
+visit(ast);
+assert.ok(callback);
+
+for (const phone of [true, false]) {
+  for (const accepted of [true, false]) {
+    test(`${phone ? 'mobile' : 'desktop'} focus after ${accepted ? 'accepted' : 'rejected'} submission`, async () => {
+      let focused = true, draft = 'hello', complete;
+      const frames = [];
+      const transport = new Promise(resolve => { complete = resolve; });
+      const submit = vm.runInNewContext(`(${callback})`, {
+        value: draft, isBlocked: false, isUploadingImage: false,
+        submittingRef: { current: false }, retrySubmissionRef: { current: null },
+        textareaRef: { current: { blur() { focused = false; }, focus() { focused = true; } } },
+        isPhoneViewport: () => phone, setIsSubmitting() {}, uuidv4: () => 'submission',
+        sessionId: 'test', sendTerminalChatMessage: () => transport,
+        toast: { error() {} }, t: key => key,
+        registerPendingTerminalChatMessage() {},
+        setValue: update => { draft = update(draft); },
+        requestAnimationFrame: callback => { frames.push(callback); },
+      });
+      const pending = submit();
+      assert.equal(focused, !phone, 'Mobile must blur before transport finishes');
+      focused = false; // The browser can also blur a disabled desktop textarea.
+      complete({ accepted, reason: 'server' });
+      await pending;
+      frames.forEach(frame => frame());
+      assert.equal(focused, !phone, 'Only desktop restores focus after transport finishes');
+      assert.equal(draft, accepted ? '' : 'hello');
+    });
+  }
+}


### PR DESCRIPTION
Mobile session controls crowded out the title, touch interactions could leave menus and tooltips open, and sending a PTY chat message restored textarea focus and reopened the software keyboard.

- Keep the provider icon in mobile PTY headers and use the workspace tab title; retain Peek's title because it has no tab. Show icon-only terminal/chat switches and put stop/archive actions in the More menu.
- Disable shared tooltips on phone viewports and devices without hover. Dismiss the session menu on outside pointer input, including PTY touches, and let a second tap on its trigger close it. Preserve PTY input blocking.
- Blur the mobile PTY chat composer before submission and suppress automatic refocus after sending, attaching images, interrupting, and opening Peek. Preserve desktop focus behavior.

Validation: 22 relevant tests passed; changed-source ESLint and full `tsc --noEmit` passed. A mobile-emulated browser against the Linux development backend verified provider loading, header controls, menu dismissal by PTY touch and trigger retap, tooltip suppression, and submit-time blur. Ordered screenshots are saved locally. Added reusable mobile Playwright checks.

Limitations: the development PTY rejected the QA submission, so successful delivery is covered by callback tests, not end-to-end QA. Physical Android keyboard dismissal and packaged Windows-backend QA have not been verified.
