### PR TITLE
feat(tabs): merge selected tabs with a floating action menu

### DIFF
--- a/src/components/keyboard/shortcut-tooltip.tsx
+++ b/src/components/keyboard/shortcut-tooltip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactElement, cloneElement, useState, useId, type MouseEvent, type FocusEvent } from 'react';
+import { ReactElement, cloneElement, useState, useId, useRef, useEffect, type MouseEvent, type FocusEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { useTooltipsEnabled } from '@/hooks/use-tooltips-enabled';
 import { useEffectiveShortcut } from '@/hooks/use-effective-shortcut';
@@ -17,6 +17,7 @@ export interface ShortcutTooltipProps {
   secondaryLabel?: string;
   /** Override platform detection. Used in tests. */
   platform?: Platform;
+  hoverDelayMs?: number;
   children: ReactElement;
 }
 
@@ -26,6 +27,7 @@ export function ShortcutTooltip({
   secondaryId,
   secondaryLabel,
   platform,
+  hoverDelayMs = 0,
   children,
 }: ShortcutTooltipProps) {
   const { t } = useI18n();
@@ -37,6 +39,14 @@ export function ShortcutTooltip({
   const plat = platform ?? detectPlatform();
   const tooltipId = useId();
   const [open, setOpen] = useState(false);
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function cancelHoverTimer() {
+    if (hoverTimer.current !== null) clearTimeout(hoverTimer.current);
+    hoverTimer.current = null;
+  }
+  useEffect(() => () => {
+    if (hoverTimer.current !== null) clearTimeout(hoverTimer.current);
+  }, [tooltipsEnabled, hoverDelayMs]);
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
 
   const formatted = key ? formatShortcut(key, plat) : '';
@@ -64,6 +74,8 @@ export function ShortcutTooltip({
     setPosition({ top: rect.bottom + 8, left: rect.left + rect.width / 2 });
   }
 
+  // cloneElement stores these handlers; it does not invoke them during render.
+  // eslint-disable-next-line react-hooks/refs
   const trigger = cloneElement(children, {
     // Suppress native browser tooltip (from this element OR any ancestor's `title`)
     // so only our ShortcutTooltip shows. An empty `title` on the hovered element
@@ -72,17 +84,29 @@ export function ShortcutTooltip({
     'aria-keyshortcuts': [key, secondaryId ? secondaryKey : null].filter(Boolean).join(' ') || undefined,
     'aria-describedby': tooltipsEnabled && open ? tooltipId : undefined,
     onMouseEnter: (e: MouseEvent<HTMLElement>) => {
+      cancelHoverTimer();
       if (tooltipsEnabled) {
-        positionFromTrigger(e.currentTarget);
-        setOpen(true);
+        const target = e.currentTarget;
+        if (hoverDelayMs > 0) {
+          hoverTimer.current = setTimeout(() => {
+            hoverTimer.current = null;
+            positionFromTrigger(target);
+            setOpen(true);
+          }, hoverDelayMs);
+        } else {
+          positionFromTrigger(target);
+          setOpen(true);
+        }
       }
       childProps.onMouseEnter?.(e);
     },
     onMouseLeave: (e: MouseEvent<HTMLElement>) => {
+      cancelHoverTimer();
       setOpen(false);
       childProps.onMouseLeave?.(e);
     },
     onClick: (e: MouseEvent<HTMLElement>) => {
+      cancelHoverTimer();
       setOpen(false);
       childProps.onClick?.(e);
     },
@@ -96,6 +120,7 @@ export function ShortcutTooltip({
       childProps.onFocus?.(e);
     },
     onBlur: (e: FocusEvent<HTMLElement>) => {
+      cancelHoverTimer();
       setOpen(false);
       childProps.onBlur?.(e);
     },

--- a/src/components/tab/tab-bar.tsx
+++ b/src/components/tab/tab-bar.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { ChevronLeft, ChevronRight, GitBranch, LoaderCircle, Plus, PanelLeft, PanelRightClose, PanelRightOpen } from 'lucide-react';
+import { createPortal } from 'react-dom';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight, GitBranch, LayoutGrid, LoaderCircle, Plus, PanelLeft, PanelRightClose, PanelRightOpen, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useElectronPlatform } from '@/hooks/use-electron-platform';
 import { useTabStore } from '@/stores/tab-store';
@@ -12,6 +13,7 @@ import { TAB_MIN_WIDTH, TAB_MAX_WIDTH } from '@/types/tab';
 import { PANEL_NODE_DRAG_MIME, PANEL_SESSION_DRAG_MIME } from '@/types/panel';
 import { useGitStore } from '@/stores/git-store';
 import { usePhoneViewport } from '@/hooks/use-phone-viewport';
+import { useTabHeaderSelection } from '@/hooks/use-tab-header-selection';
 import { PHONE_TOUCH_TARGET } from '@/lib/ui/touch-target';
 import { TabItem } from './tab-item';
 import { TabContextMenu } from './tab-context-menu';
@@ -114,12 +116,29 @@ export const TabBar = memo(function TabBar() {
   // Store subscriptions — minimal slices to avoid unnecessary re-renders
   const tabs = useTabStore((state) => state.tabs);
   const activeTabId = useTabStore((state) => state.activeTabId);
+  const isPhoneViewport = usePhoneViewport();
+  const { selectedTabIds, anchorTabId: mergeAnchorTabId, select: selectForMerge, clear: clearMergeSelection } = useTabHeaderSelection(
+    tabs.map((tab) => tab.id), activeTabId, isPhoneViewport,
+  );
+  const selectedCount = selectedTabIds.size;
+  const [mergeMenuAnchorId, setMergeMenuAnchorId] = useState<string | null>(null);
+  const [mergePointer, setMergePointer] = useState<{ x: number; y: number } | null>(null);
+  const mergeMenuPosition = useMemo(() => {
+    const anchorId = mergeMenuAnchorId ?? mergeAnchorTabId;
+    if (!anchorId || selectedCount < 2 || typeof document === 'undefined') return null;
+    const anchor = document.querySelector(`[data-tab-id="${CSS.escape(anchorId)}"]`);
+    if (!anchor) return null;
+    const rect = anchor.getBoundingClientRect();
+    return {
+      left: Math.max(8, Math.min(mergePointer?.x ?? rect.left, window.innerWidth - 168)),
+      top: Math.max(8, Math.min(Math.max((mergePointer?.y ?? rect.bottom) + 12, rect.bottom + 8), window.innerHeight - 44)),
+    };
+  }, [mergeAnchorTabId, mergeMenuAnchorId, mergePointer, selectedCount, tabs]);
   const sidebarCollapsed = useSettingsStore((state) => state.sidebarCollapsed);
   const toggleSidebar = useSettingsStore((state) => state.toggleSidebar);
   const gitPanelOpen = useGitStore((state) => state.isOpen);
   const toggleGitPanel = useGitStore((state) => state.toggle);
   const openGitPanel = useGitStore((state) => state.open);
-  const isPhoneViewport = usePhoneViewport();
   const handlePhoneGitToggle = useCallback(() => {
     if (gitPanelOpen) {
       toggleGitPanel();
@@ -351,6 +370,7 @@ export const TabBar = memo(function TabBar() {
   }, []);
 
   const handleTabActivate = useCallback(function handleTabActivate(tabId: string) {
+    clearMergeSelection();
     useWorkspacePeekStore.getState().close();
     const tabStore = useTabStore.getState();
     const panelStore = usePanelStore.getState();
@@ -361,11 +381,22 @@ export const TabBar = memo(function TabBar() {
     if (targetPanelId) {
       focusPanelControl(targetPanelId);
     }
-  }, []);
+  }, [clearMergeSelection]);
 
   const handleTabClose = useCallback(function handleTabClose(tabId: string) {
     useTabStore.getState().closeTab(tabId);
   }, []);
+
+  const handleMergeTabs = useCallback(() => {
+    const result = useTabStore.getState().mergeTabs([...selectedTabIds]);
+    if (result.ok) clearMergeSelection();
+  }, [clearMergeSelection, selectedTabIds]);
+
+  const handleSelectForMerge = useCallback((tabId: string, mode: 'toggle' | 'range' | 'add-range', position: { x: number; y: number }) => {
+    setMergeMenuAnchorId(tabId);
+    setMergePointer(position);
+    selectForMerge(tabId, mode);
+  }, [selectForMerge]);
 
   // ---------------------------------------------------------------------------
   // Context menu handlers
@@ -579,8 +610,10 @@ export const TabBar = memo(function TabBar() {
                 isPreview={tab.isPreview}
                 isDragOver={tab.id === dragOverTabId}
                 isDragging={tab.id === draggingTabId}
+                isMergeSelected={selectedTabIds.has(tab.id)}
                 style={{ minWidth: TAB_MIN_WIDTH, maxWidth: TAB_MAX_WIDTH }}
                 onActivate={handleTabActivate}
+                onSelectForMerge={handleSelectForMerge}
                 onClose={handleTabClose}
                 onDragStart={handleDragStart}
                 onDragOver={handleDragOver}
@@ -636,6 +669,24 @@ export const TabBar = memo(function TabBar() {
           )}
         </div>
       )}
+
+      {!isPhoneViewport && mergeMenuPosition && typeof document !== 'undefined' ? createPortal(
+        <div
+          role="menu"
+          data-testid="tab-bar-merge-menu"
+          style={mergeMenuPosition}
+          className="electron-no-drag fixed z-[9998] flex w-max items-center gap-1 rounded-md border border-white/20 bg-[#303841] p-1 text-[#f1f5f9] shadow-lg"
+        >
+          <button type="button" className="flex h-[26px] items-center gap-1.5 whitespace-nowrap rounded px-2 text-[12px] font-medium text-[#f1f5f9] hover:bg-white/10" onClick={handleMergeTabs} role="menuitem" data-testid="tab-bar-merge">
+            <LayoutGrid size={14} className="text-(--accent)" />
+            {t('chat.mergeTabs', { count: selectedCount })}
+          </button>
+          <span className="h-4 w-px bg-(--divider)" />
+          <button type="button" className="rounded-md p-1 text-(--text-muted) hover:bg-(--sidebar-hover) hover:text-(--text-primary)" onClick={clearMergeSelection} aria-label="Clear tab selection">
+            <X size={14} />
+          </button>
+        </div>, document.body,
+      ) : null}
 
       {/* "+" button — always visible */}
       <ShortcutTooltip id="new-tab" label={t('shortcut.newTab')}>

--- a/src/components/tab/tab-item.tsx
+++ b/src/components/tab/tab-item.tsx
@@ -46,6 +46,8 @@ export interface TabItemProps {
   isDragging?: boolean;
   style?: React.CSSProperties;
   onActivate: (tabId: string) => void;
+  onSelectForMerge?: (tabId: string, mode: 'toggle' | 'range' | 'add-range', position: { x: number; y: number }) => void;
+  isMergeSelected?: boolean;
   onClose: (tabId: string) => void;
   onDragStart: (tabId: string, event: React.DragEvent) => void;
   onDragOver: (tabId: string, event: React.DragEvent) => void;
@@ -162,6 +164,8 @@ export const TabItem = memo(function TabItem({
   isDragging = false,
   style,
   onActivate,
+  onSelectForMerge,
+  isMergeSelected = false,
   onClose,
   onDragStart,
   onDragOver,
@@ -336,17 +340,23 @@ export const TabItem = memo(function TabItem({
   // Event handlers — all stable references via useCallback
 
   const handleClick = useCallback(
-    function handleClick() {
+    function handleClick(event: React.MouseEvent) {
       const transition = transitionTabClickSuppression(
         suppressClickAfterDragRef.current,
         'click',
       );
       suppressClickAfterDragRef.current = transition.suppressed;
       if (!transition.shouldActivate || isEditingTitle) return;
+      if (onSelectForMerge && !event.altKey && (event.ctrlKey || event.metaKey || event.shiftKey)) {
+        event.preventDefault();
+        event.stopPropagation();
+        onSelectForMerge(tab.id, event.shiftKey ? (event.ctrlKey || event.metaKey ? 'add-range' : 'range') : 'toggle', { x: event.clientX, y: event.clientY });
+        return;
+      }
       void captureTelemetryUiControl('tab.select', 'tab_bar');
       onActivate(tab.id);
     },
-    [isEditingTitle, onActivate, tab.id],
+    [isEditingTitle, onActivate, onSelectForMerge, tab.id],
   );
 
   const handlePointerDown = useCallback(function handlePointerDown() {
@@ -359,6 +369,7 @@ export const TabItem = memo(function TabItem({
   const handleDoubleClick = useCallback(
     function handleDoubleClick(e: React.MouseEvent) {
       e.stopPropagation();
+      if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
       setTitleInput(displayTitle);
       setIsEditingTitle(true);
     },
@@ -540,6 +551,7 @@ export const TabItem = memo(function TabItem({
 
   return (
     <ShortcutTooltip
+      hoverDelayMs={600}
       id="prev-tab"
       label={t('shortcut.prevTab')}
       secondaryId="next-tab"
@@ -566,6 +578,10 @@ export const TabItem = memo(function TabItem({
           'shadow-[inset_2px_0_0_var(--accent)]',
         ],
         isSessionDragHover && !isDragOver && 'border-b-(--accent) bg-(--accent)/10',
+        isMergeSelected && !isDragging && [
+          'bg-[color-mix(in_srgb,var(--accent)_16%,var(--chat-header-bg))]',
+          'text-(--text-primary) hover:bg-[color-mix(in_srgb,var(--accent)_22%,var(--chat-header-bg))]',
+        ],
       )}
       onClick={handleClick}
       onPointerDown={handlePointerDown}
@@ -580,9 +596,10 @@ export const TabItem = memo(function TabItem({
       data-tab-id={tab.id}
       data-project-dir={tab.projectDir ?? 'global'}
       data-active={String(isActive)}
+      data-merge-selected={String(isMergeSelected)}
       data-dragging={String(isDragging)}
       aria-grabbed={isDragging || undefined}
-    >
+      >
       {/* Leading indicator — same dots, colors and priority as the sidebar/board */}
       {statusKind && (
         <span

--- a/src/hooks/use-tab-header-selection.ts
+++ b/src/hooks/use-tab-header-selection.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { selectTabHeader, type TabHeaderSelection } from '@/lib/tab/tab-header-selection';
+
+const EMPTY: TabHeaderSelection = { selectedTabIds: new Set(), anchorTabId: null };
+
+export function useTabHeaderSelection(orderedTabIds: readonly string[], activeTabId: string, disabled: boolean) {
+  const [state, setState] = useState<TabHeaderSelection>(EMPTY);
+  const orderedIds = useMemo(() => orderedTabIds, [orderedTabIds]);
+  const select = useCallback((tabId: string, mode: 'toggle' | 'range' | 'add-range') => {
+    if (disabled) return;
+    setState((current) => selectTabHeader(current, orderedIds, tabId, mode, activeTabId));
+  }, [activeTabId, disabled, orderedIds]);
+  const clear = useCallback(() => setState(EMPTY), []);
+  const validSelectedTabIds = useMemo(
+    () => new Set([...state.selectedTabIds].filter((id) => orderedIds.includes(id))),
+    [state.selectedTabIds, orderedIds],
+  );
+  return {
+    selectedTabIds: disabled ? EMPTY.selectedTabIds : validSelectedTabIds,
+    anchorTabId: disabled ? null : state.anchorTabId,
+    select,
+    clear,
+  };
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -740,6 +740,7 @@ export const en: I18nMessages = {
     imageFallback: '[image]',
     tabList: 'Tab list',
     newTab: 'Add new tab',
+    mergeTabs: 'Merge ({{count}})',
     newTabDefault: 'New Tab',
     openGitPanel: 'Open right Git panel',
     closeGitPanel: 'Close right Git panel',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -740,6 +740,7 @@ export const ja: I18nMessages = {
     imageFallback: '[画像]',
     tabList: 'タブ一覧',
     newTab: '新しいタブを追加',
+    mergeTabs: '結合 ({{count}})',
     newTabDefault: '新しいタブ',
     openGitPanel: '右側の Git パネルを開く',
     closeGitPanel: '右側の Git パネルを閉じる',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -742,6 +742,7 @@ export const ko: I18nMessages = {
     imageFallback: '[이미지]',
     tabList: '탭 목록',
     newTab: '새 탭 추가',
+    mergeTabs: '합치기 ({{count}})',
     newTabDefault: '새 탭',
     openGitPanel: '오른쪽 Git 패널 열기',
     closeGitPanel: '오른쪽 Git 패널 닫기',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -717,6 +717,7 @@ export interface I18nMessages {
     imageFallback: string;
     tabList: string;
     newTab: string;
+    mergeTabs: string;
     newTabDefault: string;
     openGitPanel: string;
     closeGitPanel: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -740,6 +740,7 @@ export const zh: I18nMessages = {
     imageFallback: '[图片]',
     tabList: '标签列表',
     newTab: '添加新标签',
+    mergeTabs: '合并 ({{count}})',
     newTabDefault: '新标签',
     openGitPanel: '打开右侧 Git 面板',
     closeGitPanel: '关闭右侧 Git 面板',

--- a/src/lib/tab/tab-header-selection.ts
+++ b/src/lib/tab/tab-header-selection.ts
@@ -1,0 +1,47 @@
+export type TabHeaderSelection = {
+  selectedTabIds: Set<string>;
+  anchorTabId: string | null;
+};
+
+export function selectTabHeader(
+  state: TabHeaderSelection,
+  orderedTabIds: readonly string[],
+  tabId: string,
+  mode: 'toggle' | 'range' | 'add-range',
+  fallbackAnchorId: string | null,
+): TabHeaderSelection {
+  const ids = new Set(orderedTabIds);
+  if (!ids.has(tabId)) return state;
+  const anchor: string = state.anchorTabId && ids.has(state.anchorTabId)
+    ? state.anchorTabId
+    : fallbackAnchorId && ids.has(fallbackAnchorId)
+      ? fallbackAnchorId
+      : tabId;
+  if (mode === 'toggle') {
+    const selectedTabIds = new Set(state.selectedTabIds);
+    // Starting a multi-selection extends the currently open tab.
+    if (selectedTabIds.size === 0 && fallbackAnchorId && ids.has(fallbackAnchorId) && fallbackAnchorId !== tabId) {
+      selectedTabIds.add(fallbackAnchorId);
+    }
+    selectedTabIds.has(tabId) ? selectedTabIds.delete(tabId) : selectedTabIds.add(tabId);
+    return { selectedTabIds, anchorTabId: tabId };
+  }
+  const from = Math.max(0, orderedTabIds.indexOf(anchor));
+  const to = orderedTabIds.indexOf(tabId);
+  const range = orderedTabIds.slice(Math.min(from, to), Math.max(from, to) + 1);
+  return {
+    selectedTabIds: mode === 'add-range' ? new Set([...state.selectedTabIds, ...range]) : new Set(range),
+    anchorTabId: anchor,
+  };
+}
+
+export function pruneTabHeaderSelection(
+  state: TabHeaderSelection,
+  orderedTabIds: readonly string[],
+): TabHeaderSelection {
+  const ids = new Set(orderedTabIds);
+  return {
+    selectedTabIds: new Set([...state.selectedTabIds].filter((id) => ids.has(id))),
+    anchorTabId: state.anchorTabId && ids.has(state.anchorTabId) ? state.anchorTabId : null,
+  };
+}

--- a/src/lib/tab/tab-merge.ts
+++ b/src/lib/tab/tab-merge.ts
@@ -1,0 +1,49 @@
+import type { Tab } from '@/types/tab';
+import type { Panel, PanelNode, TabPanelData } from '@/types/panel';
+
+export type TabMergeFailureReason = 'too-few-tabs' | 'stale-selection' | 'invalid-panel-data' | 'duplicate-session-conflict' | 'terminal-ownership-conflict';
+export type TabMergePlan = { ok: true; sourceTabIds: string[]; panels: Panel[]; insertionIndex: number; projectDir: string | null; deduplicatedCount: number } | { ok: false; reason: TabMergeFailureReason };
+
+function leaves(node: PanelNode): string[] {
+  return node.type === 'leaf' ? [node.panelId] : [...leaves(node.children[0]), ...leaves(node.children[1])];
+}
+
+export function planTabMerge(tabs: readonly Tab[], tabPanels: Record<string, TabPanelData>, selectedIds: readonly string[]): TabMergePlan {
+  const selected = new Set(selectedIds);
+  if (selected.size < 2) return { ok: false, reason: 'too-few-tabs' };
+  const sources = tabs.filter((tab) => selected.has(tab.id));
+  if (sources.length !== selected.size) return { ok: false, reason: 'stale-selection' };
+  const panels: Panel[] = [];
+  const seenPanelIds = new Set<string>();
+  const sessions = new Map<string, Panel>();
+  const terminals = new Set<string>();
+  let deduplicatedCount = 0;
+  for (const tab of sources) {
+    const data = tabPanels[tab.id];
+    if (!data || !data.panels[data.activePanelId]) return { ok: false, reason: 'invalid-panel-data' };
+    const leafIds = leaves(data.layout);
+    if (leafIds.length !== Object.keys(data.panels).length || new Set(leafIds).size !== leafIds.length) return { ok: false, reason: 'invalid-panel-data' };
+    for (const id of leafIds) {
+      const panel = data.panels[id];
+      if (!panel || panel.id !== id || seenPanelIds.has(id)) return { ok: false, reason: 'invalid-panel-data' };
+      seenPanelIds.add(id);
+      if (panel.terminalId) {
+        if (terminals.has(panel.terminalId)) return { ok: false, reason: 'terminal-ownership-conflict' };
+        terminals.add(panel.terminalId);
+      }
+      if (panel.sessionId) {
+        const existing = sessions.get(panel.sessionId);
+        if (existing) {
+          if (JSON.stringify(existing) !== JSON.stringify(panel)) return { ok: false, reason: 'duplicate-session-conflict' };
+          deduplicatedCount++;
+          continue;
+        }
+        sessions.set(panel.sessionId, panel);
+      }
+      panels.push(panel);
+    }
+  }
+  if (!panels.length) return { ok: false, reason: 'invalid-panel-data' };
+  const dirs = new Set(sources.map((tab) => tab.projectDir));
+  return { ok: true, sourceTabIds: sources.map((tab) => tab.id), panels, insertionIndex: tabs.indexOf(sources[0]!), projectDir: dirs.size === 1 ? sources[0]!.projectDir : null, deduplicatedCount };
+}

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -11,12 +11,14 @@ import type {
   PersistedTabStoreV2,
   PersistedTabStoreV3,
   SessionSurfaceLocation,
+  MergeTabsResult,
 } from '@/types/tab';
 import { TAB_STORE_KEY, LRU_LIMIT } from '@/types/tab';
 import { DEBUG_DIAGNOSTICS } from '@/lib/debug-diagnostics';
 import { PANEL_LAYOUT_STORAGE_KEY } from '@/types/panel';
 import type { PersistedPanelLayout, PanelNode, TabPanelData } from '@/types/panel';
 import { usePanelStore } from '@/stores/panel-store';
+import { planTabMerge } from '@/lib/tab/tab-merge';
 import { useSessionStore } from '@/stores/session-store';
 import { projectViewWorkspaceState } from '@/lib/projects/project-view-workspace-state-client';
 import { ALL_PROJECTS_SENTINEL } from '@/lib/constants/project-strip';
@@ -1119,6 +1121,43 @@ export const useTabStore = create<TabStore>()((set, get) => ({
     panelStore.setActiveTabId(destinationTabId);
 
     return destinationTabId;
+  },
+
+  mergeTabs: (tabIds: readonly string[]): MergeTabsResult => {
+    const state = get();
+    const panelStore = usePanelStore.getState();
+    const plan = planTabMerge(state.tabs, panelStore.tabPanels, tabIds);
+    if (!plan.ok) return plan;
+    const tabId = uuidv4();
+    const layout = buildBalancedPanelLayout(plan.panels.map((panel) => panel.id));
+    if (!layout) return { ok: false, reason: 'invalid-panel-data' };
+    const sourceIds = new Set(plan.sourceTabIds);
+    const resultTab: Tab = { id: tabId, projectDir: plan.projectDir, title: null, isPreview: false };
+    const nextTabs = [...state.tabs.filter((tab) => !sourceIds.has(tab.id))];
+    nextTabs.splice(plan.insertionIndex, 0, resultTab);
+    const resultData: TabPanelData = { layout, panels: Object.fromEntries(plan.panels.map((panel) => [panel.id, panel])), activePanelId: plan.panels[0]!.id };
+    // Register the new owner before sources disappear so terminal cleanup always finds it.
+    panelStore.initTab(tabId, resultData);
+    set({ tabs: nextTabs, activeTabId: tabId, lruTabIds: computeNewLru(state.lruTabIds.filter((id) => !sourceIds.has(id)), tabId) });
+    for (const sourceId of sourceIds) panelStore.removeTab(sourceId);
+    panelStore.setActiveTabId(tabId);
+    const scoped = saveVisibleTabsToScopedStates(get(), usePanelStore.getState());
+    const stripSources = (snapshot: ProjectTabState | null): ProjectTabState | null => {
+      if (!snapshot) return null;
+      const remainingTabs = snapshot.tabs.filter((tab) => !sourceIds.has(tab.id));
+      if (!remainingTabs.length) return null;
+      const snapshots = Object.fromEntries(Object.entries(snapshot.tabPanelSnapshots ?? {})
+        .filter(([id]) => !sourceIds.has(id)));
+      const active = sourceIds.has(snapshot.activeTabId) ? remainingTabs[0]!.id : snapshot.activeTabId;
+      return { ...snapshot, tabs: remainingTabs, activeTabId: active, lruTabIds: snapshot.lruTabIds.filter((id) => !sourceIds.has(id)), tabPanelSnapshots: snapshots };
+    };
+    const projectTabStates = Object.fromEntries(Object.entries(scoped.projectTabStates)
+      .map(([dir, snapshot]) => [dir, stripSources(snapshot)])
+      .filter((entry): entry is [string, ProjectTabState] => entry[1] !== null));
+    set({ ...scoped, projectTabStates, globalTabState: stripSources(scoped.globalTabState) });
+    markTabActiveSessionRead(tabId);
+    assertTabStoreInvariants(get());
+    return { ok: true, tabId, panelCount: plan.panels.length, deduplicatedCount: plan.deduplicatedCount };
   },
 
   openPreview: (sessionId: string): void => {

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -105,6 +105,10 @@ export interface SessionSurfaceLocation {
   projectDir: string | null;
 }
 
+export type MergeTabsResult =
+  | { ok: true; tabId: string; panelCount: number; deduplicatedCount: number }
+  | { ok: false; reason: import('@/lib/tab/tab-merge').TabMergeFailureReason };
+
 /**
  * tab-store의 액션 인터페이스
  */
@@ -173,6 +177,9 @@ export interface TabStoreActions {
    * @returns 새 탭 ID. 세션이 없으면 null.
    */
   createTabWithSessions(sessionIds: string[]): string | null;
+
+  /** Combine existing tabs while retaining their existing panel identities. */
+  mergeTabs(tabIds: readonly string[]): MergeTabsResult;
 
   /**
    * 프리뷰 탭에서 세션 열기. 기존 프리뷰 탭이 있으면 세션만 교체, 없으면 새 프리뷰 탭 생성.

--- a/tests/tab-header-selection.test.ts
+++ b/tests/tab-header-selection.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { pruneTabHeaderSelection, selectTabHeader } from '@/lib/tab/tab-header-selection';
+
+test('header selection toggles and ranges in visual order without changing the active fallback', () => {
+  const ids = ['a', 'b', 'c', 'd'];
+  let state = { selectedTabIds: new Set<string>(), anchorTabId: null };
+  state = selectTabHeader(state, ids, 'c', 'toggle', 'a');
+  assert.deepEqual([...state.selectedTabIds], ['a', 'c']);
+  assert.equal(state.anchorTabId, 'c');
+  state = selectTabHeader(state, ids, 'a', 'range', 'a');
+  assert.deepEqual([...state.selectedTabIds], ['a', 'b', 'c']);
+  state = selectTabHeader(state, ids, 'd', 'add-range', 'a');
+  assert.deepEqual([...state.selectedTabIds], ['a', 'b', 'c', 'd']);
+  assert.deepEqual([...pruneTabHeaderSelection(state, ['b', 'd']).selectedTabIds], ['b', 'd']);
+});

--- a/tests/tab-merge.test.ts
+++ b/tests/tab-merge.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { planTabMerge } from '@/lib/tab/tab-merge';
+import { usePanelStore } from '@/stores/panel-store';
+import { useTabStore } from '@/stores/tab-store';
+import type { Tab } from '@/types/tab';
+import type { TabPanelData } from '@/types/panel';
+
+const tabs: Tab[] = ['a', 'b', 'c'].map((id) => ({ id, projectDir: '/p', title: null, isPreview: false }));
+const panel = (id: string, sessionId: string | null): TabPanelData => ({ layout: { type: 'leaf', panelId: id }, panels: { [id]: { id, sessionId } }, activePanelId: id });
+
+test('merge plan uses tab and DFS order, not click or object insertion order', () => {
+  const plan = planTabMerge(tabs, { a: panel('a-panel', 'a'), b: panel('b-panel', 'b'), c: panel('c-panel', 'c') }, ['c', 'b']);
+  assert.ok(plan.ok);
+  if (!plan.ok) return;
+  assert.deepEqual(plan.sourceTabIds, ['b', 'c']);
+  assert.deepEqual(plan.panels.map((item) => item.id), ['b-panel', 'c-panel']);
+  assert.equal(plan.insertionIndex, 1);
+});
+
+test('merge plan rejects stale selections and conflicting duplicate sessions before mutations', () => {
+  assert.deepEqual(planTabMerge(tabs, { a: panel('a-panel', 'a'), b: panel('b-panel', 'b'), c: panel('c-panel', 'c') }, ['a', 'gone']), { ok: false, reason: 'stale-selection' });
+  assert.deepEqual(planTabMerge(tabs, { a: panel('a-panel', 'same'), b: panel('b-panel', 'same'), c: panel('c-panel', 'c') }, ['a', 'b']), { ok: false, reason: 'duplicate-session-conflict' });
+});
+
+test('store merge replaces sources at the first selected position and preserves panel IDs', () => {
+  useTabStore.setState({ tabs, activeTabId: 'a', lruTabIds: ['a', 'b', 'c'], projectTabStates: {}, globalTabState: null, tabOrderIdsByScope: {}, activeTabIdsByScope: {}, currentProjectDir: null });
+  usePanelStore.setState({ tabPanels: { a: panel('a-panel', 'a'), b: panel('b-panel', 'b'), c: panel('c-panel', 'c') }, activeTabId: 'a' });
+  const result = useTabStore.getState().mergeTabs(['c', 'b']);
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  assert.deepEqual(useTabStore.getState().tabs.map((tab) => tab.id), ['a', result.tabId]);
+  assert.equal(useTabStore.getState().activeTabId, result.tabId);
+  assert.deepEqual(Object.keys(usePanelStore.getState().tabPanels[result.tabId]!.panels), ['b-panel', 'c-panel']);
+  assert.equal(usePanelStore.getState().tabPanels.b, undefined);
+});


### PR DESCRIPTION
Add Ctrl/Cmd and Shift selection to open tab headers, with a compact floating merge action below the last click. The first Ctrl/Cmd selection includes the active tab. Selected tabs use a subtle background without checkmarks or outline boxes.

Merge selected single- and multi-panel tabs in visual/DFS order into a pinned active tab, retaining panel IDs and fields and removing source tabs. Reject stale selections and conflicting panel/session data. Delay tab shortcut hover tooltips by 600 ms and cancel pending tooltips on leave/click.

Validation:
- TypeScript check passed.
- 33 focused regression tests passed (selection, merge planner/store, Split View, drag click guard, project tab state, title rename).
- Changed-code ESLint: no errors; one dependency warning in tab-bar.
- Browser QA: Ctrl selection/toggle, floating placement and updated selected-tab appearance. Screenshots saved to Windows Downloads.

Limitations: Windows backend + WSL CLI runtime retention and complete merge-specific persistence round trips were not verified. No tab separation feature is included.
