### PR TITLE
fix(opencode): restore compact in ACP command catalogs

### DIFF
--- a/src/app/dev-command-catalog-repro/page.tsx
+++ b/src/app/dev-command-catalog-repro/page.tsx
@@ -1,0 +1,7 @@
+import { notFound } from 'next/navigation';
+import { CommandCatalogRepro } from './repro';
+
+export default function CommandCatalogReproPage() {
+  if (process.env.NODE_ENV !== 'development') notFound();
+  return <CommandCatalogRepro />;
+}

--- a/src/app/dev-command-catalog-repro/repro.tsx
+++ b/src/app/dev-command-catalog-repro/repro.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+import { SkillPicker } from '@/components/chat/skill-picker';
+import { useSkillPicker } from '@/hooks/use-skill-picker';
+import { useCommandStore, type CommandInfo } from '@/stores/command-store';
+
+const SESSION_ID = 'command-catalog-repro';
+
+export function CommandCatalogRepro() {
+  const [catalog, setCatalog] = useState('[]');
+  const [input, setInput] = useState('');
+  const picker = useSkillPicker(SESSION_ID, 'opencode', true);
+  const commands = useCommandStore((state) => state.commands[SESSION_ID]);
+  return (
+    <main className="mx-auto w-[600px] pt-8">
+      <label>Reported commands
+        <textarea aria-label="Reported commands" value={catalog} onChange={(event) => setCatalog(event.target.value)} />
+      </label>
+      <button onClick={() => useCommandStore.getState().setCommands(SESSION_ID, JSON.parse(catalog) as CommandInfo[])}>
+        Apply provider update
+      </button>
+      <output hidden data-testid="stored-commands">{JSON.stringify(commands ?? [])}</output>
+      <div className="relative mt-[350px]">
+        <input aria-label="Slash command" value={input} onChange={(event) => {
+          setInput(event.target.value);
+          picker.onInputChange(event.target.value);
+        }} />
+        <SkillPicker
+          isOpen={picker.isOpen} isLoading={picker.isLoading}
+          skills={picker.filteredSkills} selectedIndex={picker.selectedIndex}
+          onSelect={picker.selectSkill} onClose={picker.close}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/hooks/use-skill-picker.ts
+++ b/src/hooks/use-skill-picker.ts
@@ -314,22 +314,18 @@ export function useSkillPicker(
     [],
   );
 
-  // When commands first arrive while picker is in loading state, auto-populate
-  const prevCommandsRef = useRef<CommandInfo[] | undefined>(undefined);
+  // An open picker follows every catalog update, including removals. A cached
+  // nonempty catalog can be replaced by the running provider's authoritative list.
   useEffect(() => {
-    const wasEmpty = !prevCommandsRef.current || prevCommandsRef.current.length === 0;
-    prevCommandsRef.current = commands;
-    // Only trigger on transition from empty → populated
-    if (!wasEmpty) return;
+    if (!isOpen) return;
     const list = skillsOnlyMode
       ? (visibleCommands ?? []).filter((command) => !isReservedCodexSlashCommandName(command.name))
       : availableCommands;
-    if (list.length === 0) return;
     const input = lastInputRef.current;
     if (!input.startsWith('/') || input.indexOf(' ') !== -1) return;
     if (selectedSkill) return;
     filterAndShow(input, list);
-  }, [availableCommands, commands, filterAndShow, selectedSkill, skillsOnlyMode, visibleCommands]);
+  }, [availableCommands, filterAndShow, isOpen, selectedSkill, skillsOnlyMode, visibleCommands]);
 
   const selectSkill = useCallback((skill: SkillInfo) => {
     setSelectedSkill(skill);

--- a/src/lib/cli/providers/opencode/protocol-parser.ts
+++ b/src/lib/cli/providers/opencode/protocol-parser.ts
@@ -531,6 +531,12 @@ export class OpenCodeProtocolParser {
         description: typeof command.description === 'string' ? command.description : '',
       }));
 
+    // OpenCode 1.18.x executes /compact via ACP but omits it from the catalog
+    // (upstream #37229). Match pre-session discovery without duplicating it.
+    if (!commands.some((command) => command.name === 'compact')) {
+      commands.push({ name: 'compact', description: 'compact the session' });
+    }
+
     return [
       {
         serverMessage: null,

--- a/tests/command-catalog-refresh.e2e.mjs
+++ b/tests/command-catalog-refresh.e2e.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { mkdir, readFile } from 'node:fs/promises';
+import { chromium } from '@playwright/test';
+
+const url = process.env.TESSERA_E2E_APP_URL ?? 'http://127.0.0.1:3100/dev-command-catalog-repro';
+const screenshots = process.env.TESSERA_E2E_SCREENSHOT_DIR ?? 'tmp/command-catalog-qa';
+const catalog = process.env.TESSERA_E2E_CATALOG
+  ? JSON.parse(await readFile(process.env.TESSERA_E2E_CATALOG, 'utf8'))
+  : [{ name: 'init', description: 'Initialize' }, { name: 'review', description: 'Review' }, { name: 'compact', description: 'compact the session' }];
+await mkdir(screenshots, { recursive: true });
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+page.setDefaultTimeout(5000);
+async function publish(commands) {
+  // Publish without a mouse click outside the picker, which would close it.
+  await page.getByRole('textbox', { name: 'Reported commands' }).fill(JSON.stringify(commands));
+  await page.getByRole('button', { name: 'Apply provider update' }).evaluate((button) => button.click());
+  assert.deepEqual(JSON.parse(await page.getByTestId('stored-commands').textContent()), commands);
+}
+try {
+  await page.goto(url);
+  await publish(catalog.slice(0, 1));
+  await page.getByRole('textbox', { name: 'Slash command' }).fill('/');
+  await page.screenshot({ path: `${screenshots}/01-initial-catalog.png` });
+  await publish(catalog);
+  await page.screenshot({ path: `${screenshots}/02-updated-catalog.png` });
+  await page.waitForFunction((count) => document.querySelectorAll('[role=option]').length === count, catalog.length, { timeout: 3000 });
+  const names = await page.getByRole('option').locator('span.font-semibold').allTextContents();
+  assert.deepEqual(names.map((name) => name.trim()), catalog.map((command) => `/${command.name}`));
+  await page.getByRole('textbox', { name: 'Slash command' }).fill('/comp');
+  await page.getByRole('option', { name: /compact/ }).waitFor();
+  await page.screenshot({ path: `${screenshots}/03-compact-from-provider.png` });
+  await publish(catalog.filter((command) => command.name !== 'compact'));
+  await page.waitForFunction(() => ![...document.querySelectorAll('[role=option] span.font-semibold')].some((el) => el.textContent.trim() === '/compact'));
+  await page.screenshot({ path: `${screenshots}/04-removed-command.png` });
+  await page.getByRole('textbox', { name: 'Slash command' }).fill('/');
+  await publish([]);
+  await page.waitForFunction(() => document.querySelectorAll('[role=option]').length === 0);
+  await page.screenshot({ path: `${screenshots}/05-empty-catalog.png` });
+  await publish(catalog);
+  await page.getByRole('listbox').waitFor();
+  await page.getByRole('textbox', { name: 'Reported commands' }).click();
+  await publish(catalog.slice(0, 1));
+  assert.equal(await page.getByRole('option').count(), 0, 'catalog updates must not reopen a dismissed picker');
+  await page.screenshot({ path: `${screenshots}/06-dismissed-picker.png` });
+  console.log(JSON.stringify({ commands: catalog.length, addedRemovedAndEmpty: 'passed' }));
+} finally {
+  await browser.close();
+}

--- a/tests/opencode-command-catalog.test.ts
+++ b/tests/opencode-command-catalog.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { OpenCodeProtocolParser } from '@/lib/cli/providers/opencode/protocol-parser';
+
+function receiveCommands(availableCommands: unknown[]) {
+  return new OpenCodeProtocolParser().parseStdout('catalog-test', JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'session/update',
+    params: {
+      sessionId: 'opencode-session',
+      update: { sessionUpdate: 'available_commands_update', availableCommands },
+    },
+  }));
+}
+
+for (const catalog of [[], [{ name: 'review', description: 'Review code' }]]) {
+  test(`ACP catalog with ${catalog.length} commands gains compact in both storage and UI delivery`, () => {
+    const messages = receiveCommands(catalog);
+    const stored = messages.find((message) => message.sideEffect?.type === 'store_commands')?.sideEffect;
+    const delivered = messages.find((message) => message.serverMessage?.type === 'commands_ready')?.serverMessage;
+    assert.equal(stored?.type, 'store_commands');
+    assert.equal(delivered?.type, 'commands_ready');
+    if (stored?.type !== 'store_commands' || delivered?.type !== 'commands_ready') return;
+    const expected = [...catalog, { name: 'compact', description: 'compact the session' }];
+    assert.deepEqual(stored.commands, expected);
+    assert.deepEqual(delivered.commands, expected);
+  });
+}
+
+test('ACP provider-reported compact retains its description and is not duplicated', () => {
+  const catalog = [{ name: 'compact', description: 'Provider description' }];
+  const delivered = receiveCommands(catalog).find((message) => message.serverMessage?.type === 'commands_ready')?.serverMessage;
+  assert.equal(delivered?.type, 'commands_ready');
+  if (delivered?.type === 'commands_ready') assert.deepEqual(delivered.commands, catalog);
+});


### PR DESCRIPTION
## Summary

Fixes #325.

OpenCode 1.18.30 accepts `/compact` over ACP but omits it from its command catalog (anomalyco/opencode#37229). Add `compact` when an ACP catalog omits it, preserving the provider's entry when present. This matches the existing pre-session discovery fallback.

Refresh an open slash-command picker whenever the catalog changes, including command removal and empty catalogs. Previously, a nonempty cached catalog prevented later provider updates from appearing. Closed pickers remain closed.

## Testing

- [x] `npm run lint` — no errors; four existing warnings.
- [x] `npx tsc --noEmit`
- [x] `npx tsx --test tests/opencode-command-catalog.test.ts tests/opencode-command-discovery-client.test.ts` — six passing tests.
- [x] Browser regression tests for catalog replacement, filtering, removal, empty catalogs, and dismissed pickers; existing OpenCode discovery race test also passed.
- [x] Captured real OpenCode 1.18.30 ACP output: 49 reported commands become 50 stored/delivered commands with `compact`. Verified the resulting catalog in the real picker components on the WSL development web server.
- [x] Actual OpenCode ACP `/compact` execution produced a summary and persisted a compaction record in an isolated database copy.
- [ ] Production build and packaged Windows E2E were not run; this change does not modify process spawning or filesystem translation.

## Screenshots or Recordings

Numbered browser QA screenshots were captured and delivered locally to the reporter's Windows Downloads folder (`tessera-issue325-compact-fallback`). The development-only reproduction page and browser regression script are included for repeatable verification.

## Notes

The local OpenCode version/database mismatch discovered during investigation was resolved through the development user's executable setting; that environment adjustment is not part of this PR.
