### PR TITLE
fix(watcher): include missed Windows startup console fix

### DIFF
--- a/src/lib/workspace-files/native-workspace-watcher.ts
+++ b/src/lib/workspace-files/native-workspace-watcher.ts
@@ -8,6 +8,11 @@ export function workspaceWatcherOptions(platform = process.platform): Options & 
   const separator = platform === 'win32' ? '[\\\\/]' : '/';
   const component = platform === 'win32' ? '[^\\\\/]+' : '[^/]+';
   return {
+    // Parcel's default probes Watchman through _popen on Windows, briefly
+    // opening a console. Select the OS backend before that probe can run.
+    backend: platform === 'win32' ? 'windows'
+      : platform === 'darwin' ? 'fs-events'
+        : platform === 'linux' ? 'inotify' : undefined,
     // Keep the named entry observable: it may be a regular file called
     // "build". Exclude descendants, pruning generated directory contents.
     ignoreGlobs: [`^(?:${component}${separator})*(?:${alternatives})${separator}.*$`],

--- a/tests/native-workspace-watcher.test.ts
+++ b/tests/native-workspace-watcher.test.ts
@@ -1,6 +1,56 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { createRequire } from 'node:module';
 import { startNativeWorkspaceWatcher, workspaceWatcherOptions } from '@/lib/workspace-files/native-workspace-watcher';
+
+test('workspace watching selects OS backends without probing the Watchman executable', async () => {
+  for (const [platform, backend] of [['win32', 'windows'], ['linux', 'inotify'], ['darwin', 'fs-events']] as const) {
+    assert.equal(workspaceWatcherOptions(platform).backend, backend);
+  }
+  let observedBackend: string | undefined;
+  const watcher = startNativeWorkspaceWatcher('/repo', () => {}, async (_root, _callback, options) => {
+    observedBackend = options.backend;
+    return { unsubscribe: async () => {} };
+  });
+  await watcher.ready;
+  assert.equal(observedBackend, workspaceWatcherOptions().backend);
+  assert.ok(observedBackend);
+  await watcher.close();
+});
+
+test('Windows native subscription never executes the Watchman discovery command', { skip: process.platform !== 'win32' }, async () => {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const os = await import('node:os');
+  const { execFile } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'tessera-watchman-probe-'));
+  const marker = path.join(root, 'probed.txt');
+  const script = path.join(root, 'subscribe.cjs');
+  try {
+    await fs.writeFile(path.join(root, 'watchman.cmd'), '@echo off\r\necho probed>"%TESSERA_WATCHMAN_PROBE_FILE%"\r\nexit /b 1\r\n');
+    await fs.writeFile(script, `
+      const watcher = require(process.argv[2]);
+      watcher.subscribe(process.cwd(), () => {}, JSON.parse(process.argv[3]))
+        .then(subscription => subscription.unsubscribe())
+        .catch(error => { console.error(error); process.exitCode = 1; });
+    `);
+    const env: NodeJS.ProcessEnv = { ...process.env, WATCHMAN_SOCK: '', TESSERA_WATCHMAN_PROBE_FILE: marker };
+    const pathKey = Object.keys(env).find(key => key.toLowerCase() === 'path') ?? 'PATH';
+    env[pathKey] = `${root};${env[pathKey] ?? ''}`;
+    const modulePath = createRequire(path.resolve('package.json')).resolve('@parcel/watcher');
+    for (const options of [{}, workspaceWatcherOptions()]) {
+      await fs.rm(marker, { force: true });
+      await promisify(execFile)(process.execPath, [script, modulePath, JSON.stringify(options)], {
+        cwd: root, env, windowsHide: true, timeout: 10_000,
+      });
+      const probed = await fs.access(marker).then(() => true, () => false);
+      assert.equal(probed, !('backend' in options));
+    }
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
 
 test('closing during native startup releases the late subscription once and suppresses callbacks', async () => {
   let complete!: (value: { unsubscribe(): Promise<void> }) => void;


### PR DESCRIPTION
Restore the missed startup console fix from a1110052, which was added to feature/0907-xc after #456 had already merged. Select the native OS watcher backend explicitly so Windows does not invoke Watchman discovery through cmd.exe.

Validation: Windows Node ran the bundled current regression suite with 6/6 passing, including the sentinel test proving default discovery executes Watchman and explicit Windows backend selection does not. Linux: 5 passed, Windows-only test skipped. Changed-file ESLint and diff check passed. No full packaged-app startup test was run for this integration.
