### PR TITLE
perf(files): cache workspace trees across session switches

### DIFF
--- a/src/hooks/use-workspace-file-list.ts
+++ b/src/hooks/use-workspace-file-list.ts
@@ -57,6 +57,25 @@ interface WorkspaceDirectoryLoadOptions {
 const MUTATION_LIST_ATTEMPTS = 5;
 const FILE_LIST_LOAD_TIMEOUT_MS = 15_000;
 
+interface CachedWorkspaceListing {
+  listings: Record<string, WorkspaceDirectoryListing>;
+  workDir: string | null;
+}
+
+// Browser-memory only: keep recently visited trees across panel unmounts, without
+// persisting filesystem metadata or allowing an unbounded collection of sessions.
+const MAX_CACHED_WORKSPACES = 20;
+const workspaceListingCache = new Map<string, CachedWorkspaceListing>();
+const EMPTY_LISTINGS: Record<string, WorkspaceDirectoryListing> = {};
+
+function cacheWorkspaceListing(key: string, snapshot: CachedWorkspaceListing) {
+  workspaceListingCache.delete(key);
+  workspaceListingCache.set(key, snapshot);
+  while (workspaceListingCache.size > MAX_CACHED_WORKSPACES) {
+    workspaceListingCache.delete(workspaceListingCache.keys().next().value!);
+  }
+}
+
 function normalizeWorkspaceRelativePath(filePath: string): string {
   return filePath
     .replace(/\\/g, "/")
@@ -172,14 +191,17 @@ export function useWorkspaceFileList(
   const target = useMemo<WorkspaceTarget | null>(() => targetKind && targetId
     ? { kind: targetKind, id: targetId }
     : null, [targetId, targetKind]);
-  const targetKey = target ? workspaceTargetKey(target) : null;
+  const targetKey = target
+    ? JSON.stringify([workspaceTargetKey(target), target.kind === "session" ? projectId ?? null : null])
+    : null;
   const targetReady = Boolean(target && (target.kind === "worktree" || projectId));
-  const [listings, setListings] = useState<Record<string, WorkspaceDirectoryListing>>({});
-  const [listingTargetKey, setListingTargetKey] = useState<string | null>(null);
+  const cached = targetKey && targetReady ? workspaceListingCache.get(targetKey) : undefined;
+  const [listings, setListings] = useState<Record<string, WorkspaceDirectoryListing>>(() => cached?.listings ?? EMPTY_LISTINGS);
+  const [listingTargetKey, setListingTargetKey] = useState<string | null>(targetKey);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(Boolean(targetId));
+  const [loading, setLoading] = useState(Boolean(targetId) && !cached);
   const [loadingDirectories, setLoadingDirectories] = useState<string[]>([]);
-  const [workDir, setWorkDir] = useState<string | null>(null);
+  const [workDir, setWorkDir] = useState<string | null>(() => cached?.workDir ?? null);
   const [searchResult, setSearchResult] = useState<WorkspaceSearchResult>({
     directories: [], error: null, files: [], loading: false, symlinks: [], truncated: false,
   });
@@ -192,7 +214,7 @@ export function useWorkspaceFileList(
     rawDirectory: string,
     options?: WorkspaceDirectoryLoadOptions,
   ) => {
-    if (!target || !targetReady) return;
+    if (!target || !targetReady || !targetKey) return;
     const directory = normalizeWorkspaceRelativePath(rawDirectory);
     const generation = generationRef.current;
     const requestSeq = (requestSeqByDirectoryRef.current.get(directory) ?? 0) + 1;
@@ -202,9 +224,11 @@ export function useWorkspaceFileList(
       setError(null);
       setLoading(true);
     }
-    setLoadingDirectories((current) => current.includes(directory)
-      ? current
-      : [...current, directory]);
+    if (!options?.silent || !listingsRef.current[directory]) {
+      setLoadingDirectories((current) => current.includes(directory)
+        ? current
+        : [...current, directory]);
+    }
 
     try {
       let payload: WorkspaceFilesResponse | null = null;
@@ -225,12 +249,14 @@ export function useWorkspaceFileList(
       }
 
       if (
-        generationRef.current !== generation
+        options?.signal?.aborted
+        || generationRef.current !== generation
         || requestSeqByDirectoryRef.current.get(directory) !== requestSeq
       ) return;
 
       const nextListing = toListing(payload, options?.mutation);
-      setListings((current) => {
+      const nextListings = (() => {
+        const current = listingsRef.current;
         const next = { ...current, [directory]: nextListing };
         const previousChildren = current[directory]?.directories ?? [];
         const nextChildren = new Set(nextListing.directories);
@@ -241,7 +267,10 @@ export function useWorkspaceFileList(
           }
         }
         return next;
-      });
+      })();
+      listingsRef.current = nextListings;
+      cacheWorkspaceListing(targetKey, { listings: nextListings, workDir: payload?.workDir ?? null });
+      setListings(nextListings);
       setWorkDir(payload?.workDir ?? null);
       if (directory === "") {
         setError(null);
@@ -325,34 +354,54 @@ export function useWorkspaceFileList(
   useEffect(() => {
     generationRef.current += 1;
     requestSeqByDirectoryRef.current.clear();
-    setListings({});
-    setListingTargetKey(null);
+    const snapshot = targetKey && targetReady ? workspaceListingCache.get(targetKey) : undefined;
+    if (snapshot && targetKey) cacheWorkspaceListing(targetKey, snapshot);
+    listingsRef.current = snapshot?.listings ?? EMPTY_LISTINGS;
+    setListings(listingsRef.current);
+    setListingTargetKey(targetKey);
     setError(null);
-    setLoading(Boolean(target));
+    setLoading(Boolean(target) && !snapshot);
     setLoadingDirectories([]);
-    setWorkDir(null);
+    setWorkDir(snapshot?.workDir ?? null);
     setSearchResult({
       directories: [], error: null, files: [], loading: false, symlinks: [], truncated: false,
     });
     if (!target || !targetReady) return;
     const abortController = new AbortController();
-    void loadDirectory("", { signal: abortController.signal });
-    return () => abortController.abort();
+    // Revalidate parents before descendants so removed subtrees cannot be
+    // reintroduced by a late child response. Keep the cached tree on screen.
+    void (async () => {
+      await loadDirectory("", { signal: abortController.signal, silent: Boolean(snapshot) });
+      for (const directory of Object.keys(snapshot?.listings ?? {}).filter(Boolean)
+        .sort((a, b) => a.split("/").length - b.split("/").length)) {
+        if (abortController.signal.aborted) return;
+        if (!listingsRef.current[directory]) continue;
+        await loadDirectory(directory, { signal: abortController.signal, silent: true });
+      }
+    })();
+    return () => {
+      abortController.abort();
+      generationRef.current += 1;
+    };
   }, [loadDirectory, target, targetKey, targetReady]);
 
-  const flattened = useMemo(() => flattenListings(listings), [listings]);
+  // A target change renders before its effect runs. Never paint the previous
+  // target's files (or a spinner) while a cached snapshot is already available.
+  const currentTarget = listingTargetKey === targetKey;
+  const visibleListings = currentTarget ? listings : cached?.listings ?? EMPTY_LISTINGS;
+  const flattened = useMemo(() => flattenListings(visibleListings), [visibleListings]);
   return {
     ...flattened,
-    error,
-    loadedDirectories: Object.keys(listings),
-    loading: Boolean(target) && listingTargetKey !== targetKey ? true : loading,
-    loadingDirectories,
+    error: currentTarget ? error : null,
+    loadedDirectories: Object.keys(visibleListings),
+    loading: currentTarget ? loading : Boolean(target) && !cached,
+    loadingDirectories: currentTarget ? loadingDirectories : [],
     loadDirectory,
     loadFiles,
     refreshFiles,
     searchFiles,
     searchResult,
-    workDir,
+    workDir: currentTarget ? workDir : cached?.workDir ?? null,
   };
 }
 

--- a/tests/workspace-file-list-cache.test.mjs
+++ b/tests/workspace-file-list-cache.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { build } from 'esbuild';
+import { launchPhoneBrowser } from './helpers/phone-browser.mjs';
+
+const bundle = await build({
+  stdin: { resolveDir: process.cwd(), loader: 'tsx', contents: `
+    import React, { useState } from 'react';
+    import { createRoot } from 'react-dom/client';
+    import { flushSync } from 'react-dom';
+    import { useWorkspaceFileList } from './src/hooks/use-workspace-file-list';
+    window.pending = [];
+    window.fetch = (url) => new Promise(resolve => window.pending.push({url, resolve}));
+    function Listing({id, project}) {
+      const state = useWorkspaceFileList(id, project);
+      window.list = state;
+      return <pre>{JSON.stringify({files:state.files, loading:state.loading, loaded:state.loadedDirectories})}</pre>;
+    }
+    function Probe() {
+      const [target, setTarget] = useState({id:'A', project:'p', mount:0});
+      window.select = (id, project='p', mount=0) => flushSync(() => setTarget({id, project, mount}));
+      return <Listing key={target.mount} {...target}/>;
+    }
+    createRoot(document.getElementById('root')).render(<Probe/>);
+  ` },
+  bundle: true, write: false, jsx: 'automatic',
+});
+
+test('cached listings survive A/B/A, remounts and failed revalidation without a loading frame', async () => {
+  const browser = await launchPhoneBrowser();
+  try {
+    const page = await browser.newPage();
+    await page.setContent('<div id="root"></div>');
+    await page.addScriptTag({ content: bundle.outputFiles[0].text });
+    const reply = async (directory, files, directories = [], id = null) => {
+      await page.waitForFunction(({directory, id}) => window.pending.some(r => new URL(r.url, 'http://test').searchParams.get('directory') === directory && (!id || r.url.includes('/' + id + '/files'))), {directory, id});
+      await page.evaluate(({directory, files, directories, id}) => {
+        const index = window.pending.findIndex(r => new URL(r.url, 'http://test').searchParams.get('directory') === directory && (!id || r.url.includes('/' + id + '/files')));
+        window.pending.splice(index, 1)[0].resolve(new Response(JSON.stringify({files, directories, workDir:'/workspace'})));
+      }, {directory, files, directories, id});
+      await page.waitForFunction(file => window.list.files.includes(file), files[0]);
+    };
+    await reply('', ['a.txt'], ['nested']);
+    await page.evaluate(() => { void window.list.loadDirectory('nested'); });
+    await reply('nested', ['nested/deep.txt']);
+    await page.evaluate(() => window.select('B'));
+    await reply('', ['b.txt']);
+    const restored = await page.evaluate(() => {
+      window.select('A');
+      return JSON.parse(document.querySelector('pre').textContent);
+    });
+    assert.equal(restored.loading, false, 'returning to A must never show a spinner');
+    assert.deepEqual(restored.files, ['a.txt', 'nested/deep.txt']);
+    assert.deepEqual(restored.loaded, ['', 'nested']);
+    await page.evaluate(() => window.pending.splice(0).forEach(r => r.resolve(new Response('{}', {status:403}))));
+    assert.equal(await page.evaluate(() => window.list.loading), false);
+    const remounted = await page.evaluate(() => {
+      window.select('A', 'p', 1);
+      return JSON.parse(document.querySelector('pre').textContent);
+    });
+    assert.deepEqual(remounted.files, restored.files);
+    assert.equal(remounted.loading, false);
+    const otherProject = await page.evaluate(() => {
+      window.select('A', 'other', 1);
+      return JSON.parse(document.querySelector('pre').textContent);
+    });
+    assert.deepEqual(otherProject.files, [], 'project scopes must not share cached files');
+    assert.equal(otherProject.loading, true);
+    // Even a transport that completes after abort cannot overwrite the new target.
+    await page.evaluate(() => window.pending.splice(0).forEach(r => {
+      const currentProject = new URL(r.url, 'http://test').searchParams.get('projectId') === 'other';
+      r.resolve(new Response(JSON.stringify({files:[currentProject ? 'other.txt' : 'stale.txt']})));
+    }));
+    await page.waitForFunction(() => window.list.files.includes('other.txt'));
+    assert.deepEqual(await page.evaluate(() => window.list.files), ['other.txt']);
+    await page.evaluate(() => window.select('A'));
+    assert.deepEqual(await page.evaluate(() => window.list.files), restored.files);
+    await reply('', ['changed.txt'], [], 'A');
+    assert.deepEqual(await page.evaluate(() => window.list.files), ['changed.txt'], 'revalidation removes deleted cached subtrees');
+    assert.equal(await page.evaluate(() => window.list.loading), false);
+
+    // Fill the bounded cache, touch A, then insert one more: oldest B is evicted.
+    for (let i = 0; i < 17; i++) {
+      await page.evaluate(id => window.select(id), 'extra' + i);
+      await reply('', ['extra' + i + '.txt'], [], 'extra' + i);
+    }
+    await page.evaluate(() => window.select('A'));
+    await reply('', ['changed.txt'], [], 'A');
+    await page.evaluate(() => window.select('last'));
+    await reply('', ['last.txt'], [], 'last');
+    await page.evaluate(() => window.select('A'));
+    assert.equal(await page.evaluate(() => window.list.loading), false, 'recently used A stays cached');
+    await page.evaluate(() => window.select('B'));
+    assert.equal(await page.evaluate(() => window.list.loading), true, 'least recently used B is evicted');
+    assert.deepEqual(await page.evaluate(() => window.list.files), []);
+  } finally { await browser.close(); }
+});


### PR DESCRIPTION
## Summary

Switching from session A to B and back used to discard the loaded file tree and show a loading spinner again. Restore cached directory listings on the first render, including directories already loaded beneath expanded folders, and revalidate them in the background.

Keep the 20 most recently used workspace snapshots in browser memory, scoped by target kind, ID and project. Revalidate parents before descendants, discard obsolete requests, and preserve cached content when background requests fail. Cached refreshes do not display directory spinners.

## Testing

- Passed: browser regression using the actual hook for A/B/A transitions, remounts, project isolation, failed refreshes, late responses, deleted subtrees and LRU eviction.
- Passed: workspace panel refresh and inline-input state tests after merging the latest `dev`.
- Passed: ESLint on changed files and `npx tsc --noEmit`.
- Not run: full production build or packaged-app E2E for this cache change. The separate image diagnosis used an unchanged installed build and is not validation of this implementation.

## Screenshots or Recordings

No visual layout change; the browser regression asserts the cached tree is present immediately without a loading frame.

## Notes

Cache is memory-only and resets when the application reloads. Image-loading behavior and file-tree layout changes are outside this PR.
