### PR TITLE
feat(chat): search composer models by name or ID

### DIFF
--- a/src/components/chat/composer-session-control-sections.tsx
+++ b/src/components/chat/composer-session-control-sections.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+import { useI18n } from '@/lib/i18n';
 import { Gauge, Square } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type {
@@ -147,9 +149,39 @@ export function ComposerModelMenu({
   onSelectModel,
   telemetryControl,
 }: ComposerModelMenuProps) {
+  const { t } = useI18n();
+  const [query, setQuery] = useState('');
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredOptions = modelOptions.filter((option) =>
+    `${option.label} ${option.value}`.toLowerCase().includes(normalizedQuery),
+  );
+
   return (
     <>
-      {modelOptions.map((option) => (
+      <div className="sticky top-0 z-10 bg-(--chat-header-bg) px-2 pb-2 pt-1">
+        <input
+          type="search"
+          data-composer-menu-search
+          data-testid="model-selector-search"
+          aria-label={t('settings.model.searchModels')}
+          placeholder={t('settings.model.searchModels')}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.nativeEvent.isComposing || event.keyCode === 229) {
+              event.stopPropagation();
+              return;
+            }
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              event.stopPropagation();
+              if (filteredOptions[0]) onSelectModel(filteredOptions[0].value);
+            }
+          }}
+          className="w-full rounded-md border border-(--divider) bg-(--input-bg) px-2 py-1.5 text-xs text-(--text-primary) outline-none focus:border-(--accent)"
+        />
+      </div>
+      {filteredOptions.map((option) => (
         <button
           {...telemetryClickAttributes(telemetryControl, 'composer')}
           key={option.value}
@@ -168,6 +200,11 @@ export function ComposerModelMenu({
           )}
         </button>
       ))}
+      {!isLoading && filteredOptions.length === 0 && (
+        <div role="status" className="px-3 py-2 text-xs text-(--text-muted)">
+          {t('settings.model.noMatchingModels')}
+        </div>
+      )}
       {isLoading && (
         <div className="px-3 py-2 text-[10px] text-(--text-muted)">
           {loadingLabel}

--- a/src/components/chat/composer-session-controls.tsx
+++ b/src/components/chat/composer-session-controls.tsx
@@ -262,7 +262,8 @@ function ComposerControlDropdown({
         `${COMPOSER_MENU_ITEM_SELECTOR}[data-selected="true"]`,
       );
       const fallbackItem = menu.querySelector<HTMLButtonElement>(COMPOSER_MENU_ITEM_SELECTOR);
-      (selectedItem ?? fallbackItem)?.focus();
+      const searchInput = menu.querySelector<HTMLInputElement>('[data-composer-menu-search]');
+      (searchInput ?? selectedItem ?? fallbackItem)?.focus();
     });
 
     return () => cancelAnimationFrame(frame);
@@ -272,6 +273,15 @@ function ComposerControlDropdown({
     const menu = menuRef.current;
     if (!menu) return;
 
+    if (event.nativeEvent.isComposing || event.keyCode === 229) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+      requestAnimationFrame(() => triggerRef.current?.focus());
+      return;
+    }
+    const searchInput = menu.querySelector<HTMLInputElement>('[data-composer-menu-search]');
+    if (event.target === searchInput && event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
     const items = getComposerMenuItems(menu);
     if (items.length === 0) return;
 
@@ -287,7 +297,8 @@ function ComposerControlDropdown({
         break;
       case 'ArrowUp':
         event.preventDefault();
-        focusItem(currentIndex >= 0 ? currentIndex - 1 : items.length - 1);
+        if (currentIndex === 0 && searchInput) searchInput.focus();
+        else focusItem(currentIndex >= 0 ? currentIndex - 1 : items.length - 1);
         break;
       case 'Home':
         event.preventDefault();
@@ -296,11 +307,6 @@ function ComposerControlDropdown({
       case 'End':
         event.preventDefault();
         focusItem(items.length - 1);
-        break;
-      case 'Escape':
-        event.preventDefault();
-        close();
-        requestAnimationFrame(() => triggerRef.current?.focus());
         break;
       default:
         break;
@@ -365,7 +371,7 @@ function ComposerControlDropdown({
           ref={menuRef}
           data-testid={testId ? `${testId}-menu` : undefined}
           data-side="top"
-          role="menu"
+          role={controlId === 'model' ? 'group' : 'menu'}
           onKeyDown={handleMenuKeyDown}
           className="fixed z-[10001] overflow-y-auto rounded-lg border border-(--chat-header-border) bg-(--chat-header-bg) py-1 shadow-lg"
           style={{

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -349,6 +349,8 @@ export const en: I18nMessages = {
     model: {
       label: 'Default Model',
       reasoningEffortLabel: 'Thinking Intensity',
+      searchModels: 'Search models…',
+      noMatchingModels: 'No matching models',
       loadingOptions: 'Loading provider options...',
       providerDefaultsTitle: 'Provider defaults',
       providerDefaultsHint: 'Choose the model and thinking intensity used when a new session starts. These are the same choices shown in the GUI session controls.',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -349,6 +349,8 @@ export const ja: I18nMessages = {
     model: {
       label: 'デフォルトモデル',
       reasoningEffortLabel: 'Thinking 強度',
+      searchModels: 'モデルを検索…',
+      noMatchingModels: '一致するモデルがありません',
       loadingOptions: 'プロバイダー設定を読み込み中...',
       providerDefaultsTitle: 'プロバイダーごとのデフォルト',
       providerDefaultsHint: '新しいセッションの開始時に使うモデルと Thinking 強度を選択します。GUI セッションコントロールと同じ選択肢が表示されます。',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -349,6 +349,8 @@ export const ko: I18nMessages = {
     model: {
       label: '기본 모델',
       reasoningEffortLabel: 'Thinking 강도',
+      searchModels: '모델 검색…',
+      noMatchingModels: '일치하는 모델이 없습니다',
       loadingOptions: '프로바이더 옵션을 불러오는 중...',
       providerDefaultsTitle: '프로바이더별 기본값',
       providerDefaultsHint: '새 세션을 시작할 때 사용할 모델과 Thinking 강도를 지정합니다. GUI 세션 컨트롤과 동일한 선택지가 표시됩니다.',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -324,6 +324,8 @@ export interface I18nMessages {
     model: {
       label: string;
       reasoningEffortLabel: string;
+      searchModels: string;
+      noMatchingModels: string;
       loadingOptions: string;
       providerDefaultsTitle: string;
       providerDefaultsHint: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -349,6 +349,8 @@ export const zh: I18nMessages = {
     model: {
       label: '默认模型',
       reasoningEffortLabel: 'Thinking 强度',
+      searchModels: '搜索模型…',
+      noMatchingModels: '没有匹配的模型',
       loadingOptions: '正在加载 Provider 选项...',
       providerDefaultsTitle: 'Provider 默认值',
       providerDefaultsHint: '选择新会话启动时使用的模型和 Thinking 强度。选项与 GUI 会话控件中显示的相同。',


### PR DESCRIPTION
## Summary

The OpenCode model catalog can require extensive scrolling. Add a search field to the shared chat composer model selector that filters names and model IDs, ignoring case and surrounding whitespace. Opening the menu focuses search; arrow keys navigate results, Enter selects, and Escape closes even with no matches. Preserve text-editing keys and IME composition, reset search on reopen, and translate search/empty-state text into all four supported languages.

Closes #326.

## Testing

- [x] ESLint on all seven changed files
- [x] `npx tsc --noEmit`
- [x] `git diff --check`
- [x] Browser component checks using the actual menu and dropdown with 102 fixture models: filtering, initial focus, keyboard navigation, selection, reopen reset, empty results, Escape focus restoration, IME Enter guard, and a 390px viewport
- [ ] Full repository lint and production build were not run
- [ ] Authenticated session persistence and full application visual QA: development credentials unavailable

## Screenshots or Recordings

Numbered screenshots and the QA report are saved locally in Windows Downloads under `tessera-issue326-qa`. They show a minimally styled component fixture, not the final application layout; the actual development app was verified only as far as its login screen.

## Notes

The development server used `tessera-dev.db` and has been stopped. No Windows backend/WSL CLI boundary behavior changed.
