### PR TITLE
Remove workspace video zoom controls

### DIFF
--- a/src/components/workspace/workspace-video-viewer.tsx
+++ b/src/components/workspace/workspace-video-viewer.tsx
@@ -1,18 +1,8 @@
 "use client";
 
-import { AlertCircle, RefreshCw, Scan, ZoomIn, ZoomOut } from 'lucide-react';
+import { AlertCircle, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { Button } from '@/components/ui/button';
-import { Tooltip } from '@/components/ui/tooltip';
-
-const MIN_VIDEO_ZOOM = 0.5;
-const MAX_VIDEO_ZOOM = 4;
-const VIDEO_ZOOM_STEP = 0.5;
-
-interface VideoSize {
-  width: number;
-  height: number;
-}
 
 function basename(filePath: string): string {
   return filePath.split(/[/\\]/).pop() || filePath;
@@ -32,12 +22,8 @@ export function WorkspaceVideoViewer({
   rawUrl: string;
 }) {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const [surfaceElement, setSurfaceElement] = useState<HTMLDivElement | null>(null);
   const [failedSrc, setFailedSrc] = useState<string | null>(null);
   const [retryAttempt, setRetryAttempt] = useState(0);
-  const [zoom, setZoom] = useState(1);
-  const [surfaceSize, setSurfaceSize] = useState<VideoSize | null>(null);
-  const [videoSize, setVideoSize] = useState<VideoSize | null>(null);
   const previewSrc = withRetryVersion(rawUrl, retryAttempt);
   const filename = basename(path);
   const hasError = failedSrc === previewSrc;
@@ -50,29 +36,9 @@ export function WorkspaceVideoViewer({
     videoRef.current?.pause();
   }, []);
 
-  useEffect(() => {
-    if (!surfaceElement) return;
-    const updateSize = () => setSurfaceSize({
-      width: surfaceElement.clientWidth,
-      height: surfaceElement.clientHeight,
-    });
-    updateSize();
-    if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(updateSize);
-    observer.observe(surfaceElement);
-    return () => observer.disconnect();
-  }, [surfaceElement]);
-
   const keepVideoInteractionLocal = useCallback((event: KeyboardEvent<HTMLVideoElement>) => {
     event.stopPropagation();
   }, []);
-
-  const fittedSize = videoSize && surfaceSize && surfaceSize.width > 0 && surfaceSize.height > 0
-    ? (() => {
-      const scale = Math.min(surfaceSize.width / videoSize.width, surfaceSize.height / videoSize.height);
-      return { width: videoSize.width * scale * zoom, height: videoSize.height * scale * zoom };
-    })()
-    : null;
 
   if (hasError) {
     return (
@@ -102,13 +68,7 @@ export function WorkspaceVideoViewer({
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-black" data-testid="workspace-video-viewer">
-      <div
-        ref={setSurfaceElement}
-        className="min-h-0 flex-1 overflow-auto p-4"
-        data-testid="workspace-video-surface"
-      >
-        <div className="flex min-h-full min-w-full items-center justify-center">
+    <div className="flex h-full min-h-0 items-center justify-center overflow-hidden bg-black p-4" data-testid="workspace-video-viewer">
           <video
             ref={videoRef}
             key={previewSrc}
@@ -116,37 +76,12 @@ export function WorkspaceVideoViewer({
             playsInline
             preload="metadata"
             src={previewSrc}
-            className={fittedSize ? 'block shrink-0' : 'max-h-full max-w-full object-contain'}
-            style={fittedSize ? { width: fittedSize.width, height: fittedSize.height } : undefined}
+            className="max-h-full max-w-full object-contain"
             aria-label={`Video preview: ${filename}`}
-            onLoadedMetadata={(event) => {
-              const video = event.currentTarget;
-              setVideoSize({ width: video.videoWidth, height: video.videoHeight });
-              setFailedSrc(null);
-            }}
+            onLoadedMetadata={() => setFailedSrc(null)}
             onError={() => setFailedSrc(previewSrc)}
             onKeyDown={keepVideoInteractionLocal}
           />
-        </div>
-      </div>
-      <div className="flex h-10 shrink-0 items-center justify-center gap-1 border-t border-(--divider) px-3 text-xs text-(--text-muted)">
-        <Tooltip content="Zoom out (relative to fit)">
-          <Button type="button" variant="ghost" size="icon" className="h-7 w-7" onClick={() => setZoom((current) => Math.max(MIN_VIDEO_ZOOM, current - VIDEO_ZOOM_STEP))} disabled={zoom <= MIN_VIDEO_ZOOM} aria-label="Zoom out video">
-            <ZoomOut className="h-3.5 w-3.5" />
-          </Button>
-        </Tooltip>
-        <span className="min-w-10 text-center tabular-nums" aria-label={`Video zoom ${Math.round(zoom * 100)} percent`}>{Math.round(zoom * 100)}%</span>
-        <Tooltip content="Zoom in (relative to fit)">
-          <Button type="button" variant="ghost" size="icon" className="h-7 w-7" onClick={() => setZoom((current) => Math.min(MAX_VIDEO_ZOOM, current + VIDEO_ZOOM_STEP))} disabled={zoom >= MAX_VIDEO_ZOOM} aria-label="Zoom in video">
-            <ZoomIn className="h-3.5 w-3.5" />
-          </Button>
-        </Tooltip>
-        <Tooltip content="Fit video to available area (100%)">
-          <Button type="button" variant="ghost" size="icon" className="h-7 w-7" onClick={() => setZoom(1)} disabled={zoom === 1} aria-label="Fit video to available area">
-            <Scan className="h-3.5 w-3.5" />
-          </Button>
-        </Tooltip>
-      </div>
     </div>
   );
 }

--- a/tests/workspace-video-preview-contract.test.mjs
+++ b/tests/workspace-video-preview-contract.test.mjs
@@ -19,12 +19,8 @@ test('workspace video preview remains a read-only native video surface', () => {
   assert.match(videoViewer, /\bplaysInline\b/);
   assert.match(videoViewer, /preload="metadata"/);
   assert.doesNotMatch(videoViewer, /\bautoPlay\b/);
-  assert.match(videoViewer, /MIN_VIDEO_ZOOM = 0\.5/);
-  assert.match(videoViewer, /MAX_VIDEO_ZOOM = 4/);
-  assert.match(videoViewer, /overflow-auto/);
-  assert.match(videoViewer, /style=\{fittedSize \? \{ width: fittedSize\.width, height: fittedSize\.height \}/);
-  assert.match(videoViewer, /aria-label="Zoom in video"/);
-  assert.match(videoViewer, /aria-label="Fit video to available area"/);
+  assert.match(videoViewer, /max-h-full max-w-full object-contain/);
+  assert.doesNotMatch(videoViewer, /ZoomIn|ZoomOut|setZoom|ResizeObserver/);
 });
 
 test('workspace video preview isolates controls and pauses when hidden or unmounted', () => {


### PR DESCRIPTION
## Summary

- Remove the video zoom toolbar, zoom state, ResizeObserver, and calculated sizing introduced in #475, at the user's request.
- Retain native MP4 playback fitted within the available area, playback error/retry handling, hidden-tab pause behavior, and panel activation fixes.
- MP4 streaming, file drag-to-split, and development Webpack selection are unchanged.

## Testing

- Video preview contract tests passed.
- Targeted ESLint, TypeScript, and whitespace checks passed.
- Full build and manual UI QA were not rerun for this removal.
