### PR TITLE
fix: hide inactive New Tabs in All Projects

### DIFF
--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -317,7 +317,8 @@ function getVisibleTabs(
   if (!isAllProjectsScope(projectDir)) return ordered;
 
   // Empty start screens are disposable placeholders, not separate work.
-  // Keep one in All Projects; named, split, and terminal tabs stay independent.
+  // Keep only the selected placeholder when work exists, or one for an empty workspace.
+  // Named, split, and terminal tabs stay independent.
   const isEmpty = (tab: Tab) => {
     const data = tab.projectDir === null
       ? globalState?.tabPanelSnapshots?.[tab.id]
@@ -325,7 +326,8 @@ function getVisibleTabs(
     return isPristineEmptyTabData(tab, data);
   };
   const emptyTabs = ordered.filter(isEmpty);
-  const retained = emptyTabs.find((tab) => tab.id === preferredActiveTabId) ?? emptyTabs[0];
+  const retained = emptyTabs.find((tab) => tab.id === preferredActiveTabId)
+    ?? (emptyTabs.length === ordered.length ? emptyTabs[0] : undefined);
   const discarded = new Set(emptyTabs.filter((tab) => tab !== retained).map((tab) => tab.id));
   return ordered.filter((tab) => !discarded.has(tab.id));
 }

--- a/tests/project-view-tab-state.test.ts
+++ b/tests/project-view-tab-state.test.ts
@@ -115,6 +115,27 @@ test('All Projects collapses disposable New Tabs and keeps occupied tabs through
   assert.equal(useTabStore.getState().tabs.length, 3);
 });
 
+test('All Projects hides inactive New Tabs between sessions through reload and project round trips', () => {
+  resetWorkspace();
+  const sessionA = openSharedSession('project-a');
+  useTabStore.getState().openNewTab();
+  const sessionC = openSharedSession('project-c');
+
+  useTabStore.getState().switchProject(ALL_PROJECTS_SENTINEL);
+  assert.deepEqual(useTabStore.getState().tabs.map((tab) => tab.id), [sessionA, sessionC]);
+  assert.equal(useTabStore.getState().activeTabId, sessionC);
+
+  useTabStore.getState().persistToLocalStorage();
+  resetWorkspace(false);
+  useTabStore.getState().restoreFromLocalStorage();
+  assert.deepEqual(useTabStore.getState().tabs.map((tab) => tab.id), [sessionA, sessionC]);
+
+  useTabStore.getState().switchProject('project-a');
+  assert.ok(useTabStore.getState().tabs.some((tab) => tab.id === sessionA));
+  useTabStore.getState().switchProject(ALL_PROJECTS_SENTINEL);
+  assert.deepEqual(useTabStore.getState().tabs.map((tab) => tab.id), [sessionA, sessionC]);
+});
+
 test('All Projects keeps named, split, worktree and terminal surfaces when collapsing New Tabs', () => {
   resetWorkspace();
   useTabStore.getState().switchProject('project-a');


### PR DESCRIPTION
## Summary

All Projects previously retained an unused New Tab between session tabs. Hide inactive pristine empty tabs when occupied tabs exist, while preserving the selected empty tab and one placeholder for an otherwise empty workspace.

## Testing

- Passed: 23 tests covering project tab state, reload and project round trips, New Tab commands, and session opening.
- Passed: ESLint on both changed files and `git diff --check`.
- Not run: full lint, TypeScript check, production build, and manual UI QA.

## Screenshots or Recordings

No new screenshots captured; verified tab visibility and selection through store regression tests.
