### PR TITLE
fix(workspace): tighten folder rename double-click

### DIFF
--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -54,6 +54,7 @@ import {
 import { WorkspaceInlineInputRow } from "@/components/workspace/workspace-inline-input-row";
 import { useWorkspaceInlineInput } from "@/components/workspace/use-workspace-inline-input";
 import {
+  isRapidDirectoryRenameDoubleClick,
   shouldOpenOnRowClick,
   shouldToggleDirectoryOnClick,
 } from "@/components/workspace/workspace-inline-input-state";
@@ -221,6 +222,11 @@ export function WorkspaceFilePanel({
   const peekTarget = useWorkspacePeekStore((state) => state.target);
   const previousPeekTargetRef = useRef(peekTarget);
   const previousFileListTargetKeyRef = useRef(targetKey);
+  const directoryRenameDoubleClickRef = useRef<{
+    path: string;
+    qualified: boolean;
+    timestamp: number;
+  } | null>(null);
   const subscriberId = useStableWorkspaceFilesSubscriberId("workspace-file-panel");
   const [query, setQuery] = useState("");
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -553,12 +559,22 @@ export function WorkspaceFilePanel({
     toggleStoredPath(targetKey, path);
   }
 
-  /**
-   * Toggle on the first click with no double-click delay. Chromium marks the
-   * second click with detail > 1, so it is dropped instead of toggling back.
-  */
+  /** Keep native double-click support, but use a tighter app-level threshold. */
   function handleDirectoryClick(event: MouseEvent, path: string) {
-    if (!shouldToggleDirectoryOnClick(event.detail)) return;
+    const previousClick = directoryRenameDoubleClickRef.current;
+    const qualifiedDoubleClick = isRapidDirectoryRenameDoubleClick({
+      clickCount: event.detail,
+      path,
+      previousPath: previousClick?.path,
+      previousTimestamp: previousClick?.timestamp,
+      timestamp: event.timeStamp,
+    });
+    directoryRenameDoubleClickRef.current = {
+      path,
+      qualified: qualifiedDoubleClick,
+      timestamp: event.timeStamp,
+    };
+    if (!shouldToggleDirectoryOnClick(event.detail, qualifiedDoubleClick)) return;
     toggleDirectory(path);
   }
 
@@ -712,9 +728,11 @@ export function WorkspaceFilePanel({
             />
             <FolderIcon className="h-3.5 w-3.5 shrink-0 text-(--text-muted) group-hover:text-(--text-primary)" />
             <span
-              // The double-click-to-rename target is the name text alone.
+              // The name alone owns rename, with a tighter threshold than the
+              // browser's native double-click setting.
               onDoubleClick={(event) => {
                 if (!canMutate) return;
+                if (!directoryRenameDoubleClickRef.current?.qualified) return;
                 event.stopPropagation();
                 beginRename(node);
               }}

--- a/src/components/workspace/workspace-inline-input-state.ts
+++ b/src/components/workspace/workspace-inline-input-state.ts
@@ -17,13 +17,39 @@ export type WorkspaceInlineSubmitIntent =
   /** Nothing to ask the server for: close the input and touch no network. */
   | { kind: "cancel" };
 
+export const DIRECTORY_RENAME_DOUBLE_CLICK_MS = 300;
+
+/** Whether two clicks qualify as the deliberately fast folder-rename gesture. */
+export function isRapidDirectoryRenameDoubleClick({
+  clickCount,
+  path,
+  previousPath,
+  previousTimestamp,
+  timestamp,
+}: {
+  clickCount: number;
+  path: string;
+  previousPath: string | undefined;
+  previousTimestamp: number | undefined;
+  timestamp: number;
+}): boolean {
+  return clickCount === 2
+    && previousPath === path
+    && previousTimestamp !== undefined
+    && timestamp >= previousTimestamp
+    && timestamp - previousTimestamp <= DIRECTORY_RENAME_DOUBLE_CLICK_MS;
+}
+
 /**
- * The first click toggles immediately. Chromium reports the second click of a
- * double-click with detail > 1; dropping that duplicate prevents a folder from
- * toggling straight back before the rename handler runs.
+ * A qualified rapid double-click reserves its second click for rename. A slow
+ * second click is still an ordinary expand/collapse action even if Chromium
+ * groups it into a native `dblclick` gesture.
  */
-export function shouldToggleDirectoryOnClick(clickCount: number): boolean {
-  return clickCount <= 1;
+export function shouldToggleDirectoryOnClick(
+  clickCount: number,
+  isQualifiedDoubleClick = false,
+): boolean {
+  return clickCount !== 2 || !isQualifiedDoubleClick;
 }
 
 /**

--- a/tests/workspace-inline-input-state.test.ts
+++ b/tests/workspace-inline-input-state.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  DIRECTORY_RENAME_DOUBLE_CLICK_MS,
+  isRapidDirectoryRenameDoubleClick,
   resolveInlineSubmitIntent,
   shouldOpenOnRowClick,
   shouldToggleDirectoryOnClick,
@@ -56,9 +58,22 @@ test("a rename back to the name it already has issues no request", () => {
   );
 });
 
-test("a folder toggles on the first click and drops a double-click's second click", () => {
+test("a folder treats a slow second click as another toggle, not a double-click", () => {
   assert.equal(shouldToggleDirectoryOnClick(1), true);
-  assert.equal(shouldToggleDirectoryOnClick(2), false);
+  assert.equal(shouldToggleDirectoryOnClick(2, false), true);
+  assert.equal(shouldToggleDirectoryOnClick(2, true), false);
+});
+
+test("only a genuinely rapid second click qualifies to rename a folder", () => {
+  const click = (timestamp: number) => isRapidDirectoryRenameDoubleClick({
+    clickCount: 2,
+    path: "docs",
+    previousPath: "docs",
+    previousTimestamp: 100,
+    timestamp,
+  });
+  assert.equal(click(100 + DIRECTORY_RENAME_DOUBLE_CLICK_MS), true);
+  assert.equal(click(101 + DIRECTORY_RENAME_DOUBLE_CLICK_MS), false);
 });
 
 test("a rename preselects the name without its extension", () => {

--- a/tests/workspace-tree-operations-contract.test.mjs
+++ b/tests/workspace-tree-operations-contract.test.mjs
@@ -208,11 +208,12 @@ test('a watch reconcile cannot take the row being edited', () => {
 });
 
 test('double-clicking a directory name renames without fighting its toggle', () => {
-  // The first click toggles immediately and the second click is ignored before
-  // the double-click handler opens rename, so no timer delays ordinary clicks.
-  assert.match(directoryRowSource, /onDoubleClick=\{\(event\) => \{\s*if \(!canMutate\) return;\s*event\.stopPropagation\(\);\s*beginRename\(node\);/);
-  assert.match(filePanelSource, /if \(!shouldToggleDirectoryOnClick\(event\.detail\)\) return;/);
-  assert.match(inlineStateSource, /return clickCount <= 1;/);
+  // A fast second click is reserved for rename. A slower second click must
+  // remain a normal toggle even when Chromium still emits `dblclick`.
+  assert.match(directoryRowSource, /if \(!directoryRenameDoubleClickRef\.current\?\.qualified\) return;/);
+  assert.match(filePanelSource, /isRapidDirectoryRenameDoubleClick\(\{/);
+  assert.match(filePanelSource, /shouldToggleDirectoryOnClick\(event\.detail, qualifiedDoubleClick\)/);
+  assert.match(inlineStateSource, /return clickCount !== 2 \|\| !isQualifiedDoubleClick;/);
 });
 
 test('the delete confirmation survives the move to inline entry', () => {


### PR DESCRIPTION
## Summary
- require a 300 ms rapid second click before starting a folder rename
- keep slower second clicks as normal folder expand/collapse actions
- cover the threshold and tree interaction contract with regression tests

## Validation
- `npm exec tsx --test tests/workspace-inline-input-state.test.ts`
- `npm exec tsx --test tests/workspace-tree-operations-contract.test.mjs`
- `npx tsc --noEmit --pretty false`

## UI QA
A development server reached the normal login screen, but the isolated browser profile had no authenticated session; UI click-through QA could not proceed.