### PR TITLE
fix(sidebar): scope Running shift ranges to live sessions

### DIFF
--- a/src/lib/chat/build-collection-groups.ts
+++ b/src/lib/chat/build-collection-groups.ts
@@ -64,7 +64,18 @@ export function filterCollectionGroupsByRunning(groups: CollectionGroupData[]): 
   return groups
     .map((group) => ({
       collectionId: group.collectionId,
-      tasks: group.tasks.filter(taskHasVisibleRuntimeSession),
+      // A Task may contain both running and stopped child Sessions. The
+      // Running view must project the children as well as the parent Task;
+      // otherwise Shift range selection can traverse stopped rows that are
+      // absent from the filtered surface.
+      tasks: group.tasks
+        .map((task) => ({
+          ...task,
+          sessions: task.sessions.filter((session) =>
+            resolveSessionRuntimePresentation(session).showRunning
+          ),
+        }))
+        .filter((task) => task.sessions.length > 0),
       chats: group.chats.filter((session) =>
         resolveSessionRuntimePresentation(session).showRunning
       ),

--- a/tests/sidebar-project-task-selection.test.ts
+++ b/tests/sidebar-project-task-selection.test.ts
@@ -6,6 +6,7 @@ import {
   selectSidebarProjectTasks,
   shouldShowAllProjectLoading,
 } from '../src/components/chat/sidebar-utils';
+import { filterCollectionGroupsByRunning } from '../src/lib/chat/build-collection-groups';
 import type { RecentWorkItem } from '../src/lib/chat/recent-work';
 import { useSelectionStore } from '../src/stores/selection-store';
 import { useSessionStore } from '../src/stores/session-store';
@@ -119,6 +120,37 @@ test('Shift range selection includes rendered task sessions missing from the dir
     [...useSelectionStore.getState().selectedIds],
     ['session-a', 'session-b', 'session-c'],
   );
+});
+
+test('Running filter excludes stopped task sessions from Shift ranges', () => {
+  const task = {
+    id: 'task-a',
+    projectId: 'project-a',
+    projectViewId: 'project-a',
+    sessions: [
+      { id: 'running-a', title: 'running-a', isRunning: true },
+      { id: 'stopped-between', title: 'stopped-between', isRunning: false },
+      { id: 'running-b', title: 'running-b', isRunning: true },
+    ],
+  } as TaskEntity;
+  const project = { encodedDir: 'project-a', sessions: [] } as ProjectGroup;
+  const runningGroups = filterCollectionGroupsByRunning([{
+    collectionId: null,
+    tasks: [task],
+    chats: [],
+  }]);
+  const orderedIds = buildSidebarOrderedSessionIds({
+    selectedProjectDir: project.encodedDir,
+    allProjectsSessionIds: [],
+    selectedProject: project,
+    collectionGroups: runningGroups,
+  });
+
+  useSelectionStore.getState().clearSelection();
+  useSelectionStore.getState().toggleSelect('running-a');
+  useSelectionStore.getState().rangeSelect('running-b', orderedIds);
+
+  assert.deepEqual([...useSelectionStore.getState().selectedIds], ['running-a', 'running-b']);
 });
 
 test('Recent Work Shift range selection follows the rendered recent-item order', () => {


### PR DESCRIPTION
Fixes Shift-range selection in the Running tab so stopped child sessions cannot be included between two running rows.\n\nValidation: npx tsx --test tests/sidebar-project-task-selection.test.ts; npx eslint src/lib/chat/build-collection-groups.ts tests/sidebar-project-task-selection.test.ts; npx tsc --noEmit --pretty false.