### PR TITLE
fix(archive): show and advance retention cleanup

### DIFF
--- a/src/app/api/archive/retention/route.ts
+++ b/src/app/api/archive/retention/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuthenticatedUserId } from '@/lib/auth/api-auth';
+import { getArchivedWorktreeRetentionProgress } from '@/lib/archive/archive-retention-runner';
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuthenticatedUserId(req);
+  if ('response' in auth) return auth.response;
+  return NextResponse.json({ progress: getArchivedWorktreeRetentionProgress(auth.userId) }, {
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}

--- a/src/components/archive/archive-dashboard.tsx
+++ b/src/components/archive/archive-dashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useDeferredValue, useEffect, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useRef, useState } from 'react';
 import type React from 'react';
 import {
   Archive,
@@ -10,6 +10,7 @@ import {
   Search,
   Trash2,
 } from 'lucide-react';
+import { ArchiveRetentionStatus } from './archive-retention-status';
 import { AsyncConfirmDialog } from '@/components/ui/async-confirm-dialog';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
@@ -32,6 +33,11 @@ import { PHONE_TOUCH_TARGET, PHONE_TOUCH_TARGET_HEIGHT } from '@/lib/ui/touch-ta
 type TranslateFn = (key: string, params?: Record<string, unknown>) => string;
 
 type ArchiveKind = 'chat' | 'task';
+type ArchiveDeletion = 'record' | 'folder';
+
+function archiveOperationKey(item: ArchiveItem): string {
+  return item.worktreeId ?? `${item.kind}:${item.id}`;
+}
 
 interface ArchiveResponse {
   items: ArchiveItem[];
@@ -81,28 +87,7 @@ function removeItemFromArchiveKindState(
     ...current,
     items: current.items.filter((item) => item.id !== itemId),
     total: Math.max(0, current.total - 1),
-  };
-}
-
-function removeItemFromArchiveSummary(
-  current: ArchiveResponse['summary'] | null,
-  item: ArchiveItem,
-): ArchiveResponse['summary'] | null {
-  if (!current) return current;
-  const worktreeKey = item.worktreeStatus === 'present'
-    ? 'worktreesPresent'
-    : item.worktreeStatus === 'deleted'
-      ? 'worktreesDeleted'
-      : item.worktreeStatus === 'missing'
-        ? 'worktreesMissing'
-        : null;
-
-  return {
-    ...current,
-    total: Math.max(0, current.total - 1),
-    chats: item.kind === 'chat' ? Math.max(0, current.chats - 1) : current.chats,
-    tasks: item.kind === 'task' ? Math.max(0, current.tasks - 1) : current.tasks,
-    ...(worktreeKey ? { [worktreeKey]: Math.max(0, current[worktreeKey] - 1) } : {}),
+    nextCursor: current.nextCursor === null ? null : String(Math.max(0, Number(current.nextCursor) - 1)),
   };
 }
 
@@ -225,7 +210,6 @@ async function fetchArchivePage(args: {
 
 export function ArchiveDashboard() {
   const { t } = useI18n();
-  const [summary, setSummary] = useState<ArchiveResponse['summary'] | null>(null);
   const [chatState, setChatState] = useState<ArchiveKindState>(() => emptyArchiveKindState());
   const [taskState, setTaskState] = useState<ArchiveKindState>(() => emptyArchiveKindState());
   const [archiveProjects, setArchiveProjects] = useState<ArchiveProjectOption[]>([]);
@@ -238,20 +222,28 @@ export function ArchiveDashboard() {
   const [worktreeDeleteTarget, setWorktreeDeleteTarget] = useState<ArchiveItem | null>(null);
   const [bulkWorktreeDeleteOpen, setBulkWorktreeDeleteOpen] = useState(false);
   const [restoringItemIds, setRestoringItemIds] = useState<Set<string>>(() => new Set());
+  const [deletingItems, setDeletingItems] = useState<ReadonlyMap<string, ArchiveDeletion>>(() => new Map());
+  const deletingKeys = useRef(new Set<string>());
+  const [deleteErrors, setDeleteErrors] = useState<ReadonlyMap<string, string>>(() => new Map());
+  const archiveRevision = useRef(0);
+  const loadRequest = useRef(0);
   const [error, setError] = useState<string | null>(null);
   const { handleSessionClick } = useSessionClickHandlers();
 
-  const loadArchive = useCallback(async () => {
+  const loadArchive = useCallback(async (): Promise<void> => {
+    const request = ++loadRequest.current;
+    const revision = archiveRevision.current;
     setIsLoading(true);
     setError(null);
     try {
       const responses = await Promise.all(
         (['task', 'chat'] as const).map((kind) => fetchArchivePage({ kind, projectFilter, query: deferredQuery })),
       );
+      if (request !== loadRequest.current) return;
+      if (revision !== archiveRevision.current) return void loadArchive();
       const nextChat = responses.find((response) => response.pagination.kind === 'chat');
       const nextTask = responses.find((response) => response.pagination.kind === 'task');
 
-      setSummary(responses[0]?.summary ?? null);
       setArchiveProjects(responses[0]?.projects ?? []);
       setChatState(nextChat
         ? {
@@ -271,7 +263,7 @@ export function ArchiveDashboard() {
       console.error(err);
       setError(t('archive.errors.loadFailed'));
     } finally {
-      setIsLoading(false);
+      if (request === loadRequest.current) setIsLoading(false);
     }
   }, [deferredQuery, projectFilter, t]);
 
@@ -296,13 +288,15 @@ export function ArchiveDashboard() {
 
   const loadMore = useCallback(async (kind: ArchiveKind) => {
     const cursor = kind === 'chat' ? chatState.nextCursor : taskState.nextCursor;
-    if (!cursor) return;
+    if (!cursor || deletingKeys.current.size > 0) return;
+    const revision = archiveRevision.current;
+    const request = loadRequest.current;
 
     setLoadingMoreKind(kind);
     setError(null);
     try {
       const response = await fetchArchivePage({ kind, projectFilter, query: deferredQuery, cursor });
-      setSummary(response.summary);
+      if (revision !== archiveRevision.current || request !== loadRequest.current) return;
       if (kind === 'chat') {
         setChatState((current) => ({
           items: [...current.items, ...response.items],
@@ -342,7 +336,6 @@ export function ArchiveDashboard() {
     } else {
       setTaskState((current) => removeItemFromArchiveKindState(current, item.id));
     }
-    setSummary((current) => removeItemFromArchiveSummary(current, item));
   }, []);
 
   const finishRestoringItem = useCallback((itemId: string) => {
@@ -354,7 +347,7 @@ export function ArchiveDashboard() {
   }, []);
 
   const restoreItem = useCallback(async (item: ArchiveItem) => {
-    if (restoringItemIds.has(item.id)) return;
+    if (restoringItemIds.has(item.id) || deletingKeys.current.has(archiveOperationKey(item))) return;
     setRestoringItemIds((current) => new Set(current).add(item.id));
     setError(null);
     const restoredSession = primarySessionFromItem(item);
@@ -409,49 +402,71 @@ export function ArchiveDashboard() {
     });
   }, [finishRestoringItem, removeRestoredArchiveItem, restoringItemIds, t]);
 
-  const deleteItem = useCallback(async (item: ArchiveItem) => {
-    const endpoint = item.kind === 'task'
-      ? `/api/archive/tasks/${item.id}`
-      : `/api/sessions/${item.id}`;
-    const res = await fetchWithClientId(endpoint, { method: 'DELETE' });
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({})) as { error?: string };
-      const message = body.error ?? t('archive.errors.deleteFailed');
-      setError(message);
-      throw new Error(message);
-    }
-    await Promise.all([
-      loadArchive(),
-      useSessionStore.getState().loadProjects(),
-    ]);
-  }, [loadArchive, t]);
+  const startDelete = useCallback((item: ArchiveItem, deletion: ArchiveDeletion) => {
+    const key = archiveOperationKey(item);
+    if (deletingKeys.current.has(key) || restoringItemIds.has(item.id)) return;
+    if (deletion === 'folder' && !item.worktreeId) return;
+    deletingKeys.current.add(key);
+    archiveRevision.current += 1;
+    setDeletingItems((current) => new Map(current).set(key, deletion));
+    setDeleteErrors((current) => {
+      const next = new Map(current);
+      next.delete(key);
+      return next;
+    });
 
-  const deleteWorktreeOnly = useCallback(async (item: ArchiveItem) => {
-    if (!item.worktreeId) return;
-    const res = await fetch(`/api/worktrees/${item.worktreeId}`, { method: 'DELETE' });
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({})) as { error?: string };
-      const message = body.error ?? t('archive.errors.deleteWorktreeFailed');
-      setError(message);
-      throw new Error(message);
-    }
-    await Promise.all([
-      loadArchive(),
-      useSessionStore.getState().loadProjects(),
-    ]);
-  }, [loadArchive, t]);
+    void (async () => {
+      try {
+        const endpoint = deletion === 'folder'
+          ? `/api/worktrees/${item.worktreeId}`
+          : item.kind === 'task' ? `/api/archive/tasks/${item.id}` : `/api/sessions/${item.id}`;
+        const res = await fetchWithClientId(endpoint, { method: 'DELETE' });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({})) as { error?: string };
+          throw new Error(body.error ?? t(deletion === 'folder'
+            ? 'archive.errors.deleteWorktreeFailed' : 'archive.errors.deleteFailed'));
+        }
+        archiveRevision.current += 1;
+        if (deletion === 'record') {
+          removeRestoredArchiveItem(item);
+        } else {
+          const deletedAt = new Date().toISOString();
+          const markFolderDeleted = (current: ArchiveKindState): ArchiveKindState => ({
+            ...current,
+            items: current.items.map((entry) => entry.worktreeId === item.worktreeId
+              ? { ...entry, worktreeStatus: 'deleted', worktreeDeletedAt: deletedAt, canRestore: false }
+              : entry),
+          });
+          setChatState(markFolderDeleted);
+          setTaskState(markFolderDeleted);
+        }
+        // Sidebar refresh is independent of the completed row mutation.
+        void useSessionStore.getState().loadProjects().catch(console.error);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : t('archive.errors.deleteFailed');
+        setDeleteErrors((current) => new Map(current).set(key, `${item.title}: ${message}`));
+      } finally {
+        deletingKeys.current.delete(key);
+        setDeletingItems((current) => {
+          const next = new Map(current);
+          next.delete(key);
+          return next;
+        });
+      }
+    })();
+  }, [removeRestoredArchiveItem, restoringItemIds, t]);
 
-  const confirmDeleteItem = useCallback(async () => {
+  const confirmDeleteItem = useCallback(() => {
     if (!deleteTarget) return;
-    await deleteItem(deleteTarget);
+    startDelete(deleteTarget, 'record');
     setDeleteTarget(null);
-  }, [deleteItem, deleteTarget]);
+  }, [startDelete, deleteTarget]);
 
-  const confirmDeleteWorktree = useCallback(async () => {
+  const confirmDeleteWorktree = useCallback(() => {
     if (!worktreeDeleteTarget) return;
-    await deleteWorktreeOnly(worktreeDeleteTarget);
+    startDelete(worktreeDeleteTarget, 'folder');
     setWorktreeDeleteTarget(null);
-  }, [deleteWorktreeOnly, worktreeDeleteTarget]);
+  }, [startDelete, worktreeDeleteTarget]);
 
   const confirmDeleteAllWorktrees = useCallback(async () => {
     const params = new URLSearchParams();
@@ -517,6 +532,8 @@ export function ArchiveDashboard() {
             </button>
           </div>
 
+          <ArchiveRetentionStatus />
+
           <div className="flex flex-wrap items-center gap-2">
             <div className="relative w-full max-w-[360px] sm:w-[360px]">
               <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-(--text-muted)" />
@@ -550,7 +567,7 @@ export function ArchiveDashboard() {
           <div className="flex flex-wrap items-center gap-3 text-xs text-(--text-muted)">
             <span>{settings.autoDeleteArchivedWorktrees ? t('archive.autoDeleteOn') : t('archive.autoDeleteOff')}</span>
             <span>{t('archive.retentionInfo', { days: settings.archivedWorktreeRetentionDays })}</span>
-            <span>{t('archive.loadedCount', { loaded: visibleItemCount, total: summary?.total ?? 0 })}</span>
+            <span>{t('archive.loadedCount', { loaded: visibleItemCount, total: chatState.total + taskState.total })}</span>
             <span>{t('archive.worktreesPresent', { count: loadedWorktreesPresent })}</span>
             <span>{t('archive.worktreesDeleted', { count: loadedWorktreesDeleted })}</span>
             <span>{t('archive.worktreesMissing', { count: loadedWorktreesMissing })}</span>
@@ -587,7 +604,7 @@ export function ArchiveDashboard() {
             <button
               {...telemetryClickAttributes('archive.bulk_delete', 'archive')}
               onClick={() => setBulkWorktreeDeleteOpen(true)}
-              disabled={isLoading || visibleItemCount === 0}
+              disabled={isLoading || visibleItemCount === 0 || deletingItems.size > 0}
               className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color-mix(in_srgb,var(--status-error-text)_32%,var(--divider))] bg-[color-mix(in_srgb,var(--status-error-text)_8%,transparent)] px-2.5 text-xs font-medium text-(--status-error-text) transition-colors hover:bg-(--status-error-bg) disabled:cursor-not-allowed disabled:opacity-50"
             >
               <FolderX className="h-3.5 w-3.5" />
@@ -602,6 +619,12 @@ export function ArchiveDashboard() {
           </div>
         )}
 
+        {[...deleteErrors].map(([key, message]) => (
+          <div key={key} role="alert" className="rounded-lg border border-(--status-error-border) bg-(--status-error-bg) px-3 py-2 text-xs text-(--status-error-text)">
+            {message}
+          </div>
+        ))}
+
         {isLoading ? (
           <div className="py-20 text-center text-sm text-(--text-muted)">{t('archive.loading')}</div>
         ) : hasNoResults ? (
@@ -614,6 +637,7 @@ export function ArchiveDashboard() {
               <TaskArchiveTable
                 items={taskItems}
                 restoringItemIds={restoringItemIds}
+                deletingItems={deletingItems}
                 onOpenSession={openItem}
                 onRestore={restoreItem}
                 onDelete={setDeleteTarget}
@@ -624,6 +648,7 @@ export function ArchiveDashboard() {
                 loaded={taskItems.length}
                 total={taskState.total}
                 isLoading={loadingMoreKind === 'task'}
+                disabled={deletingItems.size > 0}
                 onClick={() => void loadMore('task')}
                 t={t}
               />
@@ -633,6 +658,7 @@ export function ArchiveDashboard() {
               <ChatArchiveTable
                 items={chatItems}
                 restoringItemIds={restoringItemIds}
+                deletingItems={deletingItems}
                 onOpen={openItem}
                 onRestore={restoreItem}
                 onDelete={setDeleteTarget}
@@ -642,6 +668,7 @@ export function ArchiveDashboard() {
                 loaded={chatItems.length}
                 total={chatState.total}
                 isLoading={loadingMoreKind === 'chat'}
+                disabled={deletingItems.size > 0}
                 onClick={() => void loadMore('chat')}
                 t={t}
               />
@@ -779,12 +806,14 @@ function ArchiveLoadMore({
   loaded,
   total,
   isLoading,
+  disabled = false,
   onClick,
   t,
 }: {
   loaded: number;
   total: number;
   isLoading: boolean;
+  disabled?: boolean;
   onClick: () => void;
   t: TranslateFn;
 }) {
@@ -795,7 +824,7 @@ function ArchiveLoadMore({
       <button
         {...telemetryClickAttributes('archive.load_more', 'archive')}
         onClick={onClick}
-        disabled={isLoading}
+        disabled={isLoading || disabled}
         className="rounded-lg border border-(--divider) px-3 py-1.5 text-xs text-(--text-secondary) transition-colors hover:bg-(--sidebar-hover) hover:text-(--text-primary) disabled:opacity-50"
       >
         {isLoading ? t('archive.loadingMore') : t('archive.loadMore', { loaded, total })}
@@ -874,6 +903,7 @@ function StackedField({
 function ChatRowActions({
   item,
   isRestoring,
+  deletion,
   onRestore,
   onDelete,
   t,
@@ -881,6 +911,7 @@ function ChatRowActions({
 }: {
   item: ArchiveItem;
   isRestoring: boolean;
+  deletion?: ArchiveDeletion;
   onRestore: (item: ArchiveItem) => void;
   onDelete: (item: ArchiveItem) => void;
   t: TranslateFn;
@@ -893,16 +924,16 @@ function ChatRowActions({
           telemetryControl="archive.item.restore"
           tone="primary"
           onClick={() => onRestore(item)}
-          disabled={isRestoring}
+          disabled={isRestoring || Boolean(deletion)}
           ariaBusy={isRestoring}
         >
           <RotateCcw className={cn('h-3 w-3', isRestoring && 'animate-spin')} />
           {t('archive.actions.restore')}
         </ActionButton>
       )}
-      <ActionButton telemetryControl="archive.item.delete" tone="dangerOutline" onClick={() => onDelete(item)} disabled={isRestoring}>
-        <Trash2 className="h-3 w-3" />
-        {t('archive.actions.delete')}
+      <ActionButton telemetryControl="archive.item.delete" tone="dangerOutline" onClick={() => onDelete(item)} ariaBusy={deletion === 'record'} disabled={isRestoring || Boolean(deletion)}>
+        <Trash2 className={cn('h-3 w-3', deletion === 'record' && 'animate-pulse')} />
+        {t(deletion === 'record' ? 'archive.dialog.deleting' : 'archive.actions.delete')}
       </ActionButton>
     </RowActions>
   );
@@ -916,6 +947,7 @@ function ChatRowActions({
 function TaskRowActions({
   item,
   isRestoring,
+  deletion,
   onRestore,
   onDelete,
   onDeleteWorktree,
@@ -924,6 +956,7 @@ function TaskRowActions({
 }: {
   item: ArchiveItem;
   isRestoring: boolean;
+  deletion?: ArchiveDeletion;
   onRestore: (item: ArchiveItem) => void;
   onDelete: (item: ArchiveItem) => void;
   onDeleteWorktree: (item: ArchiveItem) => void;
@@ -937,7 +970,7 @@ function TaskRowActions({
           telemetryControl="archive.item.restore"
           tone="primary"
           onClick={() => onRestore(item)}
-          disabled={isRestoring}
+          disabled={isRestoring || Boolean(deletion)}
           ariaBusy={isRestoring}
         >
           <RotateCcw className={cn('h-3 w-3', isRestoring && 'animate-spin')} />
@@ -945,14 +978,14 @@ function TaskRowActions({
         </ActionButton>
       )}
       {item.worktreeStatus === 'present' && item.worktreeManaged && !item.sharedWorktree && (
-        <ActionButton telemetryControl="archive.item.delete_worktree" tone="dangerOutline" onClick={() => onDeleteWorktree(item)} title={t('archive.actions.deleteWorktreeTooltip')} disabled={isRestoring}>
-          <FolderX className="h-3 w-3" />
-          {t('archive.actions.deleteWorktree')}
+        <ActionButton telemetryControl="archive.item.delete_worktree" tone="dangerOutline" onClick={() => onDeleteWorktree(item)} title={t('archive.actions.deleteWorktreeTooltip')} ariaBusy={deletion === 'folder'} disabled={isRestoring || Boolean(deletion)}>
+          <FolderX className={cn('h-3 w-3', deletion === 'folder' && 'animate-pulse')} />
+          {t(deletion === 'folder' ? 'archive.dialog.deleting' : 'archive.actions.deleteWorktree')}
         </ActionButton>
       )}
-      <ActionButton telemetryControl="archive.item.delete" tone="dangerOutline" onClick={() => onDelete(item)} disabled={isRestoring}>
-        <Trash2 className="h-3 w-3" />
-        {t('archive.actions.delete')}
+      <ActionButton telemetryControl="archive.item.delete" tone="dangerOutline" onClick={() => onDelete(item)} ariaBusy={deletion === 'record'} disabled={isRestoring || Boolean(deletion)}>
+        <Trash2 className={cn('h-3 w-3', deletion === 'record' && 'animate-pulse')} />
+        {t(deletion === 'record' ? 'archive.dialog.deleting' : 'archive.actions.delete')}
       </ActionButton>
     </RowActions>
   );
@@ -1065,6 +1098,7 @@ function ActionButton({
 function ChatArchiveTable({
   items,
   restoringItemIds,
+  deletingItems,
   onOpen,
   onRestore,
   onDelete,
@@ -1072,6 +1106,7 @@ function ChatArchiveTable({
 }: {
   items: ArchiveItem[];
   restoringItemIds: ReadonlySet<string>;
+  deletingItems: ReadonlyMap<string, ArchiveDeletion>;
   onOpen: (item: ArchiveItem, sessionId?: string) => void;
   onRestore: (item: ArchiveItem) => void;
   onDelete: (item: ArchiveItem) => void;
@@ -1109,7 +1144,7 @@ function ChatArchiveTable({
                     label={t('archive.columns.archived')}
                     value={formatRelativeTime(item.archivedAt, t)}
                   />
-                  <ChatRowActions item={item} isRestoring={restoringItemIds.has(item.id)} onRestore={onRestore} onDelete={onDelete} t={t} stacked />
+                  <ChatRowActions item={item} isRestoring={restoringItemIds.has(item.id)} deletion={deletingItems.get(archiveOperationKey(item))} onRestore={onRestore} onDelete={onDelete} t={t} stacked />
                 </td>
               </tr>
             ))}
@@ -1162,7 +1197,7 @@ function ChatArchiveTable({
                 {formatRelativeTime(item.archivedAt, t)}
               </td>
               <td className="h-10 px-3">
-                <ChatRowActions item={item} isRestoring={restoringItemIds.has(item.id)} onRestore={onRestore} onDelete={onDelete} t={t} />
+                <ChatRowActions item={item} isRestoring={restoringItemIds.has(item.id)} deletion={deletingItems.get(archiveOperationKey(item))} onRestore={onRestore} onDelete={onDelete} t={t} />
               </td>
             </tr>
           ))}
@@ -1175,6 +1210,7 @@ function ChatArchiveTable({
 function TaskArchiveTable({
   items,
   restoringItemIds,
+  deletingItems,
   onOpenSession,
   onRestore,
   onDelete,
@@ -1183,6 +1219,7 @@ function TaskArchiveTable({
 }: {
   items: ArchiveItem[];
   restoringItemIds: ReadonlySet<string>;
+  deletingItems: ReadonlyMap<string, ArchiveDeletion>;
   onOpenSession: (item: ArchiveItem, sessionId: string) => void;
   onRestore: (item: ArchiveItem) => void;
   onDelete: (item: ArchiveItem) => void;
@@ -1221,7 +1258,7 @@ function TaskArchiveTable({
                   />
                   <TaskRowActions
                     item={item}
-                    isRestoring={restoringItemIds.has(item.id)}
+                    isRestoring={restoringItemIds.has(item.id)} deletion={deletingItems.get(archiveOperationKey(item))}
                     onRestore={onRestore}
                     onDelete={onDelete}
                     onDeleteWorktree={onDeleteWorktree}
@@ -1280,7 +1317,7 @@ function TaskArchiveTable({
               <td className="px-3 py-2 align-top">
                 <TaskRowActions
                   item={item}
-                  isRestoring={restoringItemIds.has(item.id)}
+                  isRestoring={restoringItemIds.has(item.id)} deletion={deletingItems.get(archiveOperationKey(item))}
                   onRestore={onRestore}
                   onDelete={onDelete}
                   onDeleteWorktree={onDeleteWorktree}

--- a/src/components/archive/archive-navigation-button.tsx
+++ b/src/components/archive/archive-navigation-button.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Archive, Loader2 } from 'lucide-react';
+import { useArchiveRetentionProgress, isArchiveRetentionActive } from '@/hooks/use-archive-retention-progress';
+import { useI18n } from '@/lib/i18n';
+import { Tooltip } from '@/components/ui/tooltip';
+import { Button } from '@/components/ui/button';
+import { useTabStore } from '@/stores/tab-store';
+import { ARCHIVE_DASHBOARD_SESSION_ID } from '@/lib/constants/special-sessions';
+import { telemetryClickAttributes } from '@/lib/telemetry/ui-click';
+
+export function ArchiveNavigationButton() {
+  const { t } = useI18n();
+  const retention = useArchiveRetentionProgress();
+  const retentionActive = isArchiveRetentionActive(retention);
+  const archiveLabel = retentionActive && retention
+    ? retention.phase === 'scanning'
+      ? t('archive.retentionProgress.scanning')
+      : t('archive.retentionProgress.running', { completed: retention.completed, total: retention.total })
+    : t('archive.title');
+  return (
+    <Tooltip content={archiveLabel} delay={300}>
+      <Button
+        {...telemetryClickAttributes('sidebar.archive.open', 'sidebar')}
+        variant="ghost"
+        size="icon-lg"
+        className="rounded-none max-sm:!w-8 max-sm:!h-8 max-sm:!min-w-0 max-sm:!min-h-0"
+        onClick={() => {
+          const tabStore = useTabStore.getState();
+          const existing = tabStore.findSessionLocation(ARCHIVE_DASHBOARD_SESSION_ID);
+          if (existing) {
+            tabStore.setActiveTab(existing.tabId);
+          } else {
+            tabStore.createTab(ARCHIVE_DASHBOARD_SESSION_ID);
+          }
+        }}
+        data-testid="project-strip-archive"
+        aria-label={archiveLabel}
+      >
+        <span className="relative">
+          <Archive className="w-5 h-5 max-sm:w-3.5 max-sm:h-3.5" />
+          {retentionActive && (
+            <span className="absolute -right-1.5 -top-1.5 rounded-full bg-(--sidebar-bg) text-(--accent)" data-testid="archive-retention-spinner">
+              <span className="block motion-safe:animate-spin"><Loader2 className="h-3 w-3" aria-hidden="true" /></span>
+            </span>
+          )}
+        </span>
+      </Button>
+    </Tooltip>
+  );
+}

--- a/src/components/archive/archive-retention-status.tsx
+++ b/src/components/archive/archive-retention-status.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { useArchiveRetentionProgress, isArchiveRetentionActive } from '@/hooks/use-archive-retention-progress';
+import { useI18n } from '@/lib/i18n';
+
+export function ArchiveRetentionStatus() {
+  const { t } = useI18n();
+  const progress = useArchiveRetentionProgress();
+  if (!progress || progress.phase === 'idle' || (progress.phase === 'complete' && progress.total === 0 && progress.errors.length === 0)) return null;
+  const active = isArchiveRetentionActive(progress);
+  const label = progress.phase === 'scanning'
+    ? t('archive.retentionProgress.scanning')
+    : active
+      ? t('archive.retentionProgress.running', { completed: progress.completed, total: progress.total })
+      : t('archive.retentionProgress.complete');
+
+  return (
+    <section className="rounded-lg border border-(--divider) bg-(--board-card-bg) px-3 py-2 text-xs" data-testid="archive-retention-status">
+      <div role="status" className="flex items-center gap-2 text-(--text-primary)">
+        {active && <span className="shrink-0 motion-safe:animate-spin"><Loader2 className="h-3.5 w-3.5 text-(--accent)" aria-hidden="true" /></span>}
+        <span>{label}</span>
+        {progress.phase === 'waiting' && <span className="text-(--text-muted)">{t('archive.retentionProgress.waiting')}</span>}
+      </div>
+      {active && progress.total > 0 && (
+        <progress className="mt-2 h-1.5 w-full accent-(--accent)" max={progress.total} value={progress.completed} aria-label={label} />
+      )}
+      {progress.currentTitle && <p className="mt-1 truncate text-(--text-muted)" title={progress.currentTitle}>{progress.currentTitle}</p>}
+      {progress.phase !== 'scanning' && (
+        <p className="mt-1 text-(--text-muted)">
+          {t('archive.retentionProgress.summary', { removed: progress.removed, skipped: progress.skipped, failed: progress.errors.length })}
+        </p>
+      )}
+      {progress.errors.length > 0 && (
+        <details className="mt-2 text-(--error)">
+          <summary className="cursor-pointer">{t('archive.retentionProgress.failures', { count: progress.errors.length })}</summary>
+          <ul className="mt-1 max-h-40 space-y-1 overflow-y-auto break-words">
+            {progress.errors.map((failure, index) => (
+              <li key={`${failure.kind}:${failure.id}:${index}`}>{failure.title ?? failure.id}: {failure.error}</li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </section>
+  );
+}

--- a/src/components/chat/project-strip.tsx
+++ b/src/components/chat/project-strip.tsx
@@ -2,13 +2,14 @@
 
 import { useMemo, useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { Archive, Home, Plus, Blocks, EyeOff, MessageSquarePlus } from 'lucide-react';
+import { Home, Plus, Blocks, EyeOff, MessageSquarePlus } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { ArchiveNavigationButton } from '@/components/archive/archive-navigation-button';
 import { useBoardStore } from '@/stores/board-store';
 import { useSessionStore } from '@/stores/session-store';
 import { useTabStore } from '@/stores/tab-store';
 import { ALL_PROJECTS_SENTINEL, getProjectColor } from '@/lib/constants/project-strip';
-import { ARCHIVE_DASHBOARD_SESSION_ID, SKILLS_DASHBOARD_SESSION_ID } from '@/lib/constants/special-sessions';
+import { SKILLS_DASHBOARD_SESSION_ID } from '@/lib/constants/special-sessions';
 import { useProjectStripDnd } from '@/hooks/use-project-strip-dnd';
 import { usePopoutActive } from '@/hooks/use-popout-active';
 import { PHONE_TOUCH_TARGET, PHONE_TOUCH_TARGET_WIDTH } from '@/lib/ui/touch-target';
@@ -283,26 +284,7 @@ export function ProjectStrip({
             <Blocks className="w-5 h-5 max-sm:w-3.5 max-sm:h-3.5" />
           </Button>
         </Tooltip>
-        <Tooltip content={t('archive.title')} delay={300}>
-          <Button
-            {...telemetryClickAttributes('sidebar.archive.open', 'sidebar')}
-            variant="ghost"
-            size="icon-lg"
-            className="rounded-none max-sm:!w-8 max-sm:!h-8 max-sm:!min-w-0 max-sm:!min-h-0"
-            onClick={() => {
-              const tabStore = useTabStore.getState();
-              const existing = tabStore.findSessionLocation(ARCHIVE_DASHBOARD_SESSION_ID);
-              if (existing) {
-                tabStore.setActiveTab(existing.tabId);
-              } else {
-                tabStore.createTab(ARCHIVE_DASHBOARD_SESSION_ID);
-              }
-            }}
-            data-testid="project-strip-archive"
-          >
-            <Archive className="w-5 h-5 max-sm:w-3.5 max-sm:h-3.5" />
-          </Button>
-        </Tooltip>
+        <ArchiveNavigationButton />
         <Tooltip content={t('feedback.tooltip')} delay={300}>
           <Button
             {...telemetryClickAttributes('sidebar.feedback.open', 'sidebar')}

--- a/src/hooks/use-archive-retention-progress.ts
+++ b/src/hooks/use-archive-retention-progress.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { useAuthStore } from '@/stores/auth-store';
+
+import type { ArchiveRetentionProgress } from '@/lib/archive/retention-progress';
+
+export function isArchiveRetentionActive(progress: ArchiveRetentionProgress | null): boolean {
+  return progress !== null && ['scanning', 'running', 'waiting'].includes(progress.phase);
+}
+
+let snapshot: ArchiveRetentionProgress | null = null;
+const listeners = new Set<() => void>();
+let stopPolling: (() => void) | null = null;
+let unsubscribeAuth: (() => void) | null = null;
+
+function publish(progress: ArchiveRetentionProgress | null) {
+  if (JSON.stringify(snapshot) === JSON.stringify(progress)) return;
+  snapshot = progress;
+  listeners.forEach((listener) => listener());
+}
+
+function startPolling(): () => void {
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let request: AbortController | null = null;
+  async function poll() {
+    request = new AbortController();
+    try {
+      const response = await fetch('/api/archive/retention', {
+        cache: 'no-store',
+        signal: request.signal,
+      });
+      if (!response.ok) throw new Error('Retention progress unavailable');
+      const data = await response.json() as { progress: ArchiveRetentionProgress };
+      if (!stopped) publish(data.progress ?? null);
+    } catch {
+      // Do not leave an old "running" indicator spinning after losing contact.
+      if (!stopped) publish(null);
+    } finally {
+      if (!stopped) {
+        timer = setTimeout(poll, isArchiveRetentionActive(snapshot) ? 2_000 : 15_000);
+      }
+    }
+  }
+  void poll();
+  return () => {
+    stopped = true;
+    clearTimeout(timer);
+    request?.abort();
+  };
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  if (listeners.size === 1) {
+    const restart = () => {
+      stopPolling?.();
+      stopPolling = null;
+      publish(null);
+      if (useAuthStore.getState().user) stopPolling = startPolling();
+    };
+    unsubscribeAuth = useAuthStore.subscribe((state, previous) => {
+      if (state.user?.id !== previous.user?.id) restart();
+    });
+    restart();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      stopPolling?.();
+      stopPolling = null;
+      unsubscribeAuth?.();
+      unsubscribeAuth = null;
+      snapshot = null;
+    }
+  };
+}
+
+const getSnapshot = () => snapshot;
+const getServerSnapshot = () => null;
+
+/** One polling loop per browser window, shared by the navigation and dashboard. */
+export function useArchiveRetentionProgress() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/lib/archive/archive-retention-runner.ts
+++ b/src/lib/archive/archive-retention-runner.ts
@@ -1,26 +1,61 @@
 import logger from '@/lib/logger';
-import { pruneExpiredArchivedWorktrees, type RetentionResult } from './archive-service';
+import {
+  listExpiredArchivedWorktreeCandidates,
+  pruneExpiredArchivedWorktrees,
+  type RetentionResult,
+} from './archive-service';
+import type { ArchiveRetentionProgress } from './retention-progress';
 
 const ACTIVE_PASS_DELAY_MS = 30_000;
-const IDLE_PASS_DELAY_MS = 5 * 60_000;
+// Give startup work a short head start, then begin retention without making
+// a backlog look stalled in the Archive progress indicator.
+const IDLE_PASS_DELAY_MS = 60_000;
 
 interface RetentionPolicy {
   retentionDays: number;
   userId: string;
 }
 
+type Candidate = Awaited<ReturnType<typeof listExpiredArchivedWorktreeCandidates>>[number];
+interface RetentionCycle {
+  candidates: Candidate[];
+  progress: ArchiveRetentionProgress;
+}
 interface RetentionRunnerState {
   policy: RetentionPolicy | null;
   timer: NodeJS.Timeout | null;
   running: Promise<RetentionResult> | null;
+  cycle: RetentionCycle | null;
+  progress: ArchiveRetentionProgress;
+  ownerId: string | null;
+  generation: number;
+  configuredDelay: number;
 }
 
 const GLOBAL_KEY = Symbol.for('tessera.archiveRetentionRunner');
 const globalState = globalThis as unknown as { [GLOBAL_KEY]?: RetentionRunnerState };
 
+function idleProgress(): ArchiveRetentionProgress {
+  return {
+    phase: 'idle', total: 0, completed: 0, removed: 0, skipped: 0,
+    errors: [], currentTitle: null, startedAt: null, finishedAt: null,
+  };
+}
+function emptyResult(): RetentionResult {
+  return { removed: 0, skipped: 0, attempted: 0, errors: [] };
+}
 function getState(): RetentionRunnerState {
-  return globalState[GLOBAL_KEY]
-    ?? (globalState[GLOBAL_KEY] = { policy: null, timer: null, running: null });
+  const state = globalState[GLOBAL_KEY] ?? (globalState[GLOBAL_KEY] = {
+    policy: null, timer: null, running: null, cycle: null, progress: idleProgress(),
+    ownerId: null, generation: 0, configuredDelay: IDLE_PASS_DELAY_MS,
+  });
+  // Preserve the timer when a development hot reload upgrades the old runner state.
+  state.progress ??= idleProgress();
+  state.cycle ??= null;
+  state.ownerId ??= state.policy?.userId ?? null;
+  state.generation ??= 0;
+  state.configuredDelay ??= IDLE_PASS_DELAY_MS;
+  return state;
 }
 
 function clearTimer(state: RetentionRunnerState): void {
@@ -28,7 +63,6 @@ function clearTimer(state: RetentionRunnerState): void {
   clearTimeout(state.timer);
   state.timer = null;
 }
-
 function armNextPass(delayMs: number): void {
   const state = getState();
   clearTimer(state);
@@ -40,36 +74,90 @@ function armNextPass(delayMs: number): void {
   state.timer.unref?.();
 }
 
+async function executePass(state: RetentionRunnerState, policy: RetentionPolicy, generation: number): Promise<RetentionResult> {
+  if (generation !== state.generation) return emptyResult();
+  if (!state.cycle) {
+    const previous = state.progress;
+    state.progress = { ...idleProgress(), phase: 'scanning' };
+    const candidates = await listExpiredArchivedWorktreeCandidates(policy.retentionDays);
+    if (generation !== state.generation) return emptyResult();
+    if (candidates.length === 0) {
+      state.progress = previous.phase === 'complete' ? previous : idleProgress();
+      return emptyResult();
+    }
+    const progress: ArchiveRetentionProgress = {
+      ...idleProgress(), phase: 'running', total: candidates.length,
+      startedAt: new Date().toISOString(),
+    };
+    state.cycle = { candidates, progress };
+    state.progress = progress;
+  }
+  const cycle = state.cycle;
+  const item = cycle.candidates[cycle.progress.completed];
+  cycle.progress.phase = 'running';
+  cycle.progress.currentTitle = item.title;
+  let result: RetentionResult;
+  try {
+    // Revalidate archive/checkout state at every destructive edge; the snapshot
+    // is only a queue, never permission to remove a restored or missing folder.
+    result = await pruneExpiredArchivedWorktrees(policy.retentionDays, policy.userId, {
+      maxWorktreeAttempts: 1,
+      worktreeIds: new Set([item.worktreeId]),
+    });
+  } catch (error) {
+    result = { ...emptyResult(), errors: [{ id: item.id, kind: item.kind,
+      error: error instanceof Error ? error.message : String(error) }] };
+  }
+  if (generation !== state.generation) return result;
+  cycle.progress.completed += 1;
+  cycle.progress.removed += result.removed;
+  if (result.removed === 0 && result.errors.length === 0) cycle.progress.skipped += 1;
+  cycle.progress.errors.push(...result.errors.map((error) => ({ ...error, title: item.title })));
+  cycle.progress.currentTitle = null;
+  if (cycle.progress.completed === cycle.progress.total) {
+    cycle.progress.phase = 'complete';
+    cycle.progress.finishedAt = new Date().toISOString();
+    state.cycle = null;
+  } else {
+    cycle.progress.phase = 'waiting';
+  }
+  if (result.errors.length) logger.warn({ errors: result.errors }, 'Archived Worktree retention pass had errors');
+  return result;
+}
+
 async function runOnePass(): Promise<RetentionResult> {
   const state = getState();
-  if (state.running) return state.running;
+  if (state.running) return state.running.catch(() => emptyResult());
   const policy = state.policy;
-  if (!policy) return { removed: 0, skipped: 0, attempted: 0, errors: [] };
-
-  const pass = pruneExpiredArchivedWorktrees(
-    policy.retentionDays,
-    policy.userId,
-    { maxWorktreeAttempts: 1 },
-  );
+  if (!policy) return emptyResult();
+  const generation = state.generation;
+  // Defer execution until the running promise is installed, including synchronous failures.
+  const pass = Promise.resolve().then(() => executePass(state, policy, generation));
   state.running = pass;
-  let attempted = 0;
   try {
-    const result = await pass;
-    attempted = result.attempted;
-    if (result.errors.length > 0) {
-      logger.warn({ errors: result.errors }, 'Archived Worktree retention pass had errors');
-    }
-    return result;
+    return await pass;
   } catch (error) {
     logger.warn({ error }, 'Archived Worktree retention pass failed');
-    return { removed: 0, skipped: 0, attempted: 0, errors: [] };
+    if (generation === state.generation) {
+      state.progress = {
+        ...idleProgress(), phase: 'complete', finishedAt: new Date().toISOString(),
+        errors: [{ id: 'scan', kind: 'task', error: error instanceof Error ? error.message : String(error) }],
+      };
+      state.cycle = null;
+    }
+    return emptyResult();
   } finally {
     state.running = null;
-    // A pass that touched a Worktree stays deliberately slow: wsl.exe can exit
-    // while its Windows conhost teardown is still consuming CPU. An idle scan
-    // backs off further so an empty archive is effectively free.
-    armNextPass(attempted > 0 ? ACTIVE_PASS_DELAY_MS : IDLE_PASS_DELAY_MS);
+    // Keep the existing Windows/WSL cooldown between folders; idle scans back off.
+    armNextPass(generation !== state.generation ? state.configuredDelay
+      : state.cycle ? ACTIVE_PASS_DELAY_MS : IDLE_PASS_DELAY_MS);
   }
+}
+
+export function getArchivedWorktreeRetentionProgress(userId: string): ArchiveRetentionProgress {
+  const state = getState();
+  if (state.ownerId !== userId) return idleProgress();
+  return { ...state.progress, errors: state.progress.errors.map((error) => ({ ...error })) };
 }
 
 export function configureArchivedWorktreeRetention(
@@ -77,21 +165,27 @@ export function configureArchivedWorktreeRetention(
   options: { runImmediately?: boolean } = {},
 ): void {
   const state = getState();
+  const changed = state.policy?.userId !== policy?.userId
+    || state.policy?.retentionDays !== policy?.retentionDays;
   state.policy = policy;
+  if (!changed && !options.runImmediately && (state.timer || state.running)) return;
   clearTimer(state);
+  state.configuredDelay = options.runImmediately ? 0 : IDLE_PASS_DELAY_MS;
+  if (changed) {
+    state.generation += 1;
+    state.cycle = null;
+    state.progress = idleProgress();
+    state.ownerId = policy?.userId ?? null;
+  }
   if (!policy) return;
-  // A normal startup gets a long quiet window. Settings changes that the user
-  // explicitly confirmed may request an immediate (still single-item) pass.
-  armNextPass(options.runImmediately ? 0 : IDLE_PASS_DELAY_MS);
+  // Reapplying unrelated settings must not reset an active cycle's progress/cooldown.
+  armNextPass(state.cycle ? ACTIVE_PASS_DELAY_MS : state.configuredDelay);
 }
 
 export function runArchivedWorktreeRetentionNow(): Promise<RetentionResult> {
   clearTimer(getState());
   return runOnePass();
 }
-
 export function stopArchivedWorktreeRetention(): void {
-  const state = getState();
-  state.policy = null;
-  clearTimer(state);
+  configureArchivedWorktreeRetention(null);
 }

--- a/src/lib/archive/archive-service.ts
+++ b/src/lib/archive/archive-service.ts
@@ -614,10 +614,33 @@ function assertWorktreeDeletionAllowed(worktreeId: string): void {
   );
 }
 
+function isArchivedWorktreeRetentionCandidate(item: ArchiveItem, retentionDays: number): boolean {
+  return Boolean(item.worktreeId && item.workDir)
+    && !item.sharedWorktree
+    && isExpired(item.archivedAt, retentionDays)
+    && item.worktreeStatus === 'present'
+    && !item.worktreeDeletedAt
+    && item.worktreeManaged;
+}
+
+/** Snapshot physical folders, not archive rows: several rows may share a checkout. */
+export async function listExpiredArchivedWorktreeCandidates(
+  retentionDays: number,
+): Promise<Array<{ worktreeId: string; id: string; kind: ArchiveItemKind; title: string }>> {
+  const { items } = await listArchiveItems();
+  const seen = new Set<string>();
+  return items.flatMap((item) => {
+    if (!item.worktreeId || seen.has(item.worktreeId)
+      || !isArchivedWorktreeRetentionCandidate(item, retentionDays)) return [];
+    seen.add(item.worktreeId);
+    return [{ worktreeId: item.worktreeId, id: item.id, kind: item.kind, title: item.title }];
+  });
+}
+
 export async function pruneExpiredArchivedWorktrees(
   retentionDays: number,
   userId?: string,
-  options: { maxWorktreeAttempts?: number } = {},
+  options: { maxWorktreeAttempts?: number; worktreeIds?: ReadonlySet<string> } = {},
 ): Promise<RetentionResult> {
   const result: RetentionResult = { removed: 0, skipped: 0, attempted: 0, errors: [] };
   const { items } = await listArchiveItems();
@@ -629,9 +652,8 @@ export async function pruneExpiredArchivedWorktrees(
     if (
       !item.worktreeId
       || visitedWorktreeIds.has(item.worktreeId)
-      || !item.workDir
-      || item.sharedWorktree
-      || !isExpired(item.archivedAt, retentionDays)
+      || (options.worktreeIds && !options.worktreeIds.has(item.worktreeId))
+      || !isArchivedWorktreeRetentionCandidate(item, retentionDays)
     ) {
       result.skipped += 1;
       continue;

--- a/src/lib/archive/retention-progress.ts
+++ b/src/lib/archive/retention-progress.ts
@@ -1,0 +1,12 @@
+export interface ArchiveRetentionProgress {
+  phase: 'idle' | 'scanning' | 'running' | 'waiting' | 'complete';
+  total: number;
+  completed: number;
+  removed: number;
+  skipped: number;
+  errors: Array<{ id: string; kind: string; title?: string; error: string }>;
+  currentTitle: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+}
+

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1688,6 +1688,14 @@ export const en: I18nMessages = {
     footerNoToken: 'No token retained in URL',
   },
   archive: {
+    retentionProgress: {
+      scanning: 'Checking folders for automatic cleanup…',
+      running: 'Cleaning worktree folders · {{completed}}/{{total}} processed',
+      waiting: 'Waiting for the next folder',
+      complete: 'Automatic folder cleanup complete',
+      summary: '{{removed}} deleted · {{skipped}} skipped · {{failed}} failed',
+      failures: 'View {{count}} failed folders',
+    },
     title: 'Archive',
     description: 'Open archived chats/worktrees read-only, restore them, or permanently delete.',
     refresh: 'Refresh',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -1685,6 +1685,14 @@ export const ja: I18nMessages = {
     footerNoToken: 'URLにトークンを保持しません',
   },
   archive: {
+    retentionProgress: {
+      scanning: '自動削除の対象フォルダーを確認中…',
+      running: 'ワークツリーフォルダーを整理中 · {{completed}}/{{total}}件処理',
+      waiting: '次のフォルダーの削除を待機中',
+      complete: 'フォルダーの自動削除が完了しました',
+      summary: '削除 {{removed}}件 · スキップ {{skipped}}件 · 失敗 {{failed}}件',
+      failures: '失敗したフォルダー {{count}}件を表示',
+    },
     title: 'アーカイブ',
     description: 'アーカイブされた chat/ワークツリー を読み取り専用で開く、復元する、または完全に削除します。',
     refresh: '更新',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -1692,6 +1692,14 @@ export const ko: I18nMessages = {
     footerNoToken: 'URL에 토큰을 남기지 않음',
   },
   archive: {
+    retentionProgress: {
+      scanning: '자동삭제 대상 폴더 확인 중…',
+      running: '워크트리 폴더 정리 중 · {{completed}}/{{total}}개 처리',
+      waiting: '다음 폴더 삭제 대기 중',
+      complete: '워크트리 폴더 자동삭제 완료',
+      summary: '삭제 {{removed}}개 · 건너뜀 {{skipped}}개 · 실패 {{failed}}개',
+      failures: '삭제 실패 {{count}}개 확인',
+    },
     title: '아카이브',
     description: '아카이브된 chat/워크트리를 읽기 전용으로 열거나, 복구하거나, 영구 삭제합니다.',
     refresh: '새로고침',

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -1668,6 +1668,14 @@ export interface I18nMessages {
     footerNoToken: string;
   };
   archive: {
+    retentionProgress: {
+      scanning: string;
+      running: string;
+      waiting: string;
+      complete: string;
+      summary: string;
+      failures: string;
+    };
     title: string;
     description: string;
     refresh: string;

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -1685,6 +1685,14 @@ export const zh: I18nMessages = {
     footerNoToken: 'URL中不保留令牌',
   },
   archive: {
+    retentionProgress: {
+      scanning: '正在检查自动清理的目标文件夹…',
+      running: '正在清理工作树文件夹 · 已处理 {{completed}}/{{total}} 个',
+      waiting: '等待删除下一个文件夹',
+      complete: '文件夹自动清理完成',
+      summary: '已删除 {{removed}} 个 · 已跳过 {{skipped}} 个 · 失败 {{failed}} 个',
+      failures: '查看 {{count}} 个失败的文件夹',
+    },
     title: '归档',
     description: '以只读方式打开已归档的 chat/工作树,可恢复或永久删除。',
     refresh: '刷新',

--- a/tests/archive-delete-concurrency.browser.test.mjs
+++ b/tests/archive-delete-concurrency.browser.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+import { chromium, expect } from '@playwright/test';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import postcss from 'postcss';
+import tailwind from '@tailwindcss/postcss';
+
+// Component test: real ArchiveDashboard and dialogs, delayed fixture API responses.
+const root = process.cwd();
+const artifacts = process.env.TESSERA_TEST_ARTIFACT_DIR ?? path.join(root, 'tmp', 'archive-delete-browser');
+await fs.mkdir(artifacts, { recursive: true });
+const stub = `
+import {en} from '${root}/src/lib/i18n/en.ts';
+export const t = (key, params) => { const text = key.split('.').reduce((v,k) => v?.[k], en) ?? key; return Object.entries(params ?? {}).reduce((s,[k,v]) => s.replaceAll('{{'+k+'}}',String(v)),text); };
+export const useI18n = () => ({t});
+export const useSessionClickHandlers = () => ({handleSessionClick: async () => {}});
+export const useSessionStore = {getState: () => ({loadProjects: async () => { window.archiveProjectRefreshes = (window.archiveProjectRefreshes ?? 0) + 1; }, upsertSession() {}})};
+export const useWorktreeRetentionSettingsUpdate = () => ({settings:{archivedWorktreeRetentionDays:3},updateSettings(){},setRetentionDaysDraft(){},commitRetentionDays(){},retentionDaysInputValue:'3'});
+export const projectViewWorkspaceState = {};
+export const refreshProjectViewWorkspaceMutation = async () => {};
+export const captureTelemetryUiControl = () => {};
+export const telemetryClickAttributes = (control) => ({'data-control':control});
+`;
+const mocks = new Set(['@/lib/i18n','@/hooks/use-session-click-handlers','@/stores/session-store','@/hooks/use-worktree-retention-settings-update','@/lib/projects/project-view-workspace-state-client','@/lib/telemetry/client','@/lib/telemetry/ui-click']);
+const output = await build({
+  stdin: {contents: `import React from 'react'; import {useAuthStore} from './src/stores/auth-store'; useAuthStore.setState({user:{id:'fixture',username:'fixture'},isAuthenticated:true}); import {createRoot} from 'react-dom/client'; import {ArchiveDashboard} from './src/components/archive/archive-dashboard'; createRoot(document.getElementById('root')).render(<ArchiveDashboard/>);`, resolveDir: root, loader:'tsx'},
+  bundle:true, write:false, format:'iife', jsx:'automatic', define:{'process.env.NODE_ENV':'"development"'},
+  plugins:[{name:'fixture-dependencies',setup(b){b.onResolve({filter:/^@\//},a=>mocks.has(a.path)?{path:a.path,namespace:'fixture'}:undefined);b.onLoad({filter:/.*/,namespace:'fixture'},()=>({contents:stub,loader:'js',resolveDir:root}));}}],
+});
+const css = await postcss([tailwind()]).process(await fs.readFile('src/app/globals.css','utf8'), {from:path.join(root,'src/app/globals.css')});
+const server = http.createServer((req,res)=>{res.setHeader('Content-Type',req.url==='/app.js'?'text/javascript':req.url==='/style.css'?'text/css':'text/html');res.end(req.url==='/app.js'?output.outputFiles[0].text:req.url==='/style.css'?css.css:'<html class="dark"><head><link rel="stylesheet" href="/style.css"><style>html,body,#root{height:100%;margin:0}</style></head><body><div id="root"></div><script src="/app.js"></script></body></html>');});
+await new Promise(resolve=>server.listen(0,'127.0.0.1',resolve));
+const browser=await chromium.launch({headless:true});
+try {
+ const page=await browser.newPage({viewport:{width:1440,height:1000}});
+ const rows=Array.from({length:105},(_,i)=>({id:'task-'+i,kind:'task',title:'Archived task '+i,projectId:'project',projectName:'Project',archivedAt:'2020-01-01T00:00:00Z',updatedAt:'2020-01-01T00:00:00Z',createdAt:'2020-01-01T00:00:00Z',worktreeId:'wt_'+i,workDir:'/fixture/'+i,worktreeStatus:'present',worktreeManaged:true,canRestore:true,sharedWorktree:false,affectedProjectIds:['project'],sessions:[]}));
+ rows[6].worktreeId='wt_2';
+ const chats=[0,1].map(i=>({...rows[0],kind:'chat',id:'chat-'+i,title:'Archived chat '+i,worktreeId:undefined,workDir:undefined,worktreeStatus:'none',canRestore:true}));
+ let holdArchive=false;
+ const heldArchive=[];
+ let requests=0;
+ const pending=new Map();
+ await page.route('**/api/**',async route=>{
+  const req=route.request(),url=new URL(req.url());
+  if(req.method()==='DELETE'){pending.set(url.pathname,route);return;}
+  if(url.pathname==='/api/archive/retention'){await route.fulfill({json:{progress:{phase:'idle',total:0,completed:0,removed:0,skipped:0,errors:[],currentTitle:null,startedAt:null,finishedAt:null}}});return;}
+  if(url.pathname==='/api/archive'){
+   requests++;
+   const offset=Number(url.searchParams.get('cursor')||0),items=url.searchParams.get('kind')==='task'?rows:chats;
+   const payload={json:{items:items.slice(offset,offset+100),projects:[],summary:{total:rows.length,tasks:rows.length,chats:0,worktreesPresent:rows.length,worktreesDeleted:0,worktreesMissing:0},pagination:{kind:url.searchParams.get('kind'),total:items.length,nextCursor:offset+100<items.length?String(offset+100):null}}};
+   if(holdArchive){heldArchive.push({route,payload:JSON.parse(JSON.stringify(payload))});return;}
+   await route.fulfill(payload);return;
+  }
+  await route.fulfill({json:{}});
+ });
+ await page.goto('http://127.0.0.1:'+server.address().port);
+ const row=id=>page.getByTestId('archive-task-row-task-'+id);
+ await row(0).waitFor();
+ const shot=name=>page.screenshot({path:path.join(artifacts,name+'.png'),fullPage:true});
+ await shot('01-initial');
+ async function start(id,folder=false){
+  await row(id).locator('[data-control="archive.item.'+(folder?'delete_worktree':'delete')+'"]').click();
+  await page.getByTestId(folder?'archive-worktree-delete-confirm':'archive-delete-confirm').click();
+ }
+ await start(0);
+ await shot('02-first-pending');
+ await page.getByTestId('archive-delete-dialog').waitFor({state:'hidden',timeout:1500});
+ await start(1);
+ await expect.poll(()=>pending.size).toBe(2);
+ await shot('03-two-pending');
+ await row(0).evaluate(el=>{window.archiveTable=el.closest('table');window.archiveScroll=window.archiveTable.parentElement;window.archiveScroll.scrollTop=120;});
+ rows.splice(rows.findIndex(r=>r.id==='task-1'),1);
+ await pending.get('/api/archive/tasks/task-1').fulfill({json:{ok:true}});
+ await row(1).waitFor({state:'hidden'});
+ assert.equal(await row(0).count(),1);
+ assert.equal(requests,2,'no archive refetch after delete');
+ assert.equal(await page.evaluate(()=>window.archiveTable.isConnected && window.archiveScroll.scrollTop>0),true,'table stays mounted and scrolled');
+ await pending.get('/api/archive/tasks/task-0').fulfill({status:500,json:{error:'fixture deletion failed'}});
+ await row(0).locator('[data-control="archive.item.delete"]:enabled').waitFor();
+ await shot('04-out-of-order-error');
+ assert.match(await page.locator('body').innerText(),/fixture deletion failed/);
+ await start(0);
+ rows.splice(rows.findIndex(r=>r.id==='task-0'),1);
+ await pending.get('/api/archive/tasks/task-0').fulfill({json:{ok:true}});
+ await row(0).waitFor({state:'hidden'});
+ await start(2,true);
+ await page.getByTestId('archive-worktree-delete-dialog').waitFor({state:'hidden',timeout:1500});
+ await expect(row(6).locator('[data-control="archive.item.delete"]')).toBeDisabled();
+ await start(3,true);
+ await pending.get('/api/worktrees/wt_3').fulfill({json:{ok:true}});
+ await row(3).locator('[data-control="archive.item.delete_worktree"]').waitFor({state:'hidden'});
+ await pending.get('/api/worktrees/wt_2').fulfill({json:{ok:true}});
+ await row(2).locator('[data-control="archive.item.restore"]').waitFor({state:'hidden'});
+ await row(6).locator('[data-control="archive.item.restore"]').waitFor({state:'hidden'});
+ assert.equal(requests,2);
+ await shot('05-folder-deletions');
+ await page.locator('[data-control="archive.load_more"]').click();
+ await row(104).waitFor();
+ assert.equal(await page.locator('[data-testid^="archive-task-row-"]').count(),103,'offset adjusts after deleting loaded rows');
+ await shot('06-pagination');
+ await page.setViewportSize({width:390,height:844});
+ await start(4);
+ await page.getByTestId('archive-delete-dialog').waitFor({state:'hidden',timeout:1500});
+ await start(5);
+ await shot('07-phone-two-pending');
+ rows.splice(rows.findIndex(r=>r.id==='task-4'),1);
+ rows.splice(rows.findIndex(r=>r.id==='task-5'),1);
+ await pending.get('/api/archive/tasks/task-4').fulfill({json:{ok:true}});
+ await pending.get('/api/archive/tasks/task-5').fulfill({json:{ok:true}});
+ await row(5).waitFor({state:'hidden'});
+ await shot('08-phone-complete');
+ const chat=id=>page.getByTestId('archive-chat-row-chat-'+id);
+ for(const id of [0,1]){
+  await chat(id).locator('[data-control="archive.item.delete"]').click();
+  await page.getByTestId('archive-delete-confirm').click();
+  await page.getByTestId('archive-delete-dialog').waitFor({state:'hidden'});
+ }
+ await expect.poll(()=>pending.has('/api/sessions/chat-1')).toBe(true);
+ await pending.get('/api/sessions/chat-0').abort('failed');
+ await pending.get('/api/sessions/chat-1').fulfill({json:{ok:true}});
+ await chat(1).waitFor({state:'hidden'});
+ await expect(chat(0).locator('[data-control="archive.item.delete"]')).toBeEnabled();
+ chats.splice(1,1);
+ await shot('09-chat-network-failure');
+ await page.setViewportSize({width:1440,height:1000});
+ await start(7);
+ holdArchive=true;
+ await page.locator('[data-control="archive.retry"]').click();
+ await expect.poll(()=>heldArchive.length).toBe(2);
+ const refreshesBefore=await page.evaluate(()=>window.archiveProjectRefreshes ?? 0);
+ rows.splice(rows.findIndex(r=>r.id==='task-7'),1);
+ await pending.get('/api/archive/tasks/task-7').fulfill({json:{ok:true}});
+ // Observe the completed request before releasing the stale list snapshots.
+ await page.waitForFunction(previous=>(window.archiveProjectRefreshes ?? 0)>previous,refreshesBefore);
+ holdArchive=false;
+ for(const held of heldArchive) await held.route.fulfill(held.payload);
+ await row(8).waitFor();
+ assert.equal(await row(7).count(),0,'late list response cannot resurrect a deleted row');
+ await shot('10-late-refresh');
+ console.log('PASS: concurrent deletes, out-of-order completion, failure/retry, folder updates, pagination, phone');
+} finally {await browser.close();await new Promise(resolve=>server.close(resolve));}

--- a/tests/archive-retention-progress.browser.test.mjs
+++ b/tests/archive-retention-progress.browser.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+import { chromium, expect } from '@playwright/test';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import postcss from 'postcss';
+import tailwind from '@tailwindcss/postcss';
+
+// Real shared hook and status component; controlled API models a cleanup batch.
+const root = process.cwd();
+const artifacts = process.env.TESSERA_TEST_ARTIFACT_DIR ?? path.join(root, 'tmp', 'archive-retention-browser');
+await fs.mkdir(artifacts, { recursive: true });
+const output = await build({
+  stdin: {
+    contents: `import React from 'react'; import {createRoot} from 'react-dom/client';
+import {useAuthStore} from './src/stores/auth-store';
+useAuthStore.setState({user:{id:'user1',username:'fixture'},isAuthenticated:true});window.setUser=(id)=>useAuthStore.setState({user:id?{id,username:id}:null});
+import {ArchiveNavigationButton} from './src/components/archive/archive-navigation-button';
+import {ArchiveRetentionStatus} from './src/components/archive/archive-retention-status';
+import {useArchiveRetentionProgress,isArchiveRetentionActive} from './src/hooks/use-archive-retention-progress';
+function Probe(){const p=useArchiveRetentionProgress();return <output className="sr-only" data-testid="probe">{isArchiveRetentionActive(p)?'active':'inactive'}</output>}
+const root=createRoot(document.getElementById('root'));window.unmount=()=>root.unmount();root.render(<div className="flex gap-4 p-4"><aside className="w-11 bg-(--sidebar-bg)"><ArchiveNavigationButton/><Probe/></aside><main className="w-full max-w-xl"><ArchiveRetentionStatus/></main></div>);`,
+    resolveDir: root, loader: 'tsx',
+  },
+  bundle: true, write: false, format: 'iife', jsx: 'automatic', define: { 'process.env.NODE_ENV': '"development"' },
+  plugins: [{ name: 'translation-fixture', setup(b) {
+    b.onResolve({ filter: /^@\/(lib\/i18n|stores\/tab-store|lib\/telemetry\/ui-click|hooks\/use-tooltips-enabled)$/ }, () => ({ path: 'i18n', namespace: 'fixture' }));
+    b.onLoad({ filter: /.*/, namespace: 'fixture' }, () => ({
+      contents: `import {en} from '${root}/src/lib/i18n/en.ts';export const useTabStore={getState:()=>({findSessionLocation:()=>null,createTab:()=>window.archiveOpened=true})};export const telemetryClickAttributes=()=>({});export const useTooltipsEnabled=()=>true;export const useI18n=()=>({t:(key,params)=>Object.entries(params??{}).reduce((s,[k,v])=>s.replaceAll('{{'+k+'}}',String(v)),key.split('.').reduce((v,k)=>v?.[k],en)??key)});`,
+      loader: 'js', resolveDir: root,
+    }));
+  } }],
+});
+const css = await postcss([tailwind()]).process(await fs.readFile('src/app/globals.css', 'utf8'), {from:path.join(root,'src/app/globals.css')});
+const server = http.createServer((req, res) => {
+  res.setHeader('Content-Type', req.url === '/app.js' ? 'text/javascript' : req.url === '/style.css' ? 'text/css' : 'text/html');
+  res.end(req.url === '/app.js' ? output.outputFiles[0].text : req.url === '/style.css' ? css.css : '<html class="dark"><head><link rel="stylesheet" href="/style.css"></head><body style="background:#181818;color:#ddd;font:16px sans-serif"><div id="root"></div><script src="/app.js"></script></body></html>');
+});
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+const browser = await chromium.launch({ headless: true });
+try {
+  const page = await browser.newPage();
+  await page.clock.install();
+  let progress = { phase: 'scanning', total: 0, completed: 0, removed: 0, skipped: 0, errors: [], currentTitle: null, startedAt: '2026-09-12T00:00:00Z', finishedAt: null };
+  let requests = 0;
+  let fail = false;
+  await page.route('**/api/archive/retention', async route => {
+    requests++;
+    await route.fulfill({ status: fail ? 503 : 200, json: { progress } });
+  });
+  await page.goto('http://127.0.0.1:' + server.address().port);
+  await expect(page.getByTestId('probe')).toHaveText('active');
+  await expect(page.getByTestId('archive-retention-spinner')).toBeVisible();
+  await expect(page.getByTestId('archive-retention-status').getByRole('status')).toHaveText('Checking folders for automatic cleanup…');
+  assert.equal(requests, 1, 'three consumers share one request');
+  await page.getByTestId('project-strip-archive').click();
+  assert.equal(await page.evaluate(()=>window.archiveOpened), true, 'archive navigation still opens its tab');
+  await page.screenshot({ path: path.join(artifacts, '01-scanning.png') });
+  progress = { ...progress, phase: 'waiting', total: 3, completed: 2, removed: 1, skipped: 1 };
+  await page.clock.runFor(2_100);
+  await expect(page.getByTestId('archive-retention-status').getByRole('status')).toContainText('2/3 processed');
+  await expect(page.getByTestId('probe')).toHaveText('active');
+  await expect(page.getByTestId('project-strip-archive')).toHaveAttribute('aria-label', 'Cleaning worktree folders · 2/3 processed');
+  assert.equal(requests, 2, 'one shared timer polls during inter-folder wait');
+  await page.screenshot({ path: path.join(artifacts, '02-waiting.png') });
+  progress = { ...progress, phase: 'complete', completed: 3, errors: [{ id: 'wt1', kind: 'task', title: 'Archived example', error: 'Folder is locked' }], finishedAt: '2026-09-12T00:01:00Z' };
+  await page.clock.runFor(2_100);
+  await expect(page.getByTestId('probe')).toHaveText('inactive');
+  await expect(page.getByTestId('archive-retention-spinner')).toHaveCount(0);
+  await expect(page.getByTestId('archive-retention-status').getByRole('status')).toHaveText('Automatic folder cleanup complete');
+  await page.getByText('View 1 failed folders').click();
+  await expect(page.getByText('Archived example: Folder is locked')).toBeVisible();
+  await expect(page.getByText('1 deleted · 1 skipped · 1 failed')).toBeVisible();
+  await page.screenshot({ path: path.join(artifacts, '03-complete-failure.png') });
+  progress = {...progress, phase:'complete',total:0,completed:0,removed:0,skipped:0,errors:[{id:'scan',kind:'task',error:'Cannot inspect archived folders'}]};
+  await page.clock.runFor(15_100);
+  await expect(page.getByTestId('archive-retention-status')).toBeVisible();
+  await expect(page.getByText('scan: Cannot inspect archived folders')).toBeVisible();
+  await page.screenshot({path:path.join(artifacts,'04-scan-failed.png')});
+  progress = {...progress, phase:'idle',total:0,completed:0,errors:[]};
+  await page.clock.runFor(15_100);
+  await expect(page.getByTestId('archive-retention-status')).toHaveCount(0);
+  await expect(page.getByTestId('project-strip-archive')).toHaveAttribute('aria-label','Archive');
+  await page.screenshot({path:path.join(artifacts,'05-idle.png')});
+  fail = true;
+  await page.clock.runFor(15_100);
+  await expect(page.getByTestId('archive-retention-status')).toHaveCount(0);
+  await expect(page.getByTestId('probe')).toHaveText('inactive');
+  await page.screenshot({ path: path.join(artifacts, '06-disconnected.png') });
+  fail=false;
+  progress={...progress,phase:'running',total:1,completed:0};
+  await page.evaluate(()=>window.setUser('user2'));
+  await expect(page.getByTestId('probe')).toHaveText('active');
+  await page.evaluate(()=>window.setUser(null));
+  await expect(page.getByTestId('probe')).toHaveText('inactive');
+  await expect(page.getByTestId('archive-retention-status')).toHaveCount(0);
+  const afterLogout=requests;
+  await page.clock.runFor(30_000);
+  assert.equal(requests,afterLogout,'logout clears progress and stops polling');
+  await page.evaluate(() => window.unmount());
+  const before = requests;
+  await page.clock.runFor(30_000);
+  assert.equal(requests, before, 'polling stops when all consumers unmount');
+  console.log('PASS: shared polling, scanning, waiting, completion, failure details, disconnect and teardown');
+} finally {
+  await browser.close();
+  await new Promise(resolve => server.close(resolve));
+}

--- a/tests/archive-retention-progress.test.ts
+++ b/tests/archive-retention-progress.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const root = fs.mkdtempSync(path.join(process.cwd(), 'tmp-retention-'));
+process.env.TESSERA_DATA_DIR = path.join(root, 'data');
+process.env.TESSERA_PRODUCTION_DB = '1';
+const git = (cwd: string, args: string[]) => execFileSync('git', args, {
+  cwd, stdio: 'pipe', encoding: 'utf8',
+});
+
+test.after(async () => {
+  const { processManager } = await import('@/lib/cli/process-manager');
+  await processManager.cleanup();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('single-item retention progresses past missing and previously deleted worktrees', async () => {
+  const database = await import('@/lib/db/database');
+  await database.initDatabase();
+  const projects = await import('@/lib/db/projects');
+  const sessions = await import('@/lib/db/sessions');
+  const archive = await import('@/lib/archive/archive-service');
+  const repo = path.join(root, 'repo');
+  fs.mkdirSync(repo);
+  git(repo, ['init', '-b', 'main']);
+  git(repo, ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '--allow-empty', '-m', 'init']);
+  projects.registerProject('retention-origin', repo, 'Retention origin');
+  for (const [index, name] of ['missing', 'first', 'second'].entries()) {
+    const workDir = path.join(root, name);
+    git(repo, ['worktree', 'add', '-b', name, workDir]);
+    sessions.createSession(name, 'retention-origin', name, 'claude-code', {
+      workDir, worktreeBranch: name, worktreeManaged: true,
+    });
+    sessions.updateSession(name, {
+      archived: 1, archived_at: `2020-01-0${3 - index}T00:00:00.000Z`,
+    });
+  }
+  fs.rmSync(path.join(root, 'missing'), { recursive: true });
+  const candidates = await archive.listExpiredArchivedWorktreeCandidates(7);
+  assert.equal(candidates.length, 2, 'missing folders do not enter the progress total');
+  const firstId = sessions.getSession('first')!.worktree_id!;
+  sessions.updateSession('first', { archived: 0 });
+  const restored = await archive.pruneExpiredArchivedWorktrees(7, undefined, {
+    maxWorktreeAttempts: 1, worktreeIds: new Set([firstId]),
+  });
+  assert.equal(restored.attempted, 0, 'a queued folder restored before its turn must survive');
+  assert.equal(fs.existsSync(path.join(root, 'first')), true);
+  assert.equal(fs.existsSync(path.join(root, 'second')), true, 'only the selected folder may be attempted');
+  sessions.updateSession('first', { archived: 1 });
+  for (const name of ['first', 'second']) {
+    const result = await archive.pruneExpiredArchivedWorktrees(7, undefined, { maxWorktreeAttempts: 1 });
+    assert.equal(result.removed, 1, JSON.stringify(result));
+    assert.equal(fs.existsSync(path.join(root, name)), false);
+    assert.ok(sessions.getSession(name), 'archive history survives retention');
+  }
+  assert.equal(sessions.getSession('missing')?.worktree_deleted_at, null,
+    'missing paths preserve canonical records');
+});

--- a/tests/archive-retention-restoration-contract.test.mjs
+++ b/tests/archive-retention-restoration-contract.test.mjs
@@ -87,7 +87,7 @@ test('retention days are committed only after editing finishes', () => {
 test('Archive restore updates one row without replacing the dashboard with a full reload', () => {
   const archive = read('src/components/archive/archive-dashboard.tsx');
   const restoreStart = archive.indexOf('const restoreItem = useCallback');
-  const deleteStart = archive.indexOf('const deleteItem = useCallback', restoreStart);
+  const deleteStart = archive.indexOf('const startDelete = useCallback', restoreStart);
 
   assert.ok(restoreStart >= 0 && deleteStart > restoreStart);
   const restoreHandler = archive.slice(restoreStart, deleteStart);

--- a/tests/archive-retention-runner.test.ts
+++ b/tests/archive-retention-runner.test.ts
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { build } from 'esbuild';
+import type { RetentionResult } from '@/lib/archive/archive-service';
+
+const candidate = (id: string) => ({ worktreeId: `wt_${id}`, id, kind: 'task' as const, title: `Folder ${id}` });
+let candidates = [candidate('a'), candidate('b'), candidate('c')];
+let calls: string[] = [];
+let scanCount = 0;
+let cleanup: (id: string) => Promise<RetentionResult> = async () => ({removed:1,attempted:1,skipped:0,errors:[]});
+let scan: (() => Promise<typeof candidates>) | undefined;
+const dependencies = {
+  listExpiredArchivedWorktreeCandidates: async () => { scanCount++; return scan ? scan() : candidates; },
+  pruneExpiredArchivedWorktrees: async (_days: number, _user: string, opts: {worktreeIds: Set<string>}) => {
+    const id = [...opts.worktreeIds][0]; calls.push(id); return cleanup(id);
+  },
+};
+// Exercise the production runner and its actual timers with only disk deletion stubbed.
+(globalThis as unknown as {retentionTestDependencies: typeof dependencies}).retentionTestDependencies = dependencies;
+let runner: typeof import('@/lib/archive/archive-retention-runner');
+test.before(async () => {
+const bundle = await build({
+  entryPoints:['src/lib/archive/archive-retention-runner.ts'],bundle:true,write:false,format:'esm',platform:'node',
+  plugins:[{name:'retention-dependencies',setup(b){
+    b.onResolve({filter:/^\.\/archive-service$/},()=>({path:'service',namespace:'fixture'}));
+    b.onResolve({filter:/^@\/lib\/logger$/},()=>({path:'logger',namespace:'fixture'}));
+    b.onLoad({filter:/.*/,namespace:'fixture'},args=>({contents:args.path==='logger'
+      ? 'export default {warn(){}}'
+      : 'export const {listExpiredArchivedWorktreeCandidates,pruneExpiredArchivedWorktrees}=globalThis.retentionTestDependencies;'}));
+  }}],
+});
+runner = await import(
+  `data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString('base64')}`
+);
+});
+const progress = () => runner.getArchivedWorktreeRetentionProgress('user-a');
+const flush = () => new Promise<void>(resolve=>setImmediate(resolve));
+test.beforeEach(()=>{
+  runner.stopArchivedWorktreeRetention();
+  candidates=[candidate('a'),candidate('b'),candidate('c')];calls=[];scanCount=0;scan=undefined;
+  cleanup=async()=>({removed:1,attempted:1,skipped:0,errors:[]});
+  runner.configureArchivedWorktreeRetention({retentionDays:3,userId:'user-a'});
+});
+test.afterEach(()=>runner.stopArchivedWorktreeRetention());
+
+test('one snapshot counts physical folders and advances beyond failures',async()=>{
+  cleanup=async id=>id==='wt_a'
+    ? {removed:0,attempted:1,skipped:0,errors:[{id:'a',kind:'task',error:'locked'}]}
+    : {removed:1,attempted:1,skipped:100,errors:[]};
+  await runner.runArchivedWorktreeRetentionNow();
+  assert.deepEqual(calls,['wt_a']);
+  assert.equal(progress().phase,'waiting');
+  assert.equal(progress().total,3);
+  assert.equal(progress().completed,1);
+  assert.equal(progress().removed,0);
+  assert.equal(progress().skipped,0,'irrelevant archive rows are not skipped folders');
+  assert.equal(progress().errors[0].title,'Folder a');
+  await runner.runArchivedWorktreeRetentionNow();
+  await runner.runArchivedWorktreeRetentionNow();
+  assert.deepEqual(calls,['wt_a','wt_b','wt_c']);
+  assert.equal(scanCount,1);
+  assert.equal(progress().phase,'complete');
+  assert.equal(progress().completed,3);
+  assert.equal(progress().removed,2);
+  assert.ok(progress().finishedAt);
+  assert.equal(runner.getArchivedWorktreeRetentionProgress('other-user').phase,'idle');
+});
+
+test('in-flight folder is visible and duplicate requests share the operation',async()=>{
+  let finish!: (r:RetentionResult)=>void;
+  cleanup=()=>new Promise(resolve=>{finish=resolve;});
+  const first=runner.runArchivedWorktreeRetentionNow();
+  await flush();
+  const second=runner.runArchivedWorktreeRetentionNow();
+  assert.equal(progress().currentTitle,'Folder a');
+  assert.equal(progress().phase,'running');
+  assert.equal(progress().completed,0);
+  finish({removed:1,attempted:1,skipped:0,errors:[]});
+  await Promise.all([first,second]);
+  assert.equal(calls.length,1);
+  assert.equal(progress().completed,1);
+});
+
+test('restored or externally removed queued folders count as skipped',async()=>{
+  cleanup=async()=>({removed:0,attempted:0,skipped:250,errors:[]});
+  await runner.runArchivedWorktreeRetentionNow();
+  assert.equal(progress().completed,1);
+  assert.equal(progress().skipped,1);
+  assert.equal(progress().removed,0);
+});
+
+test('policy changes during a scan cancel the old snapshot before deletion',async()=>{
+  let finish!: (r:typeof candidates)=>void;
+  scan=()=>new Promise(resolve=>{finish=resolve;});
+  const pending=runner.runArchivedWorktreeRetentionNow();
+  await flush();
+  assert.equal(progress().phase,'scanning');
+  runner.configureArchivedWorktreeRetention({retentionDays:7,userId:'user-b'});
+  finish(candidates);
+  await pending;
+  assert.equal(calls.length,0);
+  assert.equal(progress().phase,'idle');
+  assert.equal(runner.getArchivedWorktreeRetentionProgress('user-b').phase,'idle');
+});
+
+test('unchanged settings preserve progress and deletion throws do not block the queue',async()=>{
+  cleanup=async()=>{throw new Error('disk unavailable');};
+  await runner.runArchivedWorktreeRetentionNow();
+  runner.configureArchivedWorktreeRetention({retentionDays:3,userId:'user-a'});
+  await runner.runArchivedWorktreeRetentionNow();
+  assert.deepEqual(calls,['wt_a','wt_b']);
+  assert.equal(progress().completed,2);
+  assert.equal(progress().errors.length,2);
+});
+
+test('startup waits one minute and subsequent folders wait thirty seconds',async t=>{
+  runner.stopArchivedWorktreeRetention();
+  t.mock.timers.enable({apis:['setTimeout']});
+  runner.configureArchivedWorktreeRetention({retentionDays:3,userId:'user-a'});
+  t.mock.timers.tick(59_999);await flush();assert.equal(calls.length,0);
+  t.mock.timers.tick(1);await flush();assert.equal(calls.length,1);
+  runner.configureArchivedWorktreeRetention({retentionDays:3,userId:'user-a'});
+  t.mock.timers.tick(29_999);await flush();assert.equal(calls.length,1);
+  t.mock.timers.tick(1);await flush();assert.equal(calls.length,2);
+});
+
+test('empty cycles stay idle and scan failures are visible',async()=>{
+  candidates=[];
+  await runner.runArchivedWorktreeRetentionNow();assert.equal(progress().phase,'idle');
+  scan=async()=>{throw new Error('scan failed');};
+  await runner.runArchivedWorktreeRetentionNow();
+  assert.equal(progress().phase,'complete');
+  assert.equal(progress().errors[0].error,'scan failed');
+});
+
+
+test('overlapping callers both settle when the shared scan fails', async () => {
+  let rejectScan!: (error: Error) => void;
+  scan = () => new Promise((_resolve, reject) => { rejectScan = reject; });
+  const first = runner.runArchivedWorktreeRetentionNow();
+  await flush();
+  const second = runner.runArchivedWorktreeRetentionNow();
+  rejectScan(new Error('shared scan failed'));
+  const results = await Promise.allSettled([first, second]);
+  assert.deepEqual(results.map((result) => result.status), ['fulfilled', 'fulfilled']);
+  assert.equal(progress().errors[0].error, 'shared scan failed');
+});


### PR DESCRIPTION
Fix archived Worktree retention so missing or already-removed rows no longer consume the paced cleanup attempt. Start cleanup one minute after app launch, retain the 30-second per-folder cooldown, and expose a live queue/progress indicator in the Archive navigation and dashboard. Archive item deletion now updates only the affected row, allowing concurrent deletions without resetting the list or scroll position.

Validation: targeted server lifecycle tests, archive browser fixtures for retention progress and concurrent deletion, ESLint, and TypeScript.