### PR TITLE
fix: promote Linux Wayland IME fixes to main

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -54,7 +54,8 @@ import {
   resolveTerminalPanelAtPoint,
 } from './web-contents-context-menu';
 import type { PanelSplitPlacement } from '../src/lib/panel/panel-split';
-import { isLinuxWaylandSession } from '../src/lib/terminal/linux-wayland-rendering';
+import { onWindowFirstShow } from './window-first-show';
+import { isLinuxWaylandSession, linuxWaylandImeSwitches } from '../src/lib/terminal/linux-wayland-rendering';
 
 // Must run before getTesseraDataPath() or app.requestSingleInstanceLock().
 // Normal builds do not set the test instance env and keep the production path.
@@ -718,6 +719,18 @@ const linuxWaylandSession = isLinuxWaylandSession({
 });
 if (linuxWaylandSession) {
   process.env.TESSERA_LINUX_WAYLAND = '1';
+}
+
+// XWayland/IBus can deliver Korean preedit updates but lose their commits.
+// Use the native input path on Wayland; explicit X11 choices remain supported.
+for (const [name, value] of linuxWaylandImeSwitches({
+  platform: process.platform,
+  env: process.env,
+  ozonePlatform: app.commandLine.getSwitchValue('ozone-platform'),
+})) {
+  if (name === 'ozone-platform' || !app.commandLine.hasSwitch(name)) {
+    app.commandLine.appendSwitch(name, value);
+  }
 }
 
 if (process.env.TESSERA_DISABLE_GPU === '1') {
@@ -1557,9 +1570,10 @@ function createWindow(port: number, restoredState?: RestorableWindowState): Brow
   const url = `http://localhost:${port}`;
   win.loadURL(url);
 
-  win.once('ready-to-show', () => {
+  onWindowFirstShow(win, app.commandLine.getSwitchValue('ozone-platform') === 'wayland', () => {
     applyRestoredWindowMode(win, restoredState);
     win.show();
+    clearTimeout(showTimeout);
   });
 
   // Fallback: force-show window after 15s even if page fails to load
@@ -1572,7 +1586,7 @@ function createWindow(port: number, restoredState?: RestorableWindowState): Brow
     }
   }, 15_000);
 
-  win.once('ready-to-show', () => clearTimeout(showTimeout));
+  win.once('closed', () => clearTimeout(showTimeout));
 
   // Log renderer failures
   win.webContents.on('did-fail-load', (_e, code, desc) => {
@@ -1677,7 +1691,7 @@ function createPopoutWindow(
   const url = `http://localhost:${port}${route}`;
   win.loadURL(url);
 
-  win.once('ready-to-show', () => {
+  onWindowFirstShow(win, app.commandLine.getSwitchValue('ozone-platform') === 'wayland', () => {
     applyRestoredWindowMode(win, restoredState);
     win.show();
   });

--- a/electron/window-first-show.ts
+++ b/electron/window-first-show.ts
@@ -1,0 +1,32 @@
+type ReadySource = {
+  once(event: string, listener: () => void): unknown;
+  removeListener(event: string, listener: () => void): unknown;
+};
+
+// Some Wayland compositors defer the first frame of a hidden window. Waiting
+// only for ready-to-show then leaves that window hidden after its page loads.
+export function onWindowFirstShow(
+  win: ReadySource & { webContents: ReadySource },
+  nativeWayland: boolean,
+  show: () => void,
+): void {
+  let done = false;
+  const cleanup = () => {
+    win.removeListener('ready-to-show', reveal);
+    win.removeListener('closed', cancel);
+    win.webContents.removeListener('did-finish-load', reveal);
+  };
+  const reveal = () => {
+    if (done) return;
+    done = true;
+    cleanup();
+    show();
+  };
+  const cancel = () => {
+    done = true;
+    cleanup();
+  };
+  win.once('ready-to-show', reveal);
+  win.once('closed', cancel);
+  if (nativeWayland) win.webContents.once('did-finish-load', reveal);
+}

--- a/src/lib/terminal/linux-wayland-rendering.ts
+++ b/src/lib/terminal/linux-wayland-rendering.ts
@@ -1,10 +1,12 @@
 export type LinuxWaylandRenderingEnvironment = Record<string, string | undefined>;
 
-export function isLinuxWaylandSession(options: {
+type LinuxWaylandOptions = {
   platform: NodeJS.Platform;
   env: LinuxWaylandRenderingEnvironment;
   ozonePlatform?: string;
-}): boolean {
+};
+
+export function isLinuxWaylandSession(options: LinuxWaylandOptions): boolean {
   if (options.platform !== 'linux') return false;
 
   const ozonePlatform = options.ozonePlatform?.trim().toLowerCase() ?? '';
@@ -18,4 +20,16 @@ export function isLinuxWaylandSession(options: {
     || ozonePlatform === 'wayland'
     || ozoneHint === 'wayland'
   );
+}
+
+/** Electron 33 otherwise defaults to XWayland even on a native Wayland desktop. */
+export function linuxWaylandImeSwitches(options: LinuxWaylandOptions): Array<[string, string]> {
+  if (!isLinuxWaylandSession(options)) return [];
+  const platform = options.ozonePlatform?.trim().toLowerCase();
+  if (platform && platform !== 'auto' && platform !== 'wayland') return [];
+  return [
+    ['ozone-platform', 'wayland'],
+    ['enable-wayland-ime', ''],
+    ['wayland-text-input-version', '3'],
+  ];
 }

--- a/tests/electron-window-first-show.test.ts
+++ b/tests/electron-window-first-show.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+import { onWindowFirstShow } from '../electron/window-first-show';
+
+function fixture(nativeWayland: boolean) {
+  const win = Object.assign(new EventEmitter(), { webContents: new EventEmitter() });
+  let shown = 0;
+  onWindowFirstShow(win, nativeWayland, () => { shown++; });
+  return { win, shown: () => shown };
+}
+
+test('Wayland reveals a loaded window even when the compositor defers its first frame', () => {
+  const { win, shown } = fixture(true);
+  win.webContents.emit('did-finish-load');
+  assert.equal(shown(), 1);
+  win.emit('ready-to-show');
+  win.webContents.emit('did-finish-load');
+  assert.equal(shown(), 1);
+});
+
+test('ready-to-show still reveals Wayland windows first when available', () => {
+  const { win, shown } = fixture(true);
+  win.emit('ready-to-show');
+  assert.equal(shown(), 1);
+  assert.equal(win.webContents.listenerCount('did-finish-load'), 0);
+});
+
+test('other backends wait for the first frame', () => {
+  const { win, shown } = fixture(false);
+  win.webContents.emit('did-finish-load');
+  assert.equal(shown(), 0);
+  win.emit('ready-to-show');
+  assert.equal(shown(), 1);
+});
+
+test('closing a window cancels its pending reveal', () => {
+  const { win, shown } = fixture(true);
+  win.emit('closed');
+  win.webContents.emit('did-finish-load');
+  win.emit('ready-to-show');
+  assert.equal(shown(), 0);
+});

--- a/tests/linux-wayland-rendering.test.ts
+++ b/tests/linux-wayland-rendering.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { isLinuxWaylandSession } from '../src/lib/terminal/linux-wayland-rendering';
+import { isLinuxWaylandSession, linuxWaylandImeSwitches } from '../src/lib/terminal/linux-wayland-rendering';
 
 test('detects a Linux Wayland session from the native environment', () => {
   assert.equal(isLinuxWaylandSession({
@@ -22,4 +22,44 @@ test('does not apply the policy outside Linux', () => {
     platform: 'win32',
     env: { WAYLAND_DISPLAY: 'wayland-0' },
   }), false);
+});
+
+test('selects native Wayland IME with text-input-v3 on a Wayland desktop', () => {
+  assert.deepEqual(linuxWaylandImeSwitches({
+    platform: 'linux', env: { XDG_SESSION_TYPE: 'wayland' },
+  }), [
+    ['ozone-platform', 'wayland'], ['enable-wayland-ime', ''], ['wayland-text-input-version', '3'],
+  ]);
+});
+
+test('leaves X11 desktops, explicit X11 overrides, and other operating systems unchanged', () => {
+  for (const platform of ['linux', 'darwin', 'win32'] as const) {
+    assert.deepEqual(linuxWaylandImeSwitches({ platform, env: {} }), []);
+    assert.deepEqual(linuxWaylandImeSwitches({
+      platform, env: { WAYLAND_DISPLAY: 'wayland-0' }, ozonePlatform: 'x11',
+    }), []);
+  }
+  assert.deepEqual(linuxWaylandImeSwitches({
+    platform: 'linux', env: { WAYLAND_DISPLAY: 'wayland-0', ELECTRON_OZONE_PLATFORM_HINT: 'x11' },
+  }), []);
+});
+
+test('honors an explicit native backend over an X11 environment hint', () => {
+  assert.ok(linuxWaylandImeSwitches({
+    platform: 'linux', env: { ELECTRON_OZONE_PLATFORM_HINT: 'x11' }, ozonePlatform: 'wayland',
+  }).length > 0);
+});
+
+test('does not replace an explicitly selected unrelated backend', () => {
+  assert.deepEqual(linuxWaylandImeSwitches({
+    platform: 'linux', env: { WAYLAND_DISPLAY: 'wayland-0' }, ozonePlatform: 'headless',
+  }), []);
+});
+
+test('Wayland environment variables do not activate the policy on macOS or Windows', () => {
+  for (const platform of ['darwin', 'win32'] as const) {
+    assert.deepEqual(linuxWaylandImeSwitches({
+      platform, env: { WAYLAND_DISPLAY: 'wayland-0', XDG_SESSION_TYPE: 'wayland' },
+    }), []);
+  }
 });


### PR DESCRIPTION
## Summary

Promote #463 from dev to main. On Linux Wayland desktops, Electron now selects native Wayland and enables IME text-input-v3 to address the reproduced intermittent Korean input loss through XWayland/IBus. Explicit X11 overrides remain supported.

Main and popout windows also become visible on page-load completion on native Wayland, avoiding the observed 15-second wait for a hidden window's first-frame event.

The change is limited to five files from #463. Temporary local input diagnostics and frontend refresh tooling are excluded.

## Testing

- [x] `npm run lint` — passed for #463 with four existing warnings.
- [x] `npx tsc --noEmit` — passed for #463.
- [x] `NODE_ENV=production npm run build` — passed for #463 with existing CSS highlight warnings.
- [x] `npm run electron:compile` and 15 focused regression tests passed for #463.
- [x] Manual test: Korean input recovered in the same packaged Electron binary/frontend after selecting native Wayland. The final compiled startup smoke test selected Wayland automatically and displayed its isolated fixture window in 534 ms without timeout-triggered DevTools.
- [x] Merge validation: main and dev merge without conflicts; the resulting tree matches the tested dev tree exactly.
- [ ] Not tested: native Windows/macOS GUI runs or other Linux compositor/IME combinations.
