### PR TITLE
Improve workspace file explorer readability

### DIFF
--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -7,6 +7,8 @@ import {
   EyeOff,
   FilePlus2,
   FileText,
+  FileJson,
+  ImageIcon,
   Folder,
   FolderOpen,
   FolderPlus,
@@ -97,6 +99,26 @@ interface WorkspaceDirectoryNode {
 }
 
 type WorkspaceTreeNode = WorkspaceDirectoryNode | WorkspaceFileNode;
+
+function WorkspaceFileIcon({ name }: { name: string }) {
+  const extension = name.split('.').pop()?.toLowerCase();
+  if (extension && ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif'].includes(extension)) {
+    return <ImageIcon className="h-3.5 w-3.5 shrink-0 text-emerald-500" />;
+  }
+  if (extension === 'json') return <FileJson className="h-3.5 w-3.5 shrink-0 text-amber-500" />;
+  return <FileText className={cn('h-3.5 w-3.5 shrink-0', extension === 'md' ? 'text-sky-500' : 'text-(--text-secondary)')} />;
+}
+
+function WorkspaceFileName({ name }: { name: string }) {
+  const dot = name.lastIndexOf('.');
+  const hasExtension = dot > 0 && dot < name.length - 1;
+  return (
+    <span className="flex min-w-0 flex-1 text-[13px] leading-5">
+      <span className="truncate">{hasExtension ? name.slice(0, dot) : name}</span>
+      {hasExtension ? <span className="shrink-0">{name.slice(dot)}</span> : null}
+    </span>
+  );
+}
 
 type PathContextMenuState = WorkspacePathContextMenuState<WorkspaceTreeNode>;
 
@@ -702,11 +724,14 @@ export function WorkspaceFilePanel({
 
       return (
         <div key={`dir:${node.path}`} className="flex flex-col">
-          <div className="group flex min-w-0 items-center transition-colors hover:bg-(--sidebar-hover)">
+          <div className={cn("group flex min-w-0 items-center transition-colors hover:bg-(--sidebar-hover)", selectedPath === node.path && "bg-(--accent)/10")}>
           <button
             type="button"
             {...telemetryClickAttributes("files.directory.toggle", "files_panel")}
-            onClick={(event) => handleDirectoryClick(event, node.path)}
+            onClick={(event) => {
+              setSelectedPath(node.path);
+              handleDirectoryClick(event, node.path);
+            }}
             onKeyDown={(event) => {
               if (!canMutate || event.key !== "F2") return;
               event.preventDefault();
@@ -718,7 +743,7 @@ export function WorkspaceFilePanel({
               setWorkspaceDirectoryDragData(event.dataTransfer, sessionId, node.path, absolutePath);
             }}
             draggable={Boolean(sessionId)}
-            className="flex min-w-0 flex-1 items-center gap-1.5 border-l-2 border-l-transparent py-1.5 pr-2 text-left text-(--text-secondary) transition-colors group-hover:text-(--text-primary)"
+            className="flex h-7 min-w-0 flex-1 items-center gap-1.5 border-l-2 border-l-transparent pr-2 text-left text-(--text-primary) transition-colors focus-visible:outline-1 focus-visible:outline-(--accent) focus-visible:-outline-offset-1"
             style={{ paddingLeft }}
             title={node.path}
             aria-expanded={expanded}
@@ -729,7 +754,7 @@ export function WorkspaceFilePanel({
                 expanded && "rotate-90",
               )}
             />
-            <FolderIcon className="h-3.5 w-3.5 shrink-0 text-(--text-muted) group-hover:text-(--text-primary)" />
+            <FolderIcon className="h-3.5 w-3.5 shrink-0 text-(--text-secondary)" />
             <span
               // The name alone owns rename, with a tighter threshold than the
               // browser's native double-click setting.
@@ -739,7 +764,7 @@ export function WorkspaceFilePanel({
                 event.stopPropagation();
                 beginRename(node);
               }}
-              className="min-w-0 flex-1 truncate font-mono text-[11px]"
+              className="min-w-0 flex-1 truncate text-[13px] leading-5"
             >
               {node.name}
             </span>
@@ -748,7 +773,7 @@ export function WorkspaceFilePanel({
             ) : null}
           </button>
           </div>
-          {expanded ? children : null}
+          {expanded ? <div className="relative"><span aria-hidden="true" className="pointer-events-none absolute inset-y-0 w-px bg-(--divider)" style={{ left: paddingLeft + 9 }} />{children}</div> : null}
         </div>
       );
     }
@@ -767,9 +792,8 @@ export function WorkspaceFilePanel({
           "group relative border-l-2 transition-colors",
           isSelected
             ? "border-l-(--accent) bg-(--accent)/10 text-(--text-primary)"
-            : "border-l-transparent text-(--text-secondary) hover:bg-(--sidebar-hover) hover:text-(--text-primary)",
+            : "border-l-transparent text-(--text-primary) hover:bg-(--sidebar-hover)",
         )}
-        style={{ paddingLeft: paddingLeft + 19 }}
         onContextMenu={(event) => {
           setSelectedPath(node.path);
           openRowContextMenu(event, node, absolutePath);
@@ -810,7 +834,8 @@ export function WorkspaceFilePanel({
             setWorkspaceTargetFileDragData(event.dataTransfer, target, "file", node.path, absolutePath);
           }}
           draggable={Boolean(target)}
-          className="flex w-full min-w-0 items-center gap-2 border-l-transparent py-1.5 pr-8 text-left transition-colors"
+          className="flex h-7 w-full min-w-0 items-center gap-1.5 pr-2 text-left transition-colors focus-visible:outline-1 focus-visible:outline-(--accent) focus-visible:-outline-offset-1"
+          style={{ paddingLeft: paddingLeft + 20 }}
           title={node.isSymlink ? `${node.path} (symbolic link)` : node.path}
           data-testid={`workspace-file-row-${node.path}`}
           data-symlink={node.isSymlink ? "true" : undefined}
@@ -821,11 +846,9 @@ export function WorkspaceFilePanel({
               aria-label="Symbolic link"
             />
           ) : (
-            <FileText className="h-3.5 w-3.5 shrink-0 text-(--text-muted) group-hover:text-(--text-primary)" />
+            <WorkspaceFileIcon name={node.name} />
           )}
-          <span className="min-w-0 flex-1 truncate font-mono text-[11px]">
-            {node.name}
-          </span>
+          <WorkspaceFileName name={node.name} />
         </button>
       </div>
     );
@@ -945,9 +968,9 @@ export function WorkspaceFilePanel({
           />
         </div>
       ) : (
-        <div className="flex min-h-0 flex-1 flex-col gap-2 p-3">
-          <div className="flex items-center justify-between px-1">
-            <span className="text-[10px] uppercase tracking-[0.18em] text-(--text-muted)">
+        <div className="flex min-h-0 flex-1 flex-col gap-1 py-2">
+          <div className="flex items-center justify-between px-3 pb-1">
+            <span className="text-[11px] font-medium text-(--text-secondary)">
               Workspace files
             </span>
             <span className="font-mono text-[11px] text-(--text-muted) tabular-nums">

--- a/src/components/workspace/workspace-inline-input-row.tsx
+++ b/src/components/workspace/workspace-inline-input-row.tsx
@@ -120,7 +120,7 @@ export function WorkspaceInlineInputRow({
               ? "New folder name"
               : "New file name"}
           aria-invalid={error ? true : undefined}
-          className="min-w-0 flex-1 rounded-sm border border-(--accent) bg-(--chat-bg) px-1 py-0.5 font-mono text-[11px] text-(--text-primary) outline-none"
+          className="min-w-0 flex-1 rounded-sm border border-(--accent) bg-(--chat-bg) px-1 py-0.5 text-[13px] text-(--text-primary) outline-none"
           data-testid="workspace-inline-input"
           onKeyDown={(event) => {
             if (event.key === "Enter") {


### PR DESCRIPTION
Improve workspace explorer readability in narrow panels: use 13px UI text, brighter labels, compact 28px rows, reduced padding, and folder hierarchy guides. Distinguish image, Markdown, and JSON icons, preserve filename extensions when truncating, and highlight selected folders and keyboard focus. Match inline rename/create typography to the tree.

Validation: TypeScript check passed. Targeted explorer interaction tests cover inline input, refresh, expansion state, and drag contracts. The existing React Compiler `preserve-manual-memoization` lint error also reproduces on the unchanged HEAD. The development server was verified reachable from Windows; authenticated WebSocket connection and provider delivery were observed in server logs. Visual verification of the authenticated explorer remains incomplete.

Development database project visibility changes are local only and are not included in this PR.
