### PR TITLE
fix(files): restore scroll position when switching sessions

### DIFF
--- a/src/components/workspace/workspace-file-panel.tsx
+++ b/src/components/workspace/workspace-file-panel.tsx
@@ -34,6 +34,7 @@ import {
 import { useWorkspaceFileList } from "@/hooks/use-workspace-file-list";
 import { useProjectViewSession } from "@/hooks/use-project-view-workspace-state";
 import { isHiddenWorkspaceRelativePath } from "@/lib/workspace-files/hidden-workspace-path";
+import { restoreWorkspaceFileScroll } from "@/lib/workspace-files/workspace-file-scroll";
 import {
   selectExpandedWorkspacePaths,
   useWorkspaceFileViewStore,
@@ -219,7 +220,7 @@ export function WorkspaceFilePanel({
     () => resolveWorkspaceTarget(sessionId, worktreeId),
     [sessionId, worktreeId],
   );
-  const targetKey = target ? workspaceTargetKey(target) : null;
+  const targetKey = useMemo(() => target ? workspaceTargetKey(target) : null, [target]);
   const canMutate = target !== null;
   const isDocumentVisible = useDocumentVisibility();
   const peekTarget = useWorkspacePeekStore((state) => state.target);
@@ -329,6 +330,15 @@ export function WorkspaceFilePanel({
   });
 
   const isSearching = query.trim().length > 0;
+  const scrollRef = useCallback((viewport: HTMLDivElement | null) => {
+    if (!viewport || !targetKey || isSearching) return;
+    const store = useWorkspaceFileViewStore.getState();
+    return restoreWorkspaceFileScroll(
+      viewport,
+      store.scrollTopByWorkspace[targetKey] ?? 0,
+      (scrollTop) => store.setScrollTop(targetKey, scrollTop),
+    );
+  }, [targetKey, isSearching]);
   useEffect(function loadGlobalSearchResults() {
     const trimmed = query.trim();
     const abortController = new AbortController();
@@ -954,7 +964,7 @@ export function WorkspaceFilePanel({
               {visibleFiles.length.toLocaleString()}
             </span>
           </div>
-          <ScrollArea className="min-h-0 flex-1">
+          <ScrollArea key={targetKey} ref={scrollRef} className="min-h-0 flex-1">
             {/* The rows stop their own context menu, so this one only ever
                 fires on the empty space past the last row. */}
             <div

--- a/src/lib/workspace-files/workspace-file-scroll.ts
+++ b/src/lib/workspace-files/workspace-file-scroll.ts
@@ -1,0 +1,49 @@
+/** Restore again as lazily loaded folders grow the tree; user input takes over. */
+export function restoreWorkspaceFileScroll(
+  viewport: HTMLDivElement,
+  savedTop: number,
+  save: (scrollTop: number) => void,
+): () => void {
+  let restoring = true;
+  let lastTop = savedTop;
+  const restore = () => {
+    if (!restoring) return;
+    viewport.scrollTop = savedTop;
+    if (Math.abs(viewport.scrollTop - savedTop) < 1) {
+      restoring = false;
+      lastTop = viewport.scrollTop;
+    }
+  };
+  const onScroll = () => {
+    if (!restoring && viewport.clientHeight > 0) lastTop = viewport.scrollTop;
+  };
+  const onInteraction = () => {
+    restoring = false;
+    lastTop = viewport.scrollTop;
+  };
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '].includes(event.key)) {
+      onInteraction();
+    }
+  };
+  const observer = new ResizeObserver(restore);
+  observer.observe(viewport);
+  if (viewport.firstElementChild) observer.observe(viewport.firstElementChild);
+  viewport.addEventListener('scroll', onScroll, { passive: true });
+  viewport.addEventListener('wheel', onInteraction, { passive: true });
+  viewport.addEventListener('pointerdown', onInteraction, { passive: true });
+  viewport.addEventListener('touchstart', onInteraction, { passive: true });
+  viewport.addEventListener('keydown', onKeyDown);
+  restore();
+  return () => {
+    observer.disconnect();
+    viewport.removeEventListener('scroll', onScroll);
+    viewport.removeEventListener('wheel', onInteraction);
+    viewport.removeEventListener('pointerdown', onInteraction);
+    viewport.removeEventListener('touchstart', onInteraction);
+    viewport.removeEventListener('keydown', onKeyDown);
+    // Keep the requested offset if the user leaves before folder loading ends.
+    // A hidden/unmounted viewport can already have been clamped to zero.
+    save(!restoring && viewport.clientHeight > 0 ? viewport.scrollTop : lastTop);
+  };
+}

--- a/src/stores/workspace-file-view-store.ts
+++ b/src/stores/workspace-file-view-store.ts
@@ -8,6 +8,8 @@ interface WorkspaceFileViewState {
   showHiddenFiles: boolean;
   /** Expanded directory paths, isolated by canonical Session/Worktree target. */
   expandedPathsByWorkspace: Record<string, string[]>;
+  scrollTopByWorkspace: Record<string, number>;
+  setScrollTop: (workspaceKey: string, scrollTop: number) => void;
   toggleShowHiddenFiles: () => void;
   setShowHiddenFiles: (value: boolean) => void;
   setExpandedPaths: (workspaceKey: string, paths: Iterable<string>) => void;
@@ -17,7 +19,7 @@ interface WorkspaceFileViewState {
 
 type PersistedWorkspaceFileViewState = Pick<
   WorkspaceFileViewState,
-  'showHiddenFiles' | 'expandedPathsByWorkspace'
+  'showHiddenFiles' | 'expandedPathsByWorkspace' | 'scrollTopByWorkspace'
 >;
 
 const EMPTY_EXPANDED_PATHS: string[] = [];
@@ -27,6 +29,14 @@ export const useWorkspaceFileViewStore = create<WorkspaceFileViewState>()(
     (set) => ({
       showHiddenFiles: false,
       expandedPathsByWorkspace: {},
+      scrollTopByWorkspace: {},
+      setScrollTop: (workspaceKey, scrollTop) =>
+        set((state) => ({
+          scrollTopByWorkspace: {
+            ...state.scrollTopByWorkspace,
+            [workspaceKey]: scrollTop,
+          },
+        })),
       toggleShowHiddenFiles: () =>
         set((state) => ({ showHiddenFiles: !state.showHiddenFiles })),
       setShowHiddenFiles: (value) => set({ showHiddenFiles: value }),
@@ -73,6 +83,7 @@ export const useWorkspaceFileViewStore = create<WorkspaceFileViewState>()(
       partialize: (state) => ({
         showHiddenFiles: state.showHiddenFiles,
         expandedPathsByWorkspace: state.expandedPathsByWorkspace,
+        scrollTopByWorkspace: state.scrollTopByWorkspace,
       }),
     },
   ),

--- a/tests/workspace-file-scroll.test.ts
+++ b/tests/workspace-file-scroll.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { restoreWorkspaceFileScroll } from '../src/lib/workspace-files/workspace-file-scroll';
+
+test('restores after lazy loading, saves each session, and respects user scrolling', (t) => {
+  let resize = () => {};
+  let disconnected = false;
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'ResizeObserver');
+  t.after(() => {
+    if (original) Object.defineProperty(globalThis, 'ResizeObserver', original);
+    else Reflect.deleteProperty(globalThis, 'ResizeObserver');
+  });
+  Object.defineProperty(globalThis, 'ResizeObserver', { configurable: true, value: class {
+    constructor(callback: () => void) { resize = callback; }
+    observe() {}
+    disconnect() { disconnected = true; }
+  } });
+  class Viewport extends EventTarget {
+    clientHeight = 100;
+    firstElementChild = {};
+    maxTop = 100;
+    top = 0;
+    get scrollTop() { return this.top; }
+    set scrollTop(value: number) { this.top = Math.min(value, this.maxTop); }
+  }
+  const viewport = new Viewport();
+  let saved = 0;
+  const attach = (top: number) => restoreWorkspaceFileScroll(
+    viewport as unknown as HTMLDivElement, top, (value) => { saved = value; },
+  );
+  let cleanup = attach(700);
+  assert.equal(viewport.scrollTop, 100);
+  viewport.dispatchEvent(new Event('scroll'));
+  cleanup();
+  assert.equal(saved, 700, 'leaving before loading finishes preserves the target');
+  assert.equal(disconnected, true);
+
+  cleanup = attach(saved);
+  viewport.maxTop = 1000;
+  resize();
+  assert.equal(viewport.scrollTop, 700);
+  viewport.scrollTop = 450;
+  cleanup();
+  assert.equal(saved, 450, 'captures scrolling even before the scroll event');
+
+  viewport.maxTop = 100;
+  cleanup = attach(700);
+  viewport.dispatchEvent(new Event('wheel'));
+  viewport.scrollTop = 40;
+  viewport.maxTop = 1000;
+  resize();
+  assert.equal(viewport.scrollTop, 40, 'loading must not override user input');
+  cleanup();
+  assert.equal(saved, 40);
+});


### PR DESCRIPTION
Switching away from a session and returning to its Files tab now restores that session's file-tree scroll position. The position is stored alongside the existing workspace view state, and restoration retries as expanded folders load. User scrolling takes precedence over pending restoration; search results do not overwrite the normal tree position.

Validation: six related unit tests, targeted ESLint, TypeScript checking, and git diff checks passed after integrating the latest dev branch. Actual app UI testing has not been performed.
