### PR TITLE
Add workspace MP4 previews and fix sessionless file panel splitting

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -93,7 +93,8 @@ async function startServer() {
   const server = createServer();
   let controlRuntime: ControlRuntimeHost | null = null;
 
-  const app = next({ dev, hostname, port, dir, httpServer: server } as Parameters<typeof next>[0]);
+  // Avoid the Turbopack persistent dev-cache path that caused sustained CPU saturation.
+  const app = next({ dev, ...(dev ? { webpack: true } : {}), hostname, port, dir, httpServer: server } as Parameters<typeof next>[0]);
   const handle = app.getRequestHandler();
 
   await app.prepare();

--- a/src/app/api/sessions/[id]/file/route.ts
+++ b/src/app/api/sessions/[id]/file/route.ts
@@ -88,6 +88,8 @@ export async function GET(
       rawPath: request.nextUrl.searchParams.get('path') ?? '',
       root: resolved.root,
       sourceId: id,
+      rangeHeader: request.headers.get('range'),
+      signal: request.signal,
     });
   } catch (error) {
     return toErrorResponse(error, id, 'load');

--- a/src/app/api/worktrees/[id]/file/route.ts
+++ b/src/app/api/worktrees/[id]/file/route.ts
@@ -90,6 +90,8 @@ export async function GET(
       rawPath: request.nextUrl.searchParams.get('path') ?? '',
       root: resolved.root,
       sourceId: id,
+      rangeHeader: request.headers.get('range'),
+      signal: request.signal,
     });
   } catch (error) {
     return toErrorResponse(error, id, 'load');

--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -35,6 +35,7 @@ const UpdateNotifier = dynamic(
 );
 import { SelectionActionBar } from "./selection-action-bar";
 import { usePanelStore, selectActiveTab } from "@/stores/panel-store";
+import { parseWorkspaceSpecialSessionId } from "@/lib/workspace-tabs/special-session";
 import { useTabStore } from "@/stores/tab-store";
 import { useTaskStore } from "@/stores/task-store";
 import { TabBar } from "@/components/tab/tab-bar";
@@ -144,7 +145,10 @@ export function ChatLayout() {
   );
   const activePanelWorktreeId = usePanelStore((state) => {
     const activeTabData = state.tabPanels[activeTabId];
-    return activeTabData?.panels[activeTabData.activePanelId]?.worktreeId ?? null;
+    const panel = activeTabData?.panels[activeTabData.activePanelId];
+    const fileRef = panel?.sessionId ? parseWorkspaceSpecialSessionId(panel.sessionId) : null;
+    return (fileRef && 'sourceWorktreeId' in fileRef ? fileRef.sourceWorktreeId : null)
+      ?? panel?.worktreeId ?? null;
   });
   const peekWorktreeId = useWorkspacePeekStore(
     (state) => state.target?.worktreeId ?? null,

--- a/src/components/workspace/workspace-code-view.tsx
+++ b/src/components/workspace/workspace-code-view.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { AlertCircle, Binary, ChevronDown, ChevronUp, Code2, Copy, ExternalLink, Eye, FileCode2, FileText, GitCompare, Image as ImageIcon, LoaderCircle, RefreshCw, Save, Search, X } from "lucide-react";
+import { AlertCircle, Binary, ChevronDown, ChevronUp, Code2, Copy, ExternalLink, Eye, FileCode2, FileText, GitCompare, Image as ImageIcon, LoaderCircle, RefreshCw, Save, Search, Video, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { PreviewMarkdown } from "@/components/chat/preview-markdown";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { WorkspaceFileContextMenu } from "@/components/workspace/workspace-file-context-menu";
 import { WorkspaceImageViewer } from '@/components/workspace/workspace-image-viewer';
+import { WorkspaceVideoViewer } from '@/components/workspace/workspace-video-viewer';
 import { WorkspaceMonacoEditor } from "@/components/workspace/workspace-monaco-editor";
 import {
   canUseElectronFileActions,
@@ -23,6 +24,7 @@ import { formatBytes } from '@/lib/format-bytes';
 import {
   buildWorkspaceRawFileUrl,
   isWorkspaceImageMimeType,
+  isWorkspaceVideoMimeType,
 } from '@/lib/workspace-files/workspace-file-preview';
 
 type MarkdownViewMode = "preview" | "source";
@@ -344,6 +346,7 @@ export function WorkspaceCodeView({
   path,
   saving = false,
   sourceTarget,
+  previewActive = true,
 }: {
   /** The file changed on disk under an unsaved draft; the banner is showing. */
   conflict?: boolean;
@@ -367,6 +370,8 @@ export function WorkspaceCodeView({
   path: string;
   saving?: boolean;
   sourceTarget?: WorkspaceTarget;
+  /** Inactive mounted tabs must not keep video audio playing. */
+  previewActive?: boolean;
 }) {
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const [markdownModeState, setMarkdownModeState] = useState<{ mode: MarkdownViewMode; path: string }>({
@@ -394,7 +399,13 @@ export function WorkspaceCodeView({
   const isImageFile = mode === 'file'
     && Boolean(sourceTarget)
     && isWorkspaceImageMimeType(fileData?.mimeType);
+  const isVideoFile = mode === 'file'
+    && Boolean(sourceTarget)
+    && isWorkspaceVideoMimeType(fileData?.mimeType);
   const imageRawUrl = isImageFile && sourceTarget && fileData
+    ? buildWorkspaceRawFileUrl(sourceTarget, path, `${fileData.mtimeMs}-${fileData.size}`)
+    : null;
+  const videoRawUrl = isVideoFile && sourceTarget && fileData
     ? buildWorkspaceRawFileUrl(sourceTarget, path, `${fileData.mtimeMs}-${fileData.size}`)
     : null;
   const markdownViewMode = isMarkdownFile && markdownModeState.path === path ? markdownModeState.mode : "preview";
@@ -443,6 +454,8 @@ export function WorkspaceCodeView({
     // back on the parent after it bubbles makes a file look read-only.
     const target = event.target;
     if (target instanceof Element && target.closest(".monaco-editor")) return;
+    // Let mouse events reach panel activation without stealing native media or toolbar focus.
+    if (target instanceof Element && target.closest('[data-testid="workspace-video-viewer"]')) return;
     event.currentTarget.focus({ preventScroll: true });
   }, []);
 
@@ -509,7 +522,7 @@ export function WorkspaceCodeView({
     );
   }
 
-  if (fileData?.binary && !isImageFile) {
+  if (fileData?.binary && !isImageFile && !isVideoFile) {
     return (
       <div className="flex h-full min-h-0 flex-col bg-(--chat-bg)">
         <PendingStateHeader mode={mode} path={path} onClose={onClose} />
@@ -529,6 +542,8 @@ export function WorkspaceCodeView({
             <GitCompare className="h-4 w-4 shrink-0 text-(--text-muted)" />
           ) : isImageFile ? (
             <ImageIcon className="h-4 w-4 shrink-0 text-(--text-muted)" />
+          ) : isVideoFile ? (
+            <Video className="h-4 w-4 shrink-0 text-(--text-muted)" />
           ) : isMarkdownFile ? (
             <FileText className="h-4 w-4 shrink-0 text-(--text-muted)" />
           ) : (
@@ -556,9 +571,9 @@ export function WorkspaceCodeView({
               ) : null}
             </p>
             <p className="truncate text-[10px] uppercase tracking-[0.14em] text-(--text-muted)">
-              {mode === "diff" ? "Diff" : isImageFile ? fileData?.mimeType : fileData?.language || "text"}
+              {mode === "diff" ? "Diff" : (isImageFile || isVideoFile) ? fileData?.mimeType : fileData?.language || "text"}
               {fileData ? ` · ${formatBytes(fileData.size)}` : ""}
-              {(!isImageFile && fileData?.truncated) || diffData?.truncated ? " · truncated" : ""}
+              {(!isImageFile && !isVideoFile && fileData?.truncated) || diffData?.truncated ? " · truncated" : ""}
             </p>
           </div>
         </div>
@@ -566,7 +581,7 @@ export function WorkspaceCodeView({
           {isMarkdownFile ? (
             <MarkdownModeToggle mode={markdownViewMode} onChange={handleMarkdownViewModeChange} />
           ) : null}
-          {editable ? (
+          {editable && !isVideoFile ? (
             <Tooltip content={dirty ? "Save (Ctrl/Cmd+S)" : "No unsaved changes"}>
               <Button
                 {...telemetryClickAttributes('workspace_editor.save', 'workspace_editor')}
@@ -602,7 +617,7 @@ export function WorkspaceCodeView({
               </Button>
             </Tooltip>
           ) : null}
-          {!isImageFile ? <Tooltip content={copied ? "Copied" : "Copy"}>
+          {!isImageFile && !isVideoFile ? <Tooltip content={copied ? "Copied" : "Copy"}>
             <Button
               {...telemetryClickAttributes('workspace_editor.copy_content', 'workspace_editor')}
               type="button"
@@ -700,6 +715,13 @@ export function WorkspaceCodeView({
             path={path}
             rawUrl={imageRawUrl}
             size={fileData.size}
+          />
+        ) : videoRawUrl ? (
+          <WorkspaceVideoViewer
+            key={videoRawUrl}
+            active={previewActive}
+            path={path}
+            rawUrl={videoRawUrl}
           />
         ) : shouldRenderMarkdownPreview ? (
           <div ref={markdownContentRef} className="mx-auto w-full max-w-5xl px-6 py-8 text-base">

--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -44,7 +44,10 @@ import {
   previewWorkspaceTargetFileTab,
 } from "@/lib/workspace-tabs/open-workspace-tab";
 import { resolveWorkspaceTarget, workspaceTargetKey } from '@/types/worktree';
-import { setWorkspaceDirectoryDragData, setWorkspaceFileDragData } from "@/lib/dnd/panel-session-drag";
+import {
+  setWorkspaceDirectoryDragData,
+  setWorkspaceTargetFileDragData,
+} from "@/lib/dnd/panel-session-drag";
 import { toAbsoluteWorkspacePath } from "@/lib/workspace-tabs/file-path-actions";
 import { WorkspaceFileContextMenu } from "@/components/workspace/workspace-file-context-menu";
 import {
@@ -784,11 +787,11 @@ export function WorkspaceFilePanel({
             beginRename(node);
           }}
           onDragStart={(event) => {
-            if (!sessionId) return;
+            if (!target) return;
             setSelectedPath(node.path);
-            setWorkspaceFileDragData(event.dataTransfer, sessionId, "file", node.path, absolutePath);
+            setWorkspaceTargetFileDragData(event.dataTransfer, target, "file", node.path, absolutePath);
           }}
-          draggable={Boolean(sessionId)}
+          draggable={Boolean(target)}
           className="flex w-full min-w-0 items-center gap-2 border-l-transparent py-1.5 pr-8 text-left transition-colors"
           title={node.isSymlink ? `${node.path} (symbolic link)` : node.path}
           data-testid={`workspace-file-row-${node.path}`}

--- a/src/components/workspace/workspace-file-tab.tsx
+++ b/src/components/workspace/workspace-file-tab.tsx
@@ -24,7 +24,10 @@ import {
   clearWorkspaceFileDirty,
   markWorkspaceFileDirty,
 } from "@/lib/workspace-files/workspace-dirty-registry";
-import { isWorkspaceImageMimeType } from '@/lib/workspace-files/workspace-file-preview';
+import {
+  isWorkspaceImageMimeType,
+  isWorkspaceVideoMimeType,
+} from '@/lib/workspace-files/workspace-file-preview';
 import type { GitDiffData } from "@/types/git";
 import type { WorkspaceFileData } from "@/types/workspace-file";
 import {
@@ -166,7 +169,8 @@ export function WorkspaceFileTab({
   const editable = fileData !== null
     && !fileData.binary
     && !fileData.truncated
-    && !isWorkspaceImageMimeType(fileData.mimeType);
+    && !isWorkspaceImageMimeType(fileData.mimeType)
+    && !isWorkspaceVideoMimeType(fileData.mimeType);
   const dirty = editable && draft !== null && draft !== fileData.content;
   dirtyRef.current = dirty;
 
@@ -538,6 +542,7 @@ export function WorkspaceFileTab({
       path={fileRef.path}
       editorModelKey={tabId || `${sourceTarget.kind}:${sourceTarget.id}:${kind}:${path}`}
       sourceTarget={sourceTarget}
+      previewActive={isTabActive && isDocumentVisible}
     />
   );
 }

--- a/src/components/workspace/workspace-video-viewer.tsx
+++ b/src/components/workspace/workspace-video-viewer.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { AlertCircle, RefreshCw, Scan, ZoomIn, ZoomOut } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { Button } from '@/components/ui/button';
+import { Tooltip } from '@/components/ui/tooltip';
+
+const MIN_VIDEO_ZOOM = 0.5;
+const MAX_VIDEO_ZOOM = 4;
+const VIDEO_ZOOM_STEP = 0.5;
+
+interface VideoSize {
+  width: number;
+  height: number;
+}
+
+function basename(filePath: string): string {
+  return filePath.split(/[/\\]/).pop() || filePath;
+}
+
+function withRetryVersion(rawUrl: string, retryAttempt: number): string {
+  return retryAttempt === 0 ? rawUrl : `${rawUrl}&retry=${retryAttempt}`;
+}
+
+export function WorkspaceVideoViewer({
+  active,
+  path,
+  rawUrl,
+}: {
+  active: boolean;
+  path: string;
+  rawUrl: string;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [surfaceElement, setSurfaceElement] = useState<HTMLDivElement | null>(null);
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+  const [retryAttempt, setRetryAttempt] = useState(0);
+  const [zoom, setZoom] = useState(1);
+  const [surfaceSize, setSurfaceSize] = useState<VideoSize | null>(null);
+  const [videoSize, setVideoSize] = useState<VideoSize | null>(null);
+  const previewSrc = withRetryVersion(rawUrl, retryAttempt);
+  const filename = basename(path);
+  const hasError = failedSrc === previewSrc;
+
+  useEffect(() => {
+    if (!active) videoRef.current?.pause();
+  }, [active]);
+
+  useEffect(() => () => {
+    videoRef.current?.pause();
+  }, []);
+
+  useEffect(() => {
+    if (!surfaceElement) return;
+    const updateSize = () => setSurfaceSize({
+      width: surfaceElement.clientWidth,
+      height: surfaceElement.clientHeight,
+    });
+    updateSize();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(surfaceElement);
+    return () => observer.disconnect();
+  }, [surfaceElement]);
+
+  const keepVideoInteractionLocal = useCallback((event: KeyboardEvent<HTMLVideoElement>) => {
+    event.stopPropagation();
+  }, []);
+
+  const fittedSize = videoSize && surfaceSize && surfaceSize.width > 0 && surfaceSize.height > 0
+    ? (() => {
+      const scale = Math.min(surfaceSize.width / videoSize.width, surfaceSize.height / videoSize.height);
+      return { width: videoSize.width * scale * zoom, height: videoSize.height * scale * zoom };
+    })()
+    : null;
+
+  if (hasError) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 bg-black p-8 text-center" data-testid="workspace-video-error">
+        <AlertCircle className="h-10 w-10 text-(--text-muted)" />
+        <div>
+          <p className="text-sm font-medium text-(--text-primary)">Unable to play video preview</p>
+          <p className="mt-1 max-w-md text-xs leading-5 text-(--text-muted)">
+            This video could not be loaded. Its codec may be unsupported, or the file may be unreadable or damaged. Try opening it with another app.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            setFailedSrc(null);
+            setRetryAttempt((current) => current + 1);
+          }}
+          aria-label={`Retry loading ${filename}`}
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          <span>Retry</span>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-black" data-testid="workspace-video-viewer">
+      <div
+        ref={setSurfaceElement}
+        className="min-h-0 flex-1 overflow-auto p-4"
+        data-testid="workspace-video-surface"
+      >
+        <div className="flex min-h-full min-w-full items-center justify-center">
+          <video
+            ref={videoRef}
+            key={previewSrc}
+            controls
+            playsInline
+            preload="metadata"
+            src={previewSrc}
+            className={fittedSize ? 'block shrink-0' : 'max-h-full max-w-full object-contain'}
+            style={fittedSize ? { width: fittedSize.width, height: fittedSize.height } : undefined}
+            aria-label={`Video preview: ${filename}`}
+            onLoadedMetadata={(event) => {
+              const video = event.currentTarget;
+              setVideoSize({ width: video.videoWidth, height: video.videoHeight });
+              setFailedSrc(null);
+            }}
+            onError={() => setFailedSrc(previewSrc)}
+            onKeyDown={keepVideoInteractionLocal}
+          />
+        </div>
+      </div>
+      <div className="flex h-10 shrink-0 items-center justify-center gap-1 border-t border-(--divider) px-3 text-xs text-(--text-muted)">
+        <Tooltip content="Zoom out (relative to fit)">
+          <Button type="button" variant="ghost" size="icon" className="h-7 w-7" onClick={() => setZoom((current) => Math.max(MIN_VIDEO_ZOOM, current - VIDEO_ZOOM_STEP))} disabled={zoom <= MIN_VIDEO_ZOOM} aria-label="Zoom out video">
+            <ZoomOut className="h-3.5 w-3.5" />
+          </Button>
+        </Tooltip>
+        <span className="min-w-10 text-center tabular-nums" aria-label={`Video zoom ${Math.round(zoom * 100)} percent`}>{Math.round(zoom * 100)}%</span>
+        <Tooltip content="Zoom in (relative to fit)">
+          <Button type="button" variant="ghost" size="icon" className="h-7 w-7" onClick={() => setZoom((current) => Math.min(MAX_VIDEO_ZOOM, current + VIDEO_ZOOM_STEP))} disabled={zoom >= MAX_VIDEO_ZOOM} aria-label="Zoom in video">
+            <ZoomIn className="h-3.5 w-3.5" />
+          </Button>
+        </Tooltip>
+        <Tooltip content="Fit video to available area (100%)">
+          <Button type="button" variant="ghost" size="icon" className="h-7 w-7" onClick={() => setZoom(1)} disabled={zoom === 1} aria-label="Fit video to available area">
+            <Scan className="h-3.5 w-3.5" />
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/dnd/panel-session-drag.ts
+++ b/src/lib/dnd/panel-session-drag.ts
@@ -7,9 +7,11 @@ import {
 } from '@/types/panel';
 import { TASK_DND_MIME, TASK_ENTITY_DND_MIME, TASK_MULTI_DND_MIME } from '@/types/task';
 import {
+  buildWorktreeFileSessionId,
   buildWorkspaceFileSessionId,
   type WorkspaceFileTabKind,
 } from '@/lib/workspace-tabs/special-session';
+import type { WorkspaceTarget } from '@/types/worktree';
 
 export interface PanelSessionDragPayload {
   tabId: string;
@@ -266,6 +268,36 @@ export function setWorkspaceFileDragData(
   const specialSessionId = buildWorkspaceFileSessionId(sourceSessionId, kind, filePath);
   const workspaceFilePayload: WorkspaceFileDragPayload = {
     sourceSessionId,
+    kind,
+    path: filePath,
+    ...(absolutePath ? { absolutePath } : {}),
+  };
+  setPanelSessionDragData(dataTransfer, specialSessionId);
+  dataTransfer.setData(WORKSPACE_FILE_DRAG_MIME, JSON.stringify(workspaceFilePayload));
+  dataTransfer.setData('text/plain', filePath);
+  dataTransfer.effectAllowed = 'copyMove';
+}
+
+/**
+ * Worktree-backed explorers have no source Session, but their file views use
+ * the same special-session panel contract as Session-backed explorers.
+ */
+export function setWorkspaceTargetFileDragData(
+  dataTransfer: Pick<DataTransfer, 'setData' | 'effectAllowed'>,
+  target: WorkspaceTarget,
+  kind: WorkspaceFileTabKind,
+  filePath: string,
+  absolutePath?: string | null,
+): void {
+  if (target.kind === 'session') {
+    setWorkspaceFileDragData(dataTransfer, target.id, kind, filePath, absolutePath);
+    return;
+  }
+  const specialSessionId = buildWorktreeFileSessionId(target.id, filePath, kind);
+  const workspaceFilePayload: WorkspaceFileDragPayload = {
+    // Path-insertion consumers require an owner identifier, but do not use it
+    // for routing; retain the worktree ID there for this target kind.
+    sourceSessionId: target.id,
     kind,
     path: filePath,
     ...(absolutePath ? { absolutePath } : {}),

--- a/src/lib/workspace-files/read-workspace-file.ts
+++ b/src/lib/workspace-files/read-workspace-file.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { Buffer } from 'node:buffer';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import {
@@ -80,6 +81,111 @@ async function resolveRequestedFile(root: string, rawPath: string): Promise<{
 
 const isLikelyBinary = _isLikelyBinary;
 
+const VIDEO_STREAM_CHUNK_BYTES = 64 * 1024;
+
+interface ByteRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * This route deliberately supports only a single byte range. Invalid or
+ * multiple ranges are ignored and receive the complete 200 response; a valid
+ * but unsatisfiable single range receives 416.
+ */
+function parseSingleByteRange(rangeHeader: string | null, size: number): ByteRange | null | 'unsatisfiable' {
+  if (!rangeHeader) return null;
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+  if (!match || (!match[1] && !match[2])) return null;
+
+  let start: bigint;
+  let end: bigint;
+  try {
+    if (match[1]) {
+      start = BigInt(match[1]);
+      end = match[2] ? BigInt(match[2]) : BigInt(size - 1);
+    } else {
+      const suffixLength = BigInt(match[2]);
+      if (suffixLength === 0n || size === 0) return 'unsatisfiable';
+      start = suffixLength >= BigInt(size) ? 0n : BigInt(size) - suffixLength;
+      end = BigInt(size - 1);
+    }
+  } catch {
+    return null;
+  }
+
+  if (start > end || start >= BigInt(size)) return 'unsatisfiable';
+  const clampedEnd = end >= BigInt(size) ? BigInt(size - 1) : end;
+  return { start: Number(start), end: Number(clampedEnd) };
+}
+
+function createWorkspaceFileStream(
+  absolutePath: string,
+  range: ByteRange,
+  signal?: AbortSignal,
+): ReadableStream<Uint8Array> {
+  let handle: fs.FileHandle | null = null;
+  let position = range.start;
+  let closed = false;
+  let abortListener: (() => void) | undefined;
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    if (abortListener) signal?.removeEventListener('abort', abortListener);
+    const openHandle = handle;
+    handle = null;
+    if (openHandle) void openHandle.close().catch(() => {});
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      abortListener = () => {
+        close();
+        controller.error(new DOMException('The request was aborted', 'AbortError'));
+      };
+      if (signal?.aborted) {
+        abortListener();
+        return;
+      }
+      signal?.addEventListener('abort', abortListener, { once: true });
+      try {
+        handle = await withFsDeadline(fs.open(absolutePath, 'r'));
+        if (closed) return;
+      } catch (error) {
+        close();
+        controller.error(error);
+      }
+    },
+    async pull(controller) {
+      if (closed || !handle) return;
+      if (position > range.end) {
+        close();
+        controller.close();
+        return;
+      }
+      const length = Math.min(VIDEO_STREAM_CHUNK_BYTES, range.end - position + 1);
+      const buffer = Buffer.allocUnsafe(length);
+      try {
+        const { bytesRead } = await withFsDeadline(handle.read(buffer, 0, length, position));
+        if (bytesRead === 0) {
+          close();
+          controller.close();
+          return;
+        }
+        position += bytesRead;
+        controller.enqueue(new Uint8Array(buffer.buffer, buffer.byteOffset, bytesRead));
+      } catch (error) {
+        close();
+        controller.error(error);
+      }
+    },
+    cancel() {
+      close();
+    },
+  });
+}
+
 function inferLanguage(filePath: string): string {
   const ext = path.extname(filePath).slice(1).toLowerCase();
   const basename = path.basename(filePath).toLowerCase();
@@ -99,11 +205,15 @@ export async function readWorkspaceFileResponse({
   rawPath,
   root,
   sourceId,
+  rangeHeader,
+  signal,
 }: {
   raw: boolean;
   rawPath: string;
   root: string;
   sourceId: string;
+  rangeHeader?: string | null;
+  signal?: AbortSignal;
 }): Promise<NextResponse> {
   const { absolutePath, relativePath } = await resolveRequestedFile(root, rawPath);
   const fileStat = await withFsDeadline(fs.stat(absolutePath));
@@ -112,13 +222,40 @@ export async function readWorkspaceFileResponse({
   }
 
   if (raw) {
+    const contentType = inferWorkspaceFileContentType(relativePath);
+    if (contentType === 'video/mp4') {
+      if (!Number.isSafeInteger(fileStat.size) || fileStat.size < 0) {
+        throw new WorkspaceFileError('file_too_large', 'File is too large to preview', 413);
+      }
+      const requestedRange = parseSingleByteRange(rangeHeader ?? null, fileStat.size);
+      const headers = new Headers({
+        'Content-Type': contentType,
+        'Cache-Control': 'private, max-age=30',
+        'Accept-Ranges': 'bytes',
+        'X-Content-Type-Options': 'nosniff',
+      });
+      if (requestedRange === 'unsatisfiable') {
+        headers.set('Content-Range', `bytes */${fileStat.size}`);
+        return new NextResponse(null, { status: 416, headers });
+      }
+      const range = requestedRange ?? { start: 0, end: fileStat.size - 1 };
+      const contentLength = Math.max(0, range.end - range.start + 1);
+      headers.set('Content-Length', String(contentLength));
+      if (requestedRange) {
+        headers.set('Content-Range', `bytes ${range.start}-${range.end}/${fileStat.size}`);
+      }
+      return new NextResponse(createWorkspaceFileStream(absolutePath, range, signal), {
+        status: requestedRange ? 206 : 200,
+        headers,
+      });
+    }
     if (fileStat.size > MAX_RAW_FILE_BYTES) {
       throw new WorkspaceFileError('file_too_large', 'File is too large to preview', 413);
     }
     const buffer = await withFsDeadline(fs.readFile(absolutePath));
     return new NextResponse(buffer, {
       headers: {
-        'Content-Type': inferWorkspaceFileContentType(relativePath),
+        'Content-Type': contentType,
         'Cache-Control': 'private, max-age=30',
         'Content-Length': String(buffer.byteLength),
         'X-Content-Type-Options': 'nosniff',

--- a/src/lib/workspace-files/workspace-file-preview.ts
+++ b/src/lib/workspace-files/workspace-file-preview.ts
@@ -12,6 +12,10 @@ const WORKSPACE_IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   webp: 'image/webp',
 };
 
+const WORKSPACE_VIDEO_MIME_BY_EXTENSION: Record<string, string> = {
+  mp4: 'video/mp4',
+};
+
 function extensionOf(filePath: string): string {
   const slashIndex = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
   const dotIndex = filePath.lastIndexOf('.');
@@ -19,12 +23,18 @@ function extensionOf(filePath: string): string {
 }
 
 export function inferWorkspaceFileContentType(filePath: string): string {
-  return WORKSPACE_IMAGE_MIME_BY_EXTENSION[extensionOf(filePath)]
+  const extension = extensionOf(filePath);
+  return WORKSPACE_IMAGE_MIME_BY_EXTENSION[extension]
+    ?? WORKSPACE_VIDEO_MIME_BY_EXTENSION[extension]
     ?? 'application/octet-stream';
 }
 
 export function isWorkspaceImageMimeType(mimeType: string | null | undefined): boolean {
   return typeof mimeType === 'string' && mimeType.startsWith('image/');
+}
+
+export function isWorkspaceVideoMimeType(mimeType: string | null | undefined): boolean {
+  return mimeType === 'video/mp4';
 }
 
 export function buildWorkspaceRawFileUrl(

--- a/src/stores/panel-store.ts
+++ b/src/stores/panel-store.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import type { Panel, PanelDropEdge, PanelNode, PanelStore, PanelStoreState, TabPanelData } from '@/types/panel';
 import { DEBUG_DIAGNOSTICS } from '@/lib/debug-diagnostics';
 import { useSessionStore } from '@/stores/session-store';
+import { parseWorkspaceSpecialSessionId } from '@/lib/workspace-tabs/special-session';
 
 export const EMPTY_PANELS: Record<string, Panel> = Object.freeze({});
 
@@ -243,7 +244,14 @@ export const usePanelStore = create<PanelStore>()((set, get) => ({
     if (!containsLeaf(tabData.layout, panelId)) return null;
 
     const newPanelId = uuidv4();
-    const newPanel: Panel = { id: newPanelId, sessionId: newSessionId ?? null };
+    const fileRef = newSessionId ? parseWorkspaceSpecialSessionId(newSessionId) : null;
+    const newPanel: Panel = {
+      id: newPanelId,
+      sessionId: newSessionId ?? null,
+      ...(fileRef && 'sourceWorktreeId' in fileRef
+        ? { worktreeId: fileRef.sourceWorktreeId }
+        : {}),
+    };
     const existingLeaf: PanelNode = { type: 'leaf', panelId };
     const newLeaf: PanelNode = { type: 'leaf', panelId: newPanelId };
     const splitNode: PanelNode = {

--- a/tests/workspace-file-drag-contract.test.ts
+++ b/tests/workspace-file-drag-contract.test.ts
@@ -11,13 +11,17 @@ import {
   parseWorkspaceFileDragData,
   setPathInsertDragData,
   setWorkspaceFileDragData,
+  setWorkspaceTargetFileDragData,
 } from '../src/lib/dnd/panel-session-drag';
 import {
   PATH_INSERT_DRAG_MIME,
   SESSION_DRAG_MIME,
   WORKSPACE_FILE_DRAG_MIME,
 } from '../src/types/panel';
-import { buildWorkspaceFileSessionId } from '../src/lib/workspace-tabs/special-session';
+import {
+  buildWorktreeFileSessionId,
+  buildWorkspaceFileSessionId,
+} from '../src/lib/workspace-tabs/special-session';
 import {
   formatWorkspaceFileReference,
   insertWorkspaceFileReferenceAtCursor,
@@ -80,6 +84,25 @@ test('workspace file drags preserve the host absolute path when supplied', () =>
     parseWorkspaceFileDragData(transfer)?.absolutePath,
     '/workspace/docs/readme.md',
   );
+});
+
+test('worktree explorer file drags carry a worktree file session for panel splits', () => {
+  const transfer = new FakeDataTransfer();
+  setWorkspaceTargetFileDragData(
+    transfer,
+    { kind: 'worktree', id: 'worktree-1' },
+    'file',
+    'videos/clip.mp4',
+    '/workspace/videos/clip.mp4',
+  );
+
+  assert.equal(
+    transfer.getData(SESSION_DRAG_MIME),
+    buildWorktreeFileSessionId('worktree-1', 'videos/clip.mp4'),
+  );
+  assert.equal(parseWorkspaceFileDragData(transfer)?.sourceSessionId, 'worktree-1');
+  assert.equal(parseWorkspaceFileDragData(transfer)?.absolutePath, '/workspace/videos/clip.mp4');
+  assert.equal(isSessionReferenceDragData(transfer), false);
 });
 
 test('path insertion drags carry agent-readable paths without a panel session payload', () => {

--- a/tests/workspace-file-panel-drag-contract.test.mjs
+++ b/tests/workspace-file-panel-drag-contract.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const source = await readFile(
+  new URL('../src/components/workspace/workspace-file-panel.tsx', import.meta.url),
+  'utf8',
+);
+
+test('worktree-backed Files rows remain draggable into panel split targets', () => {
+  assert.match(source, /setWorkspaceTargetFileDragData/);
+  assert.match(source, /if \(!target\) return;\s*setSelectedPath\(node\.path\);\s*setWorkspaceTargetFileDragData/);
+  assert.match(source, /draggable=\{Boolean\(target\)\}/);
+});

--- a/tests/workspace-file-preview.test.ts
+++ b/tests/workspace-file-preview.test.ts
@@ -4,6 +4,7 @@ import {
   buildWorkspaceRawFileUrl,
   inferWorkspaceFileContentType,
   isWorkspaceImageMimeType,
+  isWorkspaceVideoMimeType,
 } from '../src/lib/workspace-files/workspace-file-preview';
 
 test('infers supported workspace image MIME types', () => {
@@ -28,6 +29,9 @@ test('infers supported workspace image MIME types', () => {
   }
   assert.equal(inferWorkspaceFileContentType('archive.zip'), 'application/octet-stream');
   assert.equal(isWorkspaceImageMimeType('application/octet-stream'), false);
+  assert.equal(inferWorkspaceFileContentType('movie.MP4'), 'video/mp4');
+  assert.equal(isWorkspaceVideoMimeType('video/mp4'), true);
+  assert.equal(isWorkspaceVideoMimeType('video/webm'), false);
 });
 
 test('builds versioned raw URLs for session and worktree targets', () => {

--- a/tests/workspace-file-read.test.ts
+++ b/tests/workspace-file-read.test.ts
@@ -69,3 +69,97 @@ test('raw image previews retain the bounded file-size limit', async (t) => {
       && error.status === 413,
   );
 });
+
+test('MP4 raw previews stream complete and single-range responses without the image size limit', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'tessera-workspace-video-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const bytes = Buffer.from('0123456789');
+  await writeFile(path.join(root, 'movie.mp4'), bytes);
+
+  const full = await readWorkspaceFileResponse({
+    raw: true, rawPath: 'movie.mp4', root, sourceId: 'session-1',
+  });
+  assert.equal(full.status, 200);
+  assert.equal(full.headers.get('content-type'), 'video/mp4');
+  assert.equal(full.headers.get('accept-ranges'), 'bytes');
+  assert.equal(full.headers.get('content-length'), '10');
+  assert.deepEqual(Buffer.from(await full.arrayBuffer()), bytes);
+
+  const bounded = await readWorkspaceFileResponse({
+    raw: true, rawPath: 'movie.mp4', root, sourceId: 'session-1', rangeHeader: 'bytes=2-99',
+  });
+  assert.equal(bounded.status, 206);
+  assert.equal(bounded.headers.get('content-range'), 'bytes 2-9/10');
+  assert.equal(bounded.headers.get('content-length'), '8');
+  assert.deepEqual(Buffer.from(await bounded.arrayBuffer()), Buffer.from('23456789'));
+
+  const openEnded = await readWorkspaceFileResponse({
+    raw: true, rawPath: 'movie.mp4', root, sourceId: 'session-1', rangeHeader: 'bytes=7-',
+  });
+  assert.equal(openEnded.headers.get('content-range'), 'bytes 7-9/10');
+  assert.deepEqual(Buffer.from(await openEnded.arrayBuffer()), Buffer.from('789'));
+
+  const suffix = await readWorkspaceFileResponse({
+    raw: true, rawPath: 'movie.mp4', root, sourceId: 'session-1', rangeHeader: 'bytes=-3',
+  });
+  assert.equal(suffix.headers.get('content-range'), 'bytes 7-9/10');
+  assert.deepEqual(Buffer.from(await suffix.arrayBuffer()), Buffer.from('789'));
+});
+
+test('MP4 raw previews ignore malformed or multi-ranges and reject unsatisfiable ranges', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'tessera-workspace-video-range-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(path.join(root, 'movie.mp4'), '0123456789');
+
+  for (const rangeHeader of ['bytes=wat', 'bytes=0-1,4-5', 'items=0-1']) {
+    const response = await readWorkspaceFileResponse({
+      raw: true, rawPath: 'movie.mp4', root, sourceId: 'session-1', rangeHeader,
+    });
+    assert.equal(response.status, 200, rangeHeader);
+    assert.equal(response.headers.get('content-range'), null, rangeHeader);
+    assert.equal(Buffer.from(await response.arrayBuffer()).toString(), '0123456789', rangeHeader);
+  }
+
+  for (const rangeHeader of ['bytes=10-', 'bytes=-0', 'bytes=8-7']) {
+    const response = await readWorkspaceFileResponse({
+      raw: true, rawPath: 'movie.mp4', root, sourceId: 'session-1', rangeHeader,
+    });
+    assert.equal(response.status, 416, rangeHeader);
+    assert.equal(response.headers.get('content-range'), 'bytes */10', rangeHeader);
+  }
+});
+
+test('MP4 raw previews allow files larger than the image raw preview limit', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'tessera-workspace-large-video-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const filePath = path.join(root, 'large.mp4');
+  await writeFile(filePath, 'x');
+  await truncate(filePath, MAX_RAW_FILE_BYTES + 1);
+
+  const response = await readWorkspaceFileResponse({
+    raw: true, rawPath: 'large.mp4', root, sourceId: 'session-1', rangeHeader: 'bytes=0-0',
+  });
+  assert.equal(response.status, 206);
+  assert.equal(response.headers.get('content-range'), `bytes 0-0/${MAX_RAW_FILE_BYTES + 1}`);
+  assert.deepEqual(Buffer.from(await response.arrayBuffer()), Buffer.from('x'));
+});
+
+test('empty MP4 previews return an empty full response and reject byte ranges', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'tessera-workspace-empty-video-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(path.join(root, 'empty.mp4'), '');
+
+  const full = await readWorkspaceFileResponse({
+    raw: true, rawPath: 'empty.mp4', root, sourceId: 'session-1',
+  });
+  assert.equal(full.status, 200);
+  assert.equal(full.headers.get('content-length'), '0');
+  assert.equal(full.headers.get('accept-ranges'), 'bytes');
+  assert.equal((await full.arrayBuffer()).byteLength, 0);
+
+  const range = await readWorkspaceFileResponse({
+    raw: true, rawPath: 'empty.mp4', root, sourceId: 'session-1', rangeHeader: 'bytes=0-',
+  });
+  assert.equal(range.status, 416);
+  assert.equal(range.headers.get('content-range'), 'bytes */0');
+});

--- a/tests/workspace-video-preview-contract.test.mjs
+++ b/tests/workspace-video-preview-contract.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const [codeView, fileTab, videoViewer] = await Promise.all([
+  readFile(new URL('../src/components/workspace/workspace-code-view.tsx', import.meta.url), 'utf8'),
+  readFile(new URL('../src/components/workspace/workspace-file-tab.tsx', import.meta.url), 'utf8'),
+  readFile(new URL('../src/components/workspace/workspace-video-viewer.tsx', import.meta.url), 'utf8'),
+]);
+
+test('workspace video preview remains a read-only native video surface', () => {
+  assert.match(codeView, /isWorkspaceVideoMimeType/);
+  assert.match(codeView, /fileData\?\.binary && !isImageFile && !isVideoFile/);
+  assert.match(codeView, /!isImageFile && !isVideoFile \? <Tooltip content=\{copied/);
+  assert.match(codeView, /!isImageFile && !isVideoFile && fileData\?\.truncated/);
+  assert.match(codeView, /<WorkspaceVideoViewer/);
+  assert.match(fileTab, /!isWorkspaceVideoMimeType\(fileData\.mimeType\)/);
+  assert.match(videoViewer, /\bcontrols\b/);
+  assert.match(videoViewer, /\bplaysInline\b/);
+  assert.match(videoViewer, /preload="metadata"/);
+  assert.doesNotMatch(videoViewer, /\bautoPlay\b/);
+  assert.match(videoViewer, /MIN_VIDEO_ZOOM = 0\.5/);
+  assert.match(videoViewer, /MAX_VIDEO_ZOOM = 4/);
+  assert.match(videoViewer, /overflow-auto/);
+  assert.match(videoViewer, /style=\{fittedSize \? \{ width: fittedSize\.width, height: fittedSize\.height \}/);
+  assert.match(videoViewer, /aria-label="Zoom in video"/);
+  assert.match(videoViewer, /aria-label="Fit video to available area"/);
+});
+
+test('workspace video preview isolates controls and pauses when hidden or unmounted', () => {
+  assert.match(codeView, /active=\{previewActive\}/);
+  assert.match(fileTab, /previewActive=\{isTabActive && isDocumentVisible\}/);
+  assert.match(videoViewer, /event\.stopPropagation\(\)/);
+  assert.match(videoViewer, /if \(!active\) videoRef\.current\?\.pause\(\)/);
+  assert.match(videoViewer, /useEffect\(\(\) => \(\) => \{\s*videoRef\.current\?\.pause\(\);/);
+  assert.match(videoViewer, /key=\{previewSrc\}/);
+  assert.match(codeView, /key=\{videoRawUrl\}/);
+});

--- a/tests/worktree-file-panel-split.test.ts
+++ b/tests/worktree-file-panel-split.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { usePanelStore } from '../src/stores/panel-store';
+import { buildWorktreeFileSessionId } from '../src/lib/workspace-tabs/special-session';
+import { resolveWorkspaceTarget } from '../src/types/worktree';
+
+test('splitting B beside A without a Session retains the Files Worktree target', () => {
+  const store = usePanelStore.getState();
+  store.initTab('file-split', {
+    layout: { type: 'leaf', panelId: 'a' },
+    panels: { a: { id: 'a', sessionId: buildWorktreeFileSessionId('wt-a', 'A.txt'), worktreeId: 'wt-a' } },
+    activePanelId: 'a',
+  });
+  store.setActiveTabId('file-split');
+  const b = store.splitPanel('a', 'horizontal', buildWorktreeFileSessionId('wt-a', 'B.mp4'))!;
+  const state = usePanelStore.getState().tabPanels['file-split'];
+  assert.equal(state.activePanelId, b);
+  assert.deepEqual(resolveWorkspaceTarget(null, state.panels[b].worktreeId), { kind: 'worktree', id: 'wt-a' });
+  const c = store.splitPanel(b, 'vertical', buildWorktreeFileSessionId('wt-other', 'C.png'))!;
+  assert.equal(usePanelStore.getState().tabPanels['file-split'].panels[c].worktreeId, 'wt-other');
+});


### PR DESCRIPTION
## Summary

- Preview MP4 files using the native HTML video engine inside workspace file tabs. Stream authenticated, path-validated raw MP4 responses with single byte-range support and bounded reads.
- Enable Files explorer drag-to-split for sessionless Worktrees and retain Worktree identity when activating split file panels. Allow video interactions to activate their panel without stealing native control focus.
- Include the current video zoom toolbar implementation. Switch the custom development server to Webpack after reproducing excessive CPU use with a Turbopack disk cache; production startup is unchanged.

## Testing

- Focused workspace file, range, drag, panel target, and video contract tests.
- TypeScript and targeted ESLint checks; git diff whitespace check.
- Earlier native Windows Electron backend + WSL file QA covered MP4 metadata/play/pause/seek, a file above the old raw size limit, playback errors, and image/text regressions.
- Development Webpack server verified from Windows; authenticated chat requests and WebSocket connections observed in server logs.
- Full production build and full suite were not rerun for this handoff.

## Screenshots or Recordings

Earlier MP4 QA screenshots are available locally in Windows Downloads/Tessera-MP4-QA-20260912. They do not validate the later zoom changes.

## Known limitations

- The user reports that the zoom controls do not work. This remains unresolved and is intentionally included as-is at the user's explicit request to submit and merge the current implementation.
- No third-party player replacement or frame-stepping functionality is included.
- Later DnD/focus fixes have focused automated coverage but have not all received end-to-end browser QA.
- MP4 extension does not guarantee codec support; decoding remains limited to the host engine.
